### PR TITLE
feat: 投稿編集時に画像URLの更新に対応

### DIFF
--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -121,15 +121,16 @@ func (h *PostHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	var input struct {
-		Title   string `json:"title"`
-		Content string `json:"content"`
+		Title     string `json:"title"`
+		Content   string `json:"content"`
+		ImageURLs string `json:"image_urls"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
 		return
 	}
 
-	post, err := h.service.Update(id, userID, input.Title, input.Content)
+	post, err := h.service.Update(id, userID, input.Title, input.Content, input.ImageURLs)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/post_test.go
+++ b/backend/internal/handler/post_test.go
@@ -160,6 +160,26 @@ func TestPostUpdate_NotFound(t *testing.T) {
 	assertStatus(t, w, http.StatusNotFound)
 }
 
+func TestPostUpdate_WithImageUrls(t *testing.T) {
+	h, postRepo, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.PUT("/posts/:id", h.Update)
+
+	post := &model.Post{Title: "Old", Content: "Old", ImageURLs: ""}
+	post.ID = 10
+	post.UserID = 1
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+	postRepo.On("Update", mock.AnythingOfType("*model.Post")).Return(nil)
+
+	imageUrls := `["https://example.com/image1.jpg"]`
+	w := doRequest(r, http.MethodPut, "/posts/10", map[string]interface{}{
+		"title":      "Updated",
+		"content":    "Updated content",
+		"image_urls": imageUrls,
+	})
+	assertStatus(t, w, http.StatusOK)
+}
+
 // ---------- Delete ----------
 
 func TestPostDelete_Success(t *testing.T) {

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -62,7 +62,7 @@ func (s *PostService) Timeline(userID uint, page, limit int) ([]model.Post, erro
 }
 
 // Update は所有権を検証した後、投稿を更新する。
-func (s *PostService) Update(id, userID uint, title, content string) (*model.Post, error) {
+func (s *PostService) Update(id, userID uint, title, content, imageUrls string) (*model.Post, error) {
 	post, err := s.repo.FindByID(id)
 	if err != nil {
 		return nil, err
@@ -76,6 +76,9 @@ func (s *PostService) Update(id, userID uint, title, content string) (*model.Pos
 	}
 	if content != "" {
 		post.Content = content
+	}
+	if imageUrls != "" {
+		post.ImageURLs = imageUrls
 	}
 
 	if err := s.repo.Update(post); err != nil {

--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -39,7 +39,7 @@ export const uploadImages = async (files: File[]): Promise<{ urls: string[] }> =
   return response.data;
 };
 
-export const updatePost = (id: number, data: { title: string; content: string }) =>
+export const updatePost = (id: number, data: { title: string; content: string; image_urls?: string }) =>
   client.put<Post>(`/posts/${id}`, data);
 
 export const deletePost = (id: number) =>


### PR DESCRIPTION
## 概要
Phase 6.4の一環として、投稿編集時に画像URLも更新できるように機能を拡張しました。

## 実装内容

### バックエンド
**Service層 (post.go)**
- `Update`メソッドのシグネチャを拡張: `imageUrls`パラメータを追加
- 空文字列でない場合のみ画像URLを更新

**Handler層 (post.go)**
- 入力構造体に`ImageURLs`フィールドを追加
- Service層への呼び出しを更新

**テスト (post_test.go)**
- `TestPostUpdate_WithImageUrls`: 画像URL更新のテストケースを追加
- 既存の全Updateテストも合格

### フロントエンド
**APIクライアント (posts.ts)**
- `updatePost`関数に`image_urls?`パラメータを追加

**i18n**
- 10言語全てに編集関連キーを追加
  - edit, editing, updated, updateFailed, editPost

## テスト結果
```
=== RUN   TestPostUpdate_Success
--- PASS: TestPostUpdate_Success (0.00s)
=== RUN   TestPostUpdate_Forbidden
--- PASS: TestPostUpdate_Forbidden (0.00s)
=== RUN   TestPostUpdate_NotFound
--- PASS: TestPostUpdate_NotFound (0.00s)
=== RUN   TestPostUpdate_WithImageUrls
--- PASS: TestPostUpdate_WithImageUrls (0.00s)
PASS
```

## メリット
- 投稿作成後に画像を追加・変更可能
- 編集機能の完全性が向上
- UX改善（画像の差し替えが可能に）

## 今後の拡張
- コードスニペットの編集対応
- 編集履歴の記録
- 編集UIコンポーネントの実装

## 関連Issue
Related to #178