### PR TITLE
fix: Correct database column name mismatch

### DIFF
--- a/backend/internal/repository/github.go
+++ b/backend/internal/repository/github.go
@@ -51,7 +51,7 @@ func (r *GitHubRepository) UpsertRepos(repos []model.GitHubRepository) error {
 		return nil
 	}
 	return r.db.Clauses(clause.OnConflict{
-		Columns:   []clause.Column{{Name: "github_repo_id"}},
+		Columns:   []clause.Column{{Name: "git_hub_repo_id"}},
 		DoUpdates: clause.AssignmentColumns([]string{"name", "full_name", "description", "language", "stars", "forks", "is_private", "updated_at"}),
 	}).Create(&repos).Error
 }

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -45,7 +45,7 @@ func (r *UserRepository) Search(query string) ([]model.User, error) {
 
 func (r *UserRepository) FindByGitHubID(githubID int64) (*model.User, error) {
 	var user model.User
-	result := r.db.Where("github_id = ?", githubID).First(&user)
+	result := r.db.Where("git_hub_id = ?", githubID).First(&user)
 	if result.Error != nil {
 		return nil, result.Error
 	}


### PR DESCRIPTION
## Summary
- Fix column names in repository queries to match GORM snake_case convention
- `github_id` → `git_hub_id` in user repository
- `github_repo_id` → `git_hub_repo_id` in github repository

## Root Cause
GORM converts Go struct field names like `GitHubID` to `git_hub_id` (snake_case), but the queries were using `github_id` which doesn't exist in the database.

## Test plan
- [ ] Verify GitHub OAuth login works
- [ ] Verify GitHub data sync works
- [ ] Verify pages display correctly

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)