### PR TITLE
refactor: ハンドラーユーティリティ導入・エラーハンドリング統一

### DIFF
--- a/backend/internal/handler/activity_report.go
+++ b/backend/internal/handler/activity_report.go
@@ -1,9 +1,6 @@
 package handler
 
 import (
-	"net/http"
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -22,38 +19,34 @@ func NewActivityReportHandler(s *service.ActivityReportService) *ActivityReportH
 
 // GetWeeklyReport は指定ユーザーの週次アクティビティレポートを返す。
 func (h *ActivityReportHandler) GetWeeklyReport(c *gin.Context) {
-	userIDParam := c.Param("userId")
-	userID, err := strconv.ParseUint(userIDParam, 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	report, err := h.service.GetWeeklyReport(uint(userID))
+	report, err := h.service.GetWeeklyReport(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate report"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, report)
+	respondOK(c, report)
 }
 
 // GetMonthlyReport は指定ユーザーの月次アクティビティレポートを返す。
 func (h *ActivityReportHandler) GetMonthlyReport(c *gin.Context) {
-	userIDParam := c.Param("userId")
-	userID, err := strconv.ParseUint(userIDParam, 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	report, err := h.service.GetMonthlyReport(uint(userID))
+	report, err := h.service.GetMonthlyReport(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate report"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, report)
+	respondOK(c, report)
 }
 
 // GetMyWeeklyReport は現在のユーザーの週次レポートを返す。
@@ -62,11 +55,11 @@ func (h *ActivityReportHandler) GetMyWeeklyReport(c *gin.Context) {
 
 	report, err := h.service.GetWeeklyReport(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate report"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, report)
+	respondOK(c, report)
 }
 
 // GetMyMonthlyReport は現在のユーザーの月次レポートを返す。
@@ -75,11 +68,11 @@ func (h *ActivityReportHandler) GetMyMonthlyReport(c *gin.Context) {
 
 	report, err := h.service.GetMonthlyReport(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate report"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, report)
+	respondOK(c, report)
 }
 
 // GetComparison は現在の期間と前期間のアクティビティ比較を返す。
@@ -94,9 +87,9 @@ func (h *ActivityReportHandler) GetComparison(c *gin.Context) {
 
 	comparison, err := h.service.GetComparison(userID, period)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate comparison"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, comparison)
+	respondOK(c, comparison)
 }

--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"log"
 	"net/http"
 	"strconv"
@@ -41,7 +40,7 @@ func (h *AIAdviceHandler) GetAdvice(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"advices":              advices,
 		"llm_available":        llmAvailable,
 		"daily_chat_remaining": remaining,
@@ -50,19 +49,18 @@ func (h *AIAdviceHandler) GetAdvice(c *gin.Context) {
 
 // MarkAsRead はアドバイスを既読にする。
 func (h *AIAdviceHandler) MarkAsRead(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid advice id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
 
-	if err := h.service.MarkAsRead(uint(id), userID); err != nil {
+	if err := h.service.MarkAsRead(id, userID); err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "advice not found"})
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "marked as read"})
+	respondOK(c, gin.H{"message": "marked as read"})
 }
 
 // Chat はLLMとのチャットメッセージを送信する。
@@ -80,53 +78,28 @@ func (h *AIAdviceHandler) Chat(c *gin.Context) {
 
 	conv, err := h.service.Chat(userID, input.Message, input.ConversationID)
 	if err != nil {
-		if errors.Is(err, service.ErrLLMNotConfigured) {
-			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "LLM service not configured"})
-			return
-		}
-		if errors.Is(err, service.ErrRateLimitExceeded) {
-			c.JSON(http.StatusTooManyRequests, gin.H{"error": "daily chat limit reached"})
-			return
-		}
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "conversation not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to process chat"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, conv)
+	respondOK(c, conv)
 }
 
 // DeleteConversation は会話を削除する。
 func (h *AIAdviceHandler) DeleteConversation(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid conversation id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
 
-	if err := h.service.DeleteConversation(uint(id), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "conversation not found"})
-			return
-		}
+	if err := h.service.DeleteConversation(id, userID); err != nil {
 		log.Printf("会話削除エラー: %v", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete conversation"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "conversation deleted"})
+	respondOK(c, gin.H{"message": "conversation deleted"})
 }
 
 // GetConversations は会話履歴一覧を取得する。
@@ -148,31 +121,26 @@ func (h *AIAdviceHandler) GetConversations(c *gin.Context) {
 
 	conversations, err := h.service.GetConversations(userID, limit, offset)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get conversations"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, conversations)
+	respondOK(c, conversations)
 }
 
 // GetConversation は会話詳細を取得する。
 func (h *AIAdviceHandler) GetConversation(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid conversation id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
 
-	conv, err := h.service.GetConversation(uint(id), userID)
+	conv, err := h.service.GetConversation(id, userID)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "conversation not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, conv)
+	respondOK(c, conv)
 }

--- a/backend/internal/handler/answer.go
+++ b/backend/internal/handler/answer.go
@@ -1,10 +1,6 @@
 package handler
 
 import (
-	"errors"
-	"net/http"
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -23,19 +19,18 @@ func NewAnswerHandler(s *service.AnswerService) *AnswerHandler {
 
 // GetByQuestionID は指定された質問の回答一覧を取得する。
 func (h *AnswerHandler) GetByQuestionID(c *gin.Context) {
-	questionID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid question ID"})
+	questionID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	answers, err := h.service.GetByQuestionID(uint(questionID))
+	answers, err := h.service.GetByQuestionID(questionID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch answers"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, answers)
+	respondOK(c, answers)
 }
 
 // CreateAnswerRequest は回答作成のリクエストボディ。
@@ -51,157 +46,123 @@ type UpdateAnswerRequest struct {
 // Create は質問に対して新しい回答を作成する。
 func (h *AnswerHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
-	questionID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid question ID"})
+	questionID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	var req CreateAnswerRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[CreateAnswerRequest](c)
+	if req == nil {
 		return
 	}
 
 	answer := &model.Answer{
 		UserID:     userID,
-		QuestionID: uint(questionID),
+		QuestionID: questionID,
 		Body:       req.Body,
 	}
 
 	if err := h.service.Create(answer); err != nil {
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Question not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create answer"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, answer)
+	respondCreated(c, answer)
 }
 
 // Update は指定された回答を更新する。
 func (h *AnswerHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
-	answerID, err := strconv.ParseUint(c.Param("answerId"), 10, 32)
+	answerID, ok := parseID(c, "answerId")
+	if !ok {
+		return
+	}
+
+	req := bindJSON[UpdateAnswerRequest](c)
+	if req == nil {
+		return
+	}
+
+	answer, err := h.service.Update(answerID, userID, req.Body)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid answer ID"})
+		respondError(c, err)
 		return
 	}
 
-	var req UpdateAnswerRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	answer, err := h.service.Update(uint(answerID), userID, req.Body)
-	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to update this answer"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Answer not found"})
-		return
-	}
-
-	c.JSON(http.StatusOK, answer)
+	respondOK(c, answer)
 }
 
 // Delete は指定された回答を削除する。
 func (h *AnswerHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	answerID, err := strconv.ParseUint(c.Param("answerId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid answer ID"})
+	answerID, ok := parseID(c, "answerId")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(answerID), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to delete this answer"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Answer not found"})
+	if err := h.service.Delete(answerID, userID); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Answer deleted successfully"})
+	respondDeleted(c)
 }
 
 // SetBestAnswer は質問のベストアンサーを選定する。
 // 質問の投稿者のみがベストアンサーを選定できる。
 func (h *AnswerHandler) SetBestAnswer(c *gin.Context) {
 	userID := c.GetUint("userID")
-	questionID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid question ID"})
+	questionID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	answerID, err := strconv.ParseUint(c.Param("answerId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid answer ID"})
+	answerID, ok := parseID(c, "answerId")
+	if !ok {
 		return
 	}
 
-	if err := h.service.SetBestAnswer(uint(questionID), uint(answerID), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Only the question owner can select the best answer"})
-			return
-		}
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Answer does not belong to this question"})
-			return
-		}
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "Question or answer not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to set best answer"})
+	if err := h.service.SetBestAnswer(questionID, answerID, userID); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Best answer set successfully"})
+	respondOK(c, gin.H{"message": "Best answer set successfully"})
 }
 
 // Vote は回答に投票する。
 func (h *AnswerHandler) Vote(c *gin.Context) {
 	userID := c.GetUint("userID")
-	answerID, err := strconv.ParseUint(c.Param("answerId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid answer ID"})
+	answerID, ok := parseID(c, "answerId")
+	if !ok {
 		return
 	}
 
-	var req VoteRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[VoteRequest](c)
+	if req == nil {
 		return
 	}
 
-	if err := h.service.Vote(userID, uint(answerID), req.Value); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to vote"})
+	if err := h.service.Vote(userID, answerID, req.Value); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Voted successfully"})
+	respondOK(c, gin.H{"message": "Voted successfully"})
 }
 
 // RemoveVote は回答への投票を取り消す。
 func (h *AnswerHandler) RemoveVote(c *gin.Context) {
 	userID := c.GetUint("userID")
-	answerID, err := strconv.ParseUint(c.Param("answerId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid answer ID"})
+	answerID, ok := parseID(c, "answerId")
+	if !ok {
 		return
 	}
 
-	if err := h.service.RemoveVote(userID, uint(answerID)); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove vote"})
+	if err := h.service.RemoveVote(userID, answerID); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Vote removed successfully"})
+	respondOK(c, gin.H{"message": "Vote removed successfully"})
 }

--- a/backend/internal/handler/badge.go
+++ b/backend/internal/handler/badge.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -21,19 +20,18 @@ func NewBadgeHandler(s *service.BadgeService) *BadgeHandler {
 
 // GetUserBadges は指定ユーザーの全バッジを獲得状況付きで返す。
 func (h *BadgeHandler) GetUserBadges(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	badges, err := h.service.GetUserBadges(uint(userID))
+	badges, err := h.service.GetUserBadges(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"badges": badges})
+	respondOK(c, gin.H{"badges": badges})
 }
 
 // NotifyBadgeEarned は新しく獲得したバッジの通知を作成する。
@@ -49,9 +47,9 @@ func (h *BadgeHandler) NotifyBadgeEarned(c *gin.Context) {
 	}
 
 	if err := h.service.NotifyBadgeEarned(userID, req.BadgeID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "badge notification created"})
+	respondOK(c, gin.H{"message": "badge notification created"})
 }

--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"errors"
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -45,9 +43,8 @@ type UpdateBookReviewRequest struct {
 func (h *BookReviewHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req CreateBookReviewRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[CreateBookReviewRequest](c)
+	if req == nil {
 		return
 	}
 
@@ -62,45 +59,43 @@ func (h *BookReviewHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.service.Create(review); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create book review"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, review)
+	respondCreated(c, review)
 }
 
 // GetByID は指定IDの書籍レビューを取得する。
 func (h *BookReviewHandler) GetByID(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid review ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	review, err := h.service.GetByID(uint(id))
+	review, err := h.service.GetByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Review not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, review)
+	respondOK(c, review)
 }
 
 // GetByUserID は指定ユーザーの書籍レビュー一覧を取得する。
 func (h *BookReviewHandler) GetByUserID(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	reviews, err := h.service.GetByUserID(uint(userID))
+	reviews, err := h.service.GetByUserID(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch reviews"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, reviews)
+	respondOK(c, reviews)
 }
 
 // GetAll は書籍レビューの一覧をページネーション付きで取得する。
@@ -114,11 +109,11 @@ func (h *BookReviewHandler) GetAll(c *gin.Context) {
 
 	reviews, total, err := h.service.GetAll(limit, offset)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch reviews"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"reviews": reviews,
 		"total":   total,
 		"limit":   limit,
@@ -129,15 +124,13 @@ func (h *BookReviewHandler) GetAll(c *gin.Context) {
 // Update は指定IDの書籍レビューを更新する。
 func (h *BookReviewHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid review ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	var req UpdateBookReviewRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[UpdateBookReviewRequest](c)
+	if req == nil {
 		return
 	}
 
@@ -161,36 +154,27 @@ func (h *BookReviewHandler) Update(c *gin.Context) {
 		updates.ImageURL = req.ImageURL
 	}
 
-	review, err := h.service.Update(uint(id), userID, updates)
+	review, err := h.service.Update(id, userID, updates)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to update this review"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Review not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, review)
+	respondOK(c, review)
 }
 
 // Delete は指定IDの書籍レビューを削除する。
 func (h *BookReviewHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid review ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(id), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to delete this review"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Review not found"})
+	if err := h.service.Delete(id, userID); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Review deleted successfully"})
+	respondDeleted(c)
 }

--- a/backend/internal/handler/chat_room.go
+++ b/backend/internal/handler/chat_room.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 
@@ -43,11 +42,11 @@ func (h *ChatRoomHandler) Create(c *gin.Context) {
 
 	created, err := h.service.Create(room, input.MemberIDs)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, created)
+	respondCreated(c, created)
 }
 
 // GetMyRooms は現在のユーザーが参加しているチャットルーム一覧を取得する。
@@ -55,39 +54,33 @@ func (h *ChatRoomHandler) GetMyRooms(c *gin.Context) {
 	userID := c.GetUint("userID")
 	rooms, err := h.service.GetByUserID(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, rooms)
+	respondOK(c, rooms)
 }
 
 // GetByID は指定IDのチャットルーム詳細を取得する。
 func (h *ChatRoomHandler) GetByID(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roomID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid room id"})
+	roomID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	room, err := h.service.GetByID(uint(roomID), userID)
+	room, err := h.service.GetByID(roomID, userID)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not a member"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "room not found"})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, room)
+	respondOK(c, room)
 }
 
 // Update は指定IDのチャットルーム情報を更新する。
 func (h *ChatRoomHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roomID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid room id"})
+	roomID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
@@ -100,65 +93,50 @@ func (h *ChatRoomHandler) Update(c *gin.Context) {
 		return
 	}
 
-	room, err := h.service.Update(uint(roomID), userID, input.Name, input.Description)
+	room, err := h.service.Update(roomID, userID, input.Name, input.Description)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "only owner can update"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "room not found"})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, room)
+	respondOK(c, room)
 }
 
 // Delete は指定IDのチャットルームを削除する。
 func (h *ChatRoomHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roomID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid room id"})
+	roomID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(roomID), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "only owner can delete"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "room not found"})
+	if err := h.service.Delete(roomID, userID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "room deleted"})
+	respondDeleted(c)
 }
 
 // GetMembers は指定チャットルームのメンバー一覧を取得する。
 func (h *ChatRoomHandler) GetMembers(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roomID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid room id"})
+	roomID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	members, err := h.service.GetMembers(uint(roomID), userID)
+	members, err := h.service.GetMembers(roomID, userID)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not a member"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, members)
+	respondOK(c, members)
 }
 
 // AddMember はチャットルームに新しいメンバーを追加する。
 func (h *ChatRoomHandler) AddMember(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roomID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid room id"})
+	roomID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
@@ -170,72 +148,56 @@ func (h *ChatRoomHandler) AddMember(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.AddMember(uint(roomID), userID, input.UserID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not a member"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.service.AddMember(roomID, userID, input.UserID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "member added"})
+	respondOK(c, gin.H{"message": "member added"})
 }
 
 // RemoveMember はチャットルームからメンバーを削除する。
 func (h *ChatRoomHandler) RemoveMember(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roomID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid room id"})
+	roomID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
-	targetID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	targetID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	if err := h.service.RemoveMember(uint(roomID), userID, uint(targetID)); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "only owner can remove members"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "room not found"})
+	if err := h.service.RemoveMember(roomID, userID, targetID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "member removed"})
+	respondOK(c, gin.H{"message": "member removed"})
 }
 
 // GetMessages は指定チャットルームのメッセージ一覧をページネーション付きで取得する。
 func (h *ChatRoomHandler) GetMessages(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roomID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid room id"})
+	roomID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
 
-	messages, err := h.service.GetMessages(uint(roomID), userID, page, limit)
+	messages, err := h.service.GetMessages(roomID, userID, page, limit)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not a member"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, messages)
+	respondOK(c, messages)
 }
 
 // SendMessage は指定チャットルームにメッセージを送信する。
 func (h *ChatRoomHandler) SendMessage(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roomID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid room id"})
+	roomID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
@@ -247,15 +209,11 @@ func (h *ChatRoomHandler) SendMessage(c *gin.Context) {
 		return
 	}
 
-	msg, err := h.service.SendMessage(uint(roomID), userID, input.Content)
+	msg, err := h.service.SendMessage(roomID, userID, input.Content)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not a member"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, msg)
+	respondCreated(c, msg)
 }

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -22,9 +20,8 @@ func NewCodeSnippetHandler(s *service.CodeSnippetService) *CodeSnippetHandler {
 
 // Create は投稿にコードスニペットを追加する。
 func (h *CodeSnippetHandler) Create(c *gin.Context) {
-	postID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid post id"})
+	postID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
@@ -40,7 +37,7 @@ func (h *CodeSnippetHandler) Create(c *gin.Context) {
 	}
 
 	snippet := &model.CodeSnippet{
-		PostID:   uint(postID),
+		PostID:   postID,
 		UserID:   userID,
 		Language: input.Language,
 		FileName: input.FileName,
@@ -48,49 +45,46 @@ func (h *CodeSnippetHandler) Create(c *gin.Context) {
 	}
 	created, err := h.service.Create(snippet)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusCreated, created)
+	respondCreated(c, created)
 }
 
 // GetByPostID は投稿に紐づくスニペット一覧を返す。
 func (h *CodeSnippetHandler) GetByPostID(c *gin.Context) {
-	postID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid post id"})
+	postID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	snippets, err := h.service.GetByPostID(uint(postID))
+	snippets, err := h.service.GetByPostID(postID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, snippets)
+	respondOK(c, snippets)
 }
 
 // GetByID は指定IDのスニペットを返す。
 func (h *CodeSnippetHandler) GetByID(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	snippets, err := h.service.GetByPostID(uint(id))
+	snippets, err := h.service.GetByPostID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "snippet not found"})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, snippets)
+	respondOK(c, snippets)
 }
 
 // Update はスニペットを更新する。所有者のみ更新可能。
 func (h *CodeSnippetHandler) Update(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
@@ -105,59 +99,48 @@ func (h *CodeSnippetHandler) Update(c *gin.Context) {
 		return
 	}
 
-	snippet, err := h.service.Update(uint(id), userID, input.Language, input.FileName, input.Code)
+	snippet, err := h.service.Update(id, userID, input.Language, input.FileName, input.Code)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not your snippet"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "snippet not found"})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, snippet)
+	respondOK(c, snippet)
 }
 
 // Delete はスニペットを削除する。所有者のみ削除可能。
 func (h *CodeSnippetHandler) Delete(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
 
-	if err := h.service.Delete(uint(id), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not your snippet"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "snippet not found"})
+	if err := h.service.Delete(id, userID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "deleted"})
+	respondDeleted(c)
 }
 
 // GetComments はスニペットのインラインコメント一覧を返す。
 func (h *CodeSnippetHandler) GetComments(c *gin.Context) {
-	snippetID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid snippet id"})
+	snippetID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	comments, err := h.service.GetComments(uint(snippetID))
+	comments, err := h.service.GetComments(snippetID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, comments)
+	respondOK(c, comments)
 }
 
 // CreateComment はスニペットにインラインコメントを作成する。
 func (h *CodeSnippetHandler) CreateComment(c *gin.Context) {
-	snippetID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid snippet id"})
+	snippetID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
@@ -172,30 +155,29 @@ func (h *CodeSnippetHandler) CreateComment(c *gin.Context) {
 	}
 
 	comment := &model.SnippetComment{
-		SnippetID:  uint(snippetID),
+		SnippetID:  snippetID,
 		UserID:     userID,
 		LineNumber: input.LineNumber,
 		Content:    input.Content,
 	}
 	if err := h.service.CreateComment(comment); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusCreated, comment)
+	respondCreated(c, comment)
 }
 
 // DeleteComment はインラインコメントを削除する。所有者のみ削除可能。
 func (h *CodeSnippetHandler) DeleteComment(c *gin.Context) {
-	commentID, err := strconv.ParseUint(c.Param("commentId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid comment id"})
+	commentID, ok := parseID(c, "commentId")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
 
-	if err := h.service.DeleteComment(uint(commentID), userID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.service.DeleteComment(commentID, userID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "deleted"})
+	respondDeleted(c)
 }

--- a/backend/internal/handler/email_preferences.go
+++ b/backend/internal/handler/email_preferences.go
@@ -24,11 +24,11 @@ func (h *EmailPreferencesHandler) GetPreferences(c *gin.Context) {
 
 	user, err := h.userService.GetByID(userID)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"email_weekly_report": user.EmailWeeklyReport,
 		"email_language":      user.EmailLanguage,
 	})
@@ -50,7 +50,7 @@ func (h *EmailPreferencesHandler) UpdatePreferences(c *gin.Context) {
 
 	user, err := h.userService.GetByID(userID)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		respondError(c, err)
 		return
 	}
 
@@ -71,11 +71,11 @@ func (h *EmailPreferencesHandler) UpdatePreferences(c *gin.Context) {
 	}
 
 	if err := h.userService.Update(user); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update preferences"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"email_weekly_report": user.EmailWeeklyReport,
 		"email_language":      user.EmailLanguage,
 	})

--- a/backend/internal/handler/follow.go
+++ b/backend/internal/handler/follow.go
@@ -1,10 +1,6 @@
 package handler
 
 import (
-	"errors"
-	"net/http"
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -24,69 +20,61 @@ func NewFollowHandler(s *service.FollowService) *FollowHandler {
 // Follow は指定ユーザーをフォローする。
 func (h *FollowHandler) Follow(c *gin.Context) {
 	userID := c.GetUint("userID")
-	targetID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	targetID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
-	if err := h.service.Follow(userID, uint(targetID)); err != nil {
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "cannot follow yourself"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.service.Follow(userID, targetID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "followed"})
+	respondOK(c, gin.H{"message": "followed"})
 }
 
 // Unfollow は指定ユーザーのフォローを解除する。
 func (h *FollowHandler) Unfollow(c *gin.Context) {
 	userID := c.GetUint("userID")
-	targetID, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	targetID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
-	if err := h.service.Unfollow(userID, uint(targetID)); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.service.Unfollow(userID, targetID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "unfollowed"})
+	respondOK(c, gin.H{"message": "unfollowed"})
 }
 
 // GetFollowers は指定ユーザーのフォロワー一覧を返す。
 func (h *FollowHandler) GetFollowers(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
-	users, err := h.service.GetFollowers(uint(id))
+	users, err := h.service.GetFollowers(id)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 	if users == nil {
 		users = []model.User{}
 	}
-	c.JSON(http.StatusOK, users)
+	respondOK(c, users)
 }
 
 // GetFollowing は指定ユーザーのフォロー中一覧を返す。
 func (h *FollowHandler) GetFollowing(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
-	users, err := h.service.GetFollowing(uint(id))
+	users, err := h.service.GetFollowing(id)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 	if users == nil {
 		users = []model.User{}
 	}
-	c.JSON(http.StatusOK, users)
+	respondOK(c, users)
 }

--- a/backend/internal/handler/github.go
+++ b/backend/internal/handler/github.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -36,7 +34,7 @@ func (h *GitHubHandler) Connect(c *gin.Context) {
 		return
 	}
 	url := h.githubService.GetOAuthURL(state)
-	c.JSON(http.StatusOK, gin.H{"url": url})
+	respondOK(c, gin.H{"url": url})
 }
 
 // Callback はGitHub OAuthコールバックを処理してアカウントを連携する。
@@ -56,63 +54,56 @@ func (h *GitHubHandler) Callback(c *gin.Context) {
 	}
 
 	if err := h.githubService.ConnectGitHub(userID, code, state); err != nil {
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to connect github"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "github connected"})
+	respondOK(c, gin.H{"message": "github connected"})
 }
 
 // GetContributions は指定ユーザーのGitHubコントリビューション情報を取得する。
 func (h *GitHubHandler) GetContributions(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	contributions, err := h.githubService.GetContributions(uint(userID))
+	contributions, err := h.githubService.GetContributions(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, contributions)
+	respondOK(c, contributions)
 }
 
 // GetLanguages は指定ユーザーのGitHubリポジトリの使用言語統計を取得する。
 func (h *GitHubHandler) GetLanguages(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	stats, err := h.githubService.GetLanguages(uint(userID))
+	stats, err := h.githubService.GetLanguages(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, stats)
+	respondOK(c, stats)
 }
 
 // GetRepos は指定ユーザーのGitHubリポジトリ一覧を取得する。
 func (h *GitHubHandler) GetRepos(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	repos, err := h.githubService.GetRepos(uint(userID))
+	repos, err := h.githubService.GetRepos(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, repos)
+	respondOK(c, repos)
 }
 
 // Sync は現在のユーザーのGitHubデータを手動で同期する。
@@ -120,15 +111,11 @@ func (h *GitHubHandler) Sync(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	if err := h.githubService.SyncUserData(userID); err != nil {
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "sync complete"})
+	respondOK(c, gin.H{"message": "sync complete"})
 }
 
 // Disconnect は現在のユーザーのGitHub連携を解除する。
@@ -136,13 +123,9 @@ func (h *GitHubHandler) Disconnect(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	if err := h.githubService.DisconnectGitHub(userID); err != nil {
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "github disconnected"})
+	respondOK(c, gin.H{"message": "github disconnected"})
 }

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -1,0 +1,87 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/service"
+)
+
+// parseID はURLパラメータからuint型のIDを取得する。
+// パース失敗時は400レスポンスを返しfalseを返す。
+func parseID(c *gin.Context, param string) (uint, bool) {
+	raw := c.Param(param)
+	id, err := strconv.ParseUint(raw, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid " + param})
+		return 0, false
+	}
+	return uint(id), true
+}
+
+// parsePagination はクエリパラメータからpage/limitを取得する。
+// デフォルト: page=1, limit=20。limitの上限は100。
+func parsePagination(c *gin.Context) (page, limit int) {
+	page, _ = strconv.Atoi(c.DefaultQuery("page", "1"))
+	limit, _ = strconv.Atoi(c.DefaultQuery("limit", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
+	}
+	return page, limit
+}
+
+// bindJSON はリクエストボディをJSON構造体にバインドする。
+// バインド失敗時は400レスポンスを返しnilを返す。
+func bindJSON[T any](c *gin.Context) *T {
+	var req T
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return nil
+	}
+	return &req
+}
+
+// respondError はサービス層のエラーを適切なHTTPステータスコードに変換してレスポンスを返す。
+func respondError(c *gin.Context, err error) {
+	switch {
+	case errors.Is(err, service.ErrNotFound):
+		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrForbidden):
+		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrBadRequest):
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrUnauthorized):
+		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrConflict):
+		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrRateLimitExceeded):
+		c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
+	case errors.Is(err, service.ErrLLMNotConfigured):
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error()})
+	default:
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	}
+}
+
+// respondOK は200 OKでデータを返す。
+func respondOK(c *gin.Context, data interface{}) {
+	c.JSON(http.StatusOK, data)
+}
+
+// respondCreated は201 Createdでデータを返す。
+func respondCreated(c *gin.Context, data interface{}) {
+	c.JSON(http.StatusCreated, data)
+}
+
+// respondDeleted は200 OKで削除メッセージを返す。
+func respondDeleted(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"message": "deleted"})
+}

--- a/backend/internal/handler/helpers_test.go
+++ b/backend/internal/handler/helpers_test.go
@@ -1,0 +1,283 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+// --- parseID ---
+
+func TestParseID_Valid(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+	r.GET("/items/:id", func(c *gin.Context) {
+		id, ok := parseID(c, "id")
+		if ok {
+			c.JSON(http.StatusOK, gin.H{"id": id})
+		}
+	})
+	c.Request = httptest.NewRequest("GET", "/items/42", nil)
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(42), resp["id"])
+}
+
+func TestParseID_Invalid(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+	r.GET("/items/:id", func(c *gin.Context) {
+		_, ok := parseID(c, "id")
+		assert.False(t, ok)
+	})
+	c.Request = httptest.NewRequest("GET", "/items/abc", nil)
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Contains(t, resp["error"], "invalid id")
+}
+
+func TestParseID_Zero(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+	r.GET("/items/:id", func(c *gin.Context) {
+		id, ok := parseID(c, "id")
+		if ok {
+			c.JSON(http.StatusOK, gin.H{"id": id})
+		}
+	})
+	c.Request = httptest.NewRequest("GET", "/items/0", nil)
+	r.ServeHTTP(w, c.Request)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- parsePagination ---
+
+func TestParsePagination_Defaults(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+	r.GET("/items", func(c *gin.Context) {
+		page, limit := parsePagination(c)
+		c.JSON(http.StatusOK, gin.H{"page": page, "limit": limit})
+	})
+	c.Request = httptest.NewRequest("GET", "/items", nil)
+	r.ServeHTTP(w, c.Request)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(1), resp["page"])
+	assert.Equal(t, float64(20), resp["limit"])
+}
+
+func TestParsePagination_Custom(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+	r.GET("/items", func(c *gin.Context) {
+		page, limit := parsePagination(c)
+		c.JSON(http.StatusOK, gin.H{"page": page, "limit": limit})
+	})
+	c.Request = httptest.NewRequest("GET", "/items?page=3&limit=50", nil)
+	r.ServeHTTP(w, c.Request)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(3), resp["page"])
+	assert.Equal(t, float64(50), resp["limit"])
+}
+
+func TestParsePagination_ClampNegative(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+	r.GET("/items", func(c *gin.Context) {
+		page, limit := parsePagination(c)
+		c.JSON(http.StatusOK, gin.H{"page": page, "limit": limit})
+	})
+	c.Request = httptest.NewRequest("GET", "/items?page=-1&limit=-5", nil)
+	r.ServeHTTP(w, c.Request)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(1), resp["page"])
+	assert.Equal(t, float64(20), resp["limit"])
+}
+
+func TestParsePagination_ClampMax(t *testing.T) {
+	w := httptest.NewRecorder()
+	c, r := gin.CreateTestContext(w)
+	r.GET("/items", func(c *gin.Context) {
+		page, limit := parsePagination(c)
+		c.JSON(http.StatusOK, gin.H{"page": page, "limit": limit})
+	})
+	c.Request = httptest.NewRequest("GET", "/items?limit=999", nil)
+	r.ServeHTTP(w, c.Request)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(100), resp["limit"])
+}
+
+// --- bindJSON ---
+
+type testRequest struct {
+	Name  string `json:"name" binding:"required"`
+	Value int    `json:"value"`
+}
+
+func TestBindJSON_Valid(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.POST("/test", func(c *gin.Context) {
+		req := bindJSON[testRequest](c)
+		if req != nil {
+			c.JSON(http.StatusOK, req)
+		}
+	})
+	body, _ := json.Marshal(testRequest{Name: "hello", Value: 42})
+	req := httptest.NewRequest("POST", "/test", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp testRequest
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "hello", resp.Name)
+	assert.Equal(t, 42, resp.Value)
+}
+
+func TestBindJSON_InvalidJSON(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.POST("/test", func(c *gin.Context) {
+		req := bindJSON[testRequest](c)
+		assert.Nil(t, req)
+	})
+	req := httptest.NewRequest("POST", "/test", bytes.NewBufferString("{invalid"))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestBindJSON_MissingRequired(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.POST("/test", func(c *gin.Context) {
+		req := bindJSON[testRequest](c)
+		assert.Nil(t, req)
+	})
+	body, _ := json.Marshal(map[string]int{"value": 10})
+	req := httptest.NewRequest("POST", "/test", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- respondError ---
+
+func TestRespondError_MapsServiceErrors(t *testing.T) {
+	tests := []struct {
+		err      error
+		wantCode int
+	}{
+		{service.ErrNotFound, http.StatusNotFound},
+		{service.ErrForbidden, http.StatusForbidden},
+		{service.ErrBadRequest, http.StatusBadRequest},
+		{service.ErrUnauthorized, http.StatusUnauthorized},
+		{service.ErrConflict, http.StatusConflict},
+		{service.ErrRateLimitExceeded, http.StatusTooManyRequests},
+		{service.ErrLLMNotConfigured, http.StatusServiceUnavailable},
+		{fmt.Errorf("unknown error"), http.StatusInternalServerError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.err.Error(), func(t *testing.T) {
+			w := httptest.NewRecorder()
+			_, r := gin.CreateTestContext(w)
+			r.GET("/test", func(c *gin.Context) {
+				respondError(c, tt.err)
+			})
+			req := httptest.NewRequest("GET", "/test", nil)
+			r.ServeHTTP(w, req)
+
+			assert.Equal(t, tt.wantCode, w.Code)
+			var resp map[string]interface{}
+			json.Unmarshal(w.Body.Bytes(), &resp)
+			assert.Contains(t, resp, "error")
+		})
+	}
+}
+
+func TestRespondError_WrappedError(t *testing.T) {
+	wrapped := fmt.Errorf("user 123: %w", service.ErrNotFound)
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.GET("/test", func(c *gin.Context) {
+		respondError(c, wrapped)
+	})
+	req := httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- respondOK / respondCreated / respondDeleted ---
+
+func TestRespondOK(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.GET("/test", func(c *gin.Context) {
+		respondOK(c, gin.H{"key": "value"})
+	})
+	req := httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "value", resp["key"])
+}
+
+func TestRespondCreated(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.POST("/test", func(c *gin.Context) {
+		respondCreated(c, gin.H{"id": 1})
+	})
+	req := httptest.NewRequest("POST", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestRespondDeleted(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.DELETE("/test", func(c *gin.Context) {
+		respondDeleted(c)
+	})
+	req := httptest.NewRequest("DELETE", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "deleted", resp["message"])
+}

--- a/backend/internal/handler/learning_analytics.go
+++ b/backend/internal/handler/learning_analytics.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -21,60 +20,56 @@ func NewLearningAnalyticsHandler(s *service.LearningAnalyticsService) *LearningA
 
 // GetHeatmap は指定ユーザーの学習時間ヒートマップを返す。
 func (h *LearningAnalyticsHandler) GetHeatmap(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	data, err := h.service.GetHeatmap(uint(userID))
+	data, err := h.service.GetHeatmap(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, data)
+	respondOK(c, data)
 }
 
 // GetCategoryBreakdown は指定ユーザーのカテゴリ別学習時間を返す。
 func (h *LearningAnalyticsHandler) GetCategoryBreakdown(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	data, err := h.service.GetCategoryBreakdown(uint(userID))
+	data, err := h.service.GetCategoryBreakdown(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, data)
+	respondOK(c, data)
 }
 
 // GetProductivityScore は指定ユーザーの生産性スコアを返す。
 func (h *LearningAnalyticsHandler) GetProductivityScore(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	score, err := h.service.GetProductivityScore(uint(userID))
+	score, err := h.service.GetProductivityScore(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, score)
+	respondOK(c, score)
 }
 
 // GetWeeklyTrends は指定ユーザーの週間学習トレンドを返す。
 func (h *LearningAnalyticsHandler) GetWeeklyTrends(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
@@ -85,13 +80,13 @@ func (h *LearningAnalyticsHandler) GetWeeklyTrends(c *gin.Context) {
 		}
 	}
 
-	data, err := h.service.GetWeeklyTrends(uint(userID), weeks)
+	data, err := h.service.GetWeeklyTrends(userID, weeks)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, data)
+	respondOK(c, data)
 }
 
 // GetInsights は認証済みユーザーのAIインサイトを返す。
@@ -100,9 +95,9 @@ func (h *LearningAnalyticsHandler) GetInsights(c *gin.Context) {
 
 	insights, err := h.service.GetInsights(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, insights)
+	respondOK(c, insights)
 }

--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -61,19 +59,18 @@ func (h *LearningGoalHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.service.Create(goal); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create goal"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, goal)
+	respondCreated(c, goal)
 }
 
 // Update は指定された学習目標を更新する。
 func (h *LearningGoalHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
-	goalID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid goal ID"})
+	goalID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
@@ -118,49 +115,39 @@ func (h *LearningGoalHandler) Update(c *gin.Context) {
 		updates.Status = model.GoalStatus(*req.Status)
 	}
 
-	goal, err := h.service.Update(uint(goalID), userID, updates)
+	goal, err := h.service.Update(goalID, userID, updates)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "goal not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, goal)
+	respondOK(c, goal)
 }
 
 // Delete は指定された学習目標を削除する。
 func (h *LearningGoalHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	goalID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid goal ID"})
+	goalID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(goalID), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "goal not found"})
+	if err := h.service.Delete(goalID, userID); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "goal deleted"})
+	respondDeleted(c)
 }
 
 // GetByID は指定されたIDの学習目標を取得する。
 func (h *LearningGoalHandler) GetByID(c *gin.Context) {
-	goalID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid goal ID"})
+	goalID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	goal, err := h.service.GetByID(uint(goalID))
+	goal, err := h.service.GetByID(goalID)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "goal not found"})
 		return
@@ -171,14 +158,12 @@ func (h *LearningGoalHandler) GetByID(c *gin.Context) {
 
 // GetByUserID は指定されたユーザーの学習目標一覧を取得する。
 func (h *LearningGoalHandler) GetByUserID(c *gin.Context) {
-	userIDParam := c.Param("userId")
-	userID, err := strconv.ParseUint(userIDParam, 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	goals, err := h.service.GetByUserID(uint(userID))
+	goals, err := h.service.GetByUserID(userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get goals"})
 		return
@@ -202,14 +187,12 @@ func (h *LearningGoalHandler) GetMyGoals(c *gin.Context) {
 
 // GetStats は指定されたユーザーの学習目標統計情報を取得する。
 func (h *LearningGoalHandler) GetStats(c *gin.Context) {
-	userIDParam := c.Param("userId")
-	userID, err := strconv.ParseUint(userIDParam, 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	stats, err := h.service.GetStats(uint(userID))
+	stats, err := h.service.GetStats(userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get stats"})
 		return

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -53,23 +51,18 @@ func (h *LearningLogHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.service.Create(log); err != nil {
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request parameters"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create log"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, log)
+	respondCreated(c, log)
 }
 
 // Update は指定された学習ログを更新する。
 func (h *LearningLogHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
-	logID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid log ID"})
+	logID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
@@ -99,13 +92,9 @@ func (h *LearningLogHandler) Update(c *gin.Context) {
 		updates.Duration = *req.Duration
 	}
 
-	log, err := h.service.Update(uint(logID), userID, updates)
+	log, err := h.service.Update(logID, userID, updates)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "log not found"})
+		respondError(c, err)
 		return
 	}
 
@@ -115,18 +104,13 @@ func (h *LearningLogHandler) Update(c *gin.Context) {
 // Delete は指定された学習ログを削除する。
 func (h *LearningLogHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	logID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid log ID"})
+	logID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(logID), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "log not found"})
+	if err := h.service.Delete(logID, userID); err != nil {
+		respondError(c, err)
 		return
 	}
 
@@ -135,15 +119,14 @@ func (h *LearningLogHandler) Delete(c *gin.Context) {
 
 // GetByID は指定されたIDの学習ログを取得する。
 func (h *LearningLogHandler) GetByID(c *gin.Context) {
-	logID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid log ID"})
+	logID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	log, err := h.service.GetByID(uint(logID))
+	log, err := h.service.GetByID(logID)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "log not found"})
+		respondError(c, err)
 		return
 	}
 
@@ -156,23 +139,21 @@ func (h *LearningLogHandler) GetMyLogs(c *gin.Context) {
 
 	logs, err := h.service.GetByUserID(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get logs"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, logs)
+	respondOK(c, logs)
 }
 
 // GetByUserID は指定されたユーザーの学習ログ一覧を取得する。
 func (h *LearningLogHandler) GetByUserID(c *gin.Context) {
-	userIDParam := c.Param("userId")
-	userID, err := strconv.ParseUint(userIDParam, 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	logs, err := h.service.GetByUserID(uint(userID))
+	logs, err := h.service.GetByUserID(userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get logs"})
 		return
@@ -183,14 +164,12 @@ func (h *LearningLogHandler) GetByUserID(c *gin.Context) {
 
 // GetStreakInfo は指定されたユーザーのストリーク情報を取得する。
 func (h *LearningLogHandler) GetStreakInfo(c *gin.Context) {
-	userIDParam := c.Param("userId")
-	userID, err := strconv.ParseUint(userIDParam, 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	info, err := h.service.GetStreakInfo(uint(userID))
+	info, err := h.service.GetStreakInfo(userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get streak info"})
 		return
@@ -201,14 +180,12 @@ func (h *LearningLogHandler) GetStreakInfo(c *gin.Context) {
 
 // GetCalendarData はカレンダー表示用の日別学習ログ件数を取得する。
 func (h *LearningLogHandler) GetCalendarData(c *gin.Context) {
-	userIDParam := c.Param("userId")
-	userID, err := strconv.ParseUint(userIDParam, 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	entries, err := h.service.GetCalendarData(uint(userID))
+	entries, err := h.service.GetCalendarData(userID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get calendar data"})
 		return

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 
@@ -49,9 +48,8 @@ type UpdateResourceRequest struct {
 func (h *LearningResourceHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req CreateResourceRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[CreateResourceRequest](c)
+	if req == nil {
 		return
 	}
 
@@ -83,27 +81,22 @@ func (h *LearningResourceHandler) Create(c *gin.Context) {
 
 // GetByID は指定されたIDの学習リソースを取得する。
 func (h *LearningResourceHandler) GetByID(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid resource ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
 	userID := c.GetUint("userID")
 
-	resource, err := h.service.GetByID(uint(id), userID)
+	resource, err := h.service.GetByID(id, userID)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to view this resource"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Resource not found"})
+		respondError(c, err)
 		return
 	}
 
 	// 現在のユーザーがいいね・保存済みかを確認
-	hasLiked, _ := h.service.HasLiked(userID, uint(id))
-	hasSaved, _ := h.service.HasSaved(userID, uint(id))
+	hasLiked, _ := h.service.HasLiked(userID, id)
+	hasSaved, _ := h.service.HasSaved(userID, id)
 
 	c.JSON(http.StatusOK, gin.H{
 		"resource":  resource,
@@ -114,15 +107,14 @@ func (h *LearningResourceHandler) GetByID(c *gin.Context) {
 
 // GetByUserID は指定されたユーザーの学習リソース一覧を取得する。
 func (h *LearningResourceHandler) GetByUserID(c *gin.Context) {
-	targetUserID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
+	targetUserID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
 	currentUserID := c.GetUint("userID")
 
-	resources, err := h.service.GetByUserID(uint(targetUserID), currentUserID)
+	resources, err := h.service.GetByUserID(targetUserID, currentUserID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch resources"})
 		return
@@ -183,15 +175,13 @@ func (h *LearningResourceHandler) Search(c *gin.Context) {
 // Update は指定された学習リソースを更新する。
 func (h *LearningResourceHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid resource ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	var req UpdateResourceRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[UpdateResourceRequest](c)
+	if req == nil {
 		return
 	}
 
@@ -218,19 +208,15 @@ func (h *LearningResourceHandler) Update(c *gin.Context) {
 		updates.ImageURL = req.ImageURL
 	}
 
-	resource, err := h.service.Update(uint(id), userID, updates)
+	resource, err := h.service.Update(id, userID, updates)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to update this resource"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Resource not found"})
+		respondError(c, err)
 		return
 	}
 
 	// 公開設定が指定されている場合は別途更新
 	if req.IsPublic != nil {
-		resource, err = h.service.UpdateVisibility(uint(id), userID, *req.IsPublic)
+		resource, err = h.service.UpdateVisibility(id, userID, *req.IsPublic)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update resource"})
 			return
@@ -243,18 +229,13 @@ func (h *LearningResourceHandler) Update(c *gin.Context) {
 // Delete は指定された学習リソースを削除する。
 func (h *LearningResourceHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid resource ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(id), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to delete this resource"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Resource not found"})
+	if err := h.service.Delete(id, userID); err != nil {
+		respondError(c, err)
 		return
 	}
 
@@ -264,13 +245,12 @@ func (h *LearningResourceHandler) Delete(c *gin.Context) {
 // Like は学習リソースにいいねする。
 func (h *LearningResourceHandler) Like(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid resource ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Like(userID, uint(id)); err != nil {
+	if err := h.service.Like(userID, id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to like resource"})
 		return
 	}
@@ -281,13 +261,12 @@ func (h *LearningResourceHandler) Like(c *gin.Context) {
 // Unlike は学習リソースのいいねを取り消す。
 func (h *LearningResourceHandler) Unlike(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid resource ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Unlike(userID, uint(id)); err != nil {
+	if err := h.service.Unlike(userID, id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to unlike resource"})
 		return
 	}
@@ -298,13 +277,12 @@ func (h *LearningResourceHandler) Unlike(c *gin.Context) {
 // SaveResource は学習リソースを保存する。
 func (h *LearningResourceHandler) SaveResource(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid resource ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Save(userID, uint(id)); err != nil {
+	if err := h.service.Save(userID, id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save resource"})
 		return
 	}
@@ -315,13 +293,12 @@ func (h *LearningResourceHandler) SaveResource(c *gin.Context) {
 // UnsaveResource は学習リソースの保存を取り消す。
 func (h *LearningResourceHandler) UnsaveResource(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid resource ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Unsave(userID, uint(id)); err != nil {
+	if err := h.service.Unsave(userID, id); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to unsave resource"})
 		return
 	}

--- a/backend/internal/handler/level.go
+++ b/backend/internal/handler/level.go
@@ -1,9 +1,6 @@
 package handler
 
 import (
-	"net/http"
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
@@ -25,43 +22,41 @@ func (h *LevelHandler) GetMyLevelInfo(c *gin.Context) {
 
 	info, err := h.service.GetLevelInfo(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, info)
+	respondOK(c, info)
 }
 
 // GetLevelInfo は指定ユーザーのレベル情報を返す。
 func (h *LevelHandler) GetLevelInfo(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	info, err := h.service.GetLevelInfo(uint(userID))
+	info, err := h.service.GetLevelInfo(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, info)
+	respondOK(c, info)
 }
 
 // GetXPBreakdown は指定ユーザーのXP内訳を返す。
 func (h *LevelHandler) GetXPBreakdown(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	breakdown, err := h.service.GetXPBreakdown(uint(userID))
+	breakdown, err := h.service.GetXPBreakdown(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, breakdown)
+	respondOK(c, breakdown)
 }

--- a/backend/internal/handler/message.go
+++ b/backend/internal/handler/message.go
@@ -25,38 +25,36 @@ func (h *MessageHandler) GetConversations(c *gin.Context) {
 	userID := c.GetUint("userID")
 	conversations, err := h.service.GetConversations(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, conversations)
+	respondOK(c, conversations)
 }
 
 // GetMessages は指定ユーザーとの会話メッセージをページネーション付きで返す。
 func (h *MessageHandler) GetMessages(c *gin.Context) {
 	userID := c.GetUint("userID")
-	otherID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	otherID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
 	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
 	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
 
-	messages, err := h.service.GetConversation(userID, uint(otherID), page, limit)
+	messages, err := h.service.GetConversation(userID, otherID, page, limit)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, messages)
+	respondOK(c, messages)
 }
 
 // SendMessage は指定ユーザーにDMを送信する。
 func (h *MessageHandler) SendMessage(c *gin.Context) {
 	userID := c.GetUint("userID")
-	receiverID, err := strconv.ParseUint(c.Param("userId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+	receiverID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
@@ -70,13 +68,13 @@ func (h *MessageHandler) SendMessage(c *gin.Context) {
 
 	msg := &model.Message{
 		SenderID:   userID,
-		ReceiverID: uint(receiverID),
+		ReceiverID: receiverID,
 		Content:    input.Content,
 	}
 	if err := h.service.SendMessage(msg); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, msg)
+	respondCreated(c, msg)
 }

--- a/backend/internal/handler/notification.go
+++ b/backend/internal/handler/notification.go
@@ -1,9 +1,6 @@
 package handler
 
 import (
-	"net/http"
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
@@ -22,26 +19,22 @@ func NewNotificationHandler(s *service.NotificationService) *NotificationHandler
 // GetAll は認証ユーザーの通知一覧をページネーション付きで取得する。
 func (h *NotificationHandler) GetAll(c *gin.Context) {
 	userID := c.GetUint("userID")
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
+	page, limit := parsePagination(c)
 	notificationType := c.DefaultQuery("type", "")
-	if page < 1 {
-		page = 1
-	}
 
 	notifications, err := h.service.GetByUserID(userID, page, limit, notificationType)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
 	total, err := h.service.CountByUserID(userID, notificationType)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"notifications": notifications,
 		"total":         total,
 	})
@@ -53,26 +46,25 @@ func (h *NotificationHandler) GetUnreadCount(c *gin.Context) {
 
 	count, err := h.service.CountUnread(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"count": count})
+	respondOK(c, gin.H{"count": count})
 }
 
 // MarkAsRead は指定された通知を既読にする。
 func (h *NotificationHandler) MarkAsRead(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.MarkAsRead(uint(id), userID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.service.MarkAsRead(id, userID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "marked as read"})
+	respondOK(c, gin.H{"message": "marked as read"})
 }
 
 // MarkAllAsRead は認証ユーザーの全通知を既読にする。
@@ -80,24 +72,23 @@ func (h *NotificationHandler) MarkAllAsRead(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	if err := h.service.MarkAllAsRead(userID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "all marked as read"})
+	respondOK(c, gin.H{"message": "all marked as read"})
 }
 
 // Delete は指定された通知を削除する。
 func (h *NotificationHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(id), userID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.service.Delete(id, userID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "deleted"})
+	respondOK(c, gin.H{"message": "deleted"})
 }

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -48,7 +46,7 @@ func (h *PostHandler) Create(c *gin.Context) {
 	}
 	created, err := h.service.Create(post)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
@@ -73,36 +71,31 @@ func (h *PostHandler) Create(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusCreated, created)
+	respondCreated(c, created)
 }
 
 // GetAll は投稿一覧をページネーション付きで返す。
 func (h *PostHandler) GetAll(c *gin.Context) {
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	if page < 1 {
-		page = 1
-	}
+	page, limit := parsePagination(c)
 
 	posts, err := h.service.GetAll(page, limit)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, posts)
+	respondOK(c, posts)
 }
 
 // GetByID は指定IDの投稿を返す。いいね済みフラグも付与する。
 func (h *PostHandler) GetByID(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	post, err := h.service.GetByID(uint(id))
+	post, err := h.service.GetByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "post not found"})
+		respondError(c, err)
 		return
 	}
 
@@ -111,7 +104,7 @@ func (h *PostHandler) GetByID(c *gin.Context) {
 		model.Post
 		Liked bool `json:"liked"`
 	}
-	c.JSON(http.StatusOK, postWithLiked{
+	respondOK(c, postWithLiked{
 		Post:  *post,
 		Liked: h.service.HasLiked(userID, post.ID),
 	})
@@ -119,9 +112,8 @@ func (h *PostHandler) GetByID(c *gin.Context) {
 
 // Update は投稿を更新する。所有者のみ更新可能。
 func (h *PostHandler) Update(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
@@ -135,123 +127,105 @@ func (h *PostHandler) Update(c *gin.Context) {
 		return
 	}
 
-	post, err := h.service.Update(uint(id), userID, input.Title, input.Content)
+	post, err := h.service.Update(id, userID, input.Title, input.Content)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not your post"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "post not found"})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, post)
+	respondOK(c, post)
 }
 
 // Delete は投稿を削除する。所有者のみ削除可能。
 func (h *PostHandler) Delete(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
 
-	if err := h.service.Delete(uint(id), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not your post"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "post not found"})
+	if err := h.service.Delete(id, userID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "deleted"})
+	respondDeleted(c)
 }
 
 // Timeline はフォロー中ユーザーの投稿タイムラインを返す。
 func (h *PostHandler) Timeline(c *gin.Context) {
 	userID := c.GetUint("userID")
-	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	if page < 1 {
-		page = 1
-	}
+	page, limit := parsePagination(c)
 
 	posts, err := h.service.Timeline(userID, page, limit)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, posts)
+	respondOK(c, posts)
 }
 
 // GetUserPosts は指定ユーザーの投稿一覧を返す。
 func (h *PostHandler) GetUserPosts(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
-	posts, err := h.service.GetByUserID(uint(id))
+	posts, err := h.service.GetByUserID(id)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, posts)
+	respondOK(c, posts)
 }
 
 // Like は投稿にいいねする。
 func (h *PostHandler) Like(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
 
-	if err := h.service.Like(userID, uint(id)); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.service.Like(userID, id); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "liked"})
+	respondOK(c, gin.H{"message": "liked"})
 }
 
 // Unlike は投稿のいいねを取り消す。
 func (h *PostHandler) Unlike(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
 
-	if err := h.service.Unlike(userID, uint(id)); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.service.Unlike(userID, id); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "unliked"})
+	respondOK(c, gin.H{"message": "unliked"})
 }
 
 // GetComments は投稿のコメント一覧を返す。
 func (h *PostHandler) GetComments(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	comments, err := h.service.GetComments(uint(id))
+	comments, err := h.service.GetComments(id)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, comments)
+	respondOK(c, comments)
 }
 
 // CreateComment は投稿にコメントを作成する。
 func (h *PostHandler) CreateComment(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
@@ -264,26 +238,25 @@ func (h *PostHandler) CreateComment(c *gin.Context) {
 		return
 	}
 
-	comment := &model.Comment{UserID: userID, PostID: uint(id), Content: input.Content}
+	comment := &model.Comment{UserID: userID, PostID: id, Content: input.Content}
 	if err := h.service.CreateComment(comment); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusCreated, comment)
+	respondCreated(c, comment)
 }
 
 // DeleteComment はコメントを削除する。所有者のみ削除可能。
 func (h *PostHandler) DeleteComment(c *gin.Context) {
-	commentID, err := strconv.ParseUint(c.Param("commentId"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid comment id"})
+	commentID, ok := parseID(c, "commentId")
+	if !ok {
 		return
 	}
 	userID := c.GetUint("userID")
 
-	if err := h.service.DeleteComment(uint(commentID), userID); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	if err := h.service.DeleteComment(commentID, userID); err != nil {
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, gin.H{"message": "deleted"})
+	respondDeleted(c)
 }

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"errors"
-	"net/http"
 	"strconv"
 	"time"
 
@@ -61,9 +59,8 @@ type UpdateProjectRequest struct {
 func (h *ProjectHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req CreateProjectRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[CreateProjectRequest](c)
+	if req == nil {
 		return
 	}
 
@@ -94,76 +91,71 @@ func (h *ProjectHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.service.Create(project); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create project"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, project)
+	respondCreated(c, project)
 }
 
 // GetByID は指定IDのプロジェクトを取得する。
 func (h *ProjectHandler) GetByID(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	project, err := h.service.GetByID(uint(id))
+	project, err := h.service.GetByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Project not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, project)
+	respondOK(c, project)
 }
 
 // GetByUserID は指定ユーザーのプロジェクト一覧を取得する。
 func (h *ProjectHandler) GetByUserID(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	projects, err := h.service.GetByUserID(uint(userID))
+	projects, err := h.service.GetByUserID(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch projects"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, projects)
+	respondOK(c, projects)
 }
 
 // GetFeatured は指定ユーザーの注目プロジェクト一覧を取得する。
 func (h *ProjectHandler) GetFeatured(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	projects, err := h.service.GetFeaturedByUserID(uint(userID))
+	projects, err := h.service.GetFeaturedByUserID(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch featured projects"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, projects)
+	respondOK(c, projects)
 }
 
 // Update は指定IDのプロジェクトを更新する。
 func (h *ProjectHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	var req UpdateProjectRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[UpdateProjectRequest](c)
+	if req == nil {
 		return
 	}
 
@@ -205,47 +197,38 @@ func (h *ProjectHandler) Update(c *gin.Context) {
 		}
 	}
 
-	project, err := h.service.Update(uint(id), userID, updates)
+	project, err := h.service.Update(id, userID, updates)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to update this project"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Project not found"})
+		respondError(c, err)
 		return
 	}
 
 	// featuredはboolポインタのため別途処理する
 	if req.Featured != nil {
-		project, err = h.service.UpdateFeatured(uint(id), userID, *req.Featured)
+		project, err = h.service.UpdateFeatured(id, userID, *req.Featured)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to update project"})
+			respondError(c, err)
 			return
 		}
 	}
 
-	c.JSON(http.StatusOK, project)
+	respondOK(c, project)
 }
 
 // Delete は指定IDのプロジェクトを削除する。
 func (h *ProjectHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid project ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(id), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to delete this project"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Project not found"})
+	if err := h.service.Delete(id, userID); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Project deleted successfully"})
+	respondDeleted(c)
 }
 
 // GetAll はプロジェクトの一覧をページネーション付きで取得する。
@@ -259,11 +242,11 @@ func (h *ProjectHandler) GetAll(c *gin.Context) {
 
 	projects, total, err := h.service.GetAll(limit, offset)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch projects"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"projects": projects,
 		"total":    total,
 		"limit":    limit,

--- a/backend/internal/handler/qiita.go
+++ b/backend/internal/handler/qiita.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -35,19 +33,11 @@ func (h *QiitaHandler) Connect(c *gin.Context) {
 
 	count, err := h.service.Connect(userID, req.Username)
 	if err != nil {
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid Qiita username"})
-			return
-		}
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to connect Qiita"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"message":        "Qiita connected successfully",
 		"articles_count": count,
 	})
@@ -58,15 +48,11 @@ func (h *QiitaHandler) Disconnect(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	if err := h.service.Disconnect(userID); err != nil {
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to disconnect Qiita"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Qiita disconnected successfully"})
+	respondOK(c, gin.H{"message": "Qiita disconnected successfully"})
 }
 
 // Sync は現在のユーザーのQiita記事を再同期する。
@@ -75,19 +61,11 @@ func (h *QiitaHandler) Sync(c *gin.Context) {
 
 	count, err := h.service.Sync(userID)
 	if err != nil {
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
-		}
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Qiita not connected"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to sync Qiita articles"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"message":        "Qiita synced successfully",
 		"articles_count": count,
 	})
@@ -95,34 +73,32 @@ func (h *QiitaHandler) Sync(c *gin.Context) {
 
 // GetArticles は指定ユーザーの全Qiita記事を返す。
 func (h *QiitaHandler) GetArticles(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	articles, err := h.service.GetArticles(uint(userID))
+	articles, err := h.service.GetArticles(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get articles"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, articles)
+	respondOK(c, articles)
 }
 
 // GetStats は指定ユーザーのQiita統計情報を返す。
 func (h *QiitaHandler) GetStats(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	stats, err := h.service.GetStats(uint(userID))
+	stats, err := h.service.GetStats(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get stats"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, stats)
+	respondOK(c, stats)
 }

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 
@@ -44,9 +43,8 @@ type VoteRequest struct {
 func (h *QuestionHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req CreateQuestionRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[CreateQuestionRequest](c)
+	if req == nil {
 		return
 	}
 
@@ -58,11 +56,11 @@ func (h *QuestionHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.service.Create(question); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create question"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, question)
+	respondCreated(c, question)
 }
 
 // GetAll は質問一覧をページネーション・タグ・ソート付きで取得する。
@@ -78,11 +76,11 @@ func (h *QuestionHandler) GetAll(c *gin.Context) {
 
 	questions, total, err := h.service.GetAll(limit, offset, tag, sort)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch questions"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"questions": questions,
 		"total":     total,
 		"limit":     limit,
@@ -107,11 +105,11 @@ func (h *QuestionHandler) Search(c *gin.Context) {
 
 	questions, total, err := h.service.Search(q, limit, offset)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to search questions"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"questions": questions,
 		"total":     total,
 		"limit":     limit,
@@ -122,21 +120,20 @@ func (h *QuestionHandler) Search(c *gin.Context) {
 // GetByID は指定されたIDの質問を取得する。
 func (h *QuestionHandler) GetByID(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid question ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	question, err := h.service.GetByID(uint(id))
+	question, err := h.service.GetByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "Question not found"})
+		respondError(c, err)
 		return
 	}
 
-	userVote, _ := h.service.GetUserVote(userID, uint(id))
+	userVote, _ := h.service.GetUserVote(userID, id)
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"question":  question,
 		"user_vote": userVote,
 	})
@@ -144,106 +141,91 @@ func (h *QuestionHandler) GetByID(c *gin.Context) {
 
 // GetByUserID は指定されたユーザーの質問一覧を取得する。
 func (h *QuestionHandler) GetByUserID(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	questions, err := h.service.GetByUserID(uint(userID))
+	questions, err := h.service.GetByUserID(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to fetch questions"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, questions)
+	respondOK(c, questions)
 }
 
 // Update は指定された質問を更新する。
 func (h *QuestionHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	req := bindJSON[UpdateQuestionRequest](c)
+	if req == nil {
+		return
+	}
+
+	question, err := h.service.Update(id, userID, req.Title, req.Body, req.Tags)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid question ID"})
+		respondError(c, err)
 		return
 	}
 
-	var req UpdateQuestionRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-		return
-	}
-
-	question, err := h.service.Update(uint(id), userID, req.Title, req.Body, req.Tags)
-	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to update this question"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Question not found"})
-		return
-	}
-
-	c.JSON(http.StatusOK, question)
+	respondOK(c, question)
 }
 
 // Delete は指定された質問を削除する。
 func (h *QuestionHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid question ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(id), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "Not authorized to delete this question"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "Question not found"})
+	if err := h.service.Delete(id, userID); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Question deleted successfully"})
+	respondDeleted(c)
 }
 
 // Vote は質問に投票する。
 func (h *QuestionHandler) Vote(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid question ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	var req VoteRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	req := bindJSON[VoteRequest](c)
+	if req == nil {
 		return
 	}
 
-	if err := h.service.Vote(userID, uint(id), req.Value); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to vote"})
+	if err := h.service.Vote(userID, id, req.Value); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Voted successfully"})
+	respondOK(c, gin.H{"message": "Voted successfully"})
 }
 
 // RemoveVote は質問への投票を取り消す。
 func (h *QuestionHandler) RemoveVote(c *gin.Context) {
 	userID := c.GetUint("userID")
-	id, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid question ID"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.RemoveVote(userID, uint(id)); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to remove vote"})
+	if err := h.service.RemoveVote(userID, id); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Vote removed successfully"})
+	respondOK(c, gin.H{"message": "Vote removed successfully"})
 }

--- a/backend/internal/handler/ranking.go
+++ b/backend/internal/handler/ranking.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
@@ -23,10 +21,10 @@ func (h *RankingHandler) ContributionRanking(c *gin.Context) {
 	period := c.DefaultQuery("period", "weekly")
 	entries, err := h.service.ContributionRanking(period)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, entries)
+	respondOK(c, entries)
 }
 
 // LanguageRanking は指定言語のランキングを返す。
@@ -35,28 +33,28 @@ func (h *RankingHandler) LanguageRanking(c *gin.Context) {
 	period := c.DefaultQuery("period", "weekly")
 	entries, err := h.service.LanguageRanking(lang, period)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, entries)
+	respondOK(c, entries)
 }
 
 // LevelRanking はXP合計に基づくレベルランキングを返す。
 func (h *RankingHandler) LevelRanking(c *gin.Context) {
 	entries, err := h.service.LevelRanking()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, entries)
+	respondOK(c, entries)
 }
 
 // AvailableLanguages はランキング対象の利用可能な言語一覧を返す。
 func (h *RankingHandler) AvailableLanguages(c *gin.Context) {
 	languages, err := h.service.AvailableLanguages()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, languages)
+	respondOK(c, languages)
 }

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 
@@ -53,11 +52,11 @@ func (h *RoadmapHandler) Create(c *gin.Context) {
 	}
 
 	if err := h.service.Create(roadmap); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create roadmap"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, roadmap)
+	respondCreated(c, roadmap)
 }
 
 // GetMyRoadmaps は現在のユーザーのロードマップ一覧を取得する。
@@ -66,11 +65,11 @@ func (h *RoadmapHandler) GetMyRoadmaps(c *gin.Context) {
 
 	roadmaps, err := h.service.GetByUserID(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get roadmaps"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, roadmaps)
+	respondOK(c, roadmaps)
 }
 
 // GetPublicRoadmaps は公開ロードマップの一覧をページネーション付きで取得する。
@@ -80,11 +79,11 @@ func (h *RoadmapHandler) GetPublicRoadmaps(c *gin.Context) {
 
 	roadmaps, total, err := h.service.GetPublicRoadmaps(limit, offset)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get roadmaps"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"roadmaps": roadmaps,
 		"total":    total,
 	})
@@ -92,33 +91,27 @@ func (h *RoadmapHandler) GetPublicRoadmaps(c *gin.Context) {
 
 // GetByID は指定IDのロードマップをステップ付きで取得する。
 func (h *RoadmapHandler) GetByID(c *gin.Context) {
-	roadmapID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid roadmap ID"})
+	roadmapID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
 	userID := c.GetUint("userID")
 
-	roadmap, err := h.service.GetByID(uint(roadmapID), userID)
+	roadmap, err := h.service.GetByID(roadmapID, userID)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "roadmap not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, roadmap)
+	respondOK(c, roadmap)
 }
 
 // Update は指定IDのロードマップを更新する。
 func (h *RoadmapHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roadmapID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid roadmap ID"})
+	roadmapID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
@@ -149,101 +142,82 @@ func (h *RoadmapHandler) Update(c *gin.Context) {
 		updates.Status = model.RoadmapStatus(*req.Status)
 	}
 
-	roadmap, err := h.service.Update(uint(roadmapID), userID, updates)
+	roadmap, err := h.service.Update(roadmapID, userID, updates)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "roadmap not found"})
+		respondError(c, err)
 		return
 	}
 
 	// IsPublicが指定されている場合は別途処理する
 	if req.IsPublic != nil {
-		roadmap, err = h.service.UpdateVisibility(uint(roadmapID), userID, *req.IsPublic)
+		roadmap, err = h.service.UpdateVisibility(roadmapID, userID, *req.IsPublic)
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update roadmap"})
+			respondError(c, err)
 			return
 		}
 	}
 
-	c.JSON(http.StatusOK, roadmap)
+	respondOK(c, roadmap)
 }
 
 // Delete は指定IDのロードマップを削除する。
 func (h *RoadmapHandler) Delete(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roadmapID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid roadmap ID"})
+	roadmapID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	if err := h.service.Delete(uint(roadmapID), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "roadmap not found"})
+	if err := h.service.Delete(roadmapID, userID); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "roadmap deleted"})
+	respondDeleted(c)
 }
 
 // CopyRoadmap は公開ロードマップをテンプレートとしてコピーする。
 func (h *RoadmapHandler) CopyRoadmap(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roadmapID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid roadmap ID"})
+	roadmapID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	copied, err := h.service.CopyRoadmap(uint(roadmapID), userID)
+	copied, err := h.service.CopyRoadmap(roadmapID, userID)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "roadmap not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, copied)
+	respondCreated(c, copied)
 }
 
 // GetTemplates はテンプレートロードマップの一覧を取得する。
 func (h *RoadmapHandler) GetTemplates(c *gin.Context) {
 	templates, err := h.service.GetTemplates()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get templates"})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, templates)
+	respondOK(c, templates)
 }
 
 // CreateFromTemplate はテンプレートからユーザー用ロードマップを作成する。
 func (h *RoadmapHandler) CreateFromTemplate(c *gin.Context) {
 	userID := c.GetUint("userID")
-	templateID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid template ID"})
+	templateID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	roadmap, err := h.service.CreateFromTemplate(uint(templateID), userID)
+	roadmap, err := h.service.CreateFromTemplate(templateID, userID)
 	if err != nil {
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "not a template"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "template not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, roadmap)
+	respondCreated(c, roadmap)
 }
 
 // === ロードマップステップエンドポイント ===
@@ -251,9 +225,8 @@ func (h *RoadmapHandler) CreateFromTemplate(c *gin.Context) {
 // CreateStep はロードマップに新しいステップを作成する。
 func (h *RoadmapHandler) CreateStep(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roadmapID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid roadmap ID"})
+	roadmapID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
@@ -278,29 +251,23 @@ func (h *RoadmapHandler) CreateStep(c *gin.Context) {
 		step.OrderIndex = *req.OrderIndex
 	}
 
-	if err := h.service.CreateStep(uint(roadmapID), userID, step); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create step"})
+	if err := h.service.CreateStep(roadmapID, userID, step); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusCreated, step)
+	respondCreated(c, step)
 }
 
 // UpdateStep はロードマップのステップを更新する。
 func (h *RoadmapHandler) UpdateStep(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roadmapID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid roadmap ID"})
+	roadmapID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
-	stepID, err := strconv.ParseUint(c.Param("stepId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid step ID"})
+	stepID, ok := parseID(c, "stepId")
+	if !ok {
 		return
 	}
 
@@ -318,22 +285,14 @@ func (h *RoadmapHandler) UpdateStep(c *gin.Context) {
 
 	// 完了ステータスの変更を別途処理する
 	if req.IsCompleted != nil {
-		step, err := h.service.UpdateStepCompletion(uint(roadmapID), uint(stepID), userID, *req.IsCompleted)
+		step, err := h.service.UpdateStepCompletion(roadmapID, stepID, userID, *req.IsCompleted)
 		if err != nil {
-			if errors.Is(err, service.ErrForbidden) {
-				c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-				return
-			}
-			if errors.Is(err, service.ErrBadRequest) {
-				c.JSON(http.StatusBadRequest, gin.H{"error": "step does not belong to roadmap"})
-				return
-			}
-			c.JSON(http.StatusNotFound, gin.H{"error": "step not found"})
+			respondError(c, err)
 			return
 		}
 		// 完了ステータスのみの更新の場合は早期リターンする
 		if req.Title == nil && req.Description == nil && req.ResourceURL == nil {
-			c.JSON(http.StatusOK, step)
+			respondOK(c, step)
 			return
 		}
 	}
@@ -349,59 +308,40 @@ func (h *RoadmapHandler) UpdateStep(c *gin.Context) {
 		updates.ResourceURL = *req.ResourceURL
 	}
 
-	step, err := h.service.UpdateStep(uint(roadmapID), uint(stepID), userID, updates)
+	step, err := h.service.UpdateStep(roadmapID, stepID, userID, updates)
 	if err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "step does not belong to roadmap"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "step not found"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, step)
+	respondOK(c, step)
 }
 
 // DeleteStep はロードマップのステップを削除する。
 func (h *RoadmapHandler) DeleteStep(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roadmapID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid roadmap ID"})
+	roadmapID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
-	stepID, err := strconv.ParseUint(c.Param("stepId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid step ID"})
-		return
-	}
-
-	if err := h.service.DeleteStep(uint(roadmapID), uint(stepID), userID); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "step does not belong to roadmap"})
-			return
-		}
-		c.JSON(http.StatusNotFound, gin.H{"error": "step not found"})
+	stepID, ok := parseID(c, "stepId")
+	if !ok {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "step deleted"})
+	if err := h.service.DeleteStep(roadmapID, stepID, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondDeleted(c)
 }
 
 // ReorderSteps はロードマップ内のステップの並び順を変更する。
 func (h *RoadmapHandler) ReorderSteps(c *gin.Context) {
 	userID := c.GetUint("userID")
-	roadmapID, err := strconv.ParseUint(c.Param("id"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid roadmap ID"})
+	roadmapID, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
@@ -414,14 +354,10 @@ func (h *RoadmapHandler) ReorderSteps(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.ReorderSteps(uint(roadmapID), userID, req.Orders); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to reorder steps"})
+	if err := h.service.ReorderSteps(roadmapID, userID, req.Orders); err != nil {
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "steps reordered"})
+	respondOK(c, gin.H{"message": "steps reordered"})
 }

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -25,44 +23,42 @@ func (h *UserHandler) GetAll(c *gin.Context) {
 	q := c.Query("q")
 	users, err := h.service.GetAll(q)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, users)
+	respondOK(c, users)
 }
 
 // GetByID は指定IDのユーザー情報を返す。
 func (h *UserHandler) GetByID(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
-	user, err := h.service.GetByID(uint(id))
+	user, err := h.service.GetByID(id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
 		return
 	}
-	c.JSON(http.StatusOK, user)
+	respondOK(c, user)
 }
 
 // Update はユーザープロフィールを更新する。
 // 本人のみ更新可能（userIDとパスパラメータのIDが一致する必要がある）。
 func (h *UserHandler) Update(c *gin.Context) {
-	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+	id, ok := parseID(c, "id")
+	if !ok {
 		return
 	}
 
 	userID := c.GetUint("userID")
-	if userID != uint(id) {
+	if userID != id {
 		c.JSON(http.StatusForbidden, gin.H{"error": "cannot update other user's profile"})
 		return
 	}
 
-	existing, err := h.service.GetByID(uint(id))
+	existing, err := h.service.GetByID(id)
 	if err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
 		return
@@ -105,12 +101,8 @@ func (h *UserHandler) Update(c *gin.Context) {
 	}
 
 	if err := h.service.Update(existing); err != nil {
-		if errors.Is(err, service.ErrForbidden) {
-			c.JSON(http.StatusForbidden, gin.H{"error": "forbidden"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
-	c.JSON(http.StatusOK, existing)
+	respondOK(c, existing)
 }

--- a/backend/internal/handler/zenn.go
+++ b/backend/internal/handler/zenn.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -35,19 +33,11 @@ func (h *ZennHandler) Connect(c *gin.Context) {
 
 	count, err := h.service.Connect(userID, req.Username)
 	if err != nil {
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid Zenn username"})
-			return
-		}
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to connect Zenn"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"message":        "Zenn connected successfully",
 		"articles_count": count,
 	})
@@ -58,15 +48,11 @@ func (h *ZennHandler) Disconnect(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	if err := h.service.Disconnect(userID); err != nil {
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to disconnect Zenn"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "Zenn disconnected successfully"})
+	respondOK(c, gin.H{"message": "Zenn disconnected successfully"})
 }
 
 // Sync は現在のユーザーのZenn記事を再同期する。
@@ -75,19 +61,11 @@ func (h *ZennHandler) Sync(c *gin.Context) {
 
 	count, err := h.service.Sync(userID)
 	if err != nil {
-		if errors.Is(err, service.ErrNotFound) {
-			c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
-			return
-		}
-		if errors.Is(err, service.ErrBadRequest) {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "Zenn not connected"})
-			return
-		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to sync Zenn articles"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"message":        "Zenn synced successfully",
 		"articles_count": count,
 	})
@@ -95,34 +73,32 @@ func (h *ZennHandler) Sync(c *gin.Context) {
 
 // GetArticles は指定ユーザーの全Zenn記事を返す。
 func (h *ZennHandler) GetArticles(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	articles, err := h.service.GetArticles(uint(userID))
+	articles, err := h.service.GetArticles(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get articles"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, articles)
+	respondOK(c, articles)
 }
 
 // GetStats は指定ユーザーのZenn統計情報を返す。
 func (h *ZennHandler) GetStats(c *gin.Context) {
-	userID, err := strconv.ParseUint(c.Param("userId"), 10, 32)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+	userID, ok := parseID(c, "userId")
+	if !ok {
 		return
 	}
 
-	stats, err := h.service.GetStats(uint(userID))
+	stats, err := h.service.GetStats(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get stats"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, stats)
+	respondOK(c, stats)
 }

--- a/backend/internal/service/errors.go
+++ b/backend/internal/service/errors.go
@@ -11,6 +11,7 @@ var (
 	ErrNotFound   = errors.New("not found")   // リソースが見つからない（404）
 	ErrForbidden  = errors.New("forbidden")   // アクセス権限がない（403）
 	ErrBadRequest = errors.New("bad request") // リクエストが不正（400）
+	ErrUnauthorized      = errors.New("unauthorized")        // 認証が必要（401）
 	ErrConflict          = errors.New("conflict")            // リソースの競合（409）
 	ErrRateLimitExceeded = errors.New("rate limit exceeded") // レート制限超過（429）
 	ErrLLMNotConfigured  = errors.New("LLM not configured") // LLM未設定（503）


### PR DESCRIPTION
## 概要

全26ハンドラーに共通ヘルパー関数を導入し、エラーハンドリング・IDパース・レスポンスパターンを統一。ボイラープレートコードを**452行削減**（1,088行→636行）。

## 変更内容

### 新規ファイル
- **`handler/helpers.go`** — 7つの共通ヘルパー関数
  - `parseID` — URLパラメータからuint型ID取得 + 自動400レスポンス
  - `parsePagination` — page/limit取得（デフォルト: 1/20, 上限: 100）
  - `bindJSON[T]` — ジェネリクスによる型安全なリクエストバインド
  - `respondError` — サービスエラー→HTTPステータス自動マッピング（7種類）
  - `respondOK` / `respondCreated` / `respondDeleted` — 統一レスポンス

- **`handler/helpers_test.go`** — 15テストケースのユニットテスト

### 変更ファイル
- **`service/errors.go`** — `ErrUnauthorized` 追加
- **26ハンドラーファイル** — ヘルパー関数への書き換え

### 未変更ファイル（対象外）
- `auth.go` — Cookie/OAuth固有処理
- `upload.go` — ファイルI/O固有処理
- `websocket.go` / `health.go` — 共通化不要

## テスト計画

- [x] `go build ./...` — ビルド成功
- [x] `go test ./internal/handler/...` — 全15テストPASS
- [x] `go test ./internal/service/...` — 既存テストPASS
- [x] `docker compose up -d --build` — コンテナ起動成功

Closes #152