### PR TITLE
feat: Add Qiita integration for articles display

### DIFF
--- a/backend/internal/handler/qiita.go
+++ b/backend/internal/handler/qiita.go
@@ -1,0 +1,180 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/repository"
+	"github.com/norman6464/devsync/backend/internal/service"
+)
+
+type QiitaHandler struct {
+	qiitaRepo    *repository.QiitaRepository
+	userRepo     *repository.UserRepository
+	qiitaService *service.QiitaService
+}
+
+func NewQiitaHandler(qiitaRepo *repository.QiitaRepository, userRepo *repository.UserRepository, qiitaService *service.QiitaService) *QiitaHandler {
+	return &QiitaHandler{
+		qiitaRepo:    qiitaRepo,
+		userRepo:     userRepo,
+		qiitaService: qiitaService,
+	}
+}
+
+// Connect sets the Qiita username and syncs articles
+func (h *QiitaHandler) Connect(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	var req struct {
+		Username string `json:"username" binding:"required"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "username is required"})
+		return
+	}
+
+	// Validate username exists on Qiita
+	valid, err := h.qiitaService.ValidateUsername(req.Username)
+	if err != nil || !valid {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid Qiita username"})
+		return
+	}
+
+	// Update user's Qiita username
+	user, err := h.userRepo.FindByID(userID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	user.QiitaUsername = req.Username
+	if err := h.userRepo.Update(user); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update user"})
+		return
+	}
+
+	// Sync articles
+	articles, err := h.qiitaService.FetchArticles(req.Username)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch Qiita articles"})
+		return
+	}
+
+	// Set updated time
+	now := time.Now()
+	for i := range articles {
+		articles[i].UpdatedAt = now
+	}
+
+	if err := h.qiitaRepo.UpsertArticles(userID, articles); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save articles"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":        "Qiita connected successfully",
+		"articles_count": len(articles),
+	})
+}
+
+// Disconnect removes the Qiita username and deletes cached articles
+func (h *QiitaHandler) Disconnect(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	user, err := h.userRepo.FindByID(userID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	user.QiitaUsername = ""
+	if err := h.userRepo.Update(user); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update user"})
+		return
+	}
+
+	// Delete cached articles
+	if err := h.qiitaRepo.DeleteUserArticles(userID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete articles"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "Qiita disconnected successfully"})
+}
+
+// Sync refreshes the Qiita articles for the current user
+func (h *QiitaHandler) Sync(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	user, err := h.userRepo.FindByID(userID)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	if user.QiitaUsername == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Qiita not connected"})
+		return
+	}
+
+	articles, err := h.qiitaService.FetchArticles(user.QiitaUsername)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch Qiita articles"})
+		return
+	}
+
+	now := time.Now()
+	for i := range articles {
+		articles[i].UpdatedAt = now
+	}
+
+	if err := h.qiitaRepo.UpsertArticles(userID, articles); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save articles"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":        "Qiita synced successfully",
+		"articles_count": len(articles),
+	})
+}
+
+// GetArticles returns all Qiita articles for a user
+func (h *QiitaHandler) GetArticles(c *gin.Context) {
+	userIDParam := c.Param("userId")
+	userID, err := strconv.ParseUint(userIDParam, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+		return
+	}
+
+	articles, err := h.qiitaRepo.GetArticles(uint(userID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get articles"})
+		return
+	}
+
+	c.JSON(http.StatusOK, articles)
+}
+
+// GetStats returns Qiita statistics for a user
+func (h *QiitaHandler) GetStats(c *gin.Context) {
+	userIDParam := c.Param("userId")
+	userID, err := strconv.ParseUint(userIDParam, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+		return
+	}
+
+	stats, err := h.qiitaRepo.GetStats(uint(userID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get stats"})
+		return
+	}
+
+	c.JSON(http.StatusOK, stats)
+}

--- a/backend/internal/model/qiita.go
+++ b/backend/internal/model/qiita.go
@@ -1,0 +1,23 @@
+package model
+
+import "time"
+
+type QiitaArticle struct {
+	ID            uint      `json:"id" gorm:"primaryKey"`
+	UserID        uint      `json:"user_id" gorm:"not null;index"`
+	QiitaID       string    `json:"qiita_id" gorm:"not null;uniqueIndex"`
+	Title         string    `json:"title" gorm:"not null"`
+	URL           string    `json:"url" gorm:"not null"`
+	LikesCount    int       `json:"likes_count" gorm:"default:0"`
+	CommentsCount int       `json:"comments_count" gorm:"default:0"`
+	Tags          string    `json:"tags"` // comma-separated tag names
+	PublishedAt   time.Time `json:"published_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// QiitaStats represents aggregated Qiita statistics for a user
+type QiitaStats struct {
+	TotalArticles int `json:"total_articles"`
+	TotalLikes    int `json:"total_likes"`
+	TotalComments int `json:"total_comments"`
+}

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -14,6 +14,7 @@ type User struct {
 	GitHubToken     string    `json:"-"`
 	GitHubConnected  bool      `json:"github_connected" gorm:"default:false"`
 	ZennUsername     string    `json:"zenn_username"`
+	QiitaUsername    string    `json:"qiita_username"`
 	SkillsLanguages  string    `json:"skills_languages"`
 	SkillsFrameworks string    `json:"skills_frameworks"`
 	CreatedAt        time.Time `json:"created_at"`

--- a/backend/internal/repository/qiita.go
+++ b/backend/internal/repository/qiita.go
@@ -1,0 +1,60 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type QiitaRepository struct {
+	db *gorm.DB
+}
+
+func NewQiitaRepository(db *gorm.DB) *QiitaRepository {
+	return &QiitaRepository{db: db}
+}
+
+// UpsertArticles inserts or updates Qiita articles
+func (r *QiitaRepository) UpsertArticles(userID uint, articles []model.QiitaArticle) error {
+	if len(articles) == 0 {
+		return nil
+	}
+
+	// Set user ID for all articles
+	for i := range articles {
+		articles[i].UserID = userID
+	}
+
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "qiita_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"title", "url", "likes_count", "comments_count", "tags", "published_at", "updated_at"}),
+	}).Create(&articles).Error
+}
+
+// GetArticles retrieves all Qiita articles for a user
+func (r *QiitaRepository) GetArticles(userID uint) ([]model.QiitaArticle, error) {
+	var articles []model.QiitaArticle
+	err := r.db.Where("user_id = ?", userID).Order("published_at DESC").Find(&articles).Error
+	return articles, err
+}
+
+// GetStats calculates Qiita statistics for a user
+func (r *QiitaRepository) GetStats(userID uint) (*model.QiitaStats, error) {
+	var stats model.QiitaStats
+
+	err := r.db.Model(&model.QiitaArticle{}).
+		Where("user_id = ?", userID).
+		Select("COUNT(*) as total_articles, COALESCE(SUM(likes_count), 0) as total_likes, COALESCE(SUM(comments_count), 0) as total_comments").
+		Scan(&stats).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}
+
+// DeleteUserArticles removes all Qiita articles for a user
+func (r *QiitaRepository) DeleteUserArticles(userID uint) error {
+	return r.db.Where("user_id = ?", userID).Delete(&model.QiitaArticle{}).Error
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -34,11 +34,13 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 	notificationRepo := repository.NewNotificationRepository(db)
 	passwordResetRepo := repository.NewPasswordResetRepository(db)
 	zennRepo := repository.NewZennRepository(db)
+	qiitaRepo := repository.NewQiitaRepository(db)
 
 	// Services
 	authService := service.NewAuthService(userRepo, cfg.JWTSecret)
 	githubService := service.NewGitHubService(cfg, userRepo, githubRepo)
 	zennService := service.NewZennService()
+	qiitaService := service.NewQiitaService()
 
 	// Handlers
 	authHandler := handler.NewAuthHandler(authService, githubService, userRepo, passwordResetRepo)
@@ -52,6 +54,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 	uploadHandler := handler.NewUploadHandler()
 	notificationHandler := handler.NewNotificationHandler(notificationRepo)
 	zennHandler := handler.NewZennHandler(zennRepo, userRepo, zennService)
+	qiitaHandler := handler.NewQiitaHandler(qiitaRepo, userRepo, qiitaService)
 
 	// Static file serving for uploads
 	r.Static("/uploads", "./uploads")
@@ -167,6 +170,16 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 			zenn.POST("/sync", zennHandler.Sync)
 			zenn.GET("/articles/:userId", zennHandler.GetArticles)
 			zenn.GET("/stats/:userId", zennHandler.GetStats)
+		}
+
+		// Qiita
+		qiita := protected.Group("/qiita")
+		{
+			qiita.POST("/connect", qiitaHandler.Connect)
+			qiita.DELETE("/disconnect", qiitaHandler.Disconnect)
+			qiita.POST("/sync", qiitaHandler.Sync)
+			qiita.GET("/articles/:userId", qiitaHandler.GetArticles)
+			qiita.GET("/stats/:userId", qiitaHandler.GetStats)
 		}
 	}
 

--- a/backend/internal/service/qiita.go
+++ b/backend/internal/service/qiita.go
@@ -1,0 +1,105 @@
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+type QiitaService struct {
+	httpClient *http.Client
+}
+
+func NewQiitaService() *QiitaService {
+	return &QiitaService{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// QiitaAPIArticle represents an article from Qiita API
+type QiitaAPIArticle struct {
+	ID            string          `json:"id"`
+	Title         string          `json:"title"`
+	URL           string          `json:"url"`
+	LikesCount    int             `json:"likes_count"`
+	CommentsCount int             `json:"comments_count"`
+	Tags          []QiitaAPITag   `json:"tags"`
+	CreatedAt     time.Time       `json:"created_at"`
+}
+
+type QiitaAPITag struct {
+	Name string `json:"name"`
+}
+
+// FetchArticles fetches all articles for a Qiita user
+func (s *QiitaService) FetchArticles(username string) ([]model.QiitaArticle, error) {
+	var allArticles []model.QiitaArticle
+	page := 1
+	perPage := 100
+
+	for {
+		url := fmt.Sprintf("https://qiita.com/api/v2/users/%s/items?page=%d&per_page=%d", username, page, perPage)
+
+		resp, err := s.httpClient.Get(url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch Qiita articles: %w", err)
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("Qiita user not found")
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("Qiita API returned status %d", resp.StatusCode)
+		}
+
+		var apiArticles []QiitaAPIArticle
+		if err := json.NewDecoder(resp.Body).Decode(&apiArticles); err != nil {
+			return nil, fmt.Errorf("failed to decode Qiita response: %w", err)
+		}
+
+		for _, article := range apiArticles {
+			// Extract tag names
+			tagNames := make([]string, len(article.Tags))
+			for i, tag := range article.Tags {
+				tagNames[i] = tag.Name
+			}
+
+			allArticles = append(allArticles, model.QiitaArticle{
+				QiitaID:       article.ID,
+				Title:         article.Title,
+				URL:           article.URL,
+				LikesCount:    article.LikesCount,
+				CommentsCount: article.CommentsCount,
+				Tags:          strings.Join(tagNames, ","),
+				PublishedAt:   article.CreatedAt,
+			})
+		}
+
+		// Check if there are more pages
+		if len(apiArticles) < perPage {
+			break
+		}
+		page++
+	}
+
+	return allArticles, nil
+}
+
+// ValidateUsername checks if a Qiita username exists
+func (s *QiitaService) ValidateUsername(username string) (bool, error) {
+	url := fmt.Sprintf("https://qiita.com/api/v2/users/%s", username)
+
+	resp, err := s.httpClient.Get(url)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK, nil
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -35,6 +35,7 @@ func main() {
 		&model.Notification{},
 		&model.PasswordResetToken{},
 		&model.ZennArticle{},
+		&model.QiitaArticle{},
 	); err != nil {
 		log.Fatalf("failed to run migrations: %v", err)
 	}

--- a/frontend/src/api/qiita.ts
+++ b/frontend/src/api/qiita.ts
@@ -1,0 +1,35 @@
+import client from './client';
+
+export interface QiitaArticle {
+  id: number;
+  user_id: number;
+  qiita_id: string;
+  title: string;
+  url: string;
+  likes_count: number;
+  comments_count: number;
+  tags: string;
+  published_at: string;
+  updated_at: string;
+}
+
+export interface QiitaStats {
+  total_articles: number;
+  total_likes: number;
+  total_comments: number;
+}
+
+export const connectQiita = (username: string) =>
+  client.post('/qiita/connect', { username });
+
+export const disconnectQiita = () =>
+  client.delete('/qiita/disconnect');
+
+export const syncQiita = () =>
+  client.post('/qiita/sync');
+
+export const getQiitaArticles = (userId: number) =>
+  client.get<QiitaArticle[]>(`/qiita/articles/${userId}`);
+
+export const getQiitaStats = (userId: number) =>
+  client.get<QiitaStats>(`/qiita/stats/${userId}`);

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -93,7 +93,9 @@
     "frameworks": "Frameworks & Bibliotheken",
     "zennArticles": "Zenn Artikel",
     "articles": "Artikel",
-    "viewAllOnZenn": "Alle auf Zenn anzeigen"
+    "viewAllOnZenn": "Alle auf Zenn anzeigen",
+    "qiitaArticles": "Qiita Artikel",
+    "viewAllOnQiita": "Alle auf Qiita anzeigen"
   },
   "settings": {
     "title": "Einstellungen",
@@ -127,7 +129,12 @@
     "zennDescription": "Verbinden Sie Ihr Zenn-Konto, um Ihre Artikel anzuzeigen.",
     "zennUsername": "Zenn Benutzername",
     "zennConnected": "Zenn erfolgreich verbunden",
-    "zennInvalidUsername": "Ungültiger Zenn Benutzername"
+    "zennInvalidUsername": "Ungültiger Zenn Benutzername",
+    "qiita": "Qiita",
+    "qiitaDescription": "Verbinden Sie Ihr Qiita-Konto, um Ihre Artikel anzuzeigen.",
+    "qiitaUsername": "Qiita Benutzername",
+    "qiitaConnected": "Qiita erfolgreich verbunden",
+    "qiitaInvalidUsername": "Ungültiger Qiita Benutzername"
   },
   "explore": {
     "title": "Entdecken",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -93,7 +93,9 @@
     "frameworks": "Frameworks & Libraries",
     "zennArticles": "Zenn Articles",
     "articles": "articles",
-    "viewAllOnZenn": "View all on Zenn"
+    "viewAllOnZenn": "View all on Zenn",
+    "qiitaArticles": "Qiita Articles",
+    "viewAllOnQiita": "View all on Qiita"
   },
   "settings": {
     "title": "Settings",
@@ -127,7 +129,12 @@
     "zennDescription": "Connect your Zenn account to display your articles.",
     "zennUsername": "Zenn Username",
     "zennConnected": "Zenn connected successfully",
-    "zennInvalidUsername": "Invalid Zenn username"
+    "zennInvalidUsername": "Invalid Zenn username",
+    "qiita": "Qiita",
+    "qiitaDescription": "Connect your Qiita account to display your articles.",
+    "qiitaUsername": "Qiita Username",
+    "qiitaConnected": "Qiita connected successfully",
+    "qiitaInvalidUsername": "Invalid Qiita username"
   },
   "explore": {
     "title": "Explore",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -93,7 +93,9 @@
     "frameworks": "Frameworks y Librerías",
     "zennArticles": "Artículos de Zenn",
     "articles": "artículos",
-    "viewAllOnZenn": "Ver todo en Zenn"
+    "viewAllOnZenn": "Ver todo en Zenn",
+    "qiitaArticles": "Artículos de Qiita",
+    "viewAllOnQiita": "Ver todo en Qiita"
   },
   "settings": {
     "title": "Configuración",
@@ -127,7 +129,12 @@
     "zennDescription": "Conecta tu cuenta de Zenn para mostrar tus artículos.",
     "zennUsername": "Nombre de usuario de Zenn",
     "zennConnected": "Zenn conectado exitosamente",
-    "zennInvalidUsername": "Nombre de usuario de Zenn inválido"
+    "zennInvalidUsername": "Nombre de usuario de Zenn inválido",
+    "qiita": "Qiita",
+    "qiitaDescription": "Conecta tu cuenta de Qiita para mostrar tus artículos.",
+    "qiitaUsername": "Nombre de usuario de Qiita",
+    "qiitaConnected": "Qiita conectado exitosamente",
+    "qiitaInvalidUsername": "Nombre de usuario de Qiita inválido"
   },
   "explore": {
     "title": "Explorar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -93,7 +93,9 @@
     "frameworks": "Frameworks et Bibliothèques",
     "zennArticles": "Articles Zenn",
     "articles": "articles",
-    "viewAllOnZenn": "Voir tout sur Zenn"
+    "viewAllOnZenn": "Voir tout sur Zenn",
+    "qiitaArticles": "Articles Qiita",
+    "viewAllOnQiita": "Voir tout sur Qiita"
   },
   "settings": {
     "title": "Paramètres",
@@ -127,7 +129,12 @@
     "zennDescription": "Connectez votre compte Zenn pour afficher vos articles.",
     "zennUsername": "Nom d'utilisateur Zenn",
     "zennConnected": "Zenn connecté avec succès",
-    "zennInvalidUsername": "Nom d'utilisateur Zenn invalide"
+    "zennInvalidUsername": "Nom d'utilisateur Zenn invalide",
+    "qiita": "Qiita",
+    "qiitaDescription": "Connectez votre compte Qiita pour afficher vos articles.",
+    "qiitaUsername": "Nom d'utilisateur Qiita",
+    "qiitaConnected": "Qiita connecté avec succès",
+    "qiitaInvalidUsername": "Nom d'utilisateur Qiita invalide"
   },
   "explore": {
     "title": "Explorer",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -93,7 +93,9 @@
     "frameworks": "フレームワーク＆ライブラリ",
     "zennArticles": "Zenn記事",
     "articles": "記事",
-    "viewAllOnZenn": "Zennで全て見る"
+    "viewAllOnZenn": "Zennで全て見る",
+    "qiitaArticles": "Qiita記事",
+    "viewAllOnQiita": "Qiitaで全て見る"
   },
   "settings": {
     "title": "設定",
@@ -127,7 +129,12 @@
     "zennDescription": "Zennアカウントを連携して記事を表示します。",
     "zennUsername": "Zennユーザー名",
     "zennConnected": "Zennが正常に連携されました",
-    "zennInvalidUsername": "無効なZennユーザー名です"
+    "zennInvalidUsername": "無効なZennユーザー名です",
+    "qiita": "Qiita",
+    "qiitaDescription": "Qiitaアカウントを連携して記事を表示します。",
+    "qiitaUsername": "Qiitaユーザー名",
+    "qiitaConnected": "Qiitaが正常に連携されました",
+    "qiitaInvalidUsername": "無効なQiitaユーザー名です"
   },
   "explore": {
     "title": "探索",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -93,7 +93,9 @@
     "frameworks": "프레임워크 및 라이브러리",
     "zennArticles": "Zenn 기사",
     "articles": "기사",
-    "viewAllOnZenn": "Zenn에서 모두 보기"
+    "viewAllOnZenn": "Zenn에서 모두 보기",
+    "qiitaArticles": "Qiita 기사",
+    "viewAllOnQiita": "Qiita에서 모두 보기"
   },
   "settings": {
     "title": "설정",
@@ -127,7 +129,12 @@
     "zennDescription": "Zenn 계정을 연결하여 기사를 표시합니다.",
     "zennUsername": "Zenn 사용자 이름",
     "zennConnected": "Zenn이 성공적으로 연결되었습니다",
-    "zennInvalidUsername": "유효하지 않은 Zenn 사용자 이름"
+    "zennInvalidUsername": "유효하지 않은 Zenn 사용자 이름",
+    "qiita": "Qiita",
+    "qiitaDescription": "Qiita 계정을 연결하여 기사를 표시합니다.",
+    "qiitaUsername": "Qiita 사용자 이름",
+    "qiitaConnected": "Qiita가 성공적으로 연결되었습니다",
+    "qiitaInvalidUsername": "유효하지 않은 Qiita 사용자 이름"
   },
   "explore": {
     "title": "탐색",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -93,7 +93,9 @@
     "frameworks": "Frameworks e Bibliotecas",
     "zennArticles": "Artigos do Zenn",
     "articles": "artigos",
-    "viewAllOnZenn": "Ver tudo no Zenn"
+    "viewAllOnZenn": "Ver tudo no Zenn",
+    "qiitaArticles": "Artigos do Qiita",
+    "viewAllOnQiita": "Ver tudo no Qiita"
   },
   "settings": {
     "title": "Configurações",
@@ -127,7 +129,12 @@
     "zennDescription": "Conecte sua conta Zenn para exibir seus artigos.",
     "zennUsername": "Nome de usuário Zenn",
     "zennConnected": "Zenn conectado com sucesso",
-    "zennInvalidUsername": "Nome de usuário Zenn inválido"
+    "zennInvalidUsername": "Nome de usuário Zenn inválido",
+    "qiita": "Qiita",
+    "qiitaDescription": "Conecte sua conta Qiita para exibir seus artigos.",
+    "qiitaUsername": "Nome de usuário Qiita",
+    "qiitaConnected": "Qiita conectado com sucesso",
+    "qiitaInvalidUsername": "Nome de usuário Qiita inválido"
   },
   "explore": {
     "title": "Explorar",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -93,7 +93,9 @@
     "frameworks": "Фреймворки и Библиотеки",
     "zennArticles": "Статьи Zenn",
     "articles": "статей",
-    "viewAllOnZenn": "Смотреть все на Zenn"
+    "viewAllOnZenn": "Смотреть все на Zenn",
+    "qiitaArticles": "Статьи Qiita",
+    "viewAllOnQiita": "Смотреть все на Qiita"
   },
   "settings": {
     "title": "Настройки",
@@ -127,7 +129,12 @@
     "zennDescription": "Подключите свой аккаунт Zenn для отображения ваших статей.",
     "zennUsername": "Имя пользователя Zenn",
     "zennConnected": "Zenn успешно подключен",
-    "zennInvalidUsername": "Недействительное имя пользователя Zenn"
+    "zennInvalidUsername": "Недействительное имя пользователя Zenn",
+    "qiita": "Qiita",
+    "qiitaDescription": "Подключите свой аккаунт Qiita для отображения ваших статей.",
+    "qiitaUsername": "Имя пользователя Qiita",
+    "qiitaConnected": "Qiita успешно подключен",
+    "qiitaInvalidUsername": "Недействительное имя пользователя Qiita"
   },
   "explore": {
     "title": "Обзор",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -93,7 +93,9 @@
     "frameworks": "框架和库",
     "zennArticles": "Zenn文章",
     "articles": "文章",
-    "viewAllOnZenn": "在Zenn上查看全部"
+    "viewAllOnZenn": "在Zenn上查看全部",
+    "qiitaArticles": "Qiita文章",
+    "viewAllOnQiita": "在Qiita上查看全部"
   },
   "settings": {
     "title": "设置",
@@ -127,7 +129,12 @@
     "zennDescription": "连接您的Zenn账户以显示您的文章。",
     "zennUsername": "Zenn用户名",
     "zennConnected": "Zenn连接成功",
-    "zennInvalidUsername": "无效的Zenn用户名"
+    "zennInvalidUsername": "无效的Zenn用户名",
+    "qiita": "Qiita",
+    "qiitaDescription": "连接您的Qiita账户以显示您的文章。",
+    "qiitaUsername": "Qiita用户名",
+    "qiitaConnected": "Qiita连接成功",
+    "qiitaInvalidUsername": "无效的Qiita用户名"
   },
   "explore": {
     "title": "探索",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -93,7 +93,9 @@
     "frameworks": "框架和函式庫",
     "zennArticles": "Zenn文章",
     "articles": "文章",
-    "viewAllOnZenn": "在Zenn上查看全部"
+    "viewAllOnZenn": "在Zenn上查看全部",
+    "qiitaArticles": "Qiita文章",
+    "viewAllOnQiita": "在Qiita上查看全部"
   },
   "settings": {
     "title": "設定",
@@ -127,7 +129,12 @@
     "zennDescription": "連接您的Zenn帳戶以顯示您的文章。",
     "zennUsername": "Zenn使用者名稱",
     "zennConnected": "Zenn連接成功",
-    "zennInvalidUsername": "無效的Zenn使用者名稱"
+    "zennInvalidUsername": "無效的Zenn使用者名稱",
+    "qiita": "Qiita",
+    "qiitaDescription": "連接您的Qiita帳戶以顯示您的文章。",
+    "qiitaUsername": "Qiita使用者名稱",
+    "qiitaConnected": "Qiita連接成功",
+    "qiitaInvalidUsername": "無效的Qiita使用者名稱"
   },
   "explore": {
     "title": "探索",

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -5,6 +5,7 @@ import { getUser, getFollowers, getFollowing } from '../api/users';
 import { getUserPosts } from '../api/posts';
 import { getContributions, getLanguages, getRepos } from '../api/github';
 import { getZennArticles, getZennStats, type ZennArticle, type ZennStats } from '../api/zenn';
+import { getQiitaArticles, getQiitaStats, type QiitaArticle, type QiitaStats } from '../api/qiita';
 import { useAuthStore } from '../store/authStore';
 import type { User } from '../types/user';
 import type { Post } from '../types/post';
@@ -28,6 +29,8 @@ export default function ProfilePage() {
   const [repos, setRepos] = useState<GitHubRepository[]>([]);
   const [zennArticles, setZennArticles] = useState<ZennArticle[]>([]);
   const [zennStats, setZennStats] = useState<ZennStats | null>(null);
+  const [qiitaArticles, setQiitaArticles] = useState<QiitaArticle[]>([]);
+  const [qiitaStats, setQiitaStats] = useState<QiitaStats | null>(null);
   const [followerCount, setFollowerCount] = useState(0);
   const [followingCount, setFollowingCount] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -69,6 +72,16 @@ export default function ProfilePage() {
           ]);
           setZennArticles(articlesRes.data || []);
           setZennStats(statsRes.data);
+        }
+
+        // Fetch Qiita data if connected
+        if (userRes.data.qiita_username) {
+          const [articlesRes, statsRes] = await Promise.all([
+            getQiitaArticles(userId),
+            getQiitaStats(userId),
+          ]);
+          setQiitaArticles(articlesRes.data || []);
+          setQiitaStats(statsRes.data);
         }
       } catch {
         // handle error
@@ -121,6 +134,20 @@ export default function ProfilePage() {
                 >
                   <span className="w-4 h-4 bg-blue-500 rounded text-white text-xs flex items-center justify-center font-bold">Z</span>
                   @{user.zenn_username}
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                  </svg>
+                </a>
+              )}
+              {user.qiita_username && (
+                <a
+                  href={`https://qiita.com/${user.qiita_username}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-400 transition-colors"
+                >
+                  <span className="w-4 h-4 bg-green-500 rounded text-white text-xs flex items-center justify-center font-bold">Q</span>
+                  @{user.qiita_username}
                   <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
                   </svg>
@@ -335,6 +362,73 @@ export default function ProfilePage() {
                       <span className="px-2 py-0.5 bg-gray-800 text-gray-400 text-xs rounded">
                         {article.article_type === 'tech' ? 'Tech' : 'Idea'}
                       </span>
+                    </div>
+                  </div>
+                </div>
+              </a>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Qiita Articles */}
+      {user.qiita_username && qiitaArticles.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide flex items-center gap-2">
+              <span className="w-5 h-5 bg-green-500 rounded text-white text-xs flex items-center justify-center font-bold">Q</span>
+              {t('profile.qiitaArticles')}
+              {qiitaStats && (
+                <span className="text-xs text-gray-500 font-normal ml-2">
+                  {qiitaStats.total_articles} {t('profile.articles')} · {qiitaStats.total_likes} {t('post.like')}s
+                </span>
+              )}
+            </h2>
+            <a
+              href={`https://qiita.com/${user.qiita_username}`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-gray-500 hover:text-green-400 transition-colors flex items-center gap-1"
+            >
+              {t('profile.viewAllOnQiita')}
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+              </svg>
+            </a>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {qiitaArticles.slice(0, 6).map((article) => (
+              <a
+                key={article.id}
+                href={article.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-gray-600 transition-colors group"
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-2xl">📝</span>
+                  <div className="min-w-0 flex-1">
+                    <div className="font-medium text-sm text-green-400 group-hover:text-green-300 line-clamp-2">
+                      {article.title}
+                    </div>
+                    <div className="flex items-center gap-3 mt-2">
+                      <span className="flex items-center gap-1 text-xs text-gray-400">
+                        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
+                          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
+                        </svg>
+                        {article.likes_count}
+                      </span>
+                      <span className="flex items-center gap-1 text-xs text-gray-400">
+                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                          <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
+                        </svg>
+                        {article.comments_count}
+                      </span>
+                      {article.tags && (
+                        <span className="px-2 py-0.5 bg-gray-800 text-gray-400 text-xs rounded truncate max-w-[100px]">
+                          {article.tags.split(',')[0]}
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '../store/authStore';
 import { updateUser } from '../api/users';
 import { getGitHubConnectURL, disconnectGitHub, syncGitHub } from '../api/github';
 import { connectZenn, disconnectZenn, syncZenn } from '../api/zenn';
+import { connectQiita, disconnectQiita, syncQiita } from '../api/qiita';
 import { deleteAccount } from '../api/auth';
 import toast from 'react-hot-toast';
 
@@ -41,6 +42,9 @@ export default function SettingsPage() {
   const [zennUsername, setZennUsername] = useState('');
   const [connectingZenn, setConnectingZenn] = useState(false);
   const [syncingZenn, setSyncingZenn] = useState(false);
+  const [qiitaUsername, setQiitaUsername] = useState('');
+  const [connectingQiita, setConnectingQiita] = useState(false);
+  const [syncingQiita, setSyncingQiita] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deletePassword, setDeletePassword] = useState('');
   const [deleting, setDeleting] = useState(false);
@@ -169,6 +173,44 @@ export default function SettingsPage() {
       toast.error(t('errors.somethingWrong'));
     } finally {
       setSyncingZenn(false);
+    }
+  };
+
+  const handleConnectQiita = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!qiitaUsername.trim()) return;
+    setConnectingQiita(true);
+    try {
+      await connectQiita(qiitaUsername.trim());
+      setUser({ ...user, qiita_username: qiitaUsername.trim() });
+      setQiitaUsername('');
+      toast.success(t('settings.qiitaConnected'));
+    } catch {
+      toast.error(t('settings.qiitaInvalidUsername'));
+    } finally {
+      setConnectingQiita(false);
+    }
+  };
+
+  const handleDisconnectQiita = async () => {
+    try {
+      await disconnectQiita();
+      setUser({ ...user, qiita_username: '' });
+      toast.success(t('settings.saved'));
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  };
+
+  const handleSyncQiita = async () => {
+    setSyncingQiita(true);
+    try {
+      await syncQiita();
+      toast.success(t('settings.saved'));
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    } finally {
+      setSyncingQiita(false);
     }
   };
 
@@ -401,6 +443,65 @@ export default function SettingsPage() {
                 className="w-full px-5 py-2.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg font-semibold text-sm transition-colors"
               >
                 {connectingZenn ? t('common.loading') : t('settings.connect')}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+
+      {/* Qiita Integration */}
+      <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
+        <div className="px-6 py-4 border-b border-gray-800">
+          <h2 className="text-base font-semibold">{t('settings.qiita')}</h2>
+        </div>
+        <div className="p-6">
+          {user.qiita_username ? (
+            <div className="space-y-4">
+              <div className="flex items-center gap-3">
+                <div className="w-8 h-8 bg-green-500 rounded-lg flex items-center justify-center text-white font-bold text-sm">Q</div>
+                <div>
+                  <p className="text-sm font-medium text-green-400">{t('settings.connected')}</p>
+                  <p className="text-sm text-gray-400">@{user.qiita_username}</p>
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleSyncQiita}
+                  disabled={syncingQiita}
+                  className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium border border-gray-700 transition-colors"
+                >
+                  {syncingQiita ? t('settings.syncing') : t('settings.sync')}
+                </button>
+                <button
+                  onClick={handleDisconnectQiita}
+                  className="px-4 py-2 text-red-400 hover:text-red-300 border border-red-400/30 hover:border-red-400/50 rounded-lg text-sm font-medium transition-colors"
+                >
+                  {t('settings.disconnect')}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <form onSubmit={handleConnectQiita} className="space-y-4">
+              <div className="text-center py-2">
+                <div className="w-12 h-12 bg-green-500/20 rounded-lg flex items-center justify-center text-green-400 font-bold text-xl mx-auto mb-3">Q</div>
+                <p className="text-gray-400 text-sm mb-4">{t('settings.qiitaDescription')}</p>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">{t('settings.qiitaUsername')}</label>
+                <input
+                  type="text"
+                  value={qiitaUsername}
+                  onChange={(e) => setQiitaUsername(e.target.value)}
+                  placeholder="your-qiita-username"
+                  className={inputClass}
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={connectingQiita || !qiitaUsername.trim()}
+                className="w-full px-5 py-2.5 bg-green-600 hover:bg-green-500 disabled:opacity-50 text-white rounded-lg font-semibold text-sm transition-colors"
+              >
+                {connectingQiita ? t('common.loading') : t('settings.connect')}
               </button>
             </form>
           )}

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -8,6 +8,7 @@ export interface User {
   github_username: string;
   github_connected: boolean;
   zenn_username: string;
+  qiita_username: string;
   skills_languages: string;
   skills_frameworks: string;
   created_at: string;


### PR DESCRIPTION
## Summary
- Add Qiita account connection feature to settings page
- Display Qiita articles on user profiles with stats (likes, comments)
- Support for syncing articles from Qiita API
- Full i18n support for all 10 languages

## Changes
### Backend
- Add `qiita_username` field to User model
- Add `QiitaArticle` model for caching articles
- Add Qiita service for API calls (fetch articles, validate username)
- Add Qiita repository for database operations
- Add Qiita handler with connect/disconnect/sync endpoints
- Add routes: POST /qiita/connect, DELETE /qiita/disconnect, POST /qiita/sync, GET /qiita/articles/:userId, GET /qiita/stats/:userId

### Frontend
- Add Qiita API functions (connect, disconnect, sync, get articles/stats)
- Add Qiita settings section to SettingsPage
- Display Qiita articles on ProfilePage with likes and tags
- Add i18n translations for all 10 languages

## Test plan
- [ ] Connect Qiita account in Settings
- [ ] Verify articles appear on Profile page
- [ ] Test sync functionality
- [ ] Test disconnect functionality
- [ ] Verify translations in different languages

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)