### PR TITLE
feat: Add portfolio generation from profile data

### DIFF
--- a/frontend/src/components/profile/PortfolioModal.tsx
+++ b/frontend/src/components/profile/PortfolioModal.tsx
@@ -1,0 +1,221 @@
+import { useState, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import {
+  generatePortfolioHTML,
+  downloadPortfolio,
+  type PortfolioTheme,
+  type PortfolioData,
+} from '../../utils/portfolioGenerator';
+
+interface PortfolioModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  data: PortfolioData;
+}
+
+const themes: { id: PortfolioTheme; name: string; description: string }[] = [
+  { id: 'minimal', name: 'Minimal', description: 'Clean and simple white design' },
+  { id: 'modern', name: 'Modern', description: 'Dark theme with cards' },
+  { id: 'gradient', name: 'Gradient', description: 'Colorful glassmorphism' },
+];
+
+export default function PortfolioModal({
+  isOpen,
+  onClose,
+  data,
+}: PortfolioModalProps) {
+  const { t } = useTranslation();
+  const [selectedTheme, setSelectedTheme] = useState<PortfolioTheme>('modern');
+  const [previewMode, setPreviewMode] = useState(false);
+
+  const generatedHTML = useMemo(() => {
+    return generatePortfolioHTML(data, selectedTheme);
+  }, [data, selectedTheme]);
+
+  if (!isOpen) return null;
+
+  const handleDownload = () => {
+    const filename = `portfolio-${data.user.github_username || data.user.name || 'developer'}.html`;
+    downloadPortfolio(generatedHTML, filename);
+    toast.success(t('portfolio.downloaded'));
+  };
+
+  const handleCopyHTML = async () => {
+    try {
+      await navigator.clipboard.writeText(generatedHTML);
+      toast.success(t('portfolio.htmlCopied'));
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  };
+
+  const handleOpenPreview = () => {
+    const blob = new Blob([generatedHTML], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    window.open(url, '_blank');
+    setTimeout(() => URL.revokeObjectURL(url), 10000);
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onClose}
+      />
+
+      {/* Modal */}
+      <div className="relative bg-gray-900 border border-gray-800 rounded-xl shadow-2xl max-w-4xl w-full mx-4 max-h-[90vh] overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-800">
+          <h2 className="text-lg font-semibold">{t('portfolio.title')}</h2>
+          <button
+            onClick={onClose}
+            className="p-2 text-gray-400 hover:text-white hover:bg-gray-800 rounded-lg transition-colors"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-6">
+          {/* Theme Selection */}
+          <div>
+            <h3 className="text-sm font-semibold text-gray-300 mb-3">
+              {t('portfolio.selectTheme')}
+            </h3>
+            <div className="grid grid-cols-3 gap-3">
+              {themes.map((theme) => (
+                <button
+                  key={theme.id}
+                  onClick={() => setSelectedTheme(theme.id)}
+                  className={`p-4 rounded-xl border transition-all text-left ${
+                    selectedTheme === theme.id
+                      ? 'border-purple-500 bg-purple-500/10'
+                      : 'border-gray-700 hover:border-gray-600 bg-gray-800/50'
+                  }`}
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    {theme.id === 'minimal' && (
+                      <div className="w-8 h-8 rounded-lg bg-white flex items-center justify-center">
+                        <div className="w-4 h-4 rounded bg-gray-300"></div>
+                      </div>
+                    )}
+                    {theme.id === 'modern' && (
+                      <div className="w-8 h-8 rounded-lg bg-gray-800 border border-gray-700 flex items-center justify-center">
+                        <div className="w-4 h-4 rounded bg-blue-500"></div>
+                      </div>
+                    )}
+                    {theme.id === 'gradient' && (
+                      <div className="w-8 h-8 rounded-lg bg-gradient-to-br from-indigo-900 to-blue-900 flex items-center justify-center">
+                        <div className="w-4 h-4 rounded bg-purple-400/50 backdrop-blur"></div>
+                      </div>
+                    )}
+                    <span className="font-medium text-sm">{theme.name}</span>
+                  </div>
+                  <p className="text-xs text-gray-500">{theme.description}</p>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Preview */}
+          <div>
+            <div className="flex items-center justify-between mb-3">
+              <h3 className="text-sm font-semibold text-gray-300">
+                {t('portfolio.preview')}
+              </h3>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPreviewMode(!previewMode)}
+                  className="text-xs px-3 py-1.5 bg-gray-800 hover:bg-gray-700 rounded-lg transition-colors"
+                >
+                  {previewMode ? t('portfolio.hideCode') : t('portfolio.showCode')}
+                </button>
+                <button
+                  onClick={handleOpenPreview}
+                  className="text-xs px-3 py-1.5 bg-gray-800 hover:bg-gray-700 rounded-lg transition-colors flex items-center gap-1.5"
+                >
+                  <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+                  </svg>
+                  {t('portfolio.openInNewTab')}
+                </button>
+              </div>
+            </div>
+
+            {previewMode ? (
+              <div className="bg-gray-950 rounded-xl p-4 overflow-auto max-h-80">
+                <pre className="text-xs text-gray-400 font-mono whitespace-pre-wrap break-all">
+                  {generatedHTML.slice(0, 3000)}
+                  {generatedHTML.length > 3000 && '...'}
+                </pre>
+              </div>
+            ) : (
+              <div className="bg-gray-950 rounded-xl overflow-hidden border border-gray-800">
+                <iframe
+                  srcDoc={generatedHTML}
+                  title="Portfolio Preview"
+                  className="w-full h-80 bg-white"
+                  sandbox="allow-same-origin"
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Info */}
+          <div className="bg-gray-800/50 rounded-xl p-4">
+            <h4 className="text-sm font-medium text-gray-300 mb-2 flex items-center gap-2">
+              <svg className="w-4 h-4 text-blue-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
+              </svg>
+              {t('portfolio.included')}
+            </h4>
+            <ul className="text-xs text-gray-500 space-y-1">
+              <li>• {t('portfolio.includesProfile')}</li>
+              <li>• {t('portfolio.includesStats')}</li>
+              <li>• {t('portfolio.includesSkills')}</li>
+              <li>• {t('portfolio.includesRepos')}</li>
+              <li>• {t('portfolio.includesGoals')}</li>
+            </ul>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-gray-800 flex gap-3">
+          <button
+            onClick={handleCopyHTML}
+            className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-gray-800 hover:bg-gray-700 rounded-lg transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.666 3.888A2.25 2.25 0 0 0 13.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 0 1-.75.75H9a.75.75 0 0 1-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 0 1-2.25 2.25H6.75A2.25 2.25 0 0 1 4.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 0 1 1.927-.184" />
+            </svg>
+            {t('portfolio.copyHTML')}
+          </button>
+          <button
+            onClick={handleDownload}
+            className="flex-1 flex items-center justify-center gap-2 px-4 py-2.5 bg-purple-600 hover:bg-purple-500 text-white rounded-lg transition-colors"
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+            </svg>
+            {t('portfolio.download')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -326,5 +326,24 @@
     "downloaded": "Bild heruntergeladen!",
     "downloadFailed": "Bild konnte nicht heruntergeladen werden",
     "twitterText": "Schau dir das Entwicklerprofil von {{name}} auf DevSync an!"
+  },
+  "portfolio": {
+    "title": "Portfolio Generieren",
+    "generate": "Portfolio Generieren",
+    "selectTheme": "Thema Auswählen",
+    "preview": "Vorschau",
+    "showCode": "HTML Anzeigen",
+    "hideCode": "HTML Ausblenden",
+    "openInNewTab": "In Neuem Tab Öffnen",
+    "download": "HTML Herunterladen",
+    "copyHTML": "HTML Kopieren",
+    "downloaded": "Portfolio heruntergeladen!",
+    "htmlCopied": "HTML kopiert!",
+    "included": "Enthaltene Inhalte",
+    "includesProfile": "Profilinformationen und Bio",
+    "includesStats": "GitHub Statistiken und Beiträge",
+    "includesSkills": "Fähigkeiten und Technologien",
+    "includesRepos": "Ausgewählte Repositories",
+    "includesGoals": "Lernziele"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -326,5 +326,24 @@
     "downloaded": "Image downloaded!",
     "downloadFailed": "Failed to download image",
     "twitterText": "Check out {{name}}'s developer profile on DevSync!"
+  },
+  "portfolio": {
+    "title": "Generate Portfolio",
+    "generate": "Generate Portfolio",
+    "selectTheme": "Select Theme",
+    "preview": "Preview",
+    "showCode": "Show HTML",
+    "hideCode": "Hide HTML",
+    "openInNewTab": "Open in New Tab",
+    "download": "Download HTML",
+    "copyHTML": "Copy HTML",
+    "downloaded": "Portfolio downloaded!",
+    "htmlCopied": "HTML copied to clipboard!",
+    "included": "What's Included",
+    "includesProfile": "Profile information and bio",
+    "includesStats": "GitHub statistics and contributions",
+    "includesSkills": "Skills and technologies",
+    "includesRepos": "Featured repositories",
+    "includesGoals": "Learning goals"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -326,5 +326,24 @@
     "downloaded": "¡Imagen descargada!",
     "downloadFailed": "Error al descargar la imagen",
     "twitterText": "¡Mira el perfil de desarrollador de {{name}} en DevSync!"
+  },
+  "portfolio": {
+    "title": "Generar Portafolio",
+    "generate": "Generar Portafolio",
+    "selectTheme": "Seleccionar Tema",
+    "preview": "Vista Previa",
+    "showCode": "Mostrar HTML",
+    "hideCode": "Ocultar HTML",
+    "openInNewTab": "Abrir en Nueva Pestaña",
+    "download": "Descargar HTML",
+    "copyHTML": "Copiar HTML",
+    "downloaded": "¡Portafolio descargado!",
+    "htmlCopied": "¡HTML copiado!",
+    "included": "Contenido Incluido",
+    "includesProfile": "Información de perfil y biografía",
+    "includesStats": "Estadísticas y contribuciones de GitHub",
+    "includesSkills": "Habilidades y tecnologías",
+    "includesRepos": "Repositorios destacados",
+    "includesGoals": "Objetivos de aprendizaje"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -326,5 +326,24 @@
     "downloaded": "Image téléchargée !",
     "downloadFailed": "Échec du téléchargement de l'image",
     "twitterText": "Découvrez le profil développeur de {{name}} sur DevSync !"
+  },
+  "portfolio": {
+    "title": "Générer Portfolio",
+    "generate": "Générer Portfolio",
+    "selectTheme": "Choisir un Thème",
+    "preview": "Aperçu",
+    "showCode": "Afficher HTML",
+    "hideCode": "Masquer HTML",
+    "openInNewTab": "Ouvrir dans un Nouvel Onglet",
+    "download": "Télécharger HTML",
+    "copyHTML": "Copier HTML",
+    "downloaded": "Portfolio téléchargé !",
+    "htmlCopied": "HTML copié !",
+    "included": "Contenu Inclus",
+    "includesProfile": "Informations de profil et bio",
+    "includesStats": "Statistiques et contributions GitHub",
+    "includesSkills": "Compétences et technologies",
+    "includesRepos": "Dépôts en vedette",
+    "includesGoals": "Objectifs d'apprentissage"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -326,5 +326,24 @@
     "downloaded": "画像をダウンロードしました！",
     "downloadFailed": "画像のダウンロードに失敗しました",
     "twitterText": "{{name}}さんの開発者プロフィールをDevSyncでチェック！"
+  },
+  "portfolio": {
+    "title": "ポートフォリオ生成",
+    "generate": "ポートフォリオを生成",
+    "selectTheme": "テーマを選択",
+    "preview": "プレビュー",
+    "showCode": "HTMLを表示",
+    "hideCode": "HTMLを隠す",
+    "openInNewTab": "新しいタブで開く",
+    "download": "HTMLをダウンロード",
+    "copyHTML": "HTMLをコピー",
+    "downloaded": "ポートフォリオをダウンロードしました！",
+    "htmlCopied": "HTMLをコピーしました！",
+    "included": "含まれる内容",
+    "includesProfile": "プロフィール情報と自己紹介",
+    "includesStats": "GitHub統計とコントリビューション",
+    "includesSkills": "スキルと技術",
+    "includesRepos": "主要リポジトリ",
+    "includesGoals": "学習目標"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -326,5 +326,24 @@
     "downloaded": "이미지가 다운로드되었습니다!",
     "downloadFailed": "이미지 다운로드에 실패했습니다",
     "twitterText": "DevSync에서 {{name}}님의 개발자 프로필을 확인하세요!"
+  },
+  "portfolio": {
+    "title": "포트폴리오 생성",
+    "generate": "포트폴리오 생성",
+    "selectTheme": "테마 선택",
+    "preview": "미리보기",
+    "showCode": "HTML 보기",
+    "hideCode": "HTML 숨기기",
+    "openInNewTab": "새 탭에서 열기",
+    "download": "HTML 다운로드",
+    "copyHTML": "HTML 복사",
+    "downloaded": "포트폴리오가 다운로드되었습니다!",
+    "htmlCopied": "HTML이 복사되었습니다!",
+    "included": "포함된 내용",
+    "includesProfile": "프로필 정보 및 자기소개",
+    "includesStats": "GitHub 통계 및 기여",
+    "includesSkills": "스킬 및 기술",
+    "includesRepos": "주요 저장소",
+    "includesGoals": "학습 목표"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -326,5 +326,24 @@
     "downloaded": "Imagem baixada!",
     "downloadFailed": "Falha ao baixar imagem",
     "twitterText": "Confira o perfil de desenvolvedor de {{name}} no DevSync!"
+  },
+  "portfolio": {
+    "title": "Gerar Portfólio",
+    "generate": "Gerar Portfólio",
+    "selectTheme": "Selecionar Tema",
+    "preview": "Pré-visualização",
+    "showCode": "Mostrar HTML",
+    "hideCode": "Ocultar HTML",
+    "openInNewTab": "Abrir em Nova Aba",
+    "download": "Baixar HTML",
+    "copyHTML": "Copiar HTML",
+    "downloaded": "Portfólio baixado!",
+    "htmlCopied": "HTML copiado!",
+    "included": "Conteúdo Incluído",
+    "includesProfile": "Informações de perfil e bio",
+    "includesStats": "Estatísticas e contribuições do GitHub",
+    "includesSkills": "Habilidades e tecnologias",
+    "includesRepos": "Repositórios em destaque",
+    "includesGoals": "Metas de aprendizado"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -326,5 +326,24 @@
     "downloaded": "Изображение скачано!",
     "downloadFailed": "Не удалось скачать изображение",
     "twitterText": "Посмотрите профиль разработчика {{name}} на DevSync!"
+  },
+  "portfolio": {
+    "title": "Создать Портфолио",
+    "generate": "Создать Портфолио",
+    "selectTheme": "Выбрать Тему",
+    "preview": "Предпросмотр",
+    "showCode": "Показать HTML",
+    "hideCode": "Скрыть HTML",
+    "openInNewTab": "Открыть в Новой Вкладке",
+    "download": "Скачать HTML",
+    "copyHTML": "Копировать HTML",
+    "downloaded": "Портфолио скачано!",
+    "htmlCopied": "HTML скопирован!",
+    "included": "Включённое Содержимое",
+    "includesProfile": "Информация профиля и био",
+    "includesStats": "Статистика и вклады GitHub",
+    "includesSkills": "Навыки и технологии",
+    "includesRepos": "Избранные репозитории",
+    "includesGoals": "Цели обучения"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -326,5 +326,24 @@
     "downloaded": "图片已下载！",
     "downloadFailed": "下载图片失败",
     "twitterText": "在DevSync上查看{{name}}的开发者资料！"
+  },
+  "portfolio": {
+    "title": "生成作品集",
+    "generate": "生成作品集",
+    "selectTheme": "选择主题",
+    "preview": "预览",
+    "showCode": "显示HTML",
+    "hideCode": "隐藏HTML",
+    "openInNewTab": "在新标签页打开",
+    "download": "下载HTML",
+    "copyHTML": "复制HTML",
+    "downloaded": "作品集已下载！",
+    "htmlCopied": "HTML已复制！",
+    "included": "包含内容",
+    "includesProfile": "个人资料和简介",
+    "includesStats": "GitHub统计和贡献",
+    "includesSkills": "技能和技术",
+    "includesRepos": "精选仓库",
+    "includesGoals": "学习目标"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -326,5 +326,24 @@
     "downloaded": "圖片已下載！",
     "downloadFailed": "下載圖片失敗",
     "twitterText": "在DevSync上查看{{name}}的開發者資料！"
+  },
+  "portfolio": {
+    "title": "生成作品集",
+    "generate": "生成作品集",
+    "selectTheme": "選擇主題",
+    "preview": "預覽",
+    "showCode": "顯示HTML",
+    "hideCode": "隱藏HTML",
+    "openInNewTab": "在新分頁開啟",
+    "download": "下載HTML",
+    "copyHTML": "複製HTML",
+    "downloaded": "作品集已下載！",
+    "htmlCopied": "HTML已複製！",
+    "included": "包含內容",
+    "includesProfile": "個人資料和簡介",
+    "includesStats": "GitHub統計和貢獻",
+    "includesSkills": "技能和技術",
+    "includesRepos": "精選儲存庫",
+    "includesGoals": "學習目標"
   }
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -19,6 +19,7 @@ import LanguageChart from '../components/profile/LanguageChart';
 import BadgeDisplay from '../components/profile/BadgeDisplay';
 import PostCard from '../components/posts/PostCard';
 import ShareModal from '../components/profile/ShareModal';
+import PortfolioModal from '../components/profile/PortfolioModal';
 
 export default function ProfilePage() {
   const { t } = useTranslation();
@@ -39,6 +40,7 @@ export default function ProfilePage() {
   const [followingCount, setFollowingCount] = useState(0);
   const [loading, setLoading] = useState(true);
   const [shareModalOpen, setShareModalOpen] = useState(false);
+  const [portfolioModalOpen, setPortfolioModalOpen] = useState(false);
 
   useEffect(() => {
     if (!id) return;
@@ -130,6 +132,17 @@ export default function ProfilePage() {
                 </svg>
                 {t('sharing.share')}
               </button>
+              {isOwnProfile && (
+                <button
+                  onClick={() => setPortfolioModalOpen(true)}
+                  className="flex items-center gap-1.5 px-3 py-1.5 bg-purple-600 hover:bg-purple-500 text-white text-sm rounded-lg transition-colors"
+                >
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+                  </svg>
+                  {t('portfolio.generate')}
+                </button>
+              )}
             </div>
             {user.bio && <p className="text-gray-400 mt-1 text-sm">{user.bio}</p>}
             <div className="flex flex-wrap gap-3 mt-2">
@@ -567,6 +580,21 @@ export default function ProfilePage() {
         totalContributions={contributions.reduce((sum, c) => sum + c.count, 0)}
         languages={languages}
         postCount={posts.length}
+      />
+
+      {/* Portfolio Modal */}
+      <PortfolioModal
+        isOpen={portfolioModalOpen}
+        onClose={() => setPortfolioModalOpen(false)}
+        data={{
+          user,
+          languages,
+          repos,
+          goals,
+          totalContributions: contributions.reduce((sum, c) => sum + c.count, 0),
+          followerCount,
+          followingCount,
+        }}
       />
     </div>
   );

--- a/frontend/src/utils/portfolioGenerator.ts
+++ b/frontend/src/utils/portfolioGenerator.ts
@@ -1,0 +1,652 @@
+import type { User } from '../types/user';
+import type { GitHubLanguageStat, GitHubRepository } from '../types/github';
+import type { LearningGoal } from '../api/goals';
+
+export type PortfolioTheme = 'minimal' | 'modern' | 'gradient';
+
+export interface PortfolioData {
+  user: User;
+  languages: GitHubLanguageStat[];
+  repos: GitHubRepository[];
+  goals: LearningGoal[];
+  totalContributions: number;
+  followerCount: number;
+  followingCount: number;
+}
+
+const getLanguageColor = (lang: string): string => {
+  const colors: Record<string, string> = {
+    JavaScript: '#f7df1e',
+    TypeScript: '#3178c6',
+    Python: '#3572A5',
+    Go: '#00ADD8',
+    Rust: '#dea584',
+    Java: '#b07219',
+    'C++': '#f34b7d',
+    C: '#555555',
+    Ruby: '#701516',
+    PHP: '#4F5D95',
+    Swift: '#F05138',
+    Kotlin: '#A97BFF',
+    Vue: '#41b883',
+    HTML: '#e34c26',
+    CSS: '#563d7c',
+    Shell: '#89e051',
+  };
+  return colors[lang] || '#6b7280';
+};
+
+const generateMinimalTemplate = (data: PortfolioData): string => {
+  const { user, languages, repos, goals, totalContributions } = data;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${user.name} - Developer Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #ffffff;
+      color: #1a1a2e;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+    .container { max-width: 800px; margin: 0 auto; padding: 60px 24px; }
+    .header { text-align: center; margin-bottom: 60px; }
+    .avatar {
+      width: 120px; height: 120px; border-radius: 50%;
+      object-fit: cover; margin-bottom: 20px;
+      border: 3px solid #e5e7eb;
+    }
+    .name { font-size: 2.5rem; font-weight: 700; margin-bottom: 8px; }
+    .bio { color: #6b7280; font-size: 1.1rem; max-width: 500px; margin: 0 auto; }
+    .links { display: flex; gap: 16px; justify-content: center; margin-top: 20px; }
+    .links a {
+      color: #6b7280; text-decoration: none; font-size: 0.9rem;
+      transition: color 0.2s;
+    }
+    .links a:hover { color: #3b82f6; }
+    .section { margin-bottom: 50px; }
+    .section-title {
+      font-size: 0.75rem; font-weight: 600; text-transform: uppercase;
+      letter-spacing: 0.1em; color: #9ca3af; margin-bottom: 20px;
+    }
+    .stats-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; text-align: center; }
+    .stat-value { font-size: 2rem; font-weight: 700; color: #1a1a2e; }
+    .stat-label { font-size: 0.85rem; color: #6b7280; }
+    .skills-row { display: flex; flex-wrap: wrap; gap: 8px; }
+    .skill-tag {
+      padding: 6px 14px; background: #f3f4f6; border-radius: 20px;
+      font-size: 0.85rem; color: #374151;
+    }
+    .language-bar { height: 8px; border-radius: 4px; background: #f3f4f6; overflow: hidden; display: flex; }
+    .language-segment { height: 100%; }
+    .language-legend { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 12px; }
+    .language-item { display: flex; align-items: center; gap: 6px; font-size: 0.85rem; color: #6b7280; }
+    .language-dot { width: 10px; height: 10px; border-radius: 50%; }
+    .repo-grid { display: grid; gap: 16px; }
+    .repo-card {
+      padding: 20px; border: 1px solid #e5e7eb; border-radius: 12px;
+      transition: border-color 0.2s;
+    }
+    .repo-card:hover { border-color: #3b82f6; }
+    .repo-name { font-weight: 600; color: #1a1a2e; margin-bottom: 6px; }
+    .repo-desc { font-size: 0.9rem; color: #6b7280; margin-bottom: 10px; }
+    .repo-meta { display: flex; gap: 16px; font-size: 0.8rem; color: #9ca3af; }
+    .footer { text-align: center; padding-top: 40px; border-top: 1px solid #e5e7eb; color: #9ca3af; font-size: 0.85rem; }
+    .footer a { color: #3b82f6; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <header class="header">
+      ${user.avatar_url ? `<img src="${user.avatar_url}" alt="${user.name}" class="avatar">` : ''}
+      <h1 class="name">${user.name}</h1>
+      ${user.bio ? `<p class="bio">${user.bio}</p>` : ''}
+      <div class="links">
+        ${user.github_username ? `<a href="https://github.com/${user.github_username}" target="_blank">GitHub</a>` : ''}
+        ${user.zenn_username ? `<a href="https://zenn.dev/${user.zenn_username}" target="_blank">Zenn</a>` : ''}
+        ${user.qiita_username ? `<a href="https://qiita.com/${user.qiita_username}" target="_blank">Qiita</a>` : ''}
+      </div>
+    </header>
+
+    ${totalContributions > 0 ? `
+    <section class="section">
+      <h2 class="section-title">Statistics</h2>
+      <div class="stats-grid">
+        <div>
+          <div class="stat-value">${totalContributions.toLocaleString()}</div>
+          <div class="stat-label">Contributions</div>
+        </div>
+        <div>
+          <div class="stat-value">${repos.length}</div>
+          <div class="stat-label">Repositories</div>
+        </div>
+        <div>
+          <div class="stat-value">${languages.length}</div>
+          <div class="stat-label">Languages</div>
+        </div>
+      </div>
+    </section>
+    ` : ''}
+
+    ${(user.skills_languages || user.skills_frameworks) ? `
+    <section class="section">
+      <h2 class="section-title">Skills</h2>
+      <div class="skills-row">
+        ${(user.skills_languages || '').split(',').filter(Boolean).map(s => `<span class="skill-tag">${s.trim()}</span>`).join('')}
+        ${(user.skills_frameworks || '').split(',').filter(Boolean).map(s => `<span class="skill-tag">${s.trim()}</span>`).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    ${languages.length > 0 ? `
+    <section class="section">
+      <h2 class="section-title">Languages</h2>
+      <div class="language-bar">
+        ${languages.slice(0, 6).map(l => {
+          const total = languages.reduce((sum, lang) => sum + lang.bytes, 0);
+          const percent = (l.bytes / total) * 100;
+          return `<div class="language-segment" style="width: ${percent}%; background: ${getLanguageColor(l.language)}"></div>`;
+        }).join('')}
+      </div>
+      <div class="language-legend">
+        ${languages.slice(0, 6).map(l => {
+          const total = languages.reduce((sum, lang) => sum + lang.bytes, 0);
+          const percent = ((l.bytes / total) * 100).toFixed(1);
+          return `<div class="language-item"><span class="language-dot" style="background: ${getLanguageColor(l.language)}"></span>${l.language} ${percent}%</div>`;
+        }).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    ${repos.length > 0 ? `
+    <section class="section">
+      <h2 class="section-title">Featured Repositories</h2>
+      <div class="repo-grid">
+        ${repos.slice(0, 4).map(r => `
+          <div class="repo-card">
+            <div class="repo-name">${r.name}</div>
+            ${r.description ? `<div class="repo-desc">${r.description}</div>` : ''}
+            <div class="repo-meta">
+              ${r.language ? `<span>${r.language}</span>` : ''}
+              ${r.stars > 0 ? `<span>⭐ ${r.stars}</span>` : ''}
+              ${r.forks > 0 ? `<span>🔱 ${r.forks}</span>` : ''}
+            </div>
+          </div>
+        `).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    ${goals.filter(g => g.status === 'active').length > 0 ? `
+    <section class="section">
+      <h2 class="section-title">Currently Learning</h2>
+      <div class="skills-row">
+        ${goals.filter(g => g.status === 'active').slice(0, 5).map(g => `<span class="skill-tag">${g.title}</span>`).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    <footer class="footer">
+      Generated with <a href="https://devsync.app" target="_blank">DevSync</a>
+    </footer>
+  </div>
+</body>
+</html>`;
+};
+
+const generateModernTemplate = (data: PortfolioData): string => {
+  const { user, languages, repos, goals, totalContributions, followerCount } = data;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${user.name} - Developer Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: #0a0a0f;
+      color: #e5e7eb;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+    .container { max-width: 1000px; margin: 0 auto; padding: 40px 24px; }
+    .hero {
+      display: grid; grid-template-columns: auto 1fr; gap: 40px;
+      align-items: center; padding: 40px; background: #111118;
+      border-radius: 24px; margin-bottom: 40px; border: 1px solid #1f1f2e;
+    }
+    @media (max-width: 640px) {
+      .hero { grid-template-columns: 1fr; text-align: center; }
+    }
+    .avatar {
+      width: 160px; height: 160px; border-radius: 20px;
+      object-fit: cover; border: 4px solid #3b82f6;
+    }
+    .name { font-size: 2.5rem; font-weight: 700; margin-bottom: 8px; }
+    .bio { color: #9ca3af; font-size: 1.1rem; margin-bottom: 16px; }
+    .links { display: flex; gap: 12px; flex-wrap: wrap; }
+    @media (max-width: 640px) { .links { justify-content: center; } }
+    .link-btn {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 10px 20px; background: #1f1f2e; border-radius: 10px;
+      color: #e5e7eb; text-decoration: none; font-size: 0.9rem;
+      transition: all 0.2s;
+    }
+    .link-btn:hover { background: #3b82f6; }
+    .stats-row {
+      display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px;
+      margin-bottom: 40px;
+    }
+    @media (max-width: 640px) { .stats-row { grid-template-columns: repeat(2, 1fr); } }
+    .stat-card {
+      background: #111118; padding: 24px; border-radius: 16px;
+      text-align: center; border: 1px solid #1f1f2e;
+    }
+    .stat-value { font-size: 2.5rem; font-weight: 700; color: #3b82f6; }
+    .stat-label { font-size: 0.85rem; color: #6b7280; margin-top: 4px; }
+    .section { margin-bottom: 40px; }
+    .section-header {
+      display: flex; align-items: center; gap: 12px;
+      margin-bottom: 20px;
+    }
+    .section-icon {
+      width: 36px; height: 36px; background: #3b82f6;
+      border-radius: 10px; display: flex; align-items: center;
+      justify-content: center; font-size: 1.2rem;
+    }
+    .section-title { font-size: 1.2rem; font-weight: 600; }
+    .skills-grid { display: flex; flex-wrap: wrap; gap: 10px; }
+    .skill-chip {
+      padding: 10px 18px; background: linear-gradient(135deg, #1f1f2e, #111118);
+      border-radius: 12px; font-size: 0.9rem; border: 1px solid #2d2d3a;
+    }
+    .languages-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+    @media (max-width: 640px) { .languages-grid { grid-template-columns: repeat(2, 1fr); } }
+    .lang-card {
+      background: #111118; padding: 16px; border-radius: 12px;
+      border: 1px solid #1f1f2e; display: flex; align-items: center; gap: 12px;
+    }
+    .lang-dot { width: 12px; height: 12px; border-radius: 50%; }
+    .lang-name { font-weight: 500; }
+    .lang-percent { color: #6b7280; font-size: 0.85rem; margin-left: auto; }
+    .repo-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
+    @media (max-width: 640px) { .repo-grid { grid-template-columns: 1fr; } }
+    .repo-card {
+      background: #111118; padding: 24px; border-radius: 16px;
+      border: 1px solid #1f1f2e; transition: all 0.2s;
+    }
+    .repo-card:hover { border-color: #3b82f6; transform: translateY(-2px); }
+    .repo-name { font-weight: 600; font-size: 1.1rem; margin-bottom: 8px; color: #3b82f6; }
+    .repo-desc { font-size: 0.9rem; color: #9ca3af; margin-bottom: 12px; line-height: 1.5; }
+    .repo-meta { display: flex; gap: 16px; font-size: 0.85rem; color: #6b7280; }
+    .footer {
+      text-align: center; padding-top: 40px; border-top: 1px solid #1f1f2e;
+      color: #6b7280; font-size: 0.9rem;
+    }
+    .footer a { color: #3b82f6; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="hero">
+      ${user.avatar_url ? `<img src="${user.avatar_url}" alt="${user.name}" class="avatar">` : '<div class="avatar" style="background: #1f1f2e;"></div>'}
+      <div>
+        <h1 class="name">${user.name}</h1>
+        ${user.bio ? `<p class="bio">${user.bio}</p>` : ''}
+        <div class="links">
+          ${user.github_username ? `<a href="https://github.com/${user.github_username}" target="_blank" class="link-btn">📦 GitHub</a>` : ''}
+          ${user.zenn_username ? `<a href="https://zenn.dev/${user.zenn_username}" target="_blank" class="link-btn">📝 Zenn</a>` : ''}
+          ${user.qiita_username ? `<a href="https://qiita.com/${user.qiita_username}" target="_blank" class="link-btn">📘 Qiita</a>` : ''}
+        </div>
+      </div>
+    </div>
+
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">${totalContributions.toLocaleString()}</div>
+        <div class="stat-label">Contributions</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">${repos.length}</div>
+        <div class="stat-label">Repositories</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">${followerCount}</div>
+        <div class="stat-label">Followers</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">${languages.length}</div>
+        <div class="stat-label">Languages</div>
+      </div>
+    </div>
+
+    ${(user.skills_languages || user.skills_frameworks) ? `
+    <section class="section">
+      <div class="section-header">
+        <div class="section-icon">💡</div>
+        <h2 class="section-title">Skills & Technologies</h2>
+      </div>
+      <div class="skills-grid">
+        ${(user.skills_languages || '').split(',').filter(Boolean).map(s => `<span class="skill-chip">${s.trim()}</span>`).join('')}
+        ${(user.skills_frameworks || '').split(',').filter(Boolean).map(s => `<span class="skill-chip">${s.trim()}</span>`).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    ${languages.length > 0 ? `
+    <section class="section">
+      <div class="section-header">
+        <div class="section-icon">📊</div>
+        <h2 class="section-title">Top Languages</h2>
+      </div>
+      <div class="languages-grid">
+        ${languages.slice(0, 6).map(l => {
+          const total = languages.reduce((sum, lang) => sum + lang.bytes, 0);
+          const percent = ((l.bytes / total) * 100).toFixed(1);
+          return `
+            <div class="lang-card">
+              <span class="lang-dot" style="background: ${getLanguageColor(l.language)}"></span>
+              <span class="lang-name">${l.language}</span>
+              <span class="lang-percent">${percent}%</span>
+            </div>
+          `;
+        }).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    ${repos.length > 0 ? `
+    <section class="section">
+      <div class="section-header">
+        <div class="section-icon">🚀</div>
+        <h2 class="section-title">Featured Projects</h2>
+      </div>
+      <div class="repo-grid">
+        ${repos.slice(0, 4).map(r => `
+          <a href="https://github.com/${r.full_name}" target="_blank" class="repo-card" style="text-decoration: none; color: inherit;">
+            <div class="repo-name">${r.name}</div>
+            ${r.description ? `<div class="repo-desc">${r.description}</div>` : ''}
+            <div class="repo-meta">
+              ${r.language ? `<span>🔹 ${r.language}</span>` : ''}
+              ${r.stars > 0 ? `<span>⭐ ${r.stars}</span>` : ''}
+              ${r.forks > 0 ? `<span>🔱 ${r.forks}</span>` : ''}
+            </div>
+          </a>
+        `).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    ${goals.filter(g => g.status === 'active').length > 0 ? `
+    <section class="section">
+      <div class="section-header">
+        <div class="section-icon">🎯</div>
+        <h2 class="section-title">Learning Goals</h2>
+      </div>
+      <div class="skills-grid">
+        ${goals.filter(g => g.status === 'active').slice(0, 5).map(g => `<span class="skill-chip">📚 ${g.title}</span>`).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    <footer class="footer">
+      Built with <a href="https://devsync.app" target="_blank">DevSync</a>
+    </footer>
+  </div>
+</body>
+</html>`;
+};
+
+const generateGradientTemplate = (data: PortfolioData): string => {
+  const { user, languages, repos, goals, totalContributions, followerCount } = data;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${user.name} - Developer Portfolio</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      font-family: 'Poppins', -apple-system, BlinkMacSystemFont, sans-serif;
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 50%, #0f3460 100%);
+      color: #e5e7eb;
+      line-height: 1.6;
+      min-height: 100vh;
+    }
+    .bg-blur {
+      position: fixed; top: 0; left: 0; right: 0; bottom: 0;
+      background: radial-gradient(circle at 20% 80%, rgba(120, 119, 198, 0.3), transparent 40%),
+                  radial-gradient(circle at 80% 20%, rgba(59, 130, 246, 0.3), transparent 40%);
+      pointer-events: none; z-index: 0;
+    }
+    .container { max-width: 900px; margin: 0 auto; padding: 60px 24px; position: relative; z-index: 1; }
+    .hero { text-align: center; margin-bottom: 60px; }
+    .avatar {
+      width: 150px; height: 150px; border-radius: 50%;
+      object-fit: cover; margin-bottom: 24px;
+      border: 4px solid rgba(255,255,255,0.2);
+      box-shadow: 0 20px 40px rgba(0,0,0,0.3);
+    }
+    .name {
+      font-size: 3rem; font-weight: 700;
+      background: linear-gradient(135deg, #fff, #a5b4fc);
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+      margin-bottom: 12px;
+    }
+    .bio { color: rgba(255,255,255,0.7); font-size: 1.1rem; max-width: 500px; margin: 0 auto 24px; }
+    .links { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+    .link-pill {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 12px 24px; background: rgba(255,255,255,0.1);
+      backdrop-filter: blur(10px); border-radius: 50px;
+      color: #fff; text-decoration: none; font-size: 0.9rem;
+      border: 1px solid rgba(255,255,255,0.15);
+      transition: all 0.3s;
+    }
+    .link-pill:hover { background: rgba(255,255,255,0.2); transform: translateY(-2px); }
+    .stats-row {
+      display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px;
+      margin-bottom: 50px;
+    }
+    @media (max-width: 640px) { .stats-row { grid-template-columns: repeat(2, 1fr); } }
+    .stat-card {
+      background: rgba(255,255,255,0.05); backdrop-filter: blur(10px);
+      padding: 28px; border-radius: 20px; text-align: center;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .stat-value {
+      font-size: 2.5rem; font-weight: 700;
+      background: linear-gradient(135deg, #a5b4fc, #3b82f6);
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+    }
+    .stat-label { font-size: 0.85rem; color: rgba(255,255,255,0.6); margin-top: 4px; }
+    .section { margin-bottom: 50px; }
+    .section-title {
+      font-size: 1.3rem; font-weight: 600; margin-bottom: 20px;
+      display: flex; align-items: center; gap: 12px;
+    }
+    .title-line { flex: 1; height: 1px; background: linear-gradient(90deg, rgba(255,255,255,0.2), transparent); }
+    .glass-card {
+      background: rgba(255,255,255,0.05); backdrop-filter: blur(10px);
+      padding: 24px; border-radius: 20px;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .skills-cloud { display: flex; flex-wrap: wrap; gap: 10px; }
+    .skill-bubble {
+      padding: 10px 20px; background: linear-gradient(135deg, rgba(165, 180, 252, 0.2), rgba(59, 130, 246, 0.2));
+      border-radius: 50px; font-size: 0.9rem;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .lang-list { display: flex; flex-direction: column; gap: 12px; }
+    .lang-item { display: flex; align-items: center; gap: 12px; }
+    .lang-bar-bg { flex: 1; height: 8px; background: rgba(255,255,255,0.1); border-radius: 4px; overflow: hidden; }
+    .lang-bar-fill { height: 100%; border-radius: 4px; }
+    .lang-name { min-width: 100px; font-size: 0.9rem; }
+    .lang-percent { min-width: 50px; text-align: right; font-size: 0.85rem; color: rgba(255,255,255,0.6); }
+    .projects-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 20px; }
+    @media (max-width: 640px) { .projects-grid { grid-template-columns: 1fr; } }
+    .project-card {
+      background: rgba(255,255,255,0.05); backdrop-filter: blur(10px);
+      padding: 24px; border-radius: 20px;
+      border: 1px solid rgba(255,255,255,0.1);
+      transition: all 0.3s; text-decoration: none; color: inherit;
+    }
+    .project-card:hover { transform: translateY(-4px); border-color: rgba(165, 180, 252, 0.5); }
+    .project-name {
+      font-weight: 600; font-size: 1.1rem; margin-bottom: 8px;
+      color: #a5b4fc;
+    }
+    .project-desc { font-size: 0.9rem; color: rgba(255,255,255,0.6); margin-bottom: 12px; }
+    .project-meta { display: flex; gap: 16px; font-size: 0.8rem; color: rgba(255,255,255,0.5); }
+    .footer { text-align: center; padding-top: 40px; color: rgba(255,255,255,0.5); font-size: 0.9rem; }
+    .footer a { color: #a5b4fc; text-decoration: none; }
+  </style>
+</head>
+<body>
+  <div class="bg-blur"></div>
+  <div class="container">
+    <header class="hero">
+      ${user.avatar_url ? `<img src="${user.avatar_url}" alt="${user.name}" class="avatar">` : ''}
+      <h1 class="name">${user.name}</h1>
+      ${user.bio ? `<p class="bio">${user.bio}</p>` : ''}
+      <div class="links">
+        ${user.github_username ? `<a href="https://github.com/${user.github_username}" target="_blank" class="link-pill">🐙 GitHub</a>` : ''}
+        ${user.zenn_username ? `<a href="https://zenn.dev/${user.zenn_username}" target="_blank" class="link-pill">📝 Zenn</a>` : ''}
+        ${user.qiita_username ? `<a href="https://qiita.com/${user.qiita_username}" target="_blank" class="link-pill">📘 Qiita</a>` : ''}
+      </div>
+    </header>
+
+    <div class="stats-row">
+      <div class="stat-card">
+        <div class="stat-value">${totalContributions.toLocaleString()}</div>
+        <div class="stat-label">Contributions</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">${repos.length}</div>
+        <div class="stat-label">Repositories</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">${followerCount}</div>
+        <div class="stat-label">Followers</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-value">${languages.length}</div>
+        <div class="stat-label">Languages</div>
+      </div>
+    </div>
+
+    ${(user.skills_languages || user.skills_frameworks) ? `
+    <section class="section">
+      <h2 class="section-title">✨ Skills <span class="title-line"></span></h2>
+      <div class="glass-card">
+        <div class="skills-cloud">
+          ${(user.skills_languages || '').split(',').filter(Boolean).map(s => `<span class="skill-bubble">${s.trim()}</span>`).join('')}
+          ${(user.skills_frameworks || '').split(',').filter(Boolean).map(s => `<span class="skill-bubble">${s.trim()}</span>`).join('')}
+        </div>
+      </div>
+    </section>
+    ` : ''}
+
+    ${languages.length > 0 ? `
+    <section class="section">
+      <h2 class="section-title">📊 Languages <span class="title-line"></span></h2>
+      <div class="glass-card">
+        <div class="lang-list">
+          ${languages.slice(0, 5).map(l => {
+            const total = languages.reduce((sum, lang) => sum + lang.bytes, 0);
+            const percent = ((l.bytes / total) * 100).toFixed(1);
+            return `
+              <div class="lang-item">
+                <span class="lang-name">${l.language}</span>
+                <div class="lang-bar-bg">
+                  <div class="lang-bar-fill" style="width: ${percent}%; background: ${getLanguageColor(l.language)}"></div>
+                </div>
+                <span class="lang-percent">${percent}%</span>
+              </div>
+            `;
+          }).join('')}
+        </div>
+      </div>
+    </section>
+    ` : ''}
+
+    ${repos.length > 0 ? `
+    <section class="section">
+      <h2 class="section-title">🚀 Projects <span class="title-line"></span></h2>
+      <div class="projects-grid">
+        ${repos.slice(0, 4).map(r => `
+          <a href="https://github.com/${r.full_name}" target="_blank" class="project-card">
+            <div class="project-name">${r.name}</div>
+            ${r.description ? `<div class="project-desc">${r.description}</div>` : ''}
+            <div class="project-meta">
+              ${r.language ? `<span>${r.language}</span>` : ''}
+              ${r.stars > 0 ? `<span>⭐ ${r.stars}</span>` : ''}
+            </div>
+          </a>
+        `).join('')}
+      </div>
+    </section>
+    ` : ''}
+
+    ${goals.filter(g => g.status === 'active').length > 0 ? `
+    <section class="section">
+      <h2 class="section-title">🎯 Learning <span class="title-line"></span></h2>
+      <div class="glass-card">
+        <div class="skills-cloud">
+          ${goals.filter(g => g.status === 'active').slice(0, 5).map(g => `<span class="skill-bubble">${g.title}</span>`).join('')}
+        </div>
+      </div>
+    </section>
+    ` : ''}
+
+    <footer class="footer">
+      Crafted with <a href="https://devsync.app" target="_blank">DevSync</a>
+    </footer>
+  </div>
+</body>
+</html>`;
+};
+
+export const generatePortfolioHTML = (
+  data: PortfolioData,
+  theme: PortfolioTheme
+): string => {
+  switch (theme) {
+    case 'minimal':
+      return generateMinimalTemplate(data);
+    case 'modern':
+      return generateModernTemplate(data);
+    case 'gradient':
+      return generateGradientTemplate(data);
+    default:
+      return generateModernTemplate(data);
+  }
+};
+
+export const downloadPortfolio = (html: string, filename: string): void => {
+  const blob = new Blob([html], { type: 'text/html' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
## Summary
- プロフィール情報から静的HTMLポートフォリオサイトを自動生成する機能を追加
- 3つのテーマ（ミニマル、モダン、グラデーション）から選択可能
- GitHub統計、スキル、リポジトリ、学習目標を含む

## Changes
- `portfolioGenerator.ts` - 3テーマのHTMLポートフォリオ生成ユーティリティ
- `PortfolioModal.tsx` - テーマ選択・プレビュー・ダウンロード用モーダル
- `ProfilePage.tsx` - 自分のプロフィールに「ポートフォリオ生成」ボタンを追加
- 10言語すべてのi18n翻訳を追加

## Test plan
- [x] 自分のプロフィールページで「ポートフォリオ生成」ボタンをクリック
- [x] 3つのテーマを切り替えてプレビューを確認
- [x] 「新しいタブで開く」で全画面プレビューを確認
- [x] 「HTMLダウンロード」でファイルをダウンロード
- [x] 「HTMLコピー」でクリップボードにコピー
- [x] 他のユーザーのプロフィールでボタンが表示されないことを確認

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)