### PR TITLE
feat: Dark/Light Mode Toggle

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { useAuthStore } from './store/authStore';
+import { useThemeStore } from './store/themeStore';
 import ProtectedRoute from './components/auth/ProtectedRoute';
 import Layout from './components/layout/Layout';
 import LoginPage from './pages/LoginPage';
@@ -17,6 +18,18 @@ import GitHubCallbackPage from './pages/GitHubCallbackPage';
 
 export default function App() {
   const { isAuthenticated, loadUser } = useAuthStore();
+  const { theme, resolvedTheme } = useThemeStore();
+
+  // Initialize theme on mount
+  useEffect(() => {
+    if (resolvedTheme === 'dark') {
+      document.documentElement.classList.add('dark');
+      document.documentElement.classList.remove('light');
+    } else {
+      document.documentElement.classList.add('light');
+      document.documentElement.classList.remove('dark');
+    }
+  }, [resolvedTheme]);
 
   useEffect(() => {
     if (isAuthenticated) {

--- a/frontend/src/components/common/ThemeToggle.tsx
+++ b/frontend/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,67 @@
+import { useThemeStore } from '../../store/themeStore';
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useThemeStore();
+
+  const themes = [
+    {
+      value: 'light' as const,
+      icon: (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z"
+          />
+        </svg>
+      ),
+      label: 'Light',
+    },
+    {
+      value: 'dark' as const,
+      icon: (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M21.752 15.002A9.72 9.72 0 0 1 18 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 0 0 3 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 0 0 9.002-5.998Z"
+          />
+        </svg>
+      ),
+      label: 'Dark',
+    },
+    {
+      value: 'system' as const,
+      icon: (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9 17.25v1.007a3 3 0 0 1-.879 2.122L7.5 21h9l-.621-.621A3 3 0 0 1 15 18.257V17.25m6-12V15a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 15V5.25m18 0A2.25 2.25 0 0 0 18.75 3H5.25A2.25 2.25 0 0 0 3 5.25m18 0V12a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 12V5.25"
+          />
+        </svg>
+      ),
+      label: 'System',
+    },
+  ];
+
+  return (
+    <div className="flex items-center gap-1 p-1 bg-gray-800 dark:bg-gray-800 light:bg-gray-200 rounded-lg">
+      {themes.map((t) => (
+        <button
+          key={t.value}
+          onClick={() => setTheme(t.value)}
+          className={`p-2 rounded-md transition-all ${
+            theme === t.value
+              ? 'bg-gray-700 dark:bg-gray-700 light:bg-white text-white dark:text-white light:text-gray-900 shadow-sm'
+              : 'text-gray-400 hover:text-white dark:text-gray-400 dark:hover:text-white light:text-gray-500 light:hover:text-gray-900'
+          }`}
+          title={t.label}
+          aria-label={`Set ${t.label} theme`}
+        >
+          {t.icon}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useAuthStore } from '../../store/authStore';
 import Avatar from '../common/Avatar';
+import ThemeToggle from '../common/ThemeToggle';
 
 export default function Header() {
   const { user, logout } = useAuthStore();
@@ -46,6 +47,8 @@ export default function Header() {
 
         {/* Right side */}
         <div className="flex items-center gap-2 ml-auto">
+          <ThemeToggle />
+
           <Link
             to="/settings"
             className="p-2 text-gray-400 hover:text-white transition-colors rounded-md"

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,1 +1,135 @@
 @import "tailwindcss";
+
+/* Dark theme (default) */
+:root,
+.dark {
+  --bg-primary: #0a0a0a;
+  --bg-secondary: #111111;
+  --bg-tertiary: #1a1a1a;
+  --bg-card: #111827;
+  --bg-card-hover: #1f2937;
+  --border-color: #1f2937;
+  --border-color-hover: #374151;
+  --text-primary: #ffffff;
+  --text-secondary: #9ca3af;
+  --text-tertiary: #6b7280;
+  --text-muted: #4b5563;
+  color-scheme: dark;
+}
+
+/* Light theme */
+.light {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f9fafb;
+  --bg-tertiary: #f3f4f6;
+  --bg-card: #ffffff;
+  --bg-card-hover: #f9fafb;
+  --border-color: #e5e7eb;
+  --border-color-hover: #d1d5db;
+  --text-primary: #111827;
+  --text-secondary: #4b5563;
+  --text-tertiary: #6b7280;
+  --text-muted: #9ca3af;
+  color-scheme: light;
+}
+
+/* Apply theme colors */
+body {
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
+}
+
+/* Theme-aware utility classes */
+.light .bg-gray-950 { background-color: #ffffff; }
+.light .bg-gray-900 { background-color: #ffffff; }
+.light .bg-gray-800 { background-color: #f9fafb; }
+.light .bg-gray-800\/50 { background-color: rgba(249, 250, 251, 0.5); }
+.light .bg-gray-800\/30 { background-color: rgba(249, 250, 251, 0.3); }
+.light .bg-gray-700 { background-color: #f3f4f6; }
+
+.light .border-gray-900 { border-color: #e5e7eb; }
+.light .border-gray-800 { border-color: #e5e7eb; }
+.light .border-gray-700 { border-color: #d1d5db; }
+.light .border-gray-700\/50 { border-color: rgba(209, 213, 219, 0.5); }
+.light .border-gray-600 { border-color: #9ca3af; }
+
+.light .text-white { color: #111827; }
+.light .text-gray-100 { color: #1f2937; }
+.light .text-gray-200 { color: #374151; }
+.light .text-gray-300 { color: #4b5563; }
+.light .text-gray-400 { color: #6b7280; }
+.light .text-gray-500 { color: #9ca3af; }
+
+.light .hover\:bg-gray-800:hover { background-color: #f3f4f6; }
+.light .hover\:bg-gray-700:hover { background-color: #e5e7eb; }
+.light .hover\:border-gray-600:hover { border-color: #9ca3af; }
+.light .hover\:border-gray-700:hover { border-color: #d1d5db; }
+.light .hover\:text-white:hover { color: #111827; }
+
+.light .focus\:ring-gray-700:focus { --tw-ring-color: #d1d5db; }
+.light .focus\:border-gray-600:focus { border-color: #9ca3af; }
+
+/* Input fields */
+.light input,
+.light textarea,
+.light select {
+  background-color: #f9fafb;
+  border-color: #e5e7eb;
+  color: #111827;
+}
+
+.light input::placeholder,
+.light textarea::placeholder {
+  color: #9ca3af;
+}
+
+.light input:focus,
+.light textarea:focus,
+.light select:focus {
+  border-color: #3b82f6;
+  outline-color: #3b82f6;
+}
+
+/* Scrollbar theming */
+.light ::-webkit-scrollbar-track {
+  background: #f3f4f6;
+}
+
+.light ::-webkit-scrollbar-thumb {
+  background: #d1d5db;
+}
+
+.light ::-webkit-scrollbar-thumb:hover {
+  background: #9ca3af;
+}
+
+/* Keep accent colors consistent */
+.light .text-blue-400 { color: #3b82f6; }
+.light .text-blue-500 { color: #2563eb; }
+.light .text-green-400 { color: #22c55e; }
+.light .text-green-500 { color: #16a34a; }
+.light .text-red-400 { color: #f87171; }
+.light .text-red-500 { color: #ef4444; }
+.light .text-yellow-400 { color: #facc15; }
+.light .text-orange-400 { color: #fb923c; }
+.light .text-purple-400 { color: #a855f7; }
+.light .text-pink-400 { color: #f472b6; }
+
+/* Badge backgrounds in light mode */
+.light .bg-green-500\/10 { background-color: rgba(34, 197, 94, 0.1); }
+.light .bg-blue-500\/10 { background-color: rgba(59, 130, 246, 0.1); }
+.light .bg-purple-500\/10 { background-color: rgba(168, 85, 247, 0.1); }
+.light .bg-yellow-500\/10 { background-color: rgba(250, 204, 21, 0.1); }
+.light .bg-orange-500\/10 { background-color: rgba(251, 146, 60, 0.1); }
+.light .bg-cyan-500\/10 { background-color: rgba(6, 182, 212, 0.1); }
+.light .bg-indigo-500\/10 { background-color: rgba(99, 102, 241, 0.1); }
+.light .bg-pink-500\/10 { background-color: rgba(244, 114, 182, 0.1); }
+.light .bg-rose-500\/10 { background-color: rgba(251, 113, 133, 0.1); }
+.light .bg-teal-500\/10 { background-color: rgba(20, 184, 166, 0.1); }
+.light .bg-violet-500\/10 { background-color: rgba(139, 92, 246, 0.1); }
+.light .bg-amber-500\/10 { background-color: rgba(245, 158, 11, 0.1); }
+
+/* Shadow adjustments */
+.light .shadow-lg {
+  --tw-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+}

--- a/frontend/src/store/themeStore.ts
+++ b/frontend/src/store/themeStore.ts
@@ -1,0 +1,80 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type Theme = 'dark' | 'light' | 'system';
+
+interface ThemeState {
+  theme: Theme;
+  resolvedTheme: 'dark' | 'light';
+  setTheme: (theme: Theme) => void;
+}
+
+const getSystemTheme = (): 'dark' | 'light' => {
+  if (typeof window !== 'undefined') {
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  }
+  return 'dark';
+};
+
+const resolveTheme = (theme: Theme): 'dark' | 'light' => {
+  if (theme === 'system') {
+    return getSystemTheme();
+  }
+  return theme;
+};
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set, get) => ({
+      theme: 'dark',
+      resolvedTheme: 'dark',
+      setTheme: (theme) => {
+        const resolved = resolveTheme(theme);
+        set({ theme, resolvedTheme: resolved });
+
+        // Apply theme to document
+        if (resolved === 'dark') {
+          document.documentElement.classList.add('dark');
+          document.documentElement.classList.remove('light');
+        } else {
+          document.documentElement.classList.add('light');
+          document.documentElement.classList.remove('dark');
+        }
+      },
+    }),
+    {
+      name: 'theme-storage',
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          const resolved = resolveTheme(state.theme);
+          state.resolvedTheme = resolved;
+          if (resolved === 'dark') {
+            document.documentElement.classList.add('dark');
+            document.documentElement.classList.remove('light');
+          } else {
+            document.documentElement.classList.add('light');
+            document.documentElement.classList.remove('dark');
+          }
+        }
+      },
+    }
+  )
+);
+
+// Listen for system theme changes
+if (typeof window !== 'undefined') {
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+    const state = useThemeStore.getState();
+    if (state.theme === 'system') {
+      const newResolved = e.matches ? 'dark' : 'light';
+      useThemeStore.setState({ resolvedTheme: newResolved });
+      if (newResolved === 'dark') {
+        document.documentElement.classList.add('dark');
+        document.documentElement.classList.remove('light');
+      } else {
+        document.documentElement.classList.add('light');
+        document.documentElement.classList.remove('dark');
+      }
+    }
+  });
+}


### PR DESCRIPTION
## 概要（Summary）

* ヘッダーにテーマ切り替え（Light / Dark / System）を追加
* テーマの選択を `localStorage` に保存
* システムテーマを検出し、自動で切り替え
* 一貫したテーマ管理のために CSS カスタムプロパティを使用
* 既存のダークテーマ UI コンポーネントすべてに対してライトモード用の上書きを追加
* Issue #12 をクローズ

---

## テスト計画（Test plan）

* Light / Dark / System モードを切り替える
* ページをリロードしてもテーマが保持されていることを確認
* System モードが OS の設定に追従することを確認
* すべての UI コンポーネントが両テーマで正しく表示されることを確認

---

🤖 Claude Code によって生成

必要なら、もう少しカジュアルな README 用表現や、技術寄りな表現にも調整できますよ！
