### PR TITLE
プログラミングスキル設定・表示機能（skillicons.dev対応）

### DIFF
--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -71,9 +71,11 @@ func (h *UserHandler) Update(c *gin.Context) {
 	}
 
 	var input struct {
-		Name      string `json:"name"`
-		Bio       string `json:"bio"`
-		AvatarURL string `json:"avatar_url"`
+		Name             string  `json:"name"`
+		Bio              string  `json:"bio"`
+		AvatarURL        string  `json:"avatar_url"`
+		SkillsLanguages  *string `json:"skills_languages"`
+		SkillsFrameworks *string `json:"skills_frameworks"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
@@ -85,6 +87,12 @@ func (h *UserHandler) Update(c *gin.Context) {
 	}
 	existing.Bio = input.Bio
 	existing.AvatarURL = input.AvatarURL
+	if input.SkillsLanguages != nil {
+		existing.SkillsLanguages = *input.SkillsLanguages
+	}
+	if input.SkillsFrameworks != nil {
+		existing.SkillsFrameworks = *input.SkillsFrameworks
+	}
 
 	if err := h.repo.Update(existing); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -12,7 +12,9 @@ type User struct {
 	GitHubID        int64     `json:"github_id" gorm:"uniqueIndex"`
 	GitHubUsername  string    `json:"github_username"`
 	GitHubToken     string    `json:"-"`
-	GitHubConnected bool      `json:"github_connected" gorm:"default:false"`
-	CreatedAt       time.Time `json:"created_at"`
-	UpdatedAt       time.Time `json:"updated_at"`
+	GitHubConnected  bool      `json:"github_connected" gorm:"default:false"`
+	SkillsLanguages  string    `json:"skills_languages"`
+	SkillsFrameworks string    `json:"skills_frameworks"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
 }

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -7,7 +7,13 @@ export const getUsers = (q?: string) =>
 export const getUser = (id: number) =>
   client.get<User>(`/users/${id}`);
 
-export const updateUser = (id: number, data: { name?: string; bio?: string; avatar_url?: string }) =>
+export const updateUser = (id: number, data: {
+  name?: string;
+  bio?: string;
+  avatar_url?: string;
+  skills_languages?: string;
+  skills_frameworks?: string;
+}) =>
   client.put<User>(`/users/${id}`, data);
 
 export const followUser = (id: number) =>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -107,6 +107,40 @@ export default function ProfilePage() {
         </div>
       </div>
 
+      {/* Skills */}
+      {(user.skills_languages || user.skills_frameworks) && (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 space-y-4">
+          {user.skills_languages && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2">
+                <span>✨</span> Languages
+              </h3>
+              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer">
+                <img
+                  src={`https://skillicons.dev/icons?i=${user.skills_languages}&theme=dark`}
+                  alt="Languages"
+                  className="h-12"
+                />
+              </a>
+            </div>
+          )}
+          {user.skills_frameworks && (
+            <div>
+              <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2">
+                <span>🚀</span> Frameworks & Libraries
+              </h3>
+              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer">
+                <img
+                  src={`https://skillicons.dev/icons?i=${user.skills_frameworks}&theme=dark`}
+                  alt="Frameworks"
+                  className="h-12"
+                />
+              </a>
+            </div>
+          )}
+        </div>
+      )}
+
       {/* GitHub Data */}
       {user.github_connected && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,12 +4,33 @@ import { updateUser } from '../api/users';
 import { getGitHubConnectURL, disconnectGitHub, syncGitHub } from '../api/github';
 import toast from 'react-hot-toast';
 
+// skillicons.dev supported icons
+const LANGUAGES = [
+  'java', 'typescript', 'javascript', 'python', 'go', 'rust', 'cpp', 'c', 'cs',
+  'php', 'ruby', 'swift', 'kotlin', 'scala', 'elixir', 'haskell', 'lua', 'perl',
+  'r', 'dart', 'html', 'css', 'sass', 'bash', 'powershell', 'sql', 'graphql'
+];
+
+const FRAMEWORKS = [
+  'react', 'vue', 'angular', 'svelte', 'nextjs', 'nuxtjs', 'gatsby', 'astro',
+  'spring', 'django', 'flask', 'fastapi', 'rails', 'laravel', 'express', 'nestjs',
+  'gin', 'fiber', 'actix', 'rocket', 'tailwind', 'bootstrap', 'materialui',
+  'prisma', 'graphql', 'apollo', 'redux', 'nodejs', 'deno', 'bun'
+];
+
 export default function SettingsPage() {
   const { user, setUser } = useAuthStore();
   const [name, setName] = useState(user?.name || '');
   const [bio, setBio] = useState(user?.bio || '');
   const [avatarUrl, setAvatarUrl] = useState(user?.avatar_url || '');
+  const [selectedLanguages, setSelectedLanguages] = useState<string[]>(
+    user?.skills_languages ? user.skills_languages.split(',').filter(Boolean) : []
+  );
+  const [selectedFrameworks, setSelectedFrameworks] = useState<string[]>(
+    user?.skills_frameworks ? user.skills_frameworks.split(',').filter(Boolean) : []
+  );
   const [saving, setSaving] = useState(false);
+  const [savingSkills, setSavingSkills] = useState(false);
   const [syncing, setSyncing] = useState(false);
 
   if (!user) return null;
@@ -26,6 +47,34 @@ export default function SettingsPage() {
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleSaveSkills = async () => {
+    setSavingSkills(true);
+    try {
+      const { data } = await updateUser(user.id, {
+        skills_languages: selectedLanguages.join(','),
+        skills_frameworks: selectedFrameworks.join(','),
+      });
+      setUser(data);
+      toast.success('Skills updated');
+    } catch {
+      toast.error('Failed to update skills');
+    } finally {
+      setSavingSkills(false);
+    }
+  };
+
+  const toggleLanguage = (lang: string) => {
+    setSelectedLanguages((prev) =>
+      prev.includes(lang) ? prev.filter((l) => l !== lang) : [...prev, lang]
+    );
+  };
+
+  const toggleFramework = (fw: string) => {
+    setSelectedFrameworks((prev) =>
+      prev.includes(fw) ? prev.filter((f) => f !== fw) : [...prev, fw]
+    );
   };
 
   const handleConnectGitHub = async () => {
@@ -94,6 +143,99 @@ export default function SettingsPage() {
           </button>
         </div>
       </form>
+
+      {/* Skills Section */}
+      <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-800">
+          <h2 className="text-base font-semibold flex items-center gap-2">
+            <span>✨</span> Skills
+          </h2>
+          <p className="text-xs text-gray-500 mt-1">Select your programming languages and frameworks</p>
+        </div>
+        <div className="p-6 space-y-6">
+          {/* Languages */}
+          <div>
+            <h3 className="text-sm font-medium text-gray-300 mb-3 flex items-center gap-2">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M17.25 6.75 22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3-4.5 16.5" />
+              </svg>
+              Languages
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {LANGUAGES.map((lang) => (
+                <button
+                  key={lang}
+                  type="button"
+                  onClick={() => toggleLanguage(lang)}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all border ${
+                    selectedLanguages.includes(lang)
+                      ? 'bg-blue-600/20 text-blue-300 border-blue-500/50'
+                      : 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-500'
+                  }`}
+                >
+                  {lang}
+                </button>
+              ))}
+            </div>
+            {selectedLanguages.length > 0 && (
+              <div className="mt-3 p-3 bg-gray-800/50 rounded-lg">
+                <p className="text-xs text-gray-500 mb-2">Preview:</p>
+                <img
+                  src={`https://skillicons.dev/icons?i=${selectedLanguages.join(',')}&theme=dark`}
+                  alt="Selected languages"
+                  className="h-12"
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Frameworks */}
+          <div>
+            <h3 className="text-sm font-medium text-gray-300 mb-3 flex items-center gap-2">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.59 14.37a6 6 0 0 1-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 0 0 6.16-12.12A14.98 14.98 0 0 0 9.631 8.41m5.96 5.96a14.926 14.926 0 0 1-5.841 2.58m-.119-8.54a6 6 0 0 0-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 0 0-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 0 1-2.448-2.448 14.9 14.9 0 0 1 .06-.312m-2.24 2.39a4.493 4.493 0 0 0-1.757 4.306 4.493 4.493 0 0 0 4.306-1.758M16.5 9a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0Z" />
+              </svg>
+              Frameworks & Libraries
+            </h3>
+            <div className="flex flex-wrap gap-2">
+              {FRAMEWORKS.map((fw) => (
+                <button
+                  key={fw}
+                  type="button"
+                  onClick={() => toggleFramework(fw)}
+                  className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all border ${
+                    selectedFrameworks.includes(fw)
+                      ? 'bg-purple-600/20 text-purple-300 border-purple-500/50'
+                      : 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-500'
+                  }`}
+                >
+                  {fw}
+                </button>
+              ))}
+            </div>
+            {selectedFrameworks.length > 0 && (
+              <div className="mt-3 p-3 bg-gray-800/50 rounded-lg">
+                <p className="text-xs text-gray-500 mb-2">Preview:</p>
+                <img
+                  src={`https://skillicons.dev/icons?i=${selectedFrameworks.join(',')}&theme=dark`}
+                  alt="Selected frameworks"
+                  className="h-12"
+                />
+              </div>
+            )}
+          </div>
+        </div>
+        <div className="px-6 py-4 border-t border-gray-800 flex justify-end">
+          <button
+            type="button"
+            onClick={handleSaveSkills}
+            disabled={savingSkills}
+            className="px-5 py-2 bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white rounded-lg font-medium text-sm transition-colors"
+          >
+            {savingSkills ? 'Saving...' : 'Save skills'}
+          </button>
+        </div>
+      </div>
 
       {/* GitHub Integration */}
       <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -7,6 +7,8 @@ export interface User {
   github_id: number;
   github_username: string;
   github_connected: boolean;
+  skills_languages: string;
+  skills_frameworks: string;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary
ユーザーが使用可能なプログラミング言語・フレームワークを設定し、プロフィールページで skillicons.dev のアイコン付きで表示する機能を追加。

### バックエンド
- User model に `skills_languages` と `skills_frameworks` フィールドを追加
- User handler で新フィールドを受け付け・保存

### フロントエンド
- **SettingsPage**: 新しい「✨ Skills」セクション
  - 27種の言語ボタン（java, typescript, go, python など）
  - 30種のフレームワークボタン（react, spring, laravel など）
  - 選択中のスキルをリアルタイムプレビュー（skillicons.dev）
  
- **ProfilePage**: スキル表示セクション
  - ✨ Languages: skillicons.dev アイコン画像
  - 🚀 Frameworks & Libraries: skillicons.dev アイコン画像

## Test plan
- [ ] Settings > Skills でスキルを選択できること
- [ ] プレビューにアイコンが表示されること
- [ ] 「Save skills」で保存されること
- [ ] プロフィールページにスキルアイコンが表示されること
- [ ] スキル未設定のユーザーはセクションが非表示であること

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)