### PR TITLE
fix: Improve header nav text contrast in light theme

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -30,7 +30,7 @@ export default function Header() {
   };
 
   const isActive = (path: string) =>
-    location.pathname === path ? 'text-white bg-gray-800' : 'text-gray-400 hover:text-white';
+    location.pathname === path ? 'text-white bg-gray-800' : 'text-gray-300 hover:text-white';
 
   // Close mobile menu on route change
   useEffect(() => {
@@ -64,7 +64,7 @@ export default function Header() {
 
         {/* Mobile hamburger button */}
         <button
-          className="md:hidden p-2 text-gray-400 hover:text-white transition-colors rounded-md"
+          className="md:hidden p-2 text-gray-300 hover:text-white transition-colors rounded-md"
           onClick={() => setMobileOpen(!mobileOpen)}
           aria-label={mobileOpen ? t('common.close') : t('common.menu')}
           aria-expanded={mobileOpen}
@@ -101,7 +101,7 @@ export default function Header() {
 
           <Link
             to="/settings"
-            className="p-2 text-gray-400 hover:text-white transition-colors rounded-md"
+            className="p-2 text-gray-300 hover:text-white transition-colors rounded-md"
             title={t('nav.settings')}
             aria-label={t('nav.settings')}
           >
@@ -123,7 +123,7 @@ export default function Header() {
 
           <button
             onClick={handleLogout}
-            className="p-2 text-gray-400 hover:text-white transition-colors rounded-md"
+            className="p-2 text-gray-300 hover:text-white transition-colors rounded-md"
             title={t('nav.signOut')}
             aria-label={t('nav.signOut')}
           >


### PR DESCRIPTION
## Summary
- Fixed header navigation links appearing gray and hard-to-read in light theme
- Changed inactive nav link color from `text-gray-400` to `text-gray-300` which maps to `#4b5563` in light theme for better contrast
- Applied same fix to hamburger menu button, settings icon, and logout button

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)