### PR TITLE
refactor: カスタムフック層を追加しページコンポーネントをスリム化

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,13 @@
+export { useAsyncData } from './useAsyncData';
+export { useGoals } from './useGoals';
+export { usePosts } from './usePosts';
+export { usePostDetail } from './usePostDetail';
+export { useReport } from './useReport';
+export { useRankings } from './useRankings';
+export { useUserSearch } from './useUserSearch';
+export { useProfile } from './useProfile';
+export { useBookReviews } from './useBookReviews';
+export { useProjects } from './useProjects';
+export { useResources } from './useResources';
+export { useFollowList } from './useFollowList';
+export { useNotifications } from './useNotifications';

--- a/frontend/src/hooks/useAsyncData.ts
+++ b/frontend/src/hooks/useAsyncData.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+interface UseAsyncDataOptions<T> {
+  deps?: unknown[];
+  initialData?: T;
+  enabled?: boolean;
+}
+
+interface UseAsyncDataReturn<T> {
+  data: T;
+  loading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+
+export function useAsyncData<T>(
+  fetcher: () => Promise<T>,
+  options: UseAsyncDataOptions<T> & { initialData: T }
+): UseAsyncDataReturn<T>;
+export function useAsyncData<T>(
+  fetcher: () => Promise<T>,
+  options?: UseAsyncDataOptions<T>
+): UseAsyncDataReturn<T | null>;
+export function useAsyncData<T>(
+  fetcher: () => Promise<T>,
+  options: UseAsyncDataOptions<T> = {}
+): UseAsyncDataReturn<T | null> {
+  const { deps = [], initialData = null, enabled = true } = options;
+  const [data, setData] = useState<T | null>(initialData);
+  const [loading, setLoading] = useState(enabled);
+  const [error, setError] = useState<Error | null>(null);
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const refetch = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await fetcherRef.current();
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      setLoading(false);
+      return;
+    }
+    refetch();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enabled, ...deps]);
+
+  return { data, loading, error, refetch };
+}

--- a/frontend/src/hooks/useBookReviews.ts
+++ b/frontend/src/hooks/useBookReviews.ts
@@ -1,0 +1,83 @@
+import { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import type { BookReview, CreateBookReviewRequest } from '../types/bookReview';
+import { getBookReviews, createBookReview, updateBookReview, deleteBookReview } from '../api/bookReviews';
+import { useAsyncData } from './useAsyncData';
+
+export function useBookReviews() {
+  const { t } = useTranslation();
+  const [saving, setSaving] = useState(false);
+  const [page, setPage] = useState(0);
+  const limit = 20;
+
+  const { data, loading, refetch } = useAsyncData(
+    async () => {
+      return await getBookReviews(limit, page * limit);
+    },
+    { deps: [page] }
+  );
+
+  const reviews = data?.reviews ?? [];
+  const total = data?.total ?? 0;
+
+  const [localReviews, setLocalReviews] = useState<BookReview[] | null>(null);
+  const currentReviews = localReviews ?? reviews;
+
+  const handleCreate = useCallback(async (reqData: CreateBookReviewRequest) => {
+    setSaving(true);
+    try {
+      const newReview = await createBookReview(reqData);
+      setLocalReviews(prev => [newReview, ...(prev ?? reviews)]);
+      toast.success(t('bookReviews.createSuccess'));
+      return newReview;
+    } catch {
+      toast.error(t('bookReviews.createFailed'));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [t, reviews]);
+
+  const handleUpdate = useCallback(async (reviewId: number, reqData: CreateBookReviewRequest) => {
+    setSaving(true);
+    try {
+      const updated = await updateBookReview(reviewId, reqData);
+      setLocalReviews(prev => (prev ?? reviews).map(r => r.id === updated.id ? updated : r));
+      toast.success(t('bookReviews.updateSuccess'));
+      return updated;
+    } catch {
+      toast.error(t('bookReviews.updateFailed'));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [t, reviews]);
+
+  const handleDelete = useCallback(async (review: BookReview) => {
+    if (!confirm(t('bookReviews.confirmDelete'))) return false;
+    try {
+      await deleteBookReview(review.id);
+      setLocalReviews(prev => (prev ?? reviews).filter(r => r.id !== review.id));
+      toast.success(t('bookReviews.deleteSuccess'));
+      return true;
+    } catch {
+      toast.error(t('bookReviews.deleteFailed'));
+      return false;
+    }
+  }, [t, reviews]);
+
+  return {
+    reviews: currentReviews,
+    total,
+    loading,
+    saving,
+    page,
+    setPage,
+    limit,
+    createReview: handleCreate,
+    updateReview: handleUpdate,
+    deleteReview: handleDelete,
+    refetch,
+  };
+}

--- a/frontend/src/hooks/useFollowList.ts
+++ b/frontend/src/hooks/useFollowList.ts
@@ -1,0 +1,45 @@
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import { getUser, getFollowers, getFollowing } from '../api/users';
+import type { User } from '../types/user';
+import { useAsyncData } from './useAsyncData';
+
+type Tab = 'followers' | 'following';
+
+export function useFollowList(id: string | undefined) {
+  const location = useLocation();
+  const userId = id ? parseInt(id) : 0;
+
+  const initialTab: Tab = location.pathname.endsWith('/following') ? 'following' : 'followers';
+  const [tab, setTab] = useState<Tab>(initialTab);
+
+  useEffect(() => {
+    const newTab: Tab = location.pathname.endsWith('/following') ? 'following' : 'followers';
+    setTab(newTab);
+  }, [location.pathname]);
+
+  const { data: profileUser, loading: profileLoading } = useAsyncData(
+    async () => {
+      const { data } = await getUser(userId);
+      return data as User;
+    },
+    { deps: [userId], enabled: !!userId }
+  );
+
+  const { data: users, loading: usersLoading } = useAsyncData(
+    async () => {
+      const fetcher = tab === 'followers' ? getFollowers : getFollowing;
+      const { data } = await fetcher(userId);
+      return (data || []) as User[];
+    },
+    { initialData: [] as User[], deps: [userId, tab], enabled: !!userId }
+  );
+
+  return {
+    profileUser,
+    users,
+    tab,
+    loading: usersLoading,
+    profileLoading,
+  };
+}

--- a/frontend/src/hooks/useGoals.ts
+++ b/frontend/src/hooks/useGoals.ts
@@ -1,0 +1,110 @@
+import { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import {
+  getMyGoals,
+  createGoal,
+  updateGoal,
+  deleteGoal,
+  type LearningGoal,
+  type GoalCategory,
+  type GoalStatus,
+} from '../api/goals';
+import { useAsyncData } from './useAsyncData';
+
+export function useGoals() {
+  const { t } = useTranslation();
+  const [saving, setSaving] = useState(false);
+
+  const { data: goals, loading, refetch } = useAsyncData(
+    async () => {
+      const { data } = await getMyGoals();
+      return data || [];
+    },
+    { initialData: [] as LearningGoal[] }
+  );
+
+  const [localGoals, setLocalGoals] = useState<LearningGoal[] | null>(null);
+  const currentGoals = localGoals ?? goals;
+
+  // Sync localGoals when remote data changes
+  const setGoals = useCallback((updater: LearningGoal[] | ((prev: LearningGoal[]) => LearningGoal[])) => {
+    setLocalGoals(prev => {
+      const current = prev ?? goals;
+      return typeof updater === 'function' ? updater(current) : updater;
+    });
+  }, [goals]);
+
+  const handleCreate = useCallback(async (data: {
+    title: string;
+    description: string;
+    category: GoalCategory;
+    target_date?: string;
+  }) => {
+    setSaving(true);
+    try {
+      const { data: newGoal } = await createGoal(data);
+      setGoals(prev => [newGoal, ...prev]);
+      toast.success(t('goals.created'));
+      return newGoal;
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [t, setGoals]);
+
+  const handleUpdate = useCallback(async (goalId: number, data: {
+    title?: string;
+    description?: string;
+    category?: GoalCategory;
+    target_date?: string;
+    progress?: number;
+    status?: GoalStatus;
+  }) => {
+    try {
+      const { data: updated } = await updateGoal(goalId, data);
+      setGoals(prev => prev.map(g => g.id === updated.id ? updated : g));
+      if (data.progress === 100) {
+        toast.success(t('goals.completed'));
+      } else {
+        toast.success(t('goals.updated'));
+      }
+      return updated;
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+      return null;
+    }
+  }, [t, setGoals]);
+
+  const handleDelete = useCallback(async (id: number) => {
+    if (!confirm(t('goals.confirmDelete'))) return false;
+    try {
+      await deleteGoal(id);
+      setGoals(prev => prev.filter(g => g.id !== id));
+      toast.success(t('goals.deleted'));
+      return true;
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+      return false;
+    }
+  }, [t, setGoals]);
+
+  const activeGoals = currentGoals.filter(g => g.status === 'active');
+  const completedGoals = currentGoals.filter(g => g.status === 'completed');
+  const pausedGoals = currentGoals.filter(g => g.status === 'paused');
+
+  return {
+    goals: currentGoals,
+    loading,
+    saving,
+    activeGoals,
+    completedGoals,
+    pausedGoals,
+    createGoal: handleCreate,
+    updateGoal: handleUpdate,
+    deleteGoal: handleDelete,
+    refetch,
+  };
+}

--- a/frontend/src/hooks/useNotifications.ts
+++ b/frontend/src/hooks/useNotifications.ts
@@ -1,0 +1,64 @@
+import { useState, useEffect, useCallback } from 'react';
+import { getNotifications, getUnreadCount, markAsRead, markAllAsRead } from '../api/notifications';
+import type { Notification } from '../types/notification';
+
+export function useNotifications() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchUnreadCount = async () => {
+      try {
+        const response = await getUnreadCount();
+        setUnreadCount(response.data.count);
+      } catch {
+        // silently fail
+      }
+    };
+    fetchUnreadCount();
+    const interval = setInterval(fetchUnreadCount, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const fetchNotifications = useCallback(async () => {
+    setLoading(true);
+    try {
+      const response = await getNotifications();
+      setNotifications(response.data);
+    } catch {
+      // silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleMarkAsRead = useCallback(async (id: number) => {
+    try {
+      await markAsRead(id);
+      setNotifications(prev => prev.map(n => n.id === id ? { ...n, read: true } : n));
+      setUnreadCount(prev => Math.max(0, prev - 1));
+    } catch {
+      // silently fail
+    }
+  }, []);
+
+  const handleMarkAllAsRead = useCallback(async () => {
+    try {
+      await markAllAsRead();
+      setNotifications(prev => prev.map(n => ({ ...n, read: true })));
+      setUnreadCount(0);
+    } catch {
+      // silently fail
+    }
+  }, []);
+
+  return {
+    notifications,
+    unreadCount,
+    loading,
+    fetchNotifications,
+    markAsRead: handleMarkAsRead,
+    markAllAsRead: handleMarkAllAsRead,
+  };
+}

--- a/frontend/src/hooks/usePostDetail.ts
+++ b/frontend/src/hooks/usePostDetail.ts
@@ -1,0 +1,46 @@
+import { useState, useCallback } from 'react';
+import { getPost, getComments, createComment } from '../api/posts';
+import type { Post, Comment } from '../types/post';
+import { useAsyncData } from './useAsyncData';
+
+export function usePostDetail(id: string | undefined) {
+  const postId = id ? parseInt(id) : 0;
+  const [submitting, setSubmitting] = useState(false);
+
+  const { data, loading, refetch } = useAsyncData(
+    async () => {
+      const [postRes, commentsRes] = await Promise.all([
+        getPost(postId),
+        getComments(postId),
+      ]);
+      return {
+        post: postRes.data as Post,
+        comments: (commentsRes.data || []) as Comment[],
+      };
+    },
+    { deps: [postId], enabled: !!postId }
+  );
+
+  const handleSubmitComment = useCallback(async (content: string) => {
+    if (!content.trim() || !postId) return false;
+    setSubmitting(true);
+    try {
+      await createComment(postId, content);
+      await refetch();
+      return true;
+    } catch {
+      return false;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [postId, refetch]);
+
+  return {
+    post: data?.post ?? null,
+    comments: data?.comments ?? [],
+    loading,
+    submitting,
+    submitComment: handleSubmitComment,
+    refetch,
+  };
+}

--- a/frontend/src/hooks/usePosts.ts
+++ b/frontend/src/hooks/usePosts.ts
@@ -1,0 +1,30 @@
+import { useState, useCallback } from 'react';
+import { getTimeline, getPosts, createPost } from '../api/posts';
+import type { Post } from '../types/post';
+import { useAsyncData } from './useAsyncData';
+
+export function usePosts() {
+  const [tab, setTab] = useState<'timeline' | 'all'>('timeline');
+
+  const { data: posts, loading, refetch } = useAsyncData(
+    async () => {
+      const { data } = tab === 'timeline' ? await getTimeline() : await getPosts();
+      return data || [];
+    },
+    { initialData: [] as Post[], deps: [tab] }
+  );
+
+  const handleCreatePost = useCallback(async (title: string, content: string, imageUrls?: string) => {
+    await createPost({ title, content, image_urls: imageUrls });
+    refetch();
+  }, [refetch]);
+
+  return {
+    posts,
+    loading,
+    tab,
+    setTab,
+    createPost: handleCreatePost,
+    refetch,
+  };
+}

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -1,0 +1,119 @@
+import { getUser, getFollowers, getFollowing } from '../api/users';
+import { getUserPosts } from '../api/posts';
+import { getContributions, getLanguages, getRepos } from '../api/github';
+import { getZennArticles, getZennStats, type ZennArticle, type ZennStats } from '../api/zenn';
+import { getQiitaArticles, getQiitaStats, type QiitaArticle, type QiitaStats } from '../api/qiita';
+import { getUserGoals, getGoalStats, type LearningGoal, type LearningGoalStats } from '../api/goals';
+import type { User } from '../types/user';
+import type { Post } from '../types/post';
+import type { GitHubContribution, GitHubLanguageStat, GitHubRepository } from '../types/github';
+import { useAsyncData } from './useAsyncData';
+
+interface ProfileData {
+  user: User;
+  posts: Post[];
+  contributions: GitHubContribution[];
+  languages: GitHubLanguageStat[];
+  repos: GitHubRepository[];
+  zennArticles: ZennArticle[];
+  zennStats: ZennStats | null;
+  qiitaArticles: QiitaArticle[];
+  qiitaStats: QiitaStats | null;
+  goals: LearningGoal[];
+  goalStats: LearningGoalStats | null;
+  followerCount: number;
+  followingCount: number;
+}
+
+export function useProfile(id: string | undefined) {
+  const userId = id ? parseInt(id) : 0;
+
+  const { data, loading, refetch } = useAsyncData(
+    async (): Promise<ProfileData> => {
+      const [userRes, postsRes, followersRes, followingRes] = await Promise.all([
+        getUser(userId),
+        getUserPosts(userId),
+        getFollowers(userId),
+        getFollowing(userId),
+      ]);
+
+      const userData = userRes.data;
+      let contributions: GitHubContribution[] = [];
+      let languages: GitHubLanguageStat[] = [];
+      let repos: GitHubRepository[] = [];
+
+      if (userData.github_connected) {
+        const [contribRes, langRes, reposRes] = await Promise.all([
+          getContributions(userId),
+          getLanguages(userId),
+          getRepos(userId),
+        ]);
+        contributions = contribRes.data || [];
+        languages = langRes.data || [];
+        repos = reposRes.data || [];
+      }
+
+      let zennArticles: ZennArticle[] = [];
+      let zennStats: ZennStats | null = null;
+      if (userData.zenn_username) {
+        const [articlesRes, statsRes] = await Promise.all([
+          getZennArticles(userId),
+          getZennStats(userId),
+        ]);
+        zennArticles = articlesRes.data || [];
+        zennStats = statsRes.data;
+      }
+
+      let qiitaArticles: QiitaArticle[] = [];
+      let qiitaStats: QiitaStats | null = null;
+      if (userData.qiita_username) {
+        const [articlesRes, statsRes] = await Promise.all([
+          getQiitaArticles(userId),
+          getQiitaStats(userId),
+        ]);
+        qiitaArticles = articlesRes.data || [];
+        qiitaStats = statsRes.data;
+      }
+
+      const [goalsRes, goalStatsRes] = await Promise.all([
+        getUserGoals(userId),
+        getGoalStats(userId),
+      ]);
+
+      return {
+        user: userData,
+        posts: postsRes.data || [],
+        contributions,
+        languages,
+        repos,
+        zennArticles,
+        zennStats,
+        qiitaArticles,
+        qiitaStats,
+        goals: goalsRes.data || [],
+        goalStats: goalStatsRes.data,
+        followerCount: (followersRes.data || []).length,
+        followingCount: (followingRes.data || []).length,
+      };
+    },
+    { deps: [userId], enabled: !!userId }
+  );
+
+  return {
+    user: data?.user ?? null,
+    posts: data?.posts ?? [],
+    contributions: data?.contributions ?? [],
+    languages: data?.languages ?? [],
+    repos: data?.repos ?? [],
+    zennArticles: data?.zennArticles ?? [],
+    zennStats: data?.zennStats ?? null,
+    qiitaArticles: data?.qiitaArticles ?? [],
+    qiitaStats: data?.qiitaStats ?? null,
+    goals: data?.goals ?? [],
+    goalStats: data?.goalStats ?? null,
+    followerCount: data?.followerCount ?? 0,
+    followingCount: data?.followingCount ?? 0,
+    loading,
+    refetch,
+  };
+}

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,0 +1,90 @@
+import { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { useAuthStore } from '../store/authStore';
+import type { Project, CreateProjectRequest } from '../types/project';
+import type { GitHubRepository } from '../types/github';
+import { getProjectsByUserId, createProject, updateProject, deleteProject } from '../api/projects';
+import { getRepos } from '../api/github';
+import { useAsyncData } from './useAsyncData';
+
+export function useProjects() {
+  const { t } = useTranslation();
+  const user = useAuthStore((s) => s.user);
+  const [saving, setSaving] = useState(false);
+
+  const { data, loading, refetch } = useAsyncData(
+    async () => {
+      if (!user) return { projects: [] as Project[], repos: [] as GitHubRepository[] };
+      const [projectsData, reposResponse] = await Promise.all([
+        getProjectsByUserId(user.id),
+        user.github_connected ? getRepos(user.id) : Promise.resolve({ data: [] as GitHubRepository[] }),
+      ]);
+      return {
+        projects: projectsData,
+        repos: reposResponse.data,
+      };
+    },
+    { deps: [user?.id], enabled: !!user }
+  );
+
+  const projects = data?.projects ?? [];
+  const repos = data?.repos ?? [];
+
+  const [localProjects, setLocalProjects] = useState<Project[] | null>(null);
+  const currentProjects = localProjects ?? projects;
+
+  const handleCreate = useCallback(async (reqData: CreateProjectRequest) => {
+    setSaving(true);
+    try {
+      const newProject = await createProject(reqData);
+      setLocalProjects(prev => [newProject, ...(prev ?? projects)]);
+      toast.success(t('projects.createSuccess'));
+      return newProject;
+    } catch {
+      toast.error(t('projects.createFailed'));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [t, projects]);
+
+  const handleUpdate = useCallback(async (projectId: number, reqData: CreateProjectRequest) => {
+    setSaving(true);
+    try {
+      const updated = await updateProject(projectId, reqData);
+      setLocalProjects(prev => (prev ?? projects).map(p => p.id === updated.id ? updated : p));
+      toast.success(t('projects.updateSuccess'));
+      return updated;
+    } catch {
+      toast.error(t('projects.updateFailed'));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [t, projects]);
+
+  const handleDelete = useCallback(async (project: Project) => {
+    if (!confirm(t('projects.confirmDelete'))) return false;
+    try {
+      await deleteProject(project.id);
+      setLocalProjects(prev => (prev ?? projects).filter(p => p.id !== project.id));
+      toast.success(t('projects.deleteSuccess'));
+      return true;
+    } catch {
+      toast.error(t('projects.deleteFailed'));
+      return false;
+    }
+  }, [t, projects]);
+
+  return {
+    projects: currentProjects,
+    repos,
+    loading,
+    saving,
+    createProject: handleCreate,
+    updateProject: handleUpdate,
+    deleteProject: handleDelete,
+    refetch,
+  };
+}

--- a/frontend/src/hooks/useRankings.ts
+++ b/frontend/src/hooks/useRankings.ts
@@ -1,0 +1,54 @@
+import { useState } from 'react';
+import { getContributionRanking, getLanguageRanking, getAvailableLanguages } from '../api/rankings';
+import type { RankingEntry } from '../types/ranking';
+import { useAsyncData } from './useAsyncData';
+
+const DEFAULT_LANGUAGES = [
+  'JavaScript', 'TypeScript', 'Python', 'Java', 'Go', 'Rust', 'C++', 'C#',
+  'Ruby', 'PHP', 'Swift', 'Kotlin', 'Scala', 'C', 'Shell', 'HTML', 'CSS'
+];
+
+export function useRankings() {
+  const [tab, setTab] = useState<'contributions' | 'languages'>('contributions');
+  const [period, setPeriod] = useState<'weekly' | 'monthly'>('weekly');
+  const [language, setLanguage] = useState('JavaScript');
+
+  const { data: languages } = useAsyncData(
+    async () => {
+      const { data } = await getAvailableLanguages();
+      if (data && data.length > 0) {
+        setLanguage(data[0]);
+        return data;
+      }
+      return DEFAULT_LANGUAGES;
+    },
+    { initialData: DEFAULT_LANGUAGES }
+  );
+
+  const { data: rankings, loading } = useAsyncData(
+    async () => {
+      if (tab === 'contributions') {
+        const { data } = await getContributionRanking(period);
+        return data || [];
+      }
+      if (language) {
+        const { data } = await getLanguageRanking(language, period);
+        return data || [];
+      }
+      return [];
+    },
+    { initialData: [] as RankingEntry[], deps: [tab, period, language] }
+  );
+
+  return {
+    rankings,
+    languages,
+    loading,
+    tab,
+    setTab,
+    period,
+    setPeriod,
+    language,
+    setLanguage,
+  };
+}

--- a/frontend/src/hooks/useReport.ts
+++ b/frontend/src/hooks/useReport.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import {
+  getMyWeeklyReport,
+  getMyMonthlyReport,
+  getComparison,
+  type ActivityReport,
+  type ReportComparison,
+} from '../api/reports';
+import { useAsyncData } from './useAsyncData';
+
+type Period = 'weekly' | 'monthly';
+
+export function useReport() {
+  const { t } = useTranslation();
+  const [period, setPeriod] = useState<Period>('weekly');
+
+  const { data, loading } = useAsyncData(
+    async () => {
+      const [reportRes, comparisonRes] = await Promise.all([
+        period === 'weekly' ? getMyWeeklyReport() : getMyMonthlyReport(),
+        getComparison(period),
+      ]);
+      return {
+        report: reportRes.data as ActivityReport,
+        comparison: comparisonRes.data as ReportComparison,
+      };
+    },
+    { deps: [period] }
+  );
+
+  if (data === null && !loading) {
+    toast.error(t('errors.somethingWrong'));
+  }
+
+  return {
+    report: data?.report ?? null,
+    comparison: data?.comparison ?? null,
+    loading,
+    period,
+    setPeriod,
+  };
+}

--- a/frontend/src/hooks/useResources.ts
+++ b/frontend/src/hooks/useResources.ts
@@ -1,0 +1,157 @@
+import { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { useAuthStore } from '../store/authStore';
+import type { LearningResource, CreateResourceRequest, ResourceCategory, ResourceDifficulty } from '../types/resource';
+import {
+  getPublicResources,
+  getSavedResources,
+  searchResources,
+  createResource,
+  updateResource,
+  deleteResource,
+  likeResource,
+  unlikeResource,
+  saveResource,
+  unsaveResource,
+} from '../api/resources';
+import { useAsyncData } from './useAsyncData';
+
+type TabType = 'explore' | 'saved' | 'mine';
+
+export function useResources() {
+  const { t } = useTranslation();
+  const user = useAuthStore((s) => s.user);
+  const [tab, setTab] = useState<TabType>('explore');
+  const [saving, setSaving] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [categoryFilter, setCategoryFilter] = useState<ResourceCategory | ''>('');
+  const [difficultyFilter, setDifficultyFilter] = useState<ResourceDifficulty | ''>('');
+  const [page, setPage] = useState(0);
+  const limit = 20;
+
+  const { data, loading, refetch } = useAsyncData(
+    async () => {
+      let result: { resources: LearningResource[]; total: number };
+
+      if (tab === 'saved') {
+        result = await getSavedResources(limit, page * limit);
+      } else if (tab === 'mine' && user) {
+        const res = await import('../api/resources');
+        const myResources = await res.getResourcesByUserId(user.id);
+        result = { resources: myResources, total: myResources.length };
+      } else {
+        if (searchQuery.trim()) {
+          result = await searchResources(searchQuery, limit, page * limit);
+        } else {
+          result = await getPublicResources(limit, page * limit, categoryFilter, difficultyFilter);
+        }
+      }
+      return result;
+    },
+    { deps: [tab, categoryFilter, difficultyFilter, page] }
+  );
+
+  const resources = data?.resources ?? [];
+  const total = data?.total ?? 0;
+
+  const [localResources, setLocalResources] = useState<LearningResource[] | null>(null);
+  const currentResources = localResources ?? resources;
+
+  const handleSearch = useCallback(() => {
+    setPage(0);
+    refetch();
+  }, [refetch]);
+
+  const handleCreate = useCallback(async (reqData: CreateResourceRequest) => {
+    setSaving(true);
+    try {
+      const newResource = await createResource(reqData);
+      setLocalResources(prev => [newResource, ...(prev ?? resources)]);
+      toast.success(t('resources.createSuccess'));
+      return newResource;
+    } catch {
+      toast.error(t('resources.createFailed'));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [t, resources]);
+
+  const handleUpdate = useCallback(async (resourceId: number, reqData: CreateResourceRequest) => {
+    setSaving(true);
+    try {
+      const updated = await updateResource(resourceId, reqData);
+      setLocalResources(prev => (prev ?? resources).map(r => r.id === updated.id ? updated : r));
+      toast.success(t('resources.updateSuccess'));
+      return updated;
+    } catch {
+      toast.error(t('resources.updateFailed'));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [t, resources]);
+
+  const handleDelete = useCallback(async (resource: LearningResource) => {
+    if (!confirm(t('resources.confirmDelete'))) return false;
+    try {
+      await deleteResource(resource.id);
+      setLocalResources(prev => (prev ?? resources).filter(r => r.id !== resource.id));
+      toast.success(t('resources.deleteSuccess'));
+      return true;
+    } catch {
+      toast.error(t('resources.deleteFailed'));
+      return false;
+    }
+  }, [t, resources]);
+
+  const handleLike = useCallback(async (id: number) => {
+    try { await likeResource(id); } catch { /* noop */ }
+  }, []);
+
+  const handleUnlike = useCallback(async (id: number) => {
+    try { await unlikeResource(id); } catch { /* noop */ }
+  }, []);
+
+  const handleSave = useCallback(async (id: number) => {
+    try { await saveResource(id); } catch { /* noop */ }
+  }, []);
+
+  const handleUnsave = useCallback(async (id: number) => {
+    try { await unsaveResource(id); } catch { /* noop */ }
+  }, []);
+
+  const changeTab = useCallback((newTab: TabType) => {
+    setTab(newTab);
+    setPage(0);
+    setLocalResources(null);
+  }, []);
+
+  return {
+    resources: currentResources,
+    total,
+    loading,
+    saving,
+    tab,
+    setTab: changeTab,
+    searchQuery,
+    setSearchQuery,
+    categoryFilter,
+    setCategoryFilter: (v: ResourceCategory | '') => { setCategoryFilter(v); setPage(0); },
+    difficultyFilter,
+    setDifficultyFilter: (v: ResourceDifficulty | '') => { setDifficultyFilter(v); setPage(0); },
+    page,
+    setPage,
+    limit,
+    handleSearch,
+    createResource: handleCreate,
+    updateResource: handleUpdate,
+    deleteResource: handleDelete,
+    likeResource: handleLike,
+    unlikeResource: handleUnlike,
+    saveResource: handleSave,
+    unsaveResource: handleUnsave,
+    refetch,
+  };
+}

--- a/frontend/src/hooks/useUserSearch.ts
+++ b/frontend/src/hooks/useUserSearch.ts
@@ -1,0 +1,61 @@
+import { useState, useCallback } from 'react';
+import { getUsers } from '../api/users';
+import { useAuthStore } from '../store/authStore';
+import type { User } from '../types/user';
+import { useAsyncData } from './useAsyncData';
+
+export function useUserSearch() {
+  const currentUser = useAuthStore((s) => s.user);
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<User[]>([]);
+  const [searched, setSearched] = useState(false);
+  const [searchLoading, setSearchLoading] = useState(false);
+
+  const { data: allUsers, loading: initialLoading } = useAsyncData(
+    async () => {
+      const { data } = await getUsers();
+      return data || [];
+    },
+    { initialData: [] as User[] }
+  );
+
+  const handleSearch = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!query.trim()) {
+      setResults([]);
+      setSearched(false);
+      return;
+    }
+    setSearchLoading(true);
+    try {
+      const { data } = await getUsers(query);
+      setResults(data || []);
+      setSearched(true);
+    } catch {
+      setResults([]);
+    } finally {
+      setSearchLoading(false);
+    }
+  }, [query]);
+
+  const handleQueryChange = useCallback((value: string) => {
+    setQuery(value);
+    if (!value.trim()) {
+      setSearched(false);
+      setResults([]);
+    }
+  }, []);
+
+  const displayUsers = searched ? results : allUsers;
+  const filteredUsers = displayUsers.filter(u => u.id !== currentUser?.id);
+  const loading = initialLoading || searchLoading;
+
+  return {
+    query,
+    setQuery: handleQueryChange,
+    filteredUsers,
+    loading,
+    searched,
+    handleSearch,
+  };
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,9 +1,7 @@
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../store/authStore';
-import { getTimeline, getPosts, createPost } from '../api/posts';
-import type { Post } from '../types/post';
+import { usePosts } from '../hooks';
 import PostCard from '../components/posts/PostCard';
 import PostForm from '../components/posts/PostForm';
 import { PostCardSkeleton } from '../components/common/Skeleton';
@@ -12,29 +10,10 @@ import Avatar from '../components/common/Avatar';
 export default function DashboardPage() {
   const { t } = useTranslation();
   const user = useAuthStore((s) => s.user);
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [tab, setTab] = useState<'timeline' | 'all'>('timeline');
-
-  const fetchPosts = async () => {
-    setLoading(true);
-    try {
-      const { data } = tab === 'timeline' ? await getTimeline() : await getPosts();
-      setPosts(data || []);
-    } catch {
-      setPosts([]);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    fetchPosts();
-  }, [tab]);
+  const { posts, loading, tab, setTab, createPost, refetch } = usePosts();
 
   const handleCreatePost = async (title: string, content: string, imageUrls?: string) => {
-    await createPost({ title, content, image_urls: imageUrls });
-    fetchPosts();
+    await createPost(title, content, imageUrls);
   };
 
   return (
@@ -100,7 +79,7 @@ export default function DashboardPage() {
         ) : (
           <div className="space-y-3">
             {posts.map((post) => (
-              <PostCard key={post.id} post={post} onUpdate={fetchPosts} />
+              <PostCard key={post.id} post={post} onUpdate={refetch} />
             ))}
           </div>
         )}

--- a/frontend/src/pages/FollowListPage.tsx
+++ b/frontend/src/pages/FollowListPage.tsx
@@ -1,49 +1,16 @@
-import { useEffect, useState } from 'react';
-import { useParams, Link, useLocation } from 'react-router-dom';
-import { getUser, getFollowers, getFollowing } from '../api/users';
+import { useParams, Link } from 'react-router-dom';
 import { useAuthStore } from '../store/authStore';
-import type { User } from '../types/user';
+import { useFollowList } from '../hooks';
 import Avatar from '../components/common/Avatar';
 import FollowButton from '../components/profile/FollowButton';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 
-type Tab = 'followers' | 'following';
-
 export default function FollowListPage() {
   const { id } = useParams<{ id: string }>();
-  const location = useLocation();
   const currentUser = useAuthStore((s) => s.user);
+  const { profileUser, users, tab, loading, profileLoading } = useFollowList(id);
 
-  const initialTab: Tab = location.pathname.endsWith('/following') ? 'following' : 'followers';
-  const [tab, setTab] = useState<Tab>(initialTab);
-  const [profileUser, setProfileUser] = useState<User | null>(null);
-  const [users, setUsers] = useState<User[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    if (!id) return;
-    getUser(parseInt(id))
-      .then(({ data }) => setProfileUser(data))
-      .catch(() => {});
-  }, [id]);
-
-  useEffect(() => {
-    const newTab: Tab = location.pathname.endsWith('/following') ? 'following' : 'followers';
-    setTab(newTab);
-  }, [location.pathname]);
-
-  useEffect(() => {
-    if (!id) return;
-    const userId = parseInt(id);
-    setLoading(true);
-    const fetcher = tab === 'followers' ? getFollowers : getFollowing;
-    fetcher(userId)
-      .then(({ data }) => setUsers(data || []))
-      .catch(() => setUsers([]))
-      .finally(() => setLoading(false));
-  }, [id, tab]);
-
-  if (!profileUser && loading) return <div className="py-12"><LoadingSpinner /></div>;
+  if (!profileUser && profileLoading) return <div className="py-12"><LoadingSpinner /></div>;
 
   return (
     <div className="max-w-2xl mx-auto space-y-6">

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,16 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { getUser, getFollowers, getFollowing } from '../api/users';
-import { getUserPosts } from '../api/posts';
-import { getContributions, getLanguages, getRepos } from '../api/github';
-import { getZennArticles, getZennStats, type ZennArticle, type ZennStats } from '../api/zenn';
-import { getQiitaArticles, getQiitaStats, type QiitaArticle, type QiitaStats } from '../api/qiita';
-import { getUserGoals, getGoalStats, type LearningGoal, type LearningGoalStats } from '../api/goals';
 import { useAuthStore } from '../store/authStore';
-import type { User } from '../types/user';
-import type { Post } from '../types/post';
-import type { GitHubContribution, GitHubLanguageStat, GitHubRepository } from '../types/github';
+import { useProfile } from '../hooks';
 import Avatar from '../components/common/Avatar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import FollowButton from '../components/profile/FollowButton';
@@ -25,88 +17,14 @@ export default function ProfilePage() {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const currentUser = useAuthStore((s) => s.user);
-  const [user, setUser] = useState<User | null>(null);
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [contributions, setContributions] = useState<GitHubContribution[]>([]);
-  const [languages, setLanguages] = useState<GitHubLanguageStat[]>([]);
-  const [repos, setRepos] = useState<GitHubRepository[]>([]);
-  const [zennArticles, setZennArticles] = useState<ZennArticle[]>([]);
-  const [zennStats, setZennStats] = useState<ZennStats | null>(null);
-  const [qiitaArticles, setQiitaArticles] = useState<QiitaArticle[]>([]);
-  const [qiitaStats, setQiitaStats] = useState<QiitaStats | null>(null);
-  const [goals, setGoals] = useState<LearningGoal[]>([]);
-  const [goalStats, setGoalStats] = useState<LearningGoalStats | null>(null);
-  const [followerCount, setFollowerCount] = useState(0);
-  const [followingCount, setFollowingCount] = useState(0);
-  const [loading, setLoading] = useState(true);
+  const {
+    user, posts, contributions, languages, repos,
+    zennArticles, zennStats, qiitaArticles, qiitaStats,
+    goals, goalStats, followerCount, followingCount, loading,
+  } = useProfile(id);
+
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [portfolioModalOpen, setPortfolioModalOpen] = useState(false);
-
-  useEffect(() => {
-    if (!id) return;
-    const userId = parseInt(id);
-
-    const fetchData = async () => {
-      setLoading(true);
-      try {
-        const [userRes, postsRes, followersRes, followingRes] = await Promise.all([
-          getUser(userId),
-          getUserPosts(userId),
-          getFollowers(userId),
-          getFollowing(userId),
-        ]);
-        setUser(userRes.data);
-        setPosts(postsRes.data || []);
-        setFollowerCount((followersRes.data || []).length);
-        setFollowingCount((followingRes.data || []).length);
-
-        if (userRes.data.github_connected) {
-          const [contribRes, langRes, reposRes] = await Promise.all([
-            getContributions(userId),
-            getLanguages(userId),
-            getRepos(userId),
-          ]);
-          setContributions(contribRes.data || []);
-          setLanguages(langRes.data || []);
-          setRepos(reposRes.data || []);
-        }
-
-        // Fetch Zenn data if connected
-        if (userRes.data.zenn_username) {
-          const [articlesRes, statsRes] = await Promise.all([
-            getZennArticles(userId),
-            getZennStats(userId),
-          ]);
-          setZennArticles(articlesRes.data || []);
-          setZennStats(statsRes.data);
-        }
-
-        // Fetch Qiita data if connected
-        if (userRes.data.qiita_username) {
-          const [articlesRes, statsRes] = await Promise.all([
-            getQiitaArticles(userId),
-            getQiitaStats(userId),
-          ]);
-          setQiitaArticles(articlesRes.data || []);
-          setQiitaStats(statsRes.data);
-        }
-
-        // Fetch learning goals
-        const [goalsRes, goalStatsRes] = await Promise.all([
-          getUserGoals(userId),
-          getGoalStats(userId),
-        ]);
-        setGoals(goalsRes.data || []);
-        setGoalStats(goalStatsRes.data);
-      } catch {
-        // handle error
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    fetchData();
-  }, [id]);
 
   if (loading) return <div className="py-12"><LoadingSpinner /></div>;
   if (!user) return <div className="text-center text-gray-400 py-12">{t('errors.notFound')}</div>;
@@ -147,45 +65,24 @@ export default function ProfilePage() {
             {user.bio && <p className="text-gray-400 mt-1 text-sm">{user.bio}</p>}
             <div className="flex flex-wrap gap-3 mt-2">
               {user.github_username && (
-                <a
-                  href={`https://github.com/${user.github_username}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-400 transition-colors"
-                >
+                <a href={`https://github.com/${user.github_username}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-400 transition-colors">
                   <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
                   @{user.github_username}
-                  <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-                  </svg>
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
                 </a>
               )}
               {user.zenn_username && (
-                <a
-                  href={`https://zenn.dev/${user.zenn_username}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-400 transition-colors"
-                >
+                <a href={`https://zenn.dev/${user.zenn_username}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-400 transition-colors">
                   <span className="w-4 h-4 bg-blue-500 rounded text-white text-xs flex items-center justify-center font-bold">Z</span>
                   @{user.zenn_username}
-                  <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-                  </svg>
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
                 </a>
               )}
               {user.qiita_username && (
-                <a
-                  href={`https://qiita.com/${user.qiita_username}`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-400 transition-colors"
-                >
+                <a href={`https://qiita.com/${user.qiita_username}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-green-400 transition-colors">
                   <span className="w-4 h-4 bg-green-500 rounded text-white text-xs flex items-center justify-center font-bold">Q</span>
                   @{user.qiita_username}
-                  <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-                  </svg>
+                  <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
                 </a>
               )}
             </div>
@@ -206,30 +103,14 @@ export default function ProfilePage() {
         <div className="bg-gray-900 border border-gray-800 rounded-xl p-6 space-y-4">
           {user.skills_languages && (
             <div>
-              <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2">
-                <span>✨</span> {t('profile.languages')}
-              </h3>
-              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer">
-                <img
-                  src={`https://skillicons.dev/icons?i=${user.skills_languages}&theme=dark`}
-                  alt="Languages"
-                  className="h-12"
-                />
-              </a>
+              <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2"><span>✨</span> {t('profile.languages')}</h3>
+              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?i=${user.skills_languages}&theme=dark`} alt="Languages" className="h-12" /></a>
             </div>
           )}
           {user.skills_frameworks && (
             <div>
-              <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2">
-                <span>🚀</span> {t('profile.frameworks')}
-              </h3>
-              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer">
-                <img
-                  src={`https://skillicons.dev/icons?i=${user.skills_frameworks}&theme=dark`}
-                  alt="Frameworks"
-                  className="h-12"
-                />
-              </a>
+              <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2"><span>🚀</span> {t('profile.frameworks')}</h3>
+              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?i=${user.skills_frameworks}&theme=dark`} alt="Frameworks" className="h-12" /></a>
             </div>
           )}
         </div>
@@ -239,99 +120,44 @@ export default function ProfilePage() {
       {user.github_connected && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <div className="lg:col-span-2 bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-            <div className="px-6 py-4 border-b border-gray-800">
-              <h2 className="text-sm font-semibold">{t('profile.contributions')}</h2>
-            </div>
-            <div className="p-6">
-              <ContributionCalendar contributions={contributions} />
-            </div>
+            <div className="px-6 py-4 border-b border-gray-800"><h2 className="text-sm font-semibold">{t('profile.contributions')}</h2></div>
+            <div className="p-6"><ContributionCalendar contributions={contributions} /></div>
           </div>
-
           {languages.length > 0 && (
             <div className="bg-gray-900 border border-gray-800 rounded-xl overflow-hidden">
-              <div className="px-6 py-4 border-b border-gray-800">
-                <h2 className="text-sm font-semibold">{t('profile.languages')}</h2>
-              </div>
-              <div className="p-6">
-                <LanguageChart languages={languages} />
-              </div>
+              <div className="px-6 py-4 border-b border-gray-800"><h2 className="text-sm font-semibold">{t('profile.languages')}</h2></div>
+              <div className="p-6"><LanguageChart languages={languages} /></div>
             </div>
           )}
         </div>
       )}
 
-      {/* Badges / Achievements */}
-      <BadgeDisplay
-        contributions={contributions}
-        posts={posts}
-        followerCount={followerCount}
-        followingCount={followingCount}
-      />
+      <BadgeDisplay contributions={contributions} posts={posts} followerCount={followerCount} followingCount={followingCount} />
 
       {/* Repositories */}
       {user.github_connected && repos.length > 0 && (
         <div>
           <div className="flex items-center justify-between mb-3">
-            <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide">
-              {t('profile.repositories')}
-            </h2>
+            <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide">{t('profile.repositories')}</h2>
             {user.github_username && (
-              <a
-                href={`https://github.com/${user.github_username}?tab=repositories`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-xs text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1"
-              >
+              <a href={`https://github.com/${user.github_username}?tab=repositories`} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1">
                 {t('profile.viewAllOnGitHub')}
-                <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-                </svg>
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
               </a>
             )}
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {repos.slice(0, 6).map((repo) => (
-              <a
-                key={repo.id}
-                href={`https://github.com/${repo.full_name}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-gray-600 transition-colors group"
-              >
+              <a key={repo.id} href={`https://github.com/${repo.full_name}`} target="_blank" rel="noopener noreferrer" className="bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-gray-600 transition-colors group">
                 <div className="flex items-start gap-2">
-                  <svg className="w-4 h-4 text-gray-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
-                  </svg>
+                  <svg className="w-4 h-4 text-gray-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" /></svg>
                   <div className="min-w-0 flex-1">
-                    <div className="font-medium text-sm text-blue-400 group-hover:text-blue-300 truncate">
-                      {repo.name}
-                    </div>
-                    {repo.description && (
-                      <p className="text-xs text-gray-500 mt-1 line-clamp-2">{repo.description}</p>
-                    )}
+                    <div className="font-medium text-sm text-blue-400 group-hover:text-blue-300 truncate">{repo.name}</div>
+                    {repo.description && <p className="text-xs text-gray-500 mt-1 line-clamp-2">{repo.description}</p>}
                     <div className="flex items-center gap-3 mt-2">
-                      {repo.language && (
-                        <span className="flex items-center gap-1 text-xs text-gray-400">
-                          <span className="w-2.5 h-2.5 rounded-full bg-yellow-400" />
-                          {repo.language}
-                        </span>
-                      )}
-                      {repo.stars > 0 && (
-                        <span className="flex items-center gap-1 text-xs text-gray-400">
-                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" />
-                          </svg>
-                          {repo.stars}
-                        </span>
-                      )}
-                      {repo.forks > 0 && (
-                        <span className="flex items-center gap-1 text-xs text-gray-400">
-                          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z" />
-                          </svg>
-                          {repo.forks}
-                        </span>
-                      )}
+                      {repo.language && <span className="flex items-center gap-1 text-xs text-gray-400"><span className="w-2.5 h-2.5 rounded-full bg-yellow-400" />{repo.language}</span>}
+                      {repo.stars > 0 && <span className="flex items-center gap-1 text-xs text-gray-400"><svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z" /></svg>{repo.stars}</span>}
+                      {repo.forks > 0 && <span className="flex items-center gap-1 text-xs text-gray-400"><svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M7.217 10.907a2.25 2.25 0 1 0 0 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186 9.566-5.314m-9.566 7.5 9.566 5.314m0 0a2.25 2.25 0 1 0 3.935 2.186 2.25 2.25 0 0 0-3.935-2.186Zm0-12.814a2.25 2.25 0 1 0 3.933-2.185 2.25 2.25 0 0 0-3.933 2.185Z" /></svg>{repo.forks}</span>}
                     </div>
                   </div>
                 </div>
@@ -348,55 +174,21 @@ export default function ProfilePage() {
             <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide flex items-center gap-2">
               <span className="w-5 h-5 bg-blue-500 rounded text-white text-xs flex items-center justify-center font-bold">Z</span>
               {t('profile.zennArticles')}
-              {zennStats && (
-                <span className="text-xs text-gray-500 font-normal ml-2">
-                  {zennStats.total_articles} {t('profile.articles')} · {zennStats.total_likes} {t('post.like')}s
-                </span>
-              )}
+              {zennStats && <span className="text-xs text-gray-500 font-normal ml-2">{zennStats.total_articles} {t('profile.articles')} · {zennStats.total_likes} {t('post.like')}s</span>}
             </h2>
-            <a
-              href={`https://zenn.dev/${user.zenn_username}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1"
-            >
-              {t('profile.viewAllOnZenn')}
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-              </svg>
-            </a>
+            <a href={`https://zenn.dev/${user.zenn_username}`} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1">{t('profile.viewAllOnZenn')}<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg></a>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {zennArticles.slice(0, 6).map((article) => (
-              <a
-                key={article.id}
-                href={`https://zenn.dev/${user.zenn_username}/articles/${article.slug}`}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-gray-600 transition-colors group"
-              >
+              <a key={article.id} href={`https://zenn.dev/${user.zenn_username}/articles/${article.slug}`} target="_blank" rel="noopener noreferrer" className="bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-gray-600 transition-colors group">
                 <div className="flex items-start gap-3">
                   <span className="text-2xl">{article.emoji || '📝'}</span>
                   <div className="min-w-0 flex-1">
-                    <div className="font-medium text-sm text-blue-400 group-hover:text-blue-300 line-clamp-2">
-                      {article.title}
-                    </div>
+                    <div className="font-medium text-sm text-blue-400 group-hover:text-blue-300 line-clamp-2">{article.title}</div>
                     <div className="flex items-center gap-3 mt-2">
-                      <span className="flex items-center gap-1 text-xs text-gray-400">
-                        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                        </svg>
-                        {article.liked_count}
-                      </span>
-                      <span className="flex items-center gap-1 text-xs text-gray-400">
-                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
-                        </svg>
-                        {article.comments_count}
-                      </span>
-                      <span className="px-2 py-0.5 bg-gray-800 text-gray-400 text-xs rounded">
-                        {article.article_type === 'tech' ? 'Tech' : 'Idea'}
-                      </span>
+                      <span className="flex items-center gap-1 text-xs text-gray-400"><svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>{article.liked_count}</span>
+                      <span className="flex items-center gap-1 text-xs text-gray-400"><svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" /></svg>{article.comments_count}</span>
+                      <span className="px-2 py-0.5 bg-gray-800 text-gray-400 text-xs rounded">{article.article_type === 'tech' ? 'Tech' : 'Idea'}</span>
                     </div>
                   </div>
                 </div>
@@ -413,57 +205,21 @@ export default function ProfilePage() {
             <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide flex items-center gap-2">
               <span className="w-5 h-5 bg-green-500 rounded text-white text-xs flex items-center justify-center font-bold">Q</span>
               {t('profile.qiitaArticles')}
-              {qiitaStats && (
-                <span className="text-xs text-gray-500 font-normal ml-2">
-                  {qiitaStats.total_articles} {t('profile.articles')} · {qiitaStats.total_likes} {t('post.like')}s
-                </span>
-              )}
+              {qiitaStats && <span className="text-xs text-gray-500 font-normal ml-2">{qiitaStats.total_articles} {t('profile.articles')} · {qiitaStats.total_likes} {t('post.like')}s</span>}
             </h2>
-            <a
-              href={`https://qiita.com/${user.qiita_username}`}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-gray-500 hover:text-green-400 transition-colors flex items-center gap-1"
-            >
-              {t('profile.viewAllOnQiita')}
-              <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-              </svg>
-            </a>
+            <a href={`https://qiita.com/${user.qiita_username}`} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-500 hover:text-green-400 transition-colors flex items-center gap-1">{t('profile.viewAllOnQiita')}<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg></a>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {qiitaArticles.slice(0, 6).map((article) => (
-              <a
-                key={article.id}
-                href={article.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-gray-600 transition-colors group"
-              >
+              <a key={article.id} href={article.url} target="_blank" rel="noopener noreferrer" className="bg-gray-900 border border-gray-800 rounded-xl p-4 hover:border-gray-600 transition-colors group">
                 <div className="flex items-start gap-3">
                   <span className="text-2xl">📝</span>
                   <div className="min-w-0 flex-1">
-                    <div className="font-medium text-sm text-green-400 group-hover:text-green-300 line-clamp-2">
-                      {article.title}
-                    </div>
+                    <div className="font-medium text-sm text-green-400 group-hover:text-green-300 line-clamp-2">{article.title}</div>
                     <div className="flex items-center gap-3 mt-2">
-                      <span className="flex items-center gap-1 text-xs text-gray-400">
-                        <svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                          <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/>
-                        </svg>
-                        {article.likes_count}
-                      </span>
-                      <span className="flex items-center gap-1 text-xs text-gray-400">
-                        <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" />
-                        </svg>
-                        {article.comments_count}
-                      </span>
-                      {article.tags && (
-                        <span className="px-2 py-0.5 bg-gray-800 text-gray-400 text-xs rounded truncate max-w-[100px]">
-                          {article.tags.split(',')[0]}
-                        </span>
-                      )}
+                      <span className="flex items-center gap-1 text-xs text-gray-400"><svg className="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"/></svg>{article.likes_count}</span>
+                      <span className="flex items-center gap-1 text-xs text-gray-400"><svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 0 1 .865-.501 48.172 48.172 0 0 0 3.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0 0 12 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018Z" /></svg>{article.comments_count}</span>
+                      {article.tags && <span className="px-2 py-0.5 bg-gray-800 text-gray-400 text-xs rounded truncate max-w-[100px]">{article.tags.split(',')[0]}</span>}
                     </div>
                   </div>
                 </div>
@@ -478,72 +234,31 @@ export default function ProfilePage() {
         <div>
           <div className="flex items-center justify-between mb-3">
             <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide flex items-center gap-2">
-              <svg className="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-              </svg>
+              <svg className="w-5 h-5 text-purple-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
               {t('goals.title')}
-              {goalStats && (
-                <span className="text-xs text-gray-500 font-normal ml-2">
-                  {goalStats.active_goals} {t('goals.active')} · {goalStats.completed_goals} {t('goals.completed')}
-                </span>
-              )}
+              {goalStats && <span className="text-xs text-gray-500 font-normal ml-2">{goalStats.active_goals} {t('goals.active')} · {goalStats.completed_goals} {t('goals.completed')}</span>}
             </h2>
             {isOwnProfile && (
-              <Link
-                to="/goals"
-                className="text-xs text-gray-500 hover:text-purple-400 transition-colors flex items-center gap-1"
-              >
-                {t('goals.manageGoals')}
-                <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
-                </svg>
-              </Link>
+              <Link to="/goals" className="text-xs text-gray-500 hover:text-purple-400 transition-colors flex items-center gap-1">{t('goals.manageGoals')}<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" /></svg></Link>
             )}
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {goals.slice(0, 4).map((goal) => {
-              const categoryIcons: Record<string, string> = {
-                language: '💻',
-                framework: '🚀',
-                skill: '🎯',
-                project: '📁',
-                other: '📝',
-              };
-              const statusColors: Record<string, string> = {
-                active: 'text-green-400 bg-green-400/10',
-                completed: 'text-blue-400 bg-blue-400/10',
-                paused: 'text-yellow-400 bg-yellow-400/10',
-              };
+              const categoryIcons: Record<string, string> = { language: '💻', framework: '🚀', skill: '🎯', project: '📁', other: '📝' };
+              const statusColors: Record<string, string> = { active: 'text-green-400 bg-green-400/10', completed: 'text-blue-400 bg-blue-400/10', paused: 'text-yellow-400 bg-yellow-400/10' };
               return (
-                <div
-                  key={goal.id}
-                  className="bg-gray-900 border border-gray-800 rounded-xl p-4"
-                >
+                <div key={goal.id} className="bg-gray-900 border border-gray-800 rounded-xl p-4">
                   <div className="flex items-start gap-3">
                     <span className="text-2xl">{categoryIcons[goal.category] || '📝'}</span>
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <div className="font-medium text-sm text-white truncate flex-1">
-                          {goal.title}
-                        </div>
-                        <span className={`px-2 py-0.5 text-xs rounded ${statusColors[goal.status]}`}>
-                          {t(`goals.${goal.status}`)}
-                        </span>
+                        <div className="font-medium text-sm text-white truncate flex-1">{goal.title}</div>
+                        <span className={`px-2 py-0.5 text-xs rounded ${statusColors[goal.status]}`}>{t(`goals.${goal.status}`)}</span>
                       </div>
-                      {goal.description && (
-                        <p className="text-xs text-gray-500 mt-1 line-clamp-2">{goal.description}</p>
-                      )}
+                      {goal.description && <p className="text-xs text-gray-500 mt-1 line-clamp-2">{goal.description}</p>}
                       <div className="mt-2">
-                        <div className="flex items-center justify-between text-xs text-gray-400 mb-1">
-                          <span>{t('goals.progress')}</span>
-                          <span>{goal.progress}%</span>
-                        </div>
-                        <div className="h-1.5 bg-gray-800 rounded-full overflow-hidden">
-                          <div
-                            className="h-full bg-purple-500 rounded-full transition-all"
-                            style={{ width: `${goal.progress}%` }}
-                          />
-                        </div>
+                        <div className="flex items-center justify-between text-xs text-gray-400 mb-1"><span>{t('goals.progress')}</span><span>{goal.progress}%</span></div>
+                        <div className="h-1.5 bg-gray-800 rounded-full overflow-hidden"><div className="h-full bg-purple-500 rounded-full transition-all" style={{ width: `${goal.progress}%` }} /></div>
                       </div>
                     </div>
                   </div>
@@ -558,42 +273,14 @@ export default function ProfilePage() {
       <div>
         <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-3">{t('profile.posts')}</h2>
         {posts.length === 0 ? (
-          <div className="bg-gray-900 border border-gray-800 rounded-xl p-12 text-center text-gray-400 text-sm">
-            {t('profile.noPosts')}
-          </div>
+          <div className="bg-gray-900 border border-gray-800 rounded-xl p-12 text-center text-gray-400 text-sm">{t('profile.noPosts')}</div>
         ) : (
-          <div className="space-y-3">
-            {posts.map((post) => (
-              <PostCard key={post.id} post={post} />
-            ))}
-          </div>
+          <div className="space-y-3">{posts.map((post) => <PostCard key={post.id} post={post} />)}</div>
         )}
       </div>
 
-      {/* Share Modal */}
-      <ShareModal
-        isOpen={shareModalOpen}
-        onClose={() => setShareModalOpen(false)}
-        user={user}
-        followerCount={followerCount}
-        followingCount={followingCount}
-        totalContributions={contributions.reduce((sum, c) => sum + c.count, 0)}
-        languages={languages}
-        postCount={posts.length}
-      />
-
-      {/* Portfolio Modal */}
-      <PortfolioModal
-        isOpen={portfolioModalOpen}
-        onClose={() => setPortfolioModalOpen(false)}
-        user={user}
-        languages={languages}
-        repos={repos}
-        goals={goals}
-        totalContributions={contributions.reduce((sum, c) => sum + c.count, 0)}
-        followerCount={followerCount}
-        followingCount={followingCount}
-      />
+      <ShareModal isOpen={shareModalOpen} onClose={() => setShareModalOpen(false)} user={user} followerCount={followerCount} followingCount={followingCount} totalContributions={contributions.reduce((sum, c) => sum + c.count, 0)} languages={languages} postCount={posts.length} />
+      <PortfolioModal isOpen={portfolioModalOpen} onClose={() => setPortfolioModalOpen(false)} user={user} languages={languages} repos={repos} goals={goals} totalContributions={contributions.reduce((sum, c) => sum + c.count, 0)} followerCount={followerCount} followingCount={followingCount} />
     </div>
   );
 }

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -1,58 +1,15 @@
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { getContributionRanking, getLanguageRanking, getAvailableLanguages } from '../api/rankings';
-import type { RankingEntry } from '../types/ranking';
+import { useRankings } from '../hooks';
 import Avatar from '../components/common/Avatar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 
-// Default popular programming languages for ranking filter
-const DEFAULT_LANGUAGES = [
-  'JavaScript', 'TypeScript', 'Python', 'Java', 'Go', 'Rust', 'C++', 'C#',
-  'Ruby', 'PHP', 'Swift', 'Kotlin', 'Scala', 'C', 'Shell', 'HTML', 'CSS'
-];
-
 export default function RankingsPage() {
   const { t } = useTranslation();
-  const [tab, setTab] = useState<'contributions' | 'languages'>('contributions');
-  const [period, setPeriod] = useState<'weekly' | 'monthly'>('weekly');
-  const [language, setLanguage] = useState('JavaScript');
-  const [languages, setLanguages] = useState<string[]>(DEFAULT_LANGUAGES);
-  const [rankings, setRankings] = useState<RankingEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    getAvailableLanguages()
-      .then(({ data }) => {
-        if (data && data.length > 0) {
-          setLanguages(data);
-          setLanguage(data[0]);
-        }
-      })
-      .catch(() => {
-        // Keep using default languages on error
-      });
-  }, []);
-
-  useEffect(() => {
-    const fetchRankings = async () => {
-      setLoading(true);
-      try {
-        if (tab === 'contributions') {
-          const { data } = await getContributionRanking(period);
-          setRankings(data || []);
-        } else if (language) {
-          const { data } = await getLanguageRanking(language, period);
-          setRankings(data || []);
-        }
-      } catch {
-        setRankings([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchRankings();
-  }, [tab, period, language]);
+  const {
+    rankings, languages, loading,
+    tab, setTab, period, setPeriod, language, setLanguage,
+  } = useRankings();
 
   const medalColor = (index: number) => {
     if (index === 0) return 'text-yellow-400';

--- a/frontend/src/pages/ReportsPage.tsx
+++ b/frontend/src/pages/ReportsPage.tsx
@@ -1,43 +1,10 @@
-import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  getMyWeeklyReport,
-  getMyMonthlyReport,
-  getComparison,
-  type ActivityReport,
-  type ReportComparison,
-} from '../api/reports';
-import toast from 'react-hot-toast';
+import { useReport } from '../hooks';
 import LoadingSpinner from '../components/common/LoadingSpinner';
-
-type Period = 'weekly' | 'monthly';
 
 export default function ReportsPage() {
   const { t } = useTranslation();
-  const [period, setPeriod] = useState<Period>('weekly');
-  const [report, setReport] = useState<ActivityReport | null>(null);
-  const [comparison, setComparison] = useState<ReportComparison | null>(null);
-  const [loading, setLoading] = useState(true);
-
-  useEffect(() => {
-    fetchReport();
-  }, [period]);
-
-  const fetchReport = async () => {
-    setLoading(true);
-    try {
-      const [reportRes, comparisonRes] = await Promise.all([
-        period === 'weekly' ? getMyWeeklyReport() : getMyMonthlyReport(),
-        getComparison(period),
-      ]);
-      setReport(reportRes.data);
-      setComparison(comparisonRes.data);
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-    } finally {
-      setLoading(false);
-    }
-  };
+  const { report, comparison, loading, period, setPeriod } = useReport();
 
   const formatDate = (dateStr: string) => {
     const date = new Date(dateStr);
@@ -56,7 +23,6 @@ export default function ReportsPage() {
     return 'text-gray-400';
   };
 
-  // Calculate max contribution for chart scaling
   const maxContribution = report?.daily_contributions
     ? Math.max(...report.daily_contributions.map((d) => d.contributions), 1)
     : 1;

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -1,53 +1,16 @@
-import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { getUsers } from '../api/users';
-import { useAuthStore } from '../store/authStore';
+import { useUserSearch } from '../hooks';
 import type { User } from '../types/user';
 import Avatar from '../components/common/Avatar';
 import FollowButton from '../components/profile/FollowButton';
 import { UserCardSkeleton } from '../components/common/Skeleton';
+import { useAuthStore } from '../store/authStore';
 
 export default function SearchPage() {
   const { t } = useTranslation();
   const currentUser = useAuthStore((s) => s.user);
-  const [query, setQuery] = useState('');
-  const [results, setResults] = useState<User[]>([]);
-  const [allUsers, setAllUsers] = useState<User[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [searched, setSearched] = useState(false);
-
-  // Load all users on mount
-  useEffect(() => {
-    getUsers()
-      .then(({ data }) => {
-        setAllUsers(data || []);
-      })
-      .catch(() => {})
-      .finally(() => setLoading(false));
-  }, []);
-
-  const handleSearch = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!query.trim()) {
-      setResults([]);
-      setSearched(false);
-      return;
-    }
-    setLoading(true);
-    try {
-      const { data } = await getUsers(query);
-      setResults(data || []);
-      setSearched(true);
-    } catch {
-      setResults([]);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const displayUsers = searched ? results : allUsers;
-  const filteredUsers = displayUsers.filter((u) => u.id !== currentUser?.id);
+  const { query, setQuery, filteredUsers, loading, searched, handleSearch } = useUserSearch();
 
   return (
     <div className="max-w-3xl mx-auto space-y-6">
@@ -66,13 +29,7 @@ export default function SearchPage() {
           <input
             type="text"
             value={query}
-            onChange={(e) => {
-              setQuery(e.target.value);
-              if (!e.target.value.trim()) {
-                setSearched(false);
-                setResults([]);
-              }
-            }}
+            onChange={(e) => setQuery(e.target.value)}
             placeholder={t('explore.searchPlaceholder')}
             className="w-full pl-10 pr-3 py-2.5 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
           />


### PR DESCRIPTION
## 概要

クリーンアーキテクチャに基づき、フロントエンドにカスタムフック層（`hooks/`）を導入。
各ページに直書きされていたAPI呼び出し・状態管理・副作用をドメイン別フックに抽出し、
ページコンポーネントをUIレンダリングに専念させました。

- 汎用データ取得フック `useAsyncData` を基盤として作成
- 12個のドメインフックを新規作成
- 12ページ/コンポーネントをリファクタリング（**計1,058行削減**）
- TypeScript型チェック通過確認済み

## 新規ファイル（14ファイル）

| フック | 内容 |
|--------|------|
| `useAsyncData` | 汎用データ取得（全フックの基盤） |
| `useGoals` | 目標CRUD + 進捗・ステータス管理 |
| `usePosts` | タイムライン/全投稿取得 + 投稿作成 |
| `usePostDetail` | 投稿詳細 + コメント取得・投稿 |
| `useReport` | 週間/月間レポート + 比較データ |
| `useRankings` | ランキング + 言語フィルタ |
| `useUserSearch` | ユーザー検索 |
| `useProfile` | プロフィール全データ統合（13 state → 1 hook） |
| `useBookReviews` | レビューCRUD + ページネーション |
| `useProjects` | プロジェクトCRUD + GitHubリポジトリ |
| `useResources` | リソースCRUD + いいね/保存 + フィルタ |
| `useFollowList` | フォロー/フォロワー一覧 |
| `useNotifications` | 通知取得 + 既読処理 + ポーリング |
| `index.ts` | バレルエクスポート |

## 修正ファイル（12ファイル）

ProfilePage, GoalsPage, DashboardPage, PostDetailPage, ReportsPage, RankingsPage, SearchPage, BookReviewsPage, ProjectsPage, ResourcesPage, FollowListPage, NotificationDropdown

## テスト計画

- [x] 各ページの表示・操作が変更前と同一であることを確認
- [x] Goals: 作成・編集・削除・進捗変更・ステータス変更
- [x] Dashboard: 投稿作成・タイムライン/全投稿切り替え
- [x] Search: ユーザー検索・全ユーザー表示
- [x] Profile: GitHub/Zenn/Qiita連携ユーザーのデータ表示
- [x] Reports: 週間/月間切り替え
- [x] Rankings: ランキング表示・言語切り替え
- [x] BookReviews/Projects/Resources: CRUD操作
- [x] Notifications: 通知ドロップダウン表示・既読

Closes #61