### PR TITLE
Explore ページ改善 + GitHub プロフィール表示強化

### DIFF
--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { getUser, getFollowers, getFollowing } from '../api/users';
 import { getUserPosts } from '../api/posts';
-import { getContributions, getLanguages } from '../api/github';
+import { getContributions, getLanguages, getRepos } from '../api/github';
 import { useAuthStore } from '../store/authStore';
 import type { User } from '../types/user';
 import type { Post } from '../types/post';
-import type { GitHubContribution, GitHubLanguageStat } from '../types/github';
+import type { GitHubContribution, GitHubLanguageStat, GitHubRepository } from '../types/github';
 import Avatar from '../components/common/Avatar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import FollowButton from '../components/profile/FollowButton';
@@ -21,6 +21,7 @@ export default function ProfilePage() {
   const [posts, setPosts] = useState<Post[]>([]);
   const [contributions, setContributions] = useState<GitHubContribution[]>([]);
   const [languages, setLanguages] = useState<GitHubLanguageStat[]>([]);
+  const [repos, setRepos] = useState<GitHubRepository[]>([]);
   const [followerCount, setFollowerCount] = useState(0);
   const [followingCount, setFollowingCount] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -44,12 +45,14 @@ export default function ProfilePage() {
         setFollowingCount((followingRes.data || []).length);
 
         if (userRes.data.github_connected) {
-          const [contribRes, langRes] = await Promise.all([
+          const [contribRes, langRes, reposRes] = await Promise.all([
             getContributions(userId),
             getLanguages(userId),
+            getRepos(userId),
           ]);
           setContributions(contribRes.data || []);
           setLanguages(langRes.data || []);
+          setRepos(reposRes.data || []);
         }
       } catch {
         // handle error
@@ -79,10 +82,18 @@ export default function ProfilePage() {
             </div>
             {user.bio && <p className="text-gray-400 mt-1 text-sm">{user.bio}</p>}
             {user.github_username && (
-              <div className="flex items-center gap-1.5 mt-2 text-sm text-gray-500">
+              <a
+                href={`https://github.com/${user.github_username}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5 mt-2 text-sm text-gray-500 hover:text-blue-400 transition-colors"
+              >
                 <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
                 @{user.github_username}
-              </div>
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                </svg>
+              </a>
             )}
             <div className="flex gap-4 mt-3 text-sm">
               <Link to={`/profile/${user.id}/followers`} className="text-gray-400 hover:text-blue-400 transition-colors">
@@ -118,6 +129,79 @@ export default function ProfilePage() {
               </div>
             </div>
           )}
+        </div>
+      )}
+
+      {/* Repositories */}
+      {user.github_connected && repos.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide">
+              Repositories
+            </h2>
+            {user.github_username && (
+              <a
+                href={`https://github.com/${user.github_username}?tab=repositories`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1"
+              >
+                View all on GitHub
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                </svg>
+              </a>
+            )}
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {repos.slice(0, 6).map((repo) => (
+              <a
+                key={repo.id}
+                href={`https://github.com/${repo.full_name}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-gray-600 transition-colors group"
+              >
+                <div className="flex items-start gap-2">
+                  <svg className="w-4 h-4 text-gray-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+                  </svg>
+                  <div className="min-w-0 flex-1">
+                    <div className="font-medium text-sm text-blue-400 group-hover:text-blue-300 truncate">
+                      {repo.name}
+                    </div>
+                    {repo.description && (
+                      <p className="text-xs text-gray-500 mt-1 line-clamp-2">{repo.description}</p>
+                    )}
+                    <div className="flex items-center gap-3 mt-2">
+                      {repo.language && (
+                        <span className="flex items-center gap-1 text-xs text-gray-400">
+                          <span className="w-2.5 h-2.5 rounded-full bg-yellow-400" />
+                          {repo.language}
+                        </span>
+                      )}
+                      {repo.stars > 0 && (
+                        <span className="flex items-center gap-1 text-xs text-gray-400">
+                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
+                          </svg>
+                          {repo.stars}
+                        </span>
+                      )}
+                      {repo.forks > 0 && (
+                        <span className="flex items-center gap-1 text-xs text-gray-400">
+                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z" />
+                          </svg>
+                          {repo.forks}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </a>
+            ))}
+          </div>
         </div>
       )}
 

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,25 +1,61 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { getUsers } from '../api/users';
+import { getUsers, getFollowers, getFollowing } from '../api/users';
+import { useAuthStore } from '../store/authStore';
 import type { User } from '../types/user';
 import Avatar from '../components/common/Avatar';
+import FollowButton from '../components/profile/FollowButton';
+import LoadingSpinner from '../components/common/LoadingSpinner';
 
 export default function SearchPage() {
+  const currentUser = useAuthStore((s) => s.user);
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<User[]>([]);
+  const [allUsers, setAllUsers] = useState<User[]>([]);
+  const [loading, setLoading] = useState(true);
   const [searched, setSearched] = useState(false);
+
+  // Load all users on mount
+  useEffect(() => {
+    getUsers()
+      .then(({ data }) => {
+        setAllUsers(data || []);
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
 
   const handleSearch = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!query.trim()) return;
-    const { data } = await getUsers(query);
-    setResults(data || []);
-    setSearched(true);
+    if (!query.trim()) {
+      setResults([]);
+      setSearched(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const { data } = await getUsers(query);
+      setResults(data || []);
+      setSearched(true);
+    } catch {
+      setResults([]);
+    } finally {
+      setLoading(false);
+    }
   };
 
+  const displayUsers = searched ? results : allUsers;
+  const filteredUsers = displayUsers.filter((u) => u.id !== currentUser?.id);
+
   return (
-    <div className="max-w-2xl mx-auto space-y-6">
-      <h1 className="text-2xl font-bold">Explore</h1>
+    <div className="max-w-3xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Explore</h1>
+        <span className="text-sm text-gray-500">{filteredUsers.length} developers</span>
+      </div>
+
+      {/* Search */}
       <form onSubmit={handleSearch} className="flex gap-2">
         <div className="flex-1 relative">
           <svg className="w-4 h-4 absolute left-3 top-1/2 -translate-y-1/2 text-gray-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
@@ -28,8 +64,14 @@ export default function SearchPage() {
           <input
             type="text"
             value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search by name or email..."
+            onChange={(e) => {
+              setQuery(e.target.value);
+              if (!e.target.value.trim()) {
+                setSearched(false);
+                setResults([]);
+              }
+            }}
+            placeholder="Search developers by name or email..."
             className="w-full pl-10 pr-3 py-2.5 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
           />
         </div>
@@ -41,30 +83,82 @@ export default function SearchPage() {
         </button>
       </form>
 
-      {searched && results.length === 0 && (
-        <div className="text-center text-gray-400 py-12 text-sm">No users found</div>
+      {/* Results */}
+      {loading ? (
+        <div className="py-12"><LoadingSpinner /></div>
+      ) : searched && filteredUsers.length === 0 ? (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-12 text-center text-gray-500 text-sm">
+          No developers found matching "{query}"
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          {filteredUsers.map((user) => (
+            <UserCard key={user.id} user={user} currentUserId={currentUser?.id} />
+          ))}
+        </div>
       )}
+    </div>
+  );
+}
 
-      <div className="space-y-1">
-        {results.map((user) => (
-          <Link
-            key={user.id}
-            to={`/profile/${user.id}`}
-            className="flex items-center gap-3 p-3 rounded-xl hover:bg-gray-900 transition-colors"
-          >
-            <Avatar name={user.name} avatarUrl={user.avatar_url} />
-            <div className="min-w-0">
-              <div className="font-medium text-sm">{user.name}</div>
-              <div className="text-xs text-gray-500">{user.email}</div>
-            </div>
-            {user.github_username && (
-              <span className="ml-auto text-xs text-gray-500 flex items-center gap-1">
-                <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-                @{user.github_username}
+function UserCard({ user, currentUserId }: { user: User; currentUserId?: number }) {
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-5 hover:border-gray-700 transition-colors">
+      <div className="flex items-start gap-4">
+        <Link to={`/profile/${user.id}`}>
+          <Avatar name={user.name} avatarUrl={user.avatar_url} />
+        </Link>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <Link to={`/profile/${user.id}`} className="font-semibold text-sm hover:text-blue-400 transition-colors">
+              {user.name}
+            </Link>
+            {user.github_connected && (
+              <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-800 text-xs text-gray-400 border border-gray-700">
+                <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+                Connected
               </span>
             )}
-          </Link>
-        ))}
+          </div>
+
+          {user.github_username && (
+            <div className="text-xs text-gray-500 mt-0.5 flex items-center gap-1">
+              <svg className="w-3 h-3" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+              @{user.github_username}
+            </div>
+          )}
+
+          {user.bio && (
+            <p className="text-xs text-gray-400 mt-1.5 line-clamp-2">{user.bio}</p>
+          )}
+        </div>
+      </div>
+
+      {/* Action Buttons */}
+      <div className="flex items-center gap-2 mt-4 pt-3 border-t border-gray-800/50">
+        <Link
+          to={`/profile/${user.id}`}
+          className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-300 text-xs font-medium transition-colors"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+          </svg>
+          Profile
+        </Link>
+        <Link
+          to={`/chat/${user.id}`}
+          className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 rounded-lg bg-blue-600/10 hover:bg-blue-600/20 text-blue-400 text-xs font-medium transition-colors border border-blue-500/20"
+        >
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M20.25 8.511c.884.284 1.5 1.128 1.5 2.097v4.286c0 1.136-.847 2.1-1.98 2.193-.34.027-.68.052-1.02.072v3.091l-3-3c-1.354 0-2.694-.055-4.02-.163a2.115 2.115 0 0 1-.825-.242m9.345-8.334a2.126 2.126 0 0 0-.476-.095 48.64 48.64 0 0 0-8.048 0c-1.131.094-1.976 1.057-1.976 2.192v4.286c0 .837.46 1.58 1.155 1.951m9.345-8.334V6.637c0-1.621-1.152-3.026-2.76-3.235A48.455 48.455 0 0 0 11.25 3c-2.115 0-4.198.137-6.24.402-1.608.209-2.76 1.614-2.76 3.235v6.226c0 1.621 1.152 3.026 2.76 3.235.577.075 1.157.14 1.74.194V21l4.155-4.155" />
+          </svg>
+          Chat
+        </Link>
+        {currentUserId && currentUserId !== user.id && (
+          <div className="flex-shrink-0">
+            <FollowButton userId={user.id} />
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- **Explore ページ**: 初期表示で全ユーザー一覧、リッチなユーザーカード（bio・GitHub バッジ・フォローボタン・チャットボタン付き）
- **ProfilePage**: GitHub プロフィールへの外部リンク、リポジトリ一覧セクション（スター・フォーク・言語表示）

## Test plan
- [ ] Explore ページにアクセスして全ユーザーが2カラムグリッドで表示されること
- [ ] 検索フォームでユーザー名を入力して絞り込みができること
- [ ] 各カードの「Profile」ボタンでプロフィールページに遷移すること
- [ ] 各カードの「Chat」ボタンでチャットページに遷移すること
- [ ] GitHub連携済みユーザーに「Connected」バッジが表示されること
- [ ] ProfilePage の @username がGitHubプロフィールへのリンクになっていること
- [ ] ProfilePage にリポジトリ一覧（最大6件）が表示されること
- [ ] 各リポジトリカードからGitHubリポジトリページに遷移できること

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)