### PR TITLE
fix: ヘッダーナビゲーションの文字改行を修正

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -84,12 +84,12 @@ export default function Header() {
         </button>
 
         {/* Desktop Nav */}
-        <nav className="hidden md:flex items-center gap-1 ml-2">
+        <nav className="hidden md:flex items-center gap-1 ml-2 overflow-x-auto scrollbar-hide">
           {navItems.map(({ path, key }) => (
             <Link
               key={path}
               to={path}
-              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors ${isActive(path)}`}
+              className={`px-3 py-1.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${isActive(path)}`}
             >
               {t(key)}
             </Link>

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -129,6 +129,15 @@ body {
 .light .bg-violet-500\/10 { background-color: rgba(139, 92, 246, 0.1); }
 .light .bg-amber-500\/10 { background-color: rgba(245, 158, 11, 0.1); }
 
+/* Hide scrollbar utility */
+.scrollbar-hide {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.scrollbar-hide::-webkit-scrollbar {
+  display: none;
+}
+
 /* Shadow adjustments */
 .light .shadow-lg {
   --tw-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Closes #71

## 概要

ナビゲーション項目が増えたことでヘッダーの各リンクテキストが改行される問題を修正。

## 変更点

- **Header.tsx**: ナビリンクに `whitespace-nowrap`、ナビ領域に `overflow-x-auto scrollbar-hide` を追加
- **index.css**: `.scrollbar-hide` ユーティリティクラスを追加（スクロールバー非表示）

## テスト計画

- [ ] ヘッダーのナビ項目が1行で表示されること
- [ ] 画面幅が狭い場合にスクロールバーが表示されないこと