### PR TITLE
fix: Use light gray for empty contribution cells in light theme

### DIFF
--- a/frontend/src/components/profile/ContributionCalendar.tsx
+++ b/frontend/src/components/profile/ContributionCalendar.tsx
@@ -1,11 +1,12 @@
 import type { GitHubContribution } from '../../types/github';
+import { useThemeStore } from '../../store/themeStore';
 
 interface ContributionCalendarProps {
   contributions: GitHubContribution[];
 }
 
-function getColor(count: number): string {
-  if (count === 0) return '#1e293b';
+function getColor(count: number, resolvedTheme: 'dark' | 'light'): string {
+  if (count === 0) return resolvedTheme === 'dark' ? '#1e293b' : '#ebedf0';
   if (count <= 3) return '#166534';
   if (count <= 6) return '#16a34a';
   if (count <= 9) return '#22c55e';
@@ -13,6 +14,7 @@ function getColor(count: number): string {
 }
 
 export default function ContributionCalendar({ contributions }: ContributionCalendarProps) {
+  const resolvedTheme = useThemeStore((state) => state.resolvedTheme);
   const contributionMap = new Map(
     contributions.map((c) => [c.date.split('T')[0], c.count])
   );
@@ -102,7 +104,7 @@ export default function ContributionCalendar({ contributions }: ContributionCale
                       key={di}
                       title={`${day.date}: ${day.count} contributions`}
                       className="w-3 h-3 rounded-sm"
-                      style={{ backgroundColor: getColor(day.count) }}
+                      style={{ backgroundColor: getColor(day.count, resolvedTheme) }}
                     />
                   ))}
                 </div>


### PR DESCRIPTION
## Summary
- ライトテーマ時にコントリビューションカレンダーの空セルが黒く表示される問題を修正
- `useThemeStore` を使ってテーマに応じた色を返すように `getColor()` を変更
- ダークモード: `#1e293b`（従来通り）、ライトモード: `#ebedf0`（GitHub標準の空セル色）

Closes #51

## Test plan
- [ ] ライトテーマに切り替えて、コントリビューションカレンダーの空セルが薄い灰色（#ebedf0）で表示されることを確認
- [ ] ダークテーマで従来通りの表示であることを確認
- [ ] システムテーマ設定でも正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)