### PR TITLE
fix: ヘッダーのナビリンクとテーマ切り替えアイコンの視認性を改善

### DIFF
--- a/frontend/src/components/common/ThemeToggle.tsx
+++ b/frontend/src/components/common/ThemeToggle.tsx
@@ -54,7 +54,7 @@ export default function ThemeToggle() {
           className={`p-2 rounded-md transition-all ${
             theme === t.value
               ? 'bg-gray-700 dark:bg-gray-700 light:bg-white text-white dark:text-white light:text-gray-900 shadow-sm'
-              : 'text-gray-400 hover:text-white dark:text-gray-400 dark:hover:text-white light:text-gray-500 light:hover:text-gray-900'
+              : 'text-gray-400 hover:text-white dark:text-gray-400 dark:hover:text-white light:text-gray-600 light:hover:text-gray-900'
           }`}
           title={t.label}
           aria-label={`Set ${t.label} theme`}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -30,7 +30,9 @@ export default function Header() {
   };
 
   const isActive = (path: string) =>
-    location.pathname === path ? 'text-white bg-gray-800' : 'text-gray-300 hover:text-white';
+    location.pathname === path
+      ? 'text-white bg-gray-800'
+      : 'text-white/70 hover:text-white';
 
   // Close mobile menu on route change
   useEffect(() => {


### PR DESCRIPTION
## 概要

- ヘッダーのナビリンク（ダッシュボード、見つける、ランキング等）の文字色を白色に統一
- テーマ切り替えの非選択アイコン色をライトモードで視認できるよう修正

## 変更ファイル

- `frontend/src/components/layout/Header.tsx` — ナビリンクの文字色を `text-white` / `text-white/70` に統一
- `frontend/src/components/common/ThemeToggle.tsx` — ライトモード非選択アイコンを `light:text-gray-600` に変更

Closes #63