### PR TITLE
refactor: 投稿バリデーション層を追加

### DIFF
--- a/backend/internal/domain/validator/post.go
+++ b/backend/internal/domain/validator/post.go
@@ -1,0 +1,51 @@
+// Package validator provides validation logic for domain entities.
+package validator
+
+import (
+	"strings"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+)
+
+// PostValidator handles validation for Post entities.
+type PostValidator struct{}
+
+// NewPostValidator creates a new PostValidator instance.
+func NewPostValidator() *PostValidator {
+	return &PostValidator{}
+}
+
+// ValidateTitle validates the post title.
+func (v *PostValidator) ValidateTitle(title string) error {
+	trimmed := strings.TrimSpace(title)
+	if trimmed == "" {
+		return domain.NewError(domain.ErrCodeValidation, "タイトルは必須です", nil)
+	}
+	if len(title) > 200 {
+		return domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以内で入力してください", nil)
+	}
+	return nil
+}
+
+// ValidateContent validates the post content.
+func (v *PostValidator) ValidateContent(content string) error {
+	trimmed := strings.TrimSpace(content)
+	if trimmed == "" {
+		return domain.NewError(domain.ErrCodeValidation, "本文は必須です", nil)
+	}
+	if len(content) > 10000 {
+		return domain.NewError(domain.ErrCodeValidation, "本文は10000文字以内で入力してください", nil)
+	}
+	return nil
+}
+
+// ValidatePost validates both title and content.
+func (v *PostValidator) ValidatePost(title, content string) error {
+	if err := v.ValidateTitle(title); err != nil {
+		return err
+	}
+	if err := v.ValidateContent(content); err != nil {
+		return err
+	}
+	return nil
+}

--- a/backend/internal/domain/validator/post_test.go
+++ b/backend/internal/domain/validator/post_test.go
@@ -1,0 +1,145 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPostValidator_ValidateTitle(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "正常なタイトル",
+			title:   "テスト投稿",
+			wantErr: false,
+		},
+		{
+			name:    "空のタイトル",
+			title:   "",
+			wantErr: true,
+			errMsg:  "タイトルは必須です",
+		},
+		{
+			name:    "タイトルが長すぎる（200文字超）",
+			title:   string(make([]byte, 201)),
+			wantErr: true,
+			errMsg:  "タイトルは200文字以内で入力してください",
+		},
+		{
+			name:    "空白のみのタイトル",
+			title:   "   ",
+			wantErr: true,
+			errMsg:  "タイトルは必須です",
+		},
+	}
+
+	validator := NewPostValidator()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateTitle(tt.title)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPostValidator_ValidateContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "正常な本文",
+			content: "これはテスト投稿の本文です。",
+			wantErr: false,
+		},
+		{
+			name:    "空の本文",
+			content: "",
+			wantErr: true,
+			errMsg:  "本文は必須です",
+		},
+		{
+			name:    "本文が長すぎる（10000文字超）",
+			content: string(make([]byte, 10001)),
+			wantErr: true,
+			errMsg:  "本文は10000文字以内で入力してください",
+		},
+		{
+			name:    "空白のみの本文",
+			content: "   ",
+			wantErr: true,
+			errMsg:  "本文は必須です",
+		},
+	}
+
+	validator := NewPostValidator()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidateContent(tt.content)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPostValidator_ValidatePost(t *testing.T) {
+	tests := []struct {
+		name    string
+		title   string
+		content string
+		wantErr bool
+	}{
+		{
+			name:    "正常な投稿",
+			title:   "テストタイトル",
+			content: "テスト本文",
+			wantErr: false,
+		},
+		{
+			name:    "タイトルが空",
+			title:   "",
+			content: "テスト本文",
+			wantErr: true,
+		},
+		{
+			name:    "本文が空",
+			title:   "テストタイトル",
+			content: "",
+			wantErr: true,
+		},
+		{
+			name:    "両方空",
+			title:   "",
+			content: "",
+			wantErr: true,
+		},
+	}
+
+	validator := NewPostValidator()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validator.ValidatePost(tt.title, tt.content)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
Phase 7.2の一環として、投稿のバリデーションロジックをdomain層に集約しました。

## 実装内容

### domain/validator/post.go
**PostValidator 構造体**
- `ValidateTitle`: タイトルの必須チェックと文字数制限（最大200文字）
  - 空白のみの入力も不正として検出
  - DomainError を使用した統一的なエラーレスポンス
- `ValidateContent`: 本文の必須チェックと文字数制限（最大10000文字）
  - 空白のみの入力も不正として検出
- `ValidatePost`: タイトルと本文を一括でバリデーション

### domain/validator/post_test.go
**包括的なテストスイート**
- 12個のテストケースで正常系・異常系をカバー
- エッジケース（空白のみ、文字数上限超）もテスト
- テストカバレッジ100%

## テスト結果
```
=== RUN   TestPostValidator_ValidateTitle
--- PASS: TestPostValidator_ValidateTitle (0.00s)
=== RUN   TestPostValidator_ValidateContent
--- PASS: TestPostValidator_ValidateContent (0.00s)
=== RUN   TestPostValidator_ValidatePost
--- PASS: TestPostValidator_ValidatePost (0.00s)
PASS
ok  	github.com/norman6464/devsync/backend/internal/domain/validator	0.356s
```

## アーキテクチャ上のメリット
1. **関心の分離**: バリデーションロジックがdomain層に集約
2. **再利用性**: Handler層・Service層の両方から利用可能
3. **一貫性**: DomainError との統合で統一的なエラーハンドリング
4. **テスタビリティ**: 独立したテストが容易
5. **保守性**: バリデーションルールの変更が一箇所で完結

## 今後の展開
- Handler層での利用（Create/Update時）
- Service層でのビジネスルールバリデーション
- UserValidator, CommentValidator の追加
- カスタムバリデーションルールの拡張

## 関連Issue
Related to #180