### PR TITLE
feat: 通知ページに「未読のみ表示」フィルター追加

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -377,6 +377,7 @@
     "filterMessage": "Nachrichten",
     "filterAnswer": "Q&A-Antworten",
     "filterBadge": "Abzeichen",
+    "showUnreadOnly": "Nur ungelesene anzeigen",
     "deleteNotification": "Benachrichtigung löschen",
     "deleted": "Benachrichtigung gelöscht",
     "levelUp": "Sie haben Stufe {{level}} erreicht!",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -377,6 +377,7 @@
     "filterMessage": "Messages",
     "filterAnswer": "Q&A Answers",
     "filterBadge": "Badge",
+    "showUnreadOnly": "Show unread only",
     "deleteNotification": "Delete notification",
     "deleted": "Notification deleted",
     "levelUp": "You reached Level {{level}}!",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -377,6 +377,7 @@
     "filterMessage": "Mensajes",
     "filterAnswer": "Respuestas Q&A",
     "filterBadge": "Insignia",
+    "showUnreadOnly": "Mostrar solo no leídos",
     "deleteNotification": "Eliminar notificación",
     "deleted": "Notificación eliminada",
     "levelUp": "¡Has alcanzado el Nivel {{level}}!",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -377,6 +377,7 @@
     "filterMessage": "Messages",
     "filterAnswer": "Réponses Q&R",
     "filterBadge": "Badge",
+    "showUnreadOnly": "Afficher uniquement non lus",
     "deleteNotification": "Supprimer la notification",
     "deleted": "Notification supprimée",
     "levelUp": "Vous avez atteint le Niveau {{level}} !",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -366,6 +366,7 @@
     "filterMessage": "メッセージ",
     "filterAnswer": "Q&A回答",
     "filterBadge": "バッジ",
+    "showUnreadOnly": "未読のみ表示",
     "deleteNotification": "通知を削除",
     "deleted": "通知を削除しました",
     "levelUp": "レベル {{level}} に到達しました！",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -377,6 +377,7 @@
     "filterMessage": "메시지",
     "filterAnswer": "Q&A 답변",
     "filterBadge": "배지",
+    "showUnreadOnly": "읽지 않은 항목만 표시",
     "deleteNotification": "알림 삭제",
     "deleted": "알림이 삭제되었습니다",
     "levelUp": "레벨 {{level}}에 도달했습니다!",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -377,6 +377,7 @@
     "filterMessage": "Mensagens",
     "filterAnswer": "Respostas Q&A",
     "filterBadge": "Emblema",
+    "showUnreadOnly": "Mostrar apenas não lidos",
     "deleteNotification": "Excluir notificação",
     "deleted": "Notificação excluída",
     "levelUp": "Você alcançou o Nível {{level}}!",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -377,6 +377,7 @@
     "filterMessage": "Сообщения",
     "filterAnswer": "Ответы Q&A",
     "filterBadge": "Значок",
+    "showUnreadOnly": "Показать только непрочитанные",
     "deleteNotification": "Удалить уведомление",
     "deleted": "Уведомление удалено",
     "levelUp": "Вы достигли уровня {{level}}!",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -377,6 +377,7 @@
     "filterMessage": "消息",
     "filterAnswer": "Q&A回答",
     "filterBadge": "徽章",
+    "showUnreadOnly": "仅显示未读",
     "deleteNotification": "删除通知",
     "deleted": "通知已删除",
     "levelUp": "已达到等级 {{level}}！",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -377,6 +377,7 @@
     "filterMessage": "訊息",
     "filterAnswer": "Q&A回答",
     "filterBadge": "徽章",
+    "showUnreadOnly": "僅顯示未讀",
     "deleteNotification": "刪除通知",
     "deleted": "通知已刪除",
     "levelUp": "已達到等級 {{level}}！",

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -1,6 +1,7 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Bell, CheckCheck, Trash2 } from 'lucide-react';
+import { Bell, CheckCheck, Trash2, Filter } from 'lucide-react';
 import { useNotifications } from '../hooks';
 import type { Notification, NotificationType } from '../types/notification';
 import Avatar from '../components/common/Avatar';
@@ -52,12 +53,18 @@ function formatTime(dateString: string, t: (key: string, opts?: Record<string, u
 
 export default function NotificationsPage() {
   const { t } = useTranslation();
+  const [showUnreadOnly, setShowUnreadOnly] = useState(false);
   const {
     notifications, unreadCount, total, loading,
     page, setPage, limit,
     filterType, setFilterType,
     markAsRead, markAllAsRead, deleteNotification,
   } = useNotifications();
+
+  // Filter notifications by read status
+  const filteredNotifications = showUnreadOnly
+    ? notifications.filter((n) => !n.read)
+    : notifications;
 
   const getNotificationMessage = (notification: Notification) => {
     switch (notification.type) {
@@ -101,20 +108,35 @@ export default function NotificationsPage() {
       </div>
 
       {/* Filter Tabs */}
-      <div className="flex flex-wrap gap-2 mb-6">
-        {FILTER_TYPES.map(({ key, labelKey }) => (
-          <button
-            key={key}
-            onClick={() => setFilterType(key)}
-            className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
-              filterType === key
-                ? 'bg-gray-700 text-white'
-                : 'bg-gray-800 text-gray-400 hover:text-white'
-            }`}
-          >
-            {t(labelKey)}
-          </button>
-        ))}
+      <div className="flex flex-col gap-4 mb-6">
+        <div className="flex flex-wrap gap-2">
+          {FILTER_TYPES.map(({ key, labelKey }) => (
+            <button
+              key={key}
+              onClick={() => setFilterType(key)}
+              className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                filterType === key
+                  ? 'bg-gray-700 text-white'
+                  : 'bg-gray-800 text-gray-400 hover:text-white'
+              }`}
+            >
+              {t(labelKey)}
+            </button>
+          ))}
+        </div>
+
+        {/* Unread Only Toggle */}
+        <button
+          onClick={() => setShowUnreadOnly(!showUnreadOnly)}
+          className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors self-start ${
+            showUnreadOnly
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-800 text-gray-400 hover:text-white'
+          }`}
+        >
+          <Filter className="w-4 h-4" />
+          {t('notifications.showUnreadOnly')}
+        </button>
       </div>
 
       {/* Content */}
@@ -122,7 +144,7 @@ export default function NotificationsPage() {
         <div className="flex justify-center items-center min-h-[400px]">
           <LoadingSpinner />
         </div>
-      ) : notifications.length === 0 ? (
+      ) : filteredNotifications.length === 0 ? (
         <div className="text-center py-12">
           <div className="w-16 h-16 mx-auto mb-4 bg-gray-800 rounded-full flex items-center justify-center">
             <Bell className="w-8 h-8 text-gray-500" />
@@ -132,7 +154,7 @@ export default function NotificationsPage() {
       ) : (
         <>
           <div className="space-y-2">
-            {notifications.map((notification) => (
+            {filteredNotifications.map((notification) => (
               <div
                 key={notification.id}
                 className={`flex items-start gap-3 p-4 rounded-lg border transition-colors ${


### PR DESCRIPTION
## 概要
通知ページに未読の通知だけを表示できる「未読のみ表示」トグルボタンを追加しました。

## 変更内容
- `showUnreadOnly` ステートを追加
- `filteredNotifications` でフィルタリングロジック実装
- Filter アイコン付きトグルボタンUI実装
- アクティブ状態で青色のハイライト表示
- 10言語すべてに `notifications.showUnreadOnly` キーを追加

## テスト計画
- [ ] 通知ページで「未読のみ表示」ボタンをクリックして未読通知のみ表示されることを確認
- [ ] ボタンをもう一度クリックしてすべての通知が表示されることを確認
- [ ] 既存の通知タイプフィルターとの併用動作を確認
- [ ] 各言語でボタンのラベルが正しく表示されることを確認

## 関連Issue
Closes #183

## スクリーンショット
通知ページのフィルターUIに「未読のみ表示」トグルボタンが追加されます。

@github-copilot[bot] レビューをお願いします