### PR TITLE
feat: 学習ログページにカテゴリー別フィルター追加（Phase 6.6）

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -507,6 +507,7 @@
     "durationPlaceholder": "Minuten",
     "calendar": "Kalender",
     "list": "Liste",
+    "filterAll": "Alle",
     "noLogs": "Noch keine Einträge",
     "noLogsOnDate": "Keine Einträge an diesem Tag",
     "created": "Eintrag erstellt",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -507,6 +507,7 @@
     "durationPlaceholder": "minutes",
     "calendar": "Calendar",
     "list": "List",
+    "filterAll": "All",
     "noLogs": "No logs yet",
     "noLogsOnDate": "No logs on this date",
     "created": "Log created",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -507,6 +507,7 @@
     "durationPlaceholder": "minutos",
     "calendar": "Calendario",
     "list": "Lista",
+    "filterAll": "Todos",
     "noLogs": "Aún no hay registros",
     "noLogsOnDate": "No hay registros en esta fecha",
     "created": "Registro creado",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -507,6 +507,7 @@
     "durationPlaceholder": "minutes",
     "calendar": "Calendrier",
     "list": "Liste",
+    "filterAll": "Tous",
     "noLogs": "Aucune entrée pour le moment",
     "noLogsOnDate": "Aucune entrée à cette date",
     "created": "Entrée créée",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -486,6 +486,7 @@
     "durationPlaceholder": "分",
     "calendar": "カレンダー",
     "list": "リスト",
+    "filterAll": "全て表示",
     "noLogs": "まだログがありません",
     "noLogsOnDate": "この日のログはありません",
     "created": "ログを作成しました",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -507,6 +507,7 @@
     "durationPlaceholder": "분",
     "calendar": "캘린더",
     "list": "목록",
+    "filterAll": "전체",
     "noLogs": "아직 로그가 없습니다",
     "noLogsOnDate": "이 날의 로그가 없습니다",
     "created": "로그가 생성되었습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -507,6 +507,7 @@
     "durationPlaceholder": "minutos",
     "calendar": "Calendário",
     "list": "Lista",
+    "filterAll": "Todos",
     "noLogs": "Nenhum registro ainda",
     "noLogsOnDate": "Nenhum registro nesta data",
     "created": "Registro criado",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -507,6 +507,7 @@
     "durationPlaceholder": "минуты",
     "calendar": "Календарь",
     "list": "Список",
+    "filterAll": "Все",
     "noLogs": "Записей пока нет",
     "noLogsOnDate": "Нет записей за эту дату",
     "created": "Запись создана",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -507,6 +507,7 @@
     "durationPlaceholder": "分钟",
     "calendar": "日历",
     "list": "列表",
+    "filterAll": "全部",
     "noLogs": "还没有日志",
     "noLogsOnDate": "这一天没有日志",
     "created": "日志已创建",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -507,6 +507,7 @@
     "durationPlaceholder": "分鐘",
     "calendar": "日曆",
     "list": "列表",
+    "filterAll": "全部",
     "noLogs": "還沒有日誌",
     "noLogsOnDate": "這一天沒有日誌",
     "created": "日誌已建立",

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -28,6 +28,7 @@ export default function LearningLogsPage() {
   const [showForm, setShowForm] = useState(false);
   const [editingLog, setEditingLog] = useState<LearningLog | null>(null);
   const [filterDate, setFilterDate] = useState<string | null>(null);
+  const [filterCategory, setFilterCategory] = useState<'all' | LogCategory>('all');
 
   // Form state
   const [title, setTitle] = useState('');
@@ -97,9 +98,17 @@ export default function LearningLogsPage() {
     }
   };
 
-  const filteredLogs = filterDate
-    ? logs.filter((l) => l.created_at.split('T')[0] === filterDate)
-    : logs;
+  const filteredLogs = logs.filter((log) => {
+    // 日付フィルター
+    if (filterDate && log.created_at.split('T')[0] !== filterDate) {
+      return false;
+    }
+    // カテゴリーフィルター
+    if (filterCategory !== 'all' && log.category !== filterCategory) {
+      return false;
+    }
+    return true;
+  });
 
   if (loading) return <div className="py-12"><LoadingSpinner /></div>;
 
@@ -153,6 +162,37 @@ export default function LearningLogsPage() {
             </button>
           </div>
         )}
+      </div>
+
+      {/* Category Filter */}
+      <div className="flex flex-col gap-2">
+        <span className="text-sm text-gray-400">{t('learningLogs.category')}</span>
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => setFilterCategory('all')}
+            className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              filterCategory === 'all'
+                ? 'bg-purple-500/20 text-purple-400'
+                : 'bg-gray-800/50 text-gray-400 hover:text-white'
+            }`}
+          >
+            {t('learningLogs.filterAll')}
+          </button>
+          {CATEGORIES.map(({ value, label, Icon }) => (
+            <button
+              key={value}
+              onClick={() => setFilterCategory(value)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                filterCategory === value
+                  ? 'bg-purple-500/20 text-purple-400'
+                  : 'bg-gray-800/50 text-gray-400 hover:text-white'
+              }`}
+            >
+              <Icon className="w-4 h-4" />
+              {t(label)}
+            </button>
+          ))}
+        </div>
       </div>
 
       {/* Calendar View */}


### PR DESCRIPTION
## 概要
学習ログページにカテゴリー別フィルター機能を追加し、ユーザーが特定のカテゴリーのログのみを表示できるようにしました。

## 変更内容

### 1. フィルタリング機能の実装
- `filterCategory` ステート追加（`'all' | LogCategory`）
- 日付フィルターとカテゴリーフィルターの組み合わせ対応
- フィルタリングロジックの実装

### 2. UIの追加
カテゴリーフィルターボタンを追加:
- ✅ 「全て表示」含む6つのフィルターボタン
- ✅ アクティブ状態で紫色にハイライト
- ✅ 各カテゴリーにアイコン表示（Code, BookOpen, GraduationCap, Users, FileText）

### 3. i18n対応
10言語すべてに `learningLogs.filterAll` キーを追加:
- 日本語: 「全て表示」
- 英語: "All"
- ドイツ語: "Alle"
- スペイン語: "Todos"
- フランス語: "Tous"
- 韓国語: "전체"
- ポルトガル語: "Todos"
- ロシア語: "Все"
- 中国語（簡体字）: "全部"
- 中国語（繁体字）: "全部"

## 改善効果
- ✅ ユーザーが特定のカテゴリーのログを素早く確認できる
- ✅ 日付とカテゴリーの組み合わせでより詳細なフィルタリングが可能
- ✅ UIの一貫性を保ちつつ、直感的な操作が可能

## デザイン
```
[カレンダー表示] [リスト表示]

カテゴリー: [全て表示] [コーディング] [読書] [コース] [勉強会] [その他]
                  ↑ アクティブなボタンは紫色でハイライト

[フィルタリングされたログのリスト...]
```

## 関連Issue
Closes #189

@github-copilot[bot] レビューをお願いします