### PR TITLE
fix: ヘッダーナビの横幅最適化 — 右側要素のスペース確保

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,28 +1,40 @@
 import { useState, useEffect, useRef } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, FolderKanban, BookOpen, Library } from 'lucide-react';
+import {
+  ChevronDown,
+  Target,
+  BarChart3,
+  Map,
+  FolderKanban,
+  BookOpen,
+  Library,
+  Settings,
+} from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import Avatar from '../common/Avatar';
 import ThemeToggle from '../common/ThemeToggle';
 import LanguageSelector from '../common/LanguageSelector';
 import NotificationDropdown from '../notifications/NotificationDropdown';
 
+/** 常に表示する主要ナビ（5個以内に抑える） */
 const navItems = [
   { path: '/', key: 'nav.dashboard' },
   { path: '/search', key: 'nav.explore' },
   { path: '/rankings', key: 'nav.rankings' },
   { path: '/chat', key: 'nav.chat' },
-  { path: '/goals', key: 'nav.goals' },
-  { path: '/reports', key: 'nav.reports' },
   { path: '/qa', key: 'nav.qa' },
-  { path: '/roadmaps', key: 'nav.roadmaps' },
 ] as const;
 
+/** 「その他」ドロップダウンに格納する項目 */
 const moreItems = [
+  { path: '/goals', key: 'nav.goals', icon: Target },
+  { path: '/reports', key: 'nav.reports', icon: BarChart3 },
+  { path: '/roadmaps', key: 'nav.roadmaps', icon: Map },
   { path: '/projects', key: 'nav.projects', icon: FolderKanban },
   { path: '/resources', key: 'nav.resources', icon: Library },
   { path: '/book-reviews', key: 'nav.bookReviews', icon: BookOpen },
+  { path: '/settings', key: 'nav.settings', icon: Settings },
 ] as const;
 
 export default function Header() {
@@ -47,7 +59,7 @@ export default function Header() {
 
   const isMoreActive = moreItems.some((item) => location.pathname === item.path);
 
-  // Close mobile menu on route change
+  // Close menus on route change
   useEffect(() => {
     setMobileOpen(false);
     setMoreOpen(false);
@@ -79,7 +91,7 @@ export default function Header() {
 
   return (
     <header className="bg-gray-900/80 backdrop-blur-sm border-b border-gray-800 sticky top-0 z-50">
-      <div className="max-w-7xl mx-auto px-4 h-16 flex items-center gap-4">
+      <div className="max-w-7xl mx-auto px-4 h-16 flex items-center gap-3">
         {/* Logo */}
         <Link to="/" className="flex items-center gap-2 shrink-0">
           <svg className="w-8 h-8 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -109,7 +121,7 @@ export default function Header() {
         </button>
 
         {/* Desktop Nav */}
-        <nav className="hidden md:flex items-center gap-1 ml-2 overflow-x-auto scrollbar-hide">
+        <nav className="hidden md:flex items-center gap-1 ml-2 min-w-0">
           {navItems.map(({ path, key }) => (
             <Link
               key={path}
@@ -121,8 +133,8 @@ export default function Header() {
           ))}
         </nav>
 
-        {/* More dropdown - outside nav to avoid overflow clipping */}
-        <div className="hidden md:block relative" ref={moreRef}>
+        {/* More dropdown */}
+        <div className="hidden md:block relative shrink-0" ref={moreRef}>
           <button
             onClick={() => setMoreOpen(!moreOpen)}
             className={`flex items-center gap-1 px-3 py-1.5 rounded-md text-sm font-medium transition-colors whitespace-nowrap ${
@@ -155,23 +167,11 @@ export default function Header() {
           )}
         </div>
 
-        {/* Right side */}
-        <div className="flex items-center gap-2 ml-auto">
+        {/* Right side — shrink-0 ensures icons are never compressed */}
+        <div className="flex items-center gap-2 ml-auto shrink-0">
           <LanguageSelector />
           <ThemeToggle />
           <NotificationDropdown />
-
-          <Link
-            to="/settings"
-            className="p-2 text-gray-300 hover:text-white transition-colors rounded-md"
-            title={t('nav.settings')}
-            aria-label={t('nav.settings')}
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a7 7 0 0 1 0 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a7 7 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a7 7 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.992a7 7 0 0 1 0-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124q.108-.066.22-.128c.332-.183.582-.495.644-.869l.214-1.281Z" />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
-            </svg>
-          </Link>
 
           {user && (
             <Link
@@ -210,7 +210,7 @@ export default function Header() {
               </Link>
             ))}
 
-            {/* More items separator */}
+            {/* More items */}
             <div className="border-t border-gray-800 my-1" />
             {moreItems.map(({ path, key, icon: Icon }) => (
               <Link


### PR DESCRIPTION
## 概要

ヘッダーのナビゲーション項目が多く、右側のユーザーアイコン等が圧迫される問題を修正しました。

## 変更内容

- 主要ナビを5個に絞り（ダッシュボード、見つける、ランキング、チャット、Q&A）
- 学習目標・活動レポート・ロードマップ・プロジェクト・学習教材・技術書レビュー・設定を「その他」ドロップダウンに統合
- 右側要素に `shrink-0` を付与してアバター等の表示を保護
- navから `overflow-x-auto` を削除し `min-w-0` に変更
- 設定アイコンを右側から削除し「その他」メニューに移動

## 保守性への配慮

- `navItems` / `moreItems` 配列にJSDocコメントを追加
- 今後のナビ追加は `moreItems` 配列に項目を追加するだけで対応可能

Closes #91