### PR TITLE
feat: Add weekly/monthly activity reports feature

### DIFF
--- a/backend/internal/handler/activity_report.go
+++ b/backend/internal/handler/activity_report.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+type ActivityReportHandler struct {
+	reportRepo *repository.ActivityReportRepository
+}
+
+func NewActivityReportHandler(reportRepo *repository.ActivityReportRepository) *ActivityReportHandler {
+	return &ActivityReportHandler{reportRepo: reportRepo}
+}
+
+// GetWeeklyReport returns the weekly activity report for a user
+func (h *ActivityReportHandler) GetWeeklyReport(c *gin.Context) {
+	userIDParam := c.Param("userId")
+	userID, err := strconv.ParseUint(userIDParam, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+		return
+	}
+
+	report, err := h.reportRepo.GetWeeklyReport(uint(userID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate report"})
+		return
+	}
+
+	c.JSON(http.StatusOK, report)
+}
+
+// GetMonthlyReport returns the monthly activity report for a user
+func (h *ActivityReportHandler) GetMonthlyReport(c *gin.Context) {
+	userIDParam := c.Param("userId")
+	userID, err := strconv.ParseUint(userIDParam, 10, 32)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+		return
+	}
+
+	report, err := h.reportRepo.GetMonthlyReport(uint(userID))
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate report"})
+		return
+	}
+
+	c.JSON(http.StatusOK, report)
+}
+
+// GetMyWeeklyReport returns the weekly report for the current user
+func (h *ActivityReportHandler) GetMyWeeklyReport(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	report, err := h.reportRepo.GetWeeklyReport(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate report"})
+		return
+	}
+
+	c.JSON(http.StatusOK, report)
+}
+
+// GetMyMonthlyReport returns the monthly report for the current user
+func (h *ActivityReportHandler) GetMyMonthlyReport(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	report, err := h.reportRepo.GetMonthlyReport(userID)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate report"})
+		return
+	}
+
+	c.JSON(http.StatusOK, report)
+}
+
+// GetComparison returns the comparison between current and previous period
+func (h *ActivityReportHandler) GetComparison(c *gin.Context) {
+	userID := c.GetUint("userID")
+	periodParam := c.Query("period")
+
+	period := model.ReportPeriodWeekly
+	if periodParam == "monthly" {
+		period = model.ReportPeriodMonthly
+	}
+
+	comparison, err := h.reportRepo.GetComparison(userID, period)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate comparison"})
+		return
+	}
+
+	c.JSON(http.StatusOK, comparison)
+}

--- a/backend/internal/model/activity_report.go
+++ b/backend/internal/model/activity_report.go
@@ -1,0 +1,55 @@
+package model
+
+import "time"
+
+// ReportPeriod represents the report period type
+type ReportPeriod string
+
+const (
+	ReportPeriodWeekly  ReportPeriod = "weekly"
+	ReportPeriodMonthly ReportPeriod = "monthly"
+)
+
+// ActivityReport represents a user's activity report for a period
+type ActivityReport struct {
+	Period            ReportPeriod `json:"period"`
+	StartDate         time.Time    `json:"start_date"`
+	EndDate           time.Time    `json:"end_date"`
+	UserID            uint         `json:"user_id"`
+	TotalContributions int         `json:"total_contributions"`
+	PostsCreated      int          `json:"posts_created"`
+	CommentsCreated   int          `json:"comments_created"`
+	LikesReceived     int          `json:"likes_received"`
+	GoalsCompleted    int          `json:"goals_completed"`
+	GoalsProgress     int          `json:"goals_progress"` // Average progress of active goals
+	NewFollowers      int          `json:"new_followers"`
+	MessagesExchanged int          `json:"messages_exchanged"`
+	// Daily breakdown for charts
+	DailyContributions []DailyActivity `json:"daily_contributions"`
+	// Top languages used
+	TopLanguages []LanguageActivity `json:"top_languages"`
+}
+
+// DailyActivity represents activity for a single day
+type DailyActivity struct {
+	Date          string `json:"date"`
+	Contributions int    `json:"contributions"`
+	Posts         int    `json:"posts"`
+	Comments      int    `json:"comments"`
+}
+
+// LanguageActivity represents language usage in the period
+type LanguageActivity struct {
+	Language string `json:"language"`
+	Bytes    int64  `json:"bytes"`
+	Repos    int    `json:"repos"`
+}
+
+// ReportComparison shows comparison with previous period
+type ReportComparison struct {
+	ContributionsDiff int     `json:"contributions_diff"`
+	PostsDiff         int     `json:"posts_diff"`
+	FollowersDiff     int     `json:"followers_diff"`
+	GoalsDiff         int     `json:"goals_diff"`
+	TrendPercentage   float64 `json:"trend_percentage"` // Overall activity trend
+}

--- a/backend/internal/repository/activity_report.go
+++ b/backend/internal/repository/activity_report.go
@@ -1,0 +1,209 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+type ActivityReportRepository struct {
+	db *gorm.DB
+}
+
+func NewActivityReportRepository(db *gorm.DB) *ActivityReportRepository {
+	return &ActivityReportRepository{db: db}
+}
+
+// GetWeeklyReport generates a weekly report for a user
+func (r *ActivityReportRepository) GetWeeklyReport(userID uint) (*model.ActivityReport, error) {
+	now := time.Now()
+	// Get the start of this week (Sunday)
+	startOfWeek := now.AddDate(0, 0, -int(now.Weekday()))
+	startOfWeek = time.Date(startOfWeek.Year(), startOfWeek.Month(), startOfWeek.Day(), 0, 0, 0, 0, now.Location())
+	endOfWeek := startOfWeek.AddDate(0, 0, 7)
+
+	return r.generateReport(userID, model.ReportPeriodWeekly, startOfWeek, endOfWeek)
+}
+
+// GetMonthlyReport generates a monthly report for a user
+func (r *ActivityReportRepository) GetMonthlyReport(userID uint) (*model.ActivityReport, error) {
+	now := time.Now()
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	endOfMonth := startOfMonth.AddDate(0, 1, 0)
+
+	return r.generateReport(userID, model.ReportPeriodMonthly, startOfMonth, endOfMonth)
+}
+
+func (r *ActivityReportRepository) generateReport(userID uint, period model.ReportPeriod, startDate, endDate time.Time) (*model.ActivityReport, error) {
+	report := &model.ActivityReport{
+		Period:    period,
+		StartDate: startDate,
+		EndDate:   endDate,
+		UserID:    userID,
+	}
+
+	// Get GitHub contributions in the period
+	var totalContributions int64
+	r.db.Model(&model.GitHubContribution{}).
+		Where("user_id = ? AND date >= ? AND date < ?", userID, startDate, endDate).
+		Select("COALESCE(SUM(count), 0)").
+		Scan(&totalContributions)
+	report.TotalContributions = int(totalContributions)
+
+	// Get posts created
+	var postsCreated int64
+	r.db.Model(&model.Post{}).
+		Where("user_id = ? AND created_at >= ? AND created_at < ?", userID, startDate, endDate).
+		Count(&postsCreated)
+	report.PostsCreated = int(postsCreated)
+
+	// Get comments created
+	var commentsCreated int64
+	r.db.Model(&model.Comment{}).
+		Where("user_id = ? AND created_at >= ? AND created_at < ?", userID, startDate, endDate).
+		Count(&commentsCreated)
+	report.CommentsCreated = int(commentsCreated)
+
+	// Get likes received on user's posts
+	var likesReceived int64
+	r.db.Model(&model.Like{}).
+		Joins("JOIN posts ON likes.post_id = posts.id").
+		Where("posts.user_id = ? AND likes.created_at >= ? AND likes.created_at < ?", userID, startDate, endDate).
+		Count(&likesReceived)
+	report.LikesReceived = int(likesReceived)
+
+	// Get goals completed
+	var goalsCompleted int64
+	r.db.Model(&model.LearningGoal{}).
+		Where("user_id = ? AND status = ? AND completed_at >= ? AND completed_at < ?", userID, model.GoalStatusCompleted, startDate, endDate).
+		Count(&goalsCompleted)
+	report.GoalsCompleted = int(goalsCompleted)
+
+	// Get average progress of active goals
+	var avgProgress float64
+	r.db.Model(&model.LearningGoal{}).
+		Where("user_id = ? AND status = ?", userID, model.GoalStatusActive).
+		Select("COALESCE(AVG(progress), 0)").
+		Scan(&avgProgress)
+	report.GoalsProgress = int(avgProgress)
+
+	// Get new followers
+	var newFollowers int64
+	r.db.Model(&model.Follow{}).
+		Where("followee_id = ? AND created_at >= ? AND created_at < ?", userID, startDate, endDate).
+		Count(&newFollowers)
+	report.NewFollowers = int(newFollowers)
+
+	// Get messages exchanged
+	var messagesSent int64
+	var messagesReceived int64
+	r.db.Model(&model.Message{}).
+		Where("sender_id = ? AND created_at >= ? AND created_at < ?", userID, startDate, endDate).
+		Count(&messagesSent)
+	r.db.Model(&model.Message{}).
+		Where("receiver_id = ? AND created_at >= ? AND created_at < ?", userID, startDate, endDate).
+		Count(&messagesReceived)
+	report.MessagesExchanged = int(messagesSent + messagesReceived)
+
+	// Get daily contributions
+	report.DailyContributions = r.getDailyActivity(userID, startDate, endDate)
+
+	// Get top languages
+	report.TopLanguages = r.getTopLanguages(userID)
+
+	return report, nil
+}
+
+func (r *ActivityReportRepository) getDailyActivity(userID uint, startDate, endDate time.Time) []model.DailyActivity {
+	var activities []model.DailyActivity
+
+	// Generate all dates in the range
+	for d := startDate; d.Before(endDate); d = d.AddDate(0, 0, 1) {
+		dateStr := d.Format("2006-01-02")
+		nextDay := d.AddDate(0, 0, 1)
+
+		activity := model.DailyActivity{
+			Date: dateStr,
+		}
+
+		// Get contributions for this day
+		var contributions int64
+		r.db.Model(&model.GitHubContribution{}).
+			Where("user_id = ? AND date = ?", userID, dateStr).
+			Select("COALESCE(SUM(count), 0)").
+			Scan(&contributions)
+		activity.Contributions = int(contributions)
+
+		// Get posts for this day
+		var posts int64
+		r.db.Model(&model.Post{}).
+			Where("user_id = ? AND created_at >= ? AND created_at < ?", userID, d, nextDay).
+			Count(&posts)
+		activity.Posts = int(posts)
+
+		// Get comments for this day
+		var comments int64
+		r.db.Model(&model.Comment{}).
+			Where("user_id = ? AND created_at >= ? AND created_at < ?", userID, d, nextDay).
+			Count(&comments)
+		activity.Comments = int(comments)
+
+		activities = append(activities, activity)
+	}
+
+	return activities
+}
+
+func (r *ActivityReportRepository) getTopLanguages(userID uint) []model.LanguageActivity {
+	var languages []model.LanguageActivity
+
+	r.db.Model(&model.GitHubLanguageStat{}).
+		Where("user_id = ?", userID).
+		Select("language, bytes, repo_count as repos").
+		Order("bytes DESC").
+		Limit(5).
+		Scan(&languages)
+
+	return languages
+}
+
+// GetComparison compares current period with previous period
+func (r *ActivityReportRepository) GetComparison(userID uint, period model.ReportPeriod) (*model.ReportComparison, error) {
+	now := time.Now()
+	var currentStart, currentEnd, prevStart, prevEnd time.Time
+
+	if period == model.ReportPeriodWeekly {
+		currentStart = now.AddDate(0, 0, -int(now.Weekday()))
+		currentStart = time.Date(currentStart.Year(), currentStart.Month(), currentStart.Day(), 0, 0, 0, 0, now.Location())
+		currentEnd = currentStart.AddDate(0, 0, 7)
+		prevStart = currentStart.AddDate(0, 0, -7)
+		prevEnd = currentStart
+	} else {
+		currentStart = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+		currentEnd = currentStart.AddDate(0, 1, 0)
+		prevStart = currentStart.AddDate(0, -1, 0)
+		prevEnd = currentStart
+	}
+
+	currentReport, _ := r.generateReport(userID, period, currentStart, currentEnd)
+	prevReport, _ := r.generateReport(userID, period, prevStart, prevEnd)
+
+	comparison := &model.ReportComparison{
+		ContributionsDiff: currentReport.TotalContributions - prevReport.TotalContributions,
+		PostsDiff:         currentReport.PostsCreated - prevReport.PostsCreated,
+		FollowersDiff:     currentReport.NewFollowers - prevReport.NewFollowers,
+		GoalsDiff:         currentReport.GoalsCompleted - prevReport.GoalsCompleted,
+	}
+
+	// Calculate trend percentage
+	prevTotal := float64(prevReport.TotalContributions + prevReport.PostsCreated*10 + prevReport.GoalsCompleted*20)
+	currTotal := float64(currentReport.TotalContributions + currentReport.PostsCreated*10 + currentReport.GoalsCompleted*20)
+	if prevTotal > 0 {
+		comparison.TrendPercentage = ((currTotal - prevTotal) / prevTotal) * 100
+	} else if currTotal > 0 {
+		comparison.TrendPercentage = 100
+	}
+
+	return comparison, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -36,6 +36,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 	zennRepo := repository.NewZennRepository(db)
 	qiitaRepo := repository.NewQiitaRepository(db)
 	learningGoalRepo := repository.NewLearningGoalRepository(db)
+	activityReportRepo := repository.NewActivityReportRepository(db)
 
 	// Services
 	authService := service.NewAuthService(userRepo, cfg.JWTSecret)
@@ -57,6 +58,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 	zennHandler := handler.NewZennHandler(zennRepo, userRepo, zennService)
 	qiitaHandler := handler.NewQiitaHandler(qiitaRepo, userRepo, qiitaService)
 	learningGoalHandler := handler.NewLearningGoalHandler(learningGoalRepo)
+	activityReportHandler := handler.NewActivityReportHandler(activityReportRepo)
 
 	// Static file serving for uploads
 	r.Static("/uploads", "./uploads")
@@ -194,6 +196,16 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 			goals.DELETE("/:id", learningGoalHandler.Delete)
 			goals.GET("/user/:userId", learningGoalHandler.GetByUserID)
 			goals.GET("/stats/:userId", learningGoalHandler.GetStats)
+		}
+
+		// Activity Reports
+		reports := protected.Group("/reports")
+		{
+			reports.GET("/weekly", activityReportHandler.GetMyWeeklyReport)
+			reports.GET("/monthly", activityReportHandler.GetMyMonthlyReport)
+			reports.GET("/weekly/:userId", activityReportHandler.GetWeeklyReport)
+			reports.GET("/monthly/:userId", activityReportHandler.GetMonthlyReport)
+			reports.GET("/comparison", activityReportHandler.GetComparison)
 		}
 	}
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import PostDetailPage from './pages/PostDetailPage';
 import FollowListPage from './pages/FollowListPage';
 import GitHubCallbackPage from './pages/GitHubCallbackPage';
 import GoalsPage from './pages/GoalsPage';
+import ReportsPage from './pages/ReportsPage';
 
 export default function App() {
   const { isAuthenticated, loadUser } = useAuthStore();
@@ -60,6 +61,7 @@ export default function App() {
           <Route path="/chat/:userId" element={<ChatPage />} />
           <Route path="/posts/:id" element={<PostDetailPage />} />
           <Route path="/goals" element={<GoalsPage />} />
+          <Route path="/reports" element={<ReportsPage />} />
         </Route>
       </Route>
     </Routes>

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -1,0 +1,54 @@
+import client from './client';
+
+export interface DailyActivity {
+  date: string;
+  contributions: number;
+  posts: number;
+  comments: number;
+}
+
+export interface LanguageActivity {
+  language: string;
+  bytes: number;
+  repos: number;
+}
+
+export interface ActivityReport {
+  period: 'weekly' | 'monthly';
+  start_date: string;
+  end_date: string;
+  user_id: number;
+  total_contributions: number;
+  posts_created: number;
+  comments_created: number;
+  likes_received: number;
+  goals_completed: number;
+  goals_progress: number;
+  new_followers: number;
+  messages_exchanged: number;
+  daily_contributions: DailyActivity[];
+  top_languages: LanguageActivity[];
+}
+
+export interface ReportComparison {
+  contributions_diff: number;
+  posts_diff: number;
+  followers_diff: number;
+  goals_diff: number;
+  trend_percentage: number;
+}
+
+export const getMyWeeklyReport = () =>
+  client.get<ActivityReport>('/reports/weekly');
+
+export const getMyMonthlyReport = () =>
+  client.get<ActivityReport>('/reports/monthly');
+
+export const getWeeklyReport = (userId: number) =>
+  client.get<ActivityReport>(`/reports/weekly/${userId}`);
+
+export const getMonthlyReport = (userId: number) =>
+  client.get<ActivityReport>(`/reports/monthly/${userId}`);
+
+export const getComparison = (period: 'weekly' | 'monthly') =>
+  client.get<ReportComparison>(`/reports/comparison?period=${period}`);

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -50,6 +50,9 @@ export default function Header() {
           <Link to="/goals" className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${isActive('/goals')}`}>
             {t('nav.goals')}
           </Link>
+          <Link to="/reports" className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${isActive('/reports')}`}>
+            {t('nav.reports')}
+          </Link>
         </nav>
 
         {/* Right side */}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -22,6 +22,7 @@
     "rankings": "Ranglisten",
     "chat": "Chat",
     "goals": "Ziele",
+    "reports": "Berichte",
     "settings": "Einstellungen",
     "profile": "Profil",
     "signOut": "Abmelden"
@@ -293,5 +294,27 @@
       "completedCount": "Abgeschlossen",
       "avgProgress": "Durchschn. Fortschritt"
     }
+  },
+  "reports": {
+    "title": "Aktivitätsberichte",
+    "weekly": "Wöchentlich",
+    "monthly": "Monatlich",
+    "contributions": "Beiträge",
+    "posts": "Posts",
+    "comments": "Kommentare",
+    "newFollowers": "Neue Follower",
+    "goalsCompleted": "Abgeschlossene Ziele",
+    "likesReceived": "Erhaltene Likes",
+    "messages": "Nachrichten",
+    "trend": "Aktivitätstrend",
+    "trendUp": "im Vergleich zum vorherigen Zeitraum",
+    "trendDown": "im Vergleich zum vorherigen Zeitraum",
+    "trendStable": "gleich wie im vorherigen Zeitraum",
+    "dailyActivity": "Tägliche Aktivität",
+    "topLanguages": "Meistgenutzte Sprachen",
+    "repos": "Repos",
+    "goalsProgress": "Zielfortschritt",
+    "avgProgress": "Durchschnittlicher Fortschritt aktiver Ziele",
+    "goalsCompletedThisPeriod": "in diesem Zeitraum abgeschlossene Ziele"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -22,6 +22,7 @@
     "rankings": "Rankings",
     "chat": "Chat",
     "goals": "Goals",
+    "reports": "Reports",
     "settings": "Settings",
     "profile": "Profile",
     "signOut": "Sign out"
@@ -293,5 +294,27 @@
       "completedCount": "Completed",
       "avgProgress": "Avg. Progress"
     }
+  },
+  "reports": {
+    "title": "Activity Reports",
+    "weekly": "Weekly",
+    "monthly": "Monthly",
+    "contributions": "Contributions",
+    "posts": "Posts",
+    "comments": "Comments",
+    "newFollowers": "New Followers",
+    "goalsCompleted": "Goals Completed",
+    "likesReceived": "Likes Received",
+    "messages": "Messages",
+    "trend": "Activity Trend",
+    "trendUp": "compared to last period",
+    "trendDown": "compared to last period",
+    "trendStable": "same as last period",
+    "dailyActivity": "Daily Activity",
+    "topLanguages": "Top Languages",
+    "repos": "repos",
+    "goalsProgress": "Learning Goals Progress",
+    "avgProgress": "Average progress of active goals",
+    "goalsCompletedThisPeriod": "goals completed this period"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -22,6 +22,7 @@
     "rankings": "Rankings",
     "chat": "Chat",
     "goals": "Objetivos",
+    "reports": "Informes",
     "settings": "Configuración",
     "profile": "Perfil",
     "signOut": "Cerrar sesión"
@@ -293,5 +294,27 @@
       "completedCount": "Completados",
       "avgProgress": "Progreso Promedio"
     }
+  },
+  "reports": {
+    "title": "Informes de Actividad",
+    "weekly": "Semanal",
+    "monthly": "Mensual",
+    "contributions": "Contribuciones",
+    "posts": "Publicaciones",
+    "comments": "Comentarios",
+    "newFollowers": "Nuevos Seguidores",
+    "goalsCompleted": "Objetivos Completados",
+    "likesReceived": "Me gusta Recibidos",
+    "messages": "Mensajes",
+    "trend": "Tendencia de Actividad",
+    "trendUp": "comparado con el período anterior",
+    "trendDown": "comparado con el período anterior",
+    "trendStable": "igual que el período anterior",
+    "dailyActivity": "Actividad Diaria",
+    "topLanguages": "Lenguajes Más Usados",
+    "repos": "repos",
+    "goalsProgress": "Progreso de Objetivos",
+    "avgProgress": "Progreso promedio de objetivos activos",
+    "goalsCompletedThisPeriod": "objetivos completados este período"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -22,6 +22,7 @@
     "rankings": "Classements",
     "chat": "Chat",
     "goals": "Objectifs",
+    "reports": "Rapports",
     "settings": "Paramètres",
     "profile": "Profil",
     "signOut": "Déconnexion"
@@ -293,5 +294,27 @@
       "completedCount": "Terminés",
       "avgProgress": "Progression moyenne"
     }
+  },
+  "reports": {
+    "title": "Rapports d'Activité",
+    "weekly": "Hebdomadaire",
+    "monthly": "Mensuel",
+    "contributions": "Contributions",
+    "posts": "Publications",
+    "comments": "Commentaires",
+    "newFollowers": "Nouveaux Abonnés",
+    "goalsCompleted": "Objectifs Terminés",
+    "likesReceived": "J'aime Reçus",
+    "messages": "Messages",
+    "trend": "Tendance d'Activité",
+    "trendUp": "par rapport à la période précédente",
+    "trendDown": "par rapport à la période précédente",
+    "trendStable": "identique à la période précédente",
+    "dailyActivity": "Activité Quotidienne",
+    "topLanguages": "Langages Les Plus Utilisés",
+    "repos": "repos",
+    "goalsProgress": "Progression des Objectifs",
+    "avgProgress": "Progression moyenne des objectifs actifs",
+    "goalsCompletedThisPeriod": "objectifs terminés cette période"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -22,6 +22,7 @@
     "rankings": "ランキング",
     "chat": "チャット",
     "goals": "目標",
+    "reports": "レポート",
     "settings": "設定",
     "profile": "プロフィール",
     "signOut": "ログアウト"
@@ -293,5 +294,27 @@
       "completedCount": "完了",
       "avgProgress": "平均進捗"
     }
+  },
+  "reports": {
+    "title": "アクティビティレポート",
+    "weekly": "週間",
+    "monthly": "月間",
+    "contributions": "コントリビューション",
+    "posts": "投稿",
+    "comments": "コメント",
+    "newFollowers": "新規フォロワー",
+    "goalsCompleted": "達成した目標",
+    "likesReceived": "もらったいいね",
+    "messages": "メッセージ",
+    "trend": "アクティビティ推移",
+    "trendUp": "前期間と比較",
+    "trendDown": "前期間と比較",
+    "trendStable": "前期間と同じ",
+    "dailyActivity": "日別アクティビティ",
+    "topLanguages": "よく使う言語",
+    "repos": "リポジトリ",
+    "goalsProgress": "学習目標の進捗",
+    "avgProgress": "アクティブな目標の平均進捗",
+    "goalsCompletedThisPeriod": "今期達成した目標数"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -22,6 +22,7 @@
     "rankings": "랭킹",
     "chat": "채팅",
     "goals": "목표",
+    "reports": "리포트",
     "settings": "설정",
     "profile": "프로필",
     "signOut": "로그아웃"
@@ -293,5 +294,27 @@
       "completedCount": "완료",
       "avgProgress": "평균 진행률"
     }
+  },
+  "reports": {
+    "title": "활동 리포트",
+    "weekly": "주간",
+    "monthly": "월간",
+    "contributions": "기여",
+    "posts": "게시물",
+    "comments": "댓글",
+    "newFollowers": "새 팔로워",
+    "goalsCompleted": "완료한 목표",
+    "likesReceived": "받은 좋아요",
+    "messages": "메시지",
+    "trend": "활동 추이",
+    "trendUp": "지난 기간 대비",
+    "trendDown": "지난 기간 대비",
+    "trendStable": "지난 기간과 동일",
+    "dailyActivity": "일별 활동",
+    "topLanguages": "자주 사용하는 언어",
+    "repos": "저장소",
+    "goalsProgress": "학습 목표 진행률",
+    "avgProgress": "활성 목표의 평균 진행률",
+    "goalsCompletedThisPeriod": "이번 기간에 완료한 목표 수"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -22,6 +22,7 @@
     "rankings": "Rankings",
     "chat": "Chat",
     "goals": "Metas",
+    "reports": "Relatórios",
     "settings": "Configurações",
     "profile": "Perfil",
     "signOut": "Sair"
@@ -293,5 +294,27 @@
       "completedCount": "Concluídas",
       "avgProgress": "Progresso Médio"
     }
+  },
+  "reports": {
+    "title": "Relatórios de Atividade",
+    "weekly": "Semanal",
+    "monthly": "Mensal",
+    "contributions": "Contribuições",
+    "posts": "Publicações",
+    "comments": "Comentários",
+    "newFollowers": "Novos Seguidores",
+    "goalsCompleted": "Metas Concluídas",
+    "likesReceived": "Curtidas Recebidas",
+    "messages": "Mensagens",
+    "trend": "Tendência de Atividade",
+    "trendUp": "comparado ao período anterior",
+    "trendDown": "comparado ao período anterior",
+    "trendStable": "igual ao período anterior",
+    "dailyActivity": "Atividade Diária",
+    "topLanguages": "Linguagens Mais Usadas",
+    "repos": "repos",
+    "goalsProgress": "Progresso das Metas",
+    "avgProgress": "Progresso médio das metas ativas",
+    "goalsCompletedThisPeriod": "metas concluídas neste período"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -22,6 +22,7 @@
     "rankings": "Рейтинги",
     "chat": "Чат",
     "goals": "Цели",
+    "reports": "Отчёты",
     "settings": "Настройки",
     "profile": "Профиль",
     "signOut": "Выйти"
@@ -293,5 +294,27 @@
       "completedCount": "Завершённых",
       "avgProgress": "Средний прогресс"
     }
+  },
+  "reports": {
+    "title": "Отчёты об Активности",
+    "weekly": "Еженедельный",
+    "monthly": "Ежемесячный",
+    "contributions": "Вклады",
+    "posts": "Посты",
+    "comments": "Комментарии",
+    "newFollowers": "Новые подписчики",
+    "goalsCompleted": "Завершённые цели",
+    "likesReceived": "Полученные лайки",
+    "messages": "Сообщения",
+    "trend": "Тренд активности",
+    "trendUp": "по сравнению с прошлым периодом",
+    "trendDown": "по сравнению с прошлым периодом",
+    "trendStable": "так же как в прошлом периоде",
+    "dailyActivity": "Ежедневная активность",
+    "topLanguages": "Самые используемые языки",
+    "repos": "репозиториев",
+    "goalsProgress": "Прогресс целей",
+    "avgProgress": "Средний прогресс активных целей",
+    "goalsCompletedThisPeriod": "целей завершено за этот период"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -22,6 +22,7 @@
     "rankings": "排行榜",
     "chat": "聊天",
     "goals": "目标",
+    "reports": "报告",
     "settings": "设置",
     "profile": "个人资料",
     "signOut": "退出登录"
@@ -293,5 +294,27 @@
       "completedCount": "已完成",
       "avgProgress": "平均进度"
     }
+  },
+  "reports": {
+    "title": "活动报告",
+    "weekly": "周报",
+    "monthly": "月报",
+    "contributions": "贡献",
+    "posts": "帖子",
+    "comments": "评论",
+    "newFollowers": "新粉丝",
+    "goalsCompleted": "完成的目标",
+    "likesReceived": "收到的点赞",
+    "messages": "消息",
+    "trend": "活动趋势",
+    "trendUp": "与上期相比",
+    "trendDown": "与上期相比",
+    "trendStable": "与上期持平",
+    "dailyActivity": "日活动",
+    "topLanguages": "常用语言",
+    "repos": "仓库",
+    "goalsProgress": "学习目标进度",
+    "avgProgress": "活跃目标的平均进度",
+    "goalsCompletedThisPeriod": "本期完成的目标数"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -22,6 +22,7 @@
     "rankings": "排行榜",
     "chat": "聊天",
     "goals": "目標",
+    "reports": "報告",
     "settings": "設定",
     "profile": "個人資料",
     "signOut": "登出"
@@ -293,5 +294,27 @@
       "completedCount": "已完成",
       "avgProgress": "平均進度"
     }
+  },
+  "reports": {
+    "title": "活動報告",
+    "weekly": "週報",
+    "monthly": "月報",
+    "contributions": "貢獻",
+    "posts": "貼文",
+    "comments": "留言",
+    "newFollowers": "新追蹤者",
+    "goalsCompleted": "完成的目標",
+    "likesReceived": "收到的按讚",
+    "messages": "訊息",
+    "trend": "活動趨勢",
+    "trendUp": "與上期相比",
+    "trendDown": "與上期相比",
+    "trendStable": "與上期持平",
+    "dailyActivity": "每日活動",
+    "topLanguages": "常用語言",
+    "repos": "儲存庫",
+    "goalsProgress": "學習目標進度",
+    "avgProgress": "進行中目標的平均進度",
+    "goalsCompletedThisPeriod": "本期完成的目標數"
   }
 }

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -1,0 +1,332 @@
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  getMyWeeklyReport,
+  getMyMonthlyReport,
+  getComparison,
+  type ActivityReport,
+  type ReportComparison,
+} from '../api/reports';
+import toast from 'react-hot-toast';
+import LoadingSpinner from '../components/common/LoadingSpinner';
+
+type Period = 'weekly' | 'monthly';
+
+export default function ReportsPage() {
+  const { t } = useTranslation();
+  const [period, setPeriod] = useState<Period>('weekly');
+  const [report, setReport] = useState<ActivityReport | null>(null);
+  const [comparison, setComparison] = useState<ReportComparison | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchReport();
+  }, [period]);
+
+  const fetchReport = async () => {
+    setLoading(true);
+    try {
+      const [reportRes, comparisonRes] = await Promise.all([
+        period === 'weekly' ? getMyWeeklyReport() : getMyMonthlyReport(),
+        getComparison(period),
+      ]);
+      setReport(reportRes.data);
+      setComparison(comparisonRes.data);
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  };
+
+  const formatBytes = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  };
+
+  const getTrendColor = (diff: number) => {
+    if (diff > 0) return 'text-green-400';
+    if (diff < 0) return 'text-red-400';
+    return 'text-gray-400';
+  };
+
+  // Calculate max contribution for chart scaling
+  const maxContribution = report?.daily_contributions
+    ? Math.max(...report.daily_contributions.map((d) => d.contributions), 1)
+    : 1;
+
+  if (loading) {
+    return (
+      <div className="py-12">
+        <LoadingSpinner />
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">{t('reports.title')}</h1>
+        <div className="flex bg-gray-800 rounded-lg p-1">
+          <button
+            onClick={() => setPeriod('weekly')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              period === 'weekly'
+                ? 'bg-gray-700 text-white'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            {t('reports.weekly')}
+          </button>
+          <button
+            onClick={() => setPeriod('monthly')}
+            className={`px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+              period === 'monthly'
+                ? 'bg-gray-700 text-white'
+                : 'text-gray-400 hover:text-white'
+            }`}
+          >
+            {t('reports.monthly')}
+          </button>
+        </div>
+      </div>
+
+      {/* Period Info */}
+      {report && (
+        <p className="text-gray-400 text-sm">
+          {formatDate(report.start_date)} - {formatDate(report.end_date)}
+        </p>
+      )}
+
+      {/* Stats Grid */}
+      {report && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          <StatCard
+            label={t('reports.contributions')}
+            value={report.total_contributions}
+            diff={comparison?.contributions_diff || 0}
+            icon="📊"
+          />
+          <StatCard
+            label={t('reports.posts')}
+            value={report.posts_created}
+            diff={comparison?.posts_diff || 0}
+            icon="📝"
+          />
+          <StatCard
+            label={t('reports.newFollowers')}
+            value={report.new_followers}
+            diff={comparison?.followers_diff || 0}
+            icon="👥"
+          />
+          <StatCard
+            label={t('reports.goalsCompleted')}
+            value={report.goals_completed}
+            diff={comparison?.goals_diff || 0}
+            icon="🎯"
+          />
+        </div>
+      )}
+
+      {/* Activity Overview */}
+      {report && (
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <span>💬</span>
+              <span className="text-sm text-gray-400">{t('reports.comments')}</span>
+            </div>
+            <p className="text-2xl font-bold">{report.comments_created}</p>
+          </div>
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <span>❤️</span>
+              <span className="text-sm text-gray-400">{t('reports.likesReceived')}</span>
+            </div>
+            <p className="text-2xl font-bold">{report.likes_received}</p>
+          </div>
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <span>💬</span>
+              <span className="text-sm text-gray-400">{t('reports.messages')}</span>
+            </div>
+            <p className="text-2xl font-bold">{report.messages_exchanged}</p>
+          </div>
+        </div>
+      )}
+
+      {/* Trend Indicator */}
+      {comparison && (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+          <h2 className="text-lg font-semibold mb-4">{t('reports.trend')}</h2>
+          <div className="flex items-center gap-4">
+            <div
+              className={`text-4xl font-bold ${getTrendColor(
+                comparison.trend_percentage
+              )}`}
+            >
+              {comparison.trend_percentage > 0 ? '+' : ''}
+              {comparison.trend_percentage.toFixed(1)}%
+            </div>
+            <div className="text-gray-400 text-sm">
+              {comparison.trend_percentage > 0
+                ? t('reports.trendUp')
+                : comparison.trend_percentage < 0
+                ? t('reports.trendDown')
+                : t('reports.trendStable')}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Daily Activity Chart */}
+      {report && report.daily_contributions && report.daily_contributions.length > 0 && (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+          <h2 className="text-lg font-semibold mb-4">{t('reports.dailyActivity')}</h2>
+          <div className="flex items-end gap-1 h-40">
+            {report.daily_contributions.map((day, index) => {
+              const height = (day.contributions / maxContribution) * 100;
+              return (
+                <div
+                  key={index}
+                  className="flex-1 flex flex-col items-center gap-1 group"
+                >
+                  <div className="relative w-full">
+                    <div
+                      className="w-full bg-purple-500/80 rounded-t hover:bg-purple-400 transition-colors cursor-pointer"
+                      style={{ height: `${Math.max(height, 4)}%`, minHeight: '4px' }}
+                    />
+                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 hidden group-hover:block bg-gray-800 text-white text-xs px-2 py-1 rounded whitespace-nowrap">
+                      {day.contributions} {t('reports.contributions')}
+                      <br />
+                      {day.posts} {t('reports.posts')}
+                    </div>
+                  </div>
+                  <span className="text-[10px] text-gray-500 rotate-45 origin-left">
+                    {new Date(day.date).toLocaleDateString(undefined, {
+                      weekday: 'short',
+                    })}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Top Languages */}
+      {report && report.top_languages && report.top_languages.length > 0 && (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+          <h2 className="text-lg font-semibold mb-4">{t('reports.topLanguages')}</h2>
+          <div className="space-y-3">
+            {report.top_languages.map((lang, index) => {
+              const maxBytes = report.top_languages[0].bytes;
+              const width = (lang.bytes / maxBytes) * 100;
+              return (
+                <div key={index}>
+                  <div className="flex justify-between text-sm mb-1">
+                    <span className="font-medium">{lang.language}</span>
+                    <span className="text-gray-400">
+                      {formatBytes(lang.bytes)} · {lang.repos} {t('reports.repos')}
+                    </span>
+                  </div>
+                  <div className="h-2 bg-gray-800 rounded-full overflow-hidden">
+                    <div
+                      className="h-full bg-gradient-to-r from-purple-500 to-blue-500 rounded-full transition-all"
+                      style={{ width: `${width}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Goals Progress */}
+      {report && (
+        <div className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+          <h2 className="text-lg font-semibold mb-4">{t('reports.goalsProgress')}</h2>
+          <div className="flex items-center gap-4">
+            <div className="relative w-24 h-24">
+              <svg className="w-24 h-24 transform -rotate-90">
+                <circle
+                  cx="48"
+                  cy="48"
+                  r="40"
+                  stroke="currentColor"
+                  strokeWidth="8"
+                  fill="none"
+                  className="text-gray-800"
+                />
+                <circle
+                  cx="48"
+                  cy="48"
+                  r="40"
+                  stroke="currentColor"
+                  strokeWidth="8"
+                  fill="none"
+                  strokeDasharray={`${report.goals_progress * 2.51} 251`}
+                  className="text-purple-500"
+                />
+              </svg>
+              <div className="absolute inset-0 flex items-center justify-center">
+                <span className="text-lg font-bold">{report.goals_progress}%</span>
+              </div>
+            </div>
+            <div>
+              <p className="text-gray-400 text-sm">{t('reports.avgProgress')}</p>
+              <p className="text-sm mt-1">
+                <span className="font-medium">{report.goals_completed}</span>{' '}
+                <span className="text-gray-400">{t('reports.goalsCompletedThisPeriod')}</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface StatCardProps {
+  label: string;
+  value: number;
+  diff: number;
+  icon: string;
+}
+
+function StatCard({ label, value, diff, icon }: StatCardProps) {
+  const getTrendIcon = (d: number) => {
+    if (d > 0) return '↑';
+    if (d < 0) return '↓';
+    return '—';
+  };
+
+  const getTrendColor = (d: number) => {
+    if (d > 0) return 'text-green-400';
+    if (d < 0) return 'text-red-400';
+    return 'text-gray-400';
+  };
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-xl p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <span>{icon}</span>
+        <span className="text-sm text-gray-400">{label}</span>
+      </div>
+      <div className="flex items-end gap-2">
+        <p className="text-2xl font-bold">{value}</p>
+        <span className={`text-sm ${getTrendColor(diff)}`}>
+          {getTrendIcon(diff)} {Math.abs(diff)}
+        </span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add ActivityReport model with DailyActivity, LanguageActivity, ReportComparison structs
- Add repository methods for generating weekly/monthly reports and period comparisons
- Add handlers for `/reports/weekly`, `/reports/monthly`, `/reports/comparison` endpoints
- Create ReportsPage component with:
  - Weekly/Monthly period toggle
  - Stats grid (contributions, posts, followers, goals)
  - Trend indicator with percentage comparison
  - Daily activity bar chart
  - Top programming languages visualization
  - Circular goals progress chart
- Add navigation link in header
- Add i18n translations for all 10 languages

## Test plan
- [x] Navigate to Reports page via header navigation
- [x] Toggle between Weekly and Monthly views
- [x] Verify stats display correctly
- [x] Check daily activity chart renders with tooltips
- [ ] Verify top languages section shows language stats
- [x] Test goals progress circular chart displays correctly
- [ ] Test all 10 language translations

Closes #36