### PR TITLE
feat: Add learning goals tracking feature

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -1,0 +1,243 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+type LearningGoalHandler struct {
+	goalRepo *repository.LearningGoalRepository
+}
+
+func NewLearningGoalHandler(goalRepo *repository.LearningGoalRepository) *LearningGoalHandler {
+	return &LearningGoalHandler{goalRepo: goalRepo}
+}
+
+// Create creates a new learning goal
+func (h *LearningGoalHandler) Create(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	var req struct {
+		Title       string `json:"title" binding:"required"`
+		Description string `json:"description"`
+		Category    string `json:"category"`
+		TargetDate  string `json:"target_date"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "title is required"})
+		return
+	}
+
+	goal := &model.LearningGoal{
+		UserID:      userID,
+		Title:       req.Title,
+		Description: req.Description,
+		Category:    model.GoalCategory(req.Category),
+		Status:      model.GoalStatusActive,
+		Progress:    0,
+	}
+
+	if req.Category == "" {
+		goal.Category = model.GoalCategoryOther
+	}
+
+	if req.TargetDate != "" {
+		targetDate, err := time.Parse("2006-01-02", req.TargetDate)
+		if err == nil {
+			goal.TargetDate = &targetDate
+		}
+	}
+
+	if err := h.goalRepo.Create(goal); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create goal"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, goal)
+}
+
+// Update updates a learning goal
+func (h *LearningGoalHandler) Update(c *gin.Context) {
+	userID := c.GetUint("userID")
+	goalID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid goal ID"})
+		return
+	}
+
+	goal, err := h.goalRepo.FindByID(uint(goalID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "goal not found"})
+		return
+	}
+
+	if goal.UserID != userID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
+		return
+	}
+
+	var req struct {
+		Title       *string `json:"title"`
+		Description *string `json:"description"`
+		Category    *string `json:"category"`
+		TargetDate  *string `json:"target_date"`
+		Progress    *int    `json:"progress"`
+		Status      *string `json:"status"`
+	}
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	if req.Title != nil {
+		goal.Title = *req.Title
+	}
+	if req.Description != nil {
+		goal.Description = *req.Description
+	}
+	if req.Category != nil {
+		goal.Category = model.GoalCategory(*req.Category)
+	}
+	if req.TargetDate != nil {
+		if *req.TargetDate == "" {
+			goal.TargetDate = nil
+		} else {
+			targetDate, err := time.Parse("2006-01-02", *req.TargetDate)
+			if err == nil {
+				goal.TargetDate = &targetDate
+			}
+		}
+	}
+	if req.Progress != nil {
+		progress := *req.Progress
+		if progress < 0 {
+			progress = 0
+		}
+		if progress > 100 {
+			progress = 100
+		}
+		goal.Progress = progress
+
+		// Auto-complete if progress reaches 100
+		if progress == 100 && goal.Status == model.GoalStatusActive {
+			goal.Status = model.GoalStatusCompleted
+			now := time.Now()
+			goal.CompletedAt = &now
+		}
+	}
+	if req.Status != nil {
+		goal.Status = model.GoalStatus(*req.Status)
+		if goal.Status == model.GoalStatusCompleted && goal.CompletedAt == nil {
+			now := time.Now()
+			goal.CompletedAt = &now
+		}
+	}
+
+	if err := h.goalRepo.Update(goal); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update goal"})
+		return
+	}
+
+	c.JSON(http.StatusOK, goal)
+}
+
+// Delete deletes a learning goal
+func (h *LearningGoalHandler) Delete(c *gin.Context) {
+	userID := c.GetUint("userID")
+	goalID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid goal ID"})
+		return
+	}
+
+	goal, err := h.goalRepo.FindByID(uint(goalID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "goal not found"})
+		return
+	}
+
+	if goal.UserID != userID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
+		return
+	}
+
+	if err := h.goalRepo.Delete(uint(goalID)); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete goal"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "goal deleted"})
+}
+
+// GetByID gets a learning goal by ID
+func (h *LearningGoalHandler) GetByID(c *gin.Context) {
+	goalID, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid goal ID"})
+		return
+	}
+
+	goal, err := h.goalRepo.FindByID(uint(goalID))
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "goal not found"})
+		return
+	}
+
+	c.JSON(http.StatusOK, goal)
+}
+
+// GetByUserID gets all learning goals for a user
+func (h *LearningGoalHandler) GetByUserID(c *gin.Context) {
+	userIDParam := c.Param("userId")
+	userID, err := strconv.ParseUint(userIDParam, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+		return
+	}
+
+	goals, err := h.goalRepo.GetByUserID(uint(userID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get goals"})
+		return
+	}
+
+	c.JSON(http.StatusOK, goals)
+}
+
+// GetMyGoals gets all learning goals for the current user
+func (h *LearningGoalHandler) GetMyGoals(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	goals, err := h.goalRepo.GetByUserID(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get goals"})
+		return
+	}
+
+	c.JSON(http.StatusOK, goals)
+}
+
+// GetStats gets learning goal statistics for a user
+func (h *LearningGoalHandler) GetStats(c *gin.Context) {
+	userIDParam := c.Param("userId")
+	userID, err := strconv.ParseUint(userIDParam, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+		return
+	}
+
+	stats, err := h.goalRepo.GetStats(uint(userID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get stats"})
+		return
+	}
+
+	c.JSON(http.StatusOK, stats)
+}

--- a/backend/internal/model/learning_goal.go
+++ b/backend/internal/model/learning_goal.go
@@ -1,0 +1,46 @@
+package model
+
+import "time"
+
+// GoalStatus represents the status of a learning goal
+type GoalStatus string
+
+const (
+	GoalStatusActive    GoalStatus = "active"
+	GoalStatusCompleted GoalStatus = "completed"
+	GoalStatusPaused    GoalStatus = "paused"
+)
+
+// GoalCategory represents the category of a learning goal
+type GoalCategory string
+
+const (
+	GoalCategoryLanguage  GoalCategory = "language"
+	GoalCategoryFramework GoalCategory = "framework"
+	GoalCategorySkill     GoalCategory = "skill"
+	GoalCategoryProject   GoalCategory = "project"
+	GoalCategoryOther     GoalCategory = "other"
+)
+
+// LearningGoal represents a user's learning goal
+type LearningGoal struct {
+	ID          uint         `json:"id" gorm:"primaryKey"`
+	UserID      uint         `json:"user_id" gorm:"not null;index"`
+	Title       string       `json:"title" gorm:"not null"`
+	Description string       `json:"description"`
+	Category    GoalCategory `json:"category" gorm:"default:'other'"`
+	TargetDate  *time.Time   `json:"target_date"`
+	Progress    int          `json:"progress" gorm:"default:0"` // 0-100
+	Status      GoalStatus   `json:"status" gorm:"default:'active'"`
+	CreatedAt   time.Time    `json:"created_at"`
+	UpdatedAt   time.Time    `json:"updated_at"`
+	CompletedAt *time.Time   `json:"completed_at"`
+}
+
+// LearningGoalStats represents aggregated learning goal statistics for a user
+type LearningGoalStats struct {
+	TotalGoals     int `json:"total_goals"`
+	ActiveGoals    int `json:"active_goals"`
+	CompletedGoals int `json:"completed_goals"`
+	AverageProgress int `json:"average_progress"`
+}

--- a/backend/internal/repository/learning_goal.go
+++ b/backend/internal/repository/learning_goal.go
@@ -1,0 +1,80 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+type LearningGoalRepository struct {
+	db *gorm.DB
+}
+
+func NewLearningGoalRepository(db *gorm.DB) *LearningGoalRepository {
+	return &LearningGoalRepository{db: db}
+}
+
+// Create creates a new learning goal
+func (r *LearningGoalRepository) Create(goal *model.LearningGoal) error {
+	return r.db.Create(goal).Error
+}
+
+// Update updates an existing learning goal
+func (r *LearningGoalRepository) Update(goal *model.LearningGoal) error {
+	return r.db.Save(goal).Error
+}
+
+// Delete deletes a learning goal
+func (r *LearningGoalRepository) Delete(id uint) error {
+	return r.db.Delete(&model.LearningGoal{}, id).Error
+}
+
+// FindByID finds a learning goal by ID
+func (r *LearningGoalRepository) FindByID(id uint) (*model.LearningGoal, error) {
+	var goal model.LearningGoal
+	err := r.db.First(&goal, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return &goal, nil
+}
+
+// GetByUserID gets all learning goals for a user
+func (r *LearningGoalRepository) GetByUserID(userID uint) ([]model.LearningGoal, error) {
+	var goals []model.LearningGoal
+	err := r.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&goals).Error
+	return goals, err
+}
+
+// GetActiveByUserID gets all active learning goals for a user
+func (r *LearningGoalRepository) GetActiveByUserID(userID uint) ([]model.LearningGoal, error) {
+	var goals []model.LearningGoal
+	err := r.db.Where("user_id = ? AND status = ?", userID, model.GoalStatusActive).Order("created_at DESC").Find(&goals).Error
+	return goals, err
+}
+
+// GetStats gets learning goal statistics for a user
+func (r *LearningGoalRepository) GetStats(userID uint) (*model.LearningGoalStats, error) {
+	var stats model.LearningGoalStats
+
+	// Get total goals
+	var totalCount int64
+	r.db.Model(&model.LearningGoal{}).Where("user_id = ?", userID).Count(&totalCount)
+	stats.TotalGoals = int(totalCount)
+
+	// Get active goals
+	var activeCount int64
+	r.db.Model(&model.LearningGoal{}).Where("user_id = ? AND status = ?", userID, model.GoalStatusActive).Count(&activeCount)
+	stats.ActiveGoals = int(activeCount)
+
+	// Get completed goals
+	var completedCount int64
+	r.db.Model(&model.LearningGoal{}).Where("user_id = ? AND status = ?", userID, model.GoalStatusCompleted).Count(&completedCount)
+	stats.CompletedGoals = int(completedCount)
+
+	// Get average progress of active goals
+	var avgProgress float64
+	r.db.Model(&model.LearningGoal{}).Where("user_id = ? AND status = ?", userID, model.GoalStatusActive).Select("COALESCE(AVG(progress), 0)").Scan(&avgProgress)
+	stats.AverageProgress = int(avgProgress)
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -35,6 +35,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 	passwordResetRepo := repository.NewPasswordResetRepository(db)
 	zennRepo := repository.NewZennRepository(db)
 	qiitaRepo := repository.NewQiitaRepository(db)
+	learningGoalRepo := repository.NewLearningGoalRepository(db)
 
 	// Services
 	authService := service.NewAuthService(userRepo, cfg.JWTSecret)
@@ -55,6 +56,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 	notificationHandler := handler.NewNotificationHandler(notificationRepo)
 	zennHandler := handler.NewZennHandler(zennRepo, userRepo, zennService)
 	qiitaHandler := handler.NewQiitaHandler(qiitaRepo, userRepo, qiitaService)
+	learningGoalHandler := handler.NewLearningGoalHandler(learningGoalRepo)
 
 	// Static file serving for uploads
 	r.Static("/uploads", "./uploads")
@@ -180,6 +182,18 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 			qiita.POST("/sync", qiitaHandler.Sync)
 			qiita.GET("/articles/:userId", qiitaHandler.GetArticles)
 			qiita.GET("/stats/:userId", qiitaHandler.GetStats)
+		}
+
+		// Learning Goals
+		goals := protected.Group("/goals")
+		{
+			goals.POST("", learningGoalHandler.Create)
+			goals.GET("", learningGoalHandler.GetMyGoals)
+			goals.GET("/:id", learningGoalHandler.GetByID)
+			goals.PUT("/:id", learningGoalHandler.Update)
+			goals.DELETE("/:id", learningGoalHandler.Delete)
+			goals.GET("/user/:userId", learningGoalHandler.GetByUserID)
+			goals.GET("/stats/:userId", learningGoalHandler.GetStats)
 		}
 	}
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -36,6 +36,7 @@ func main() {
 		&model.PasswordResetToken{},
 		&model.ZennArticle{},
 		&model.QiitaArticle{},
+		&model.LearningGoal{},
 	); err != nil {
 		log.Fatalf("failed to run migrations: %v", err)
 	}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import ChatPage from './pages/ChatPage';
 import PostDetailPage from './pages/PostDetailPage';
 import FollowListPage from './pages/FollowListPage';
 import GitHubCallbackPage from './pages/GitHubCallbackPage';
+import GoalsPage from './pages/GoalsPage';
 
 export default function App() {
   const { isAuthenticated, loadUser } = useAuthStore();
@@ -58,6 +59,7 @@ export default function App() {
           <Route path="/chat" element={<ChatPage />} />
           <Route path="/chat/:userId" element={<ChatPage />} />
           <Route path="/posts/:id" element={<PostDetailPage />} />
+          <Route path="/goals" element={<GoalsPage />} />
         </Route>
       </Route>
     </Routes>

--- a/frontend/src/api/goals.ts
+++ b/frontend/src/api/goals.ts
@@ -1,0 +1,62 @@
+import client from './client';
+
+export type GoalStatus = 'active' | 'completed' | 'paused';
+export type GoalCategory = 'language' | 'framework' | 'skill' | 'project' | 'other';
+
+export interface LearningGoal {
+  id: number;
+  user_id: number;
+  title: string;
+  description: string;
+  category: GoalCategory;
+  target_date: string | null;
+  progress: number;
+  status: GoalStatus;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+export interface LearningGoalStats {
+  total_goals: number;
+  active_goals: number;
+  completed_goals: number;
+  average_progress: number;
+}
+
+export interface CreateGoalRequest {
+  title: string;
+  description?: string;
+  category?: GoalCategory;
+  target_date?: string;
+}
+
+export interface UpdateGoalRequest {
+  title?: string;
+  description?: string;
+  category?: GoalCategory;
+  target_date?: string;
+  progress?: number;
+  status?: GoalStatus;
+}
+
+export const createGoal = (data: CreateGoalRequest) =>
+  client.post<LearningGoal>('/goals', data);
+
+export const updateGoal = (id: number, data: UpdateGoalRequest) =>
+  client.put<LearningGoal>(`/goals/${id}`, data);
+
+export const deleteGoal = (id: number) =>
+  client.delete(`/goals/${id}`);
+
+export const getGoal = (id: number) =>
+  client.get<LearningGoal>(`/goals/${id}`);
+
+export const getMyGoals = () =>
+  client.get<LearningGoal[]>('/goals');
+
+export const getUserGoals = (userId: number) =>
+  client.get<LearningGoal[]>(`/goals/user/${userId}`);
+
+export const getGoalStats = (userId: number) =>
+  client.get<LearningGoalStats>(`/goals/stats/${userId}`);

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -47,6 +47,9 @@ export default function Header() {
           <Link to="/chat" className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${isActive('/chat')}`}>
             {t('nav.chat')}
           </Link>
+          <Link to="/goals" className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${isActive('/goals')}`}>
+            {t('nav.goals')}
+          </Link>
         </nav>
 
         {/* Right side */}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -21,6 +21,7 @@
     "explore": "Entdecken",
     "rankings": "Ranglisten",
     "chat": "Chat",
+    "goals": "Ziele",
     "settings": "Einstellungen",
     "profile": "Profil",
     "signOut": "Abmelden"
@@ -253,5 +254,44 @@
     "serverError": "Serverfehler",
     "networkError": "Netzwerkfehler",
     "tryAgain": "Bitte erneut versuchen"
+  },
+  "goals": {
+    "title": "Lernziele",
+    "myGoals": "Meine Lernziele",
+    "description": "Verfolgen Sie Ihren Lernfortschritt und setzen Sie Ziele",
+    "addGoal": "Ziel hinzufügen",
+    "editGoal": "Ziel bearbeiten",
+    "newGoal": "Neues Ziel",
+    "goalTitle": "Titel",
+    "goalTitlePlaceholder": "z.B. TypeScript lernen",
+    "goalDescription": "Beschreibung",
+    "goalDescriptionPlaceholder": "Beschreiben Sie Ihr Ziel...",
+    "category": "Kategorie",
+    "targetDate": "Zieldatum",
+    "progress": "Fortschritt",
+    "status": "Status",
+    "active": "Aktiv",
+    "completed": "Abgeschlossen",
+    "paused": "Pausiert",
+    "language": "Sprache",
+    "framework": "Framework",
+    "skill": "Fähigkeit",
+    "project": "Projekt",
+    "other": "Sonstiges",
+    "noGoals": "Noch keine Lernziele. Beginnen Sie damit, Ihr erstes Ziel hinzuzufügen!",
+    "manageGoals": "Ziele verwalten",
+    "createSuccess": "Ziel erfolgreich erstellt",
+    "updateSuccess": "Ziel erfolgreich aktualisiert",
+    "deleteSuccess": "Ziel erfolgreich gelöscht",
+    "createFailed": "Ziel konnte nicht erstellt werden",
+    "updateFailed": "Ziel konnte nicht aktualisiert werden",
+    "deleteFailed": "Ziel konnte nicht gelöscht werden",
+    "confirmDelete": "Sind Sie sicher, dass Sie dieses Ziel löschen möchten?",
+    "stats": {
+      "total": "Gesamtziele",
+      "activeCount": "Aktiv",
+      "completedCount": "Abgeschlossen",
+      "avgProgress": "Durchschn. Fortschritt"
+    }
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -21,6 +21,7 @@
     "explore": "Explore",
     "rankings": "Rankings",
     "chat": "Chat",
+    "goals": "Goals",
     "settings": "Settings",
     "profile": "Profile",
     "signOut": "Sign out"
@@ -253,5 +254,44 @@
     "serverError": "Server error",
     "networkError": "Network error",
     "tryAgain": "Please try again"
+  },
+  "goals": {
+    "title": "Learning Goals",
+    "myGoals": "My Learning Goals",
+    "description": "Track your learning progress and set goals",
+    "addGoal": "Add Goal",
+    "editGoal": "Edit Goal",
+    "newGoal": "New Goal",
+    "goalTitle": "Title",
+    "goalTitlePlaceholder": "e.g., Learn TypeScript",
+    "goalDescription": "Description",
+    "goalDescriptionPlaceholder": "Describe your goal...",
+    "category": "Category",
+    "targetDate": "Target Date",
+    "progress": "Progress",
+    "status": "Status",
+    "active": "Active",
+    "completed": "Completed",
+    "paused": "Paused",
+    "language": "Language",
+    "framework": "Framework",
+    "skill": "Skill",
+    "project": "Project",
+    "other": "Other",
+    "noGoals": "No learning goals yet. Start by adding your first goal!",
+    "manageGoals": "Manage Goals",
+    "createSuccess": "Goal created successfully",
+    "updateSuccess": "Goal updated successfully",
+    "deleteSuccess": "Goal deleted successfully",
+    "createFailed": "Failed to create goal",
+    "updateFailed": "Failed to update goal",
+    "deleteFailed": "Failed to delete goal",
+    "confirmDelete": "Are you sure you want to delete this goal?",
+    "stats": {
+      "total": "Total Goals",
+      "activeCount": "Active",
+      "completedCount": "Completed",
+      "avgProgress": "Avg. Progress"
+    }
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -21,6 +21,7 @@
     "explore": "Explorar",
     "rankings": "Rankings",
     "chat": "Chat",
+    "goals": "Objetivos",
     "settings": "Configuración",
     "profile": "Perfil",
     "signOut": "Cerrar sesión"
@@ -253,5 +254,44 @@
     "serverError": "Error del servidor",
     "networkError": "Error de red",
     "tryAgain": "Por favor, inténtalo de nuevo"
+  },
+  "goals": {
+    "title": "Objetivos de Aprendizaje",
+    "myGoals": "Mis Objetivos de Aprendizaje",
+    "description": "Rastrea tu progreso de aprendizaje y establece metas",
+    "addGoal": "Agregar Objetivo",
+    "editGoal": "Editar Objetivo",
+    "newGoal": "Nuevo Objetivo",
+    "goalTitle": "Título",
+    "goalTitlePlaceholder": "Ej: Aprender TypeScript",
+    "goalDescription": "Descripción",
+    "goalDescriptionPlaceholder": "Describe tu objetivo...",
+    "category": "Categoría",
+    "targetDate": "Fecha Objetivo",
+    "progress": "Progreso",
+    "status": "Estado",
+    "active": "Activo",
+    "completed": "Completado",
+    "paused": "Pausado",
+    "language": "Lenguaje",
+    "framework": "Framework",
+    "skill": "Habilidad",
+    "project": "Proyecto",
+    "other": "Otro",
+    "noGoals": "No tienes objetivos de aprendizaje. ¡Comienza agregando tu primer objetivo!",
+    "manageGoals": "Gestionar Objetivos",
+    "createSuccess": "Objetivo creado exitosamente",
+    "updateSuccess": "Objetivo actualizado exitosamente",
+    "deleteSuccess": "Objetivo eliminado exitosamente",
+    "createFailed": "Error al crear objetivo",
+    "updateFailed": "Error al actualizar objetivo",
+    "deleteFailed": "Error al eliminar objetivo",
+    "confirmDelete": "¿Estás seguro de que deseas eliminar este objetivo?",
+    "stats": {
+      "total": "Total de Objetivos",
+      "activeCount": "Activos",
+      "completedCount": "Completados",
+      "avgProgress": "Progreso Promedio"
+    }
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -21,6 +21,7 @@
     "explore": "Explorer",
     "rankings": "Classements",
     "chat": "Chat",
+    "goals": "Objectifs",
     "settings": "Paramètres",
     "profile": "Profil",
     "signOut": "Déconnexion"
@@ -253,5 +254,44 @@
     "serverError": "Erreur serveur",
     "networkError": "Erreur réseau",
     "tryAgain": "Veuillez réessayer"
+  },
+  "goals": {
+    "title": "Objectifs d'apprentissage",
+    "myGoals": "Mes objectifs d'apprentissage",
+    "description": "Suivez vos progrès et définissez des objectifs",
+    "addGoal": "Ajouter un objectif",
+    "editGoal": "Modifier l'objectif",
+    "newGoal": "Nouvel objectif",
+    "goalTitle": "Titre",
+    "goalTitlePlaceholder": "Ex: Apprendre TypeScript",
+    "goalDescription": "Description",
+    "goalDescriptionPlaceholder": "Décrivez votre objectif...",
+    "category": "Catégorie",
+    "targetDate": "Date cible",
+    "progress": "Progression",
+    "status": "Statut",
+    "active": "Actif",
+    "completed": "Terminé",
+    "paused": "En pause",
+    "language": "Langage",
+    "framework": "Framework",
+    "skill": "Compétence",
+    "project": "Projet",
+    "other": "Autre",
+    "noGoals": "Pas encore d'objectifs d'apprentissage. Commencez par ajouter votre premier objectif !",
+    "manageGoals": "Gérer les objectifs",
+    "createSuccess": "Objectif créé avec succès",
+    "updateSuccess": "Objectif mis à jour avec succès",
+    "deleteSuccess": "Objectif supprimé avec succès",
+    "createFailed": "Échec de la création de l'objectif",
+    "updateFailed": "Échec de la mise à jour de l'objectif",
+    "deleteFailed": "Échec de la suppression de l'objectif",
+    "confirmDelete": "Êtes-vous sûr de vouloir supprimer cet objectif ?",
+    "stats": {
+      "total": "Total des objectifs",
+      "activeCount": "Actifs",
+      "completedCount": "Terminés",
+      "avgProgress": "Progression moyenne"
+    }
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -21,6 +21,7 @@
     "explore": "探索",
     "rankings": "ランキング",
     "chat": "チャット",
+    "goals": "目標",
     "settings": "設定",
     "profile": "プロフィール",
     "signOut": "ログアウト"
@@ -253,5 +254,44 @@
     "serverError": "サーバーエラー",
     "networkError": "ネットワークエラー",
     "tryAgain": "もう一度お試しください"
+  },
+  "goals": {
+    "title": "学習目標",
+    "myGoals": "学習目標",
+    "description": "学習の進捗を追跡し、目標を設定しましょう",
+    "addGoal": "目標を追加",
+    "editGoal": "目標を編集",
+    "newGoal": "新しい目標",
+    "goalTitle": "タイトル",
+    "goalTitlePlaceholder": "例：TypeScriptを学ぶ",
+    "goalDescription": "説明",
+    "goalDescriptionPlaceholder": "目標を説明してください...",
+    "category": "カテゴリ",
+    "targetDate": "目標日",
+    "progress": "進捗",
+    "status": "ステータス",
+    "active": "進行中",
+    "completed": "完了",
+    "paused": "一時停止",
+    "language": "言語",
+    "framework": "フレームワーク",
+    "skill": "スキル",
+    "project": "プロジェクト",
+    "other": "その他",
+    "noGoals": "学習目標がまだありません。最初の目標を追加しましょう！",
+    "manageGoals": "目標を管理",
+    "createSuccess": "目標を作成しました",
+    "updateSuccess": "目標を更新しました",
+    "deleteSuccess": "目標を削除しました",
+    "createFailed": "目標の作成に失敗しました",
+    "updateFailed": "目標の更新に失敗しました",
+    "deleteFailed": "目標の削除に失敗しました",
+    "confirmDelete": "この目標を削除してもよろしいですか？",
+    "stats": {
+      "total": "合計目標",
+      "activeCount": "進行中",
+      "completedCount": "完了",
+      "avgProgress": "平均進捗"
+    }
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -21,6 +21,7 @@
     "explore": "탐색",
     "rankings": "랭킹",
     "chat": "채팅",
+    "goals": "목표",
     "settings": "설정",
     "profile": "프로필",
     "signOut": "로그아웃"
@@ -253,5 +254,44 @@
     "serverError": "서버 오류",
     "networkError": "네트워크 오류",
     "tryAgain": "다시 시도해주세요"
+  },
+  "goals": {
+    "title": "학습 목표",
+    "myGoals": "내 학습 목표",
+    "description": "학습 진행 상황을 추적하고 목표를 설정하세요",
+    "addGoal": "목표 추가",
+    "editGoal": "목표 편집",
+    "newGoal": "새 목표",
+    "goalTitle": "제목",
+    "goalTitlePlaceholder": "예: TypeScript 배우기",
+    "goalDescription": "설명",
+    "goalDescriptionPlaceholder": "목표를 설명하세요...",
+    "category": "카테고리",
+    "targetDate": "목표 날짜",
+    "progress": "진행률",
+    "status": "상태",
+    "active": "진행 중",
+    "completed": "완료",
+    "paused": "일시 중지",
+    "language": "언어",
+    "framework": "프레임워크",
+    "skill": "스킬",
+    "project": "프로젝트",
+    "other": "기타",
+    "noGoals": "학습 목표가 없습니다. 첫 번째 목표를 추가해보세요!",
+    "manageGoals": "목표 관리",
+    "createSuccess": "목표가 생성되었습니다",
+    "updateSuccess": "목표가 업데이트되었습니다",
+    "deleteSuccess": "목표가 삭제되었습니다",
+    "createFailed": "목표 생성에 실패했습니다",
+    "updateFailed": "목표 업데이트에 실패했습니다",
+    "deleteFailed": "목표 삭제에 실패했습니다",
+    "confirmDelete": "이 목표를 삭제하시겠습니까?",
+    "stats": {
+      "total": "총 목표",
+      "activeCount": "진행 중",
+      "completedCount": "완료",
+      "avgProgress": "평균 진행률"
+    }
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -21,6 +21,7 @@
     "explore": "Explorar",
     "rankings": "Rankings",
     "chat": "Chat",
+    "goals": "Metas",
     "settings": "Configurações",
     "profile": "Perfil",
     "signOut": "Sair"
@@ -253,5 +254,44 @@
     "serverError": "Erro do servidor",
     "networkError": "Erro de rede",
     "tryAgain": "Por favor, tente novamente"
+  },
+  "goals": {
+    "title": "Metas de Aprendizado",
+    "myGoals": "Minhas Metas de Aprendizado",
+    "description": "Acompanhe seu progresso e defina metas",
+    "addGoal": "Adicionar Meta",
+    "editGoal": "Editar Meta",
+    "newGoal": "Nova Meta",
+    "goalTitle": "Título",
+    "goalTitlePlaceholder": "Ex: Aprender TypeScript",
+    "goalDescription": "Descrição",
+    "goalDescriptionPlaceholder": "Descreva sua meta...",
+    "category": "Categoria",
+    "targetDate": "Data Alvo",
+    "progress": "Progresso",
+    "status": "Status",
+    "active": "Ativo",
+    "completed": "Concluído",
+    "paused": "Pausado",
+    "language": "Linguagem",
+    "framework": "Framework",
+    "skill": "Habilidade",
+    "project": "Projeto",
+    "other": "Outro",
+    "noGoals": "Nenhuma meta de aprendizado ainda. Comece adicionando sua primeira meta!",
+    "manageGoals": "Gerenciar Metas",
+    "createSuccess": "Meta criada com sucesso",
+    "updateSuccess": "Meta atualizada com sucesso",
+    "deleteSuccess": "Meta excluída com sucesso",
+    "createFailed": "Falha ao criar meta",
+    "updateFailed": "Falha ao atualizar meta",
+    "deleteFailed": "Falha ao excluir meta",
+    "confirmDelete": "Tem certeza de que deseja excluir esta meta?",
+    "stats": {
+      "total": "Total de Metas",
+      "activeCount": "Ativas",
+      "completedCount": "Concluídas",
+      "avgProgress": "Progresso Médio"
+    }
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -21,6 +21,7 @@
     "explore": "Обзор",
     "rankings": "Рейтинги",
     "chat": "Чат",
+    "goals": "Цели",
     "settings": "Настройки",
     "profile": "Профиль",
     "signOut": "Выйти"
@@ -253,5 +254,44 @@
     "serverError": "Ошибка сервера",
     "networkError": "Ошибка сети",
     "tryAgain": "Пожалуйста, попробуйте снова"
+  },
+  "goals": {
+    "title": "Цели обучения",
+    "myGoals": "Мои цели обучения",
+    "description": "Отслеживайте свой прогресс и ставьте цели",
+    "addGoal": "Добавить цель",
+    "editGoal": "Редактировать цель",
+    "newGoal": "Новая цель",
+    "goalTitle": "Название",
+    "goalTitlePlaceholder": "Например: Изучить TypeScript",
+    "goalDescription": "Описание",
+    "goalDescriptionPlaceholder": "Опишите свою цель...",
+    "category": "Категория",
+    "targetDate": "Целевая дата",
+    "progress": "Прогресс",
+    "status": "Статус",
+    "active": "Активная",
+    "completed": "Завершена",
+    "paused": "Приостановлена",
+    "language": "Язык",
+    "framework": "Фреймворк",
+    "skill": "Навык",
+    "project": "Проект",
+    "other": "Другое",
+    "noGoals": "Пока нет целей обучения. Начните с добавления первой цели!",
+    "manageGoals": "Управление целями",
+    "createSuccess": "Цель успешно создана",
+    "updateSuccess": "Цель успешно обновлена",
+    "deleteSuccess": "Цель успешно удалена",
+    "createFailed": "Не удалось создать цель",
+    "updateFailed": "Не удалось обновить цель",
+    "deleteFailed": "Не удалось удалить цель",
+    "confirmDelete": "Вы уверены, что хотите удалить эту цель?",
+    "stats": {
+      "total": "Всего целей",
+      "activeCount": "Активных",
+      "completedCount": "Завершённых",
+      "avgProgress": "Средний прогресс"
+    }
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -21,6 +21,7 @@
     "explore": "探索",
     "rankings": "排行榜",
     "chat": "聊天",
+    "goals": "目标",
     "settings": "设置",
     "profile": "个人资料",
     "signOut": "退出登录"
@@ -253,5 +254,44 @@
     "serverError": "服务器错误",
     "networkError": "网络错误",
     "tryAgain": "请重试"
+  },
+  "goals": {
+    "title": "学习目标",
+    "myGoals": "我的学习目标",
+    "description": "追踪学习进度并设定目标",
+    "addGoal": "添加目标",
+    "editGoal": "编辑目标",
+    "newGoal": "新目标",
+    "goalTitle": "标题",
+    "goalTitlePlaceholder": "例如：学习 TypeScript",
+    "goalDescription": "描述",
+    "goalDescriptionPlaceholder": "描述你的目标...",
+    "category": "类别",
+    "targetDate": "目标日期",
+    "progress": "进度",
+    "status": "状态",
+    "active": "进行中",
+    "completed": "已完成",
+    "paused": "已暂停",
+    "language": "语言",
+    "framework": "框架",
+    "skill": "技能",
+    "project": "项目",
+    "other": "其他",
+    "noGoals": "还没有学习目标。开始添加你的第一个目标吧！",
+    "manageGoals": "管理目标",
+    "createSuccess": "目标创建成功",
+    "updateSuccess": "目标更新成功",
+    "deleteSuccess": "目标删除成功",
+    "createFailed": "创建目标失败",
+    "updateFailed": "更新目标失败",
+    "deleteFailed": "删除目标失败",
+    "confirmDelete": "确定要删除这个目标吗？",
+    "stats": {
+      "total": "总目标",
+      "activeCount": "进行中",
+      "completedCount": "已完成",
+      "avgProgress": "平均进度"
+    }
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -21,6 +21,7 @@
     "explore": "探索",
     "rankings": "排行榜",
     "chat": "聊天",
+    "goals": "目標",
     "settings": "設定",
     "profile": "個人資料",
     "signOut": "登出"
@@ -253,5 +254,44 @@
     "serverError": "伺服器錯誤",
     "networkError": "網路錯誤",
     "tryAgain": "請重試"
+  },
+  "goals": {
+    "title": "學習目標",
+    "myGoals": "我的學習目標",
+    "description": "追蹤學習進度並設定目標",
+    "addGoal": "新增目標",
+    "editGoal": "編輯目標",
+    "newGoal": "新目標",
+    "goalTitle": "標題",
+    "goalTitlePlaceholder": "例如：學習 TypeScript",
+    "goalDescription": "描述",
+    "goalDescriptionPlaceholder": "描述你的目標...",
+    "category": "類別",
+    "targetDate": "目標日期",
+    "progress": "進度",
+    "status": "狀態",
+    "active": "進行中",
+    "completed": "已完成",
+    "paused": "已暫停",
+    "language": "語言",
+    "framework": "框架",
+    "skill": "技能",
+    "project": "專案",
+    "other": "其他",
+    "noGoals": "還沒有學習目標。開始新增你的第一個目標吧！",
+    "manageGoals": "管理目標",
+    "createSuccess": "目標建立成功",
+    "updateSuccess": "目標更新成功",
+    "deleteSuccess": "目標刪除成功",
+    "createFailed": "建立目標失敗",
+    "updateFailed": "更新目標失敗",
+    "deleteFailed": "刪除目標失敗",
+    "confirmDelete": "確定要刪除這個目標嗎？",
+    "stats": {
+      "total": "總目標",
+      "activeCount": "進行中",
+      "completedCount": "已完成",
+      "avgProgress": "平均進度"
+    }
   }
 }

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -1,0 +1,483 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  getMyGoals,
+  createGoal,
+  updateGoal,
+  deleteGoal,
+  type LearningGoal,
+  type GoalCategory,
+  type GoalStatus,
+} from '../api/goals';
+import toast from 'react-hot-toast';
+import LoadingSpinner from '../components/common/LoadingSpinner';
+
+const CATEGORIES: { value: GoalCategory; label: string; icon: string }[] = [
+  { value: 'language', label: 'goals.categoryLanguage', icon: '💻' },
+  { value: 'framework', label: 'goals.categoryFramework', icon: '🚀' },
+  { value: 'skill', label: 'goals.categorySkill', icon: '🎯' },
+  { value: 'project', label: 'goals.categoryProject', icon: '📁' },
+  { value: 'other', label: 'goals.categoryOther', icon: '📝' },
+];
+
+export default function GoalsPage() {
+  const { t } = useTranslation();
+  const [goals, setGoals] = useState<LearningGoal[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [editingGoal, setEditingGoal] = useState<LearningGoal | null>(null);
+  const [saving, setSaving] = useState(false);
+
+  // Form state
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState<GoalCategory>('other');
+  const [targetDate, setTargetDate] = useState('');
+
+  useEffect(() => {
+    fetchGoals();
+  }, []);
+
+  const fetchGoals = async () => {
+    try {
+      const { data } = await getMyGoals();
+      setGoals(data || []);
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const resetForm = () => {
+    setTitle('');
+    setDescription('');
+    setCategory('other');
+    setTargetDate('');
+    setEditingGoal(null);
+    setShowForm(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    setSaving(true);
+    try {
+      if (editingGoal) {
+        const { data } = await updateGoal(editingGoal.id, {
+          title,
+          description,
+          category,
+          target_date: targetDate || undefined,
+        });
+        setGoals(goals.map((g) => (g.id === data.id ? data : g)));
+        toast.success(t('goals.updated'));
+      } else {
+        const { data } = await createGoal({
+          title,
+          description,
+          category,
+          target_date: targetDate || undefined,
+        });
+        setGoals([data, ...goals]);
+        toast.success(t('goals.created'));
+      }
+      resetForm();
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleEdit = (goal: LearningGoal) => {
+    setEditingGoal(goal);
+    setTitle(goal.title);
+    setDescription(goal.description);
+    setCategory(goal.category);
+    setTargetDate(goal.target_date ? goal.target_date.split('T')[0] : '');
+    setShowForm(true);
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm(t('goals.confirmDelete'))) return;
+    try {
+      await deleteGoal(id);
+      setGoals(goals.filter((g) => g.id !== id));
+      toast.success(t('goals.deleted'));
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  };
+
+  const handleProgressChange = async (goal: LearningGoal, newProgress: number) => {
+    try {
+      const { data } = await updateGoal(goal.id, { progress: newProgress });
+      setGoals(goals.map((g) => (g.id === data.id ? data : g)));
+      if (newProgress === 100) {
+        toast.success(t('goals.completed'));
+      }
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  };
+
+  const handleStatusChange = async (goal: LearningGoal, newStatus: GoalStatus) => {
+    try {
+      const { data } = await updateGoal(goal.id, { status: newStatus });
+      setGoals(goals.map((g) => (g.id === data.id ? data : g)));
+      toast.success(t('goals.updated'));
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  };
+
+  const getCategoryInfo = (cat: GoalCategory) => {
+    return CATEGORIES.find((c) => c.value === cat) || CATEGORIES[4];
+  };
+
+  const getStatusColor = (status: GoalStatus) => {
+    switch (status) {
+      case 'active':
+        return 'text-blue-400 bg-blue-400/10';
+      case 'completed':
+        return 'text-green-400 bg-green-400/10';
+      case 'paused':
+        return 'text-yellow-400 bg-yellow-400/10';
+    }
+  };
+
+  const activeGoals = goals.filter((g) => g.status === 'active');
+  const completedGoals = goals.filter((g) => g.status === 'completed');
+  const pausedGoals = goals.filter((g) => g.status === 'paused');
+
+  if (loading) return <div className="py-12"><LoadingSpinner /></div>;
+
+  const inputClass = "w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow";
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{t('goals.title')}</h1>
+        <button
+          onClick={() => setShowForm(true)}
+          className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg font-medium text-sm transition-colors"
+        >
+          {t('goals.addGoal')}
+        </button>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+          <p className="text-2xl font-bold">{goals.length}</p>
+          <p className="text-sm text-gray-400">{t('goals.totalGoals')}</p>
+        </div>
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+          <p className="text-2xl font-bold text-blue-400">{activeGoals.length}</p>
+          <p className="text-sm text-gray-400">{t('goals.activeGoals')}</p>
+        </div>
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+          <p className="text-2xl font-bold text-green-400">{completedGoals.length}</p>
+          <p className="text-sm text-gray-400">{t('goals.completedGoals')}</p>
+        </div>
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+          <p className="text-2xl font-bold text-yellow-400">{pausedGoals.length}</p>
+          <p className="text-sm text-gray-400">{t('goals.pausedGoals')}</p>
+        </div>
+      </div>
+
+      {/* Create/Edit Form Modal */}
+      {showForm && (
+        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 px-4">
+          <div className="bg-gray-900 border border-gray-700 rounded-xl max-w-md w-full p-6">
+            <h3 className="text-lg font-semibold mb-4">
+              {editingGoal ? t('goals.editGoal') : t('goals.addGoal')}
+            </h3>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  {t('goals.goalTitle')}
+                </label>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder={t('goals.titlePlaceholder')}
+                  className={inputClass}
+                  required
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  {t('goals.description')}
+                </label>
+                <textarea
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  placeholder={t('goals.descriptionPlaceholder')}
+                  rows={3}
+                  className={`${inputClass} resize-none`}
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  {t('goals.category')}
+                </label>
+                <select
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value as GoalCategory)}
+                  className={inputClass}
+                >
+                  {CATEGORIES.map((cat) => (
+                    <option key={cat.value} value={cat.value}>
+                      {cat.icon} {t(cat.label)}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  {t('goals.targetDate')}
+                </label>
+                <input
+                  type="date"
+                  value={targetDate}
+                  onChange={(e) => setTargetDate(e.target.value)}
+                  className={inputClass}
+                />
+              </div>
+              <div className="flex gap-3 justify-end pt-2">
+                <button
+                  type="button"
+                  onClick={resetForm}
+                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
+                >
+                  {t('common.cancel')}
+                </button>
+                <button
+                  type="submit"
+                  disabled={saving || !title.trim()}
+                  className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+                >
+                  {saving ? t('common.loading') : editingGoal ? t('common.save') : t('goals.create')}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+
+      {/* Goals List */}
+      {goals.length === 0 ? (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-12 text-center">
+          <p className="text-gray-400 text-sm mb-4">{t('goals.noGoals')}</p>
+          <button
+            onClick={() => setShowForm(true)}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg font-medium text-sm transition-colors"
+          >
+            {t('goals.createFirst')}
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {/* Active Goals */}
+          {activeGoals.length > 0 && (
+            <div>
+              <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-3">
+                {t('goals.activeGoals')}
+              </h2>
+              <div className="space-y-3">
+                {activeGoals.map((goal) => (
+                  <GoalCard
+                    key={goal.id}
+                    goal={goal}
+                    onEdit={handleEdit}
+                    onDelete={handleDelete}
+                    onProgressChange={handleProgressChange}
+                    onStatusChange={handleStatusChange}
+                    getCategoryInfo={getCategoryInfo}
+                    getStatusColor={getStatusColor}
+                    t={t}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Paused Goals */}
+          {pausedGoals.length > 0 && (
+            <div>
+              <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-3">
+                {t('goals.pausedGoals')}
+              </h2>
+              <div className="space-y-3">
+                {pausedGoals.map((goal) => (
+                  <GoalCard
+                    key={goal.id}
+                    goal={goal}
+                    onEdit={handleEdit}
+                    onDelete={handleDelete}
+                    onProgressChange={handleProgressChange}
+                    onStatusChange={handleStatusChange}
+                    getCategoryInfo={getCategoryInfo}
+                    getStatusColor={getStatusColor}
+                    t={t}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Completed Goals */}
+          {completedGoals.length > 0 && (
+            <div>
+              <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-3">
+                {t('goals.completedGoals')}
+              </h2>
+              <div className="space-y-3">
+                {completedGoals.map((goal) => (
+                  <GoalCard
+                    key={goal.id}
+                    goal={goal}
+                    onEdit={handleEdit}
+                    onDelete={handleDelete}
+                    onProgressChange={handleProgressChange}
+                    onStatusChange={handleStatusChange}
+                    getCategoryInfo={getCategoryInfo}
+                    getStatusColor={getStatusColor}
+                    t={t}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface GoalCardProps {
+  goal: LearningGoal;
+  onEdit: (goal: LearningGoal) => void;
+  onDelete: (id: number) => void;
+  onProgressChange: (goal: LearningGoal, progress: number) => void;
+  onStatusChange: (goal: LearningGoal, status: GoalStatus) => void;
+  getCategoryInfo: (cat: GoalCategory) => { value: GoalCategory; label: string; icon: string };
+  getStatusColor: (status: GoalStatus) => string;
+  t: (key: string) => string;
+}
+
+function GoalCard({
+  goal,
+  onEdit,
+  onDelete,
+  onProgressChange,
+  onStatusChange,
+  getCategoryInfo,
+  getStatusColor,
+  t,
+}: GoalCardProps) {
+  const categoryInfo = getCategoryInfo(goal.category);
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3 min-w-0 flex-1">
+          <span className="text-2xl">{categoryInfo.icon}</span>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <h3 className="font-medium">{goal.title}</h3>
+              <span className={`px-2 py-0.5 text-xs rounded-full ${getStatusColor(goal.status)}`}>
+                {t(`goals.status${goal.status.charAt(0).toUpperCase() + goal.status.slice(1)}`)}
+              </span>
+            </div>
+            {goal.description && (
+              <p className="text-sm text-gray-400 mt-1">{goal.description}</p>
+            )}
+            <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
+              <span>{t(categoryInfo.label)}</span>
+              {goal.target_date && (
+                <span>
+                  {t('goals.targetDateLabel')}: {new Date(goal.target_date).toLocaleDateString()}
+                </span>
+              )}
+            </div>
+
+            {/* Progress Bar */}
+            <div className="mt-3">
+              <div className="flex items-center justify-between text-xs mb-1">
+                <span className="text-gray-400">{t('goals.progress')}</span>
+                <span className="text-gray-300">{goal.progress}%</span>
+              </div>
+              <div className="h-2 bg-gray-700 rounded-full overflow-hidden">
+                <div
+                  className={`h-full transition-all ${
+                    goal.status === 'completed' ? 'bg-green-500' : 'bg-blue-500'
+                  }`}
+                  style={{ width: `${goal.progress}%` }}
+                />
+              </div>
+              {goal.status === 'active' && (
+                <input
+                  type="range"
+                  min="0"
+                  max="100"
+                  value={goal.progress}
+                  onChange={(e) => onProgressChange(goal, parseInt(e.target.value))}
+                  className="w-full mt-2 accent-blue-500"
+                />
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center gap-2">
+          {goal.status === 'active' && (
+            <button
+              onClick={() => onStatusChange(goal, 'paused')}
+              className="p-2 text-gray-400 hover:text-yellow-400 transition-colors"
+              title={t('goals.pause')}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
+              </svg>
+            </button>
+          )}
+          {goal.status === 'paused' && (
+            <button
+              onClick={() => onStatusChange(goal, 'active')}
+              className="p-2 text-gray-400 hover:text-blue-400 transition-colors"
+              title={t('goals.resume')}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z" />
+              </svg>
+            </button>
+          )}
+          <button
+            onClick={() => onEdit(goal)}
+            className="p-2 text-gray-400 hover:text-blue-400 transition-colors"
+            title={t('common.edit')}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+            </svg>
+          </button>
+          <button
+            onClick={() => onDelete(goal.id)}
+            className="p-2 text-gray-400 hover:text-red-400 transition-colors"
+            title={t('common.delete')}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -6,6 +6,7 @@ import { getUserPosts } from '../api/posts';
 import { getContributions, getLanguages, getRepos } from '../api/github';
 import { getZennArticles, getZennStats, type ZennArticle, type ZennStats } from '../api/zenn';
 import { getQiitaArticles, getQiitaStats, type QiitaArticle, type QiitaStats } from '../api/qiita';
+import { getUserGoals, getGoalStats, type LearningGoal, type LearningGoalStats } from '../api/goals';
 import { useAuthStore } from '../store/authStore';
 import type { User } from '../types/user';
 import type { Post } from '../types/post';
@@ -31,6 +32,8 @@ export default function ProfilePage() {
   const [zennStats, setZennStats] = useState<ZennStats | null>(null);
   const [qiitaArticles, setQiitaArticles] = useState<QiitaArticle[]>([]);
   const [qiitaStats, setQiitaStats] = useState<QiitaStats | null>(null);
+  const [goals, setGoals] = useState<LearningGoal[]>([]);
+  const [goalStats, setGoalStats] = useState<LearningGoalStats | null>(null);
   const [followerCount, setFollowerCount] = useState(0);
   const [followingCount, setFollowingCount] = useState(0);
   const [loading, setLoading] = useState(true);
@@ -83,6 +86,14 @@ export default function ProfilePage() {
           setQiitaArticles(articlesRes.data || []);
           setQiitaStats(statsRes.data);
         }
+
+        // Fetch learning goals
+        const [goalsRes, goalStatsRes] = await Promise.all([
+          getUserGoals(userId),
+          getGoalStats(userId),
+        ]);
+        setGoals(goalsRes.data || []);
+        setGoalStats(goalStatsRes.data);
       } catch {
         // handle error
       } finally {
@@ -434,6 +445,87 @@ export default function ProfilePage() {
                 </div>
               </a>
             ))}
+          </div>
+        </div>
+      )}
+
+      {/* Learning Goals */}
+      {goals.length > 0 && (
+        <div>
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide flex items-center gap-2">
+              <svg className="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+              </svg>
+              {t('goals.title')}
+              {goalStats && (
+                <span className="text-xs text-gray-500 font-normal ml-2">
+                  {goalStats.active_goals} {t('goals.active')} · {goalStats.completed_goals} {t('goals.completed')}
+                </span>
+              )}
+            </h2>
+            {isOwnProfile && (
+              <Link
+                to="/goals"
+                className="text-xs text-gray-500 hover:text-purple-400 transition-colors flex items-center gap-1"
+              >
+                {t('goals.manageGoals')}
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+                </svg>
+              </Link>
+            )}
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            {goals.slice(0, 4).map((goal) => {
+              const categoryIcons: Record<string, string> = {
+                language: '💻',
+                framework: '🚀',
+                skill: '🎯',
+                project: '📁',
+                other: '📝',
+              };
+              const statusColors: Record<string, string> = {
+                active: 'text-green-400 bg-green-400/10',
+                completed: 'text-blue-400 bg-blue-400/10',
+                paused: 'text-yellow-400 bg-yellow-400/10',
+              };
+              return (
+                <div
+                  key={goal.id}
+                  className="bg-gray-900 border border-gray-800 rounded-xl p-4"
+                >
+                  <div className="flex items-start gap-3">
+                    <span className="text-2xl">{categoryIcons[goal.category] || '📝'}</span>
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <div className="font-medium text-sm text-white truncate flex-1">
+                          {goal.title}
+                        </div>
+                        <span className={`px-2 py-0.5 text-xs rounded ${statusColors[goal.status]}`}>
+                          {t(`goals.${goal.status}`)}
+                        </span>
+                      </div>
+                      {goal.description && (
+                        <p className="text-xs text-gray-500 mt-1 line-clamp-2">{goal.description}</p>
+                      )}
+                      <div className="mt-2">
+                        <div className="flex items-center justify-between text-xs text-gray-400 mb-1">
+                          <span>{t('goals.progress')}</span>
+                          <span>{goal.progress}%</span>
+                        </div>
+                        <div className="h-1.5 bg-gray-800 rounded-full overflow-hidden">
+                          <div
+                            className="h-full bg-purple-500 rounded-full transition-all"
+                            style={{ width: `${goal.progress}%` }}
+                          />
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Add learning goals feature to track learning progress with categories (language, framework, skill, project, other) and status (active, completed, paused)
- Users can set goals, track progress with a slider, and view stats on their profile
- Full i18n support for all 10 languages

## Changes
- Backend: LearningGoal model, repository, handler, and routes
- Frontend: GoalsPage, goals API, ProfilePage goals section, Header navigation
- i18n: Translations for all 10 languages

## Test plan
- [ ] Create a new learning goal
- [ ] Update progress with slider
- [ ] Change goal status (active/paused/completed)
- [ ] Delete a goal
- [ ] View goals on profile page
- [ ] Verify i18n translations work

🤖 Generated with [Claude Code](https://claude.com/claude-code)