### PR TITLE
feat: ダッシュボードにクイック投稿フォーム追加（Phase 6.7）

### DIFF
--- a/frontend/src/components/posts/QuickPostForm.tsx
+++ b/frontend/src/components/posts/QuickPostForm.tsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Send, FileText } from 'lucide-react';
+import { useAuthStore } from '../../store/authStore';
+import Avatar from '../common/Avatar';
+
+interface QuickPostFormProps {
+  onSubmit: (title: string, content: string, isDraft?: boolean) => Promise<void>;
+}
+
+export default function QuickPostForm({ onSubmit }: QuickPostFormProps) {
+  const { t } = useTranslation();
+  const user = useAuthStore((s) => s.user);
+  const [content, setContent] = useState('');
+  const [isFocused, setIsFocused] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (isDraft = false) => {
+    if (!content.trim()) return;
+
+    setIsSubmitting(true);
+    try {
+      // タイトルは本文の最初の50文字から自動生成
+      const title = content.trim().substring(0, 50) + (content.length > 50 ? '...' : '');
+      await onSubmit(title, content, isDraft);
+      setContent('');
+      setIsFocused(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="bg-gray-900/50 backdrop-blur-sm border border-gray-800 rounded-xl p-4 transition-all">
+      <div className="flex gap-3">
+        <Avatar name={user?.name || ''} avatarUrl={user?.avatar_url} size="sm" />
+        <div className="flex-1">
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            onFocus={() => setIsFocused(true)}
+            placeholder={t('post.createTitle')}
+            className={`w-full bg-gray-800/50 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none transition-all ${
+              isFocused ? 'min-h-[120px]' : 'min-h-[60px]'
+            }`}
+            disabled={isSubmitting}
+          />
+
+          {isFocused && (
+            <div className="mt-3 flex items-center justify-between animate-in fade-in duration-200">
+              <p className="text-xs text-gray-500">
+                {t('post.markdownSupported')}
+              </p>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => setIsFocused(false)}
+                  disabled={isSubmitting}
+                  className="px-3 py-1.5 text-sm text-gray-400 hover:text-white transition-colors disabled:opacity-50"
+                >
+                  {t('common.cancel')}
+                </button>
+                <button
+                  onClick={() => handleSubmit(true)}
+                  disabled={!content.trim() || isSubmitting}
+                  className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <FileText className="w-4 h-4" />
+                  {t('post.saveDraft')}
+                </button>
+                <button
+                  onClick={() => handleSubmit(false)}
+                  disabled={!content.trim() || isSubmitting}
+                  className="flex items-center gap-1.5 px-4 py-1.5 text-sm bg-purple-600 hover:bg-purple-700 text-white rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  <Send className="w-4 h-4" />
+                  {isSubmitting ? t('post.posting') : t('post.post')}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -7,7 +7,7 @@ import { getUserBadges } from '../api/badges';
 import { useAsyncData } from '../hooks/useAsyncData';
 import type { BadgeResult } from '../types/badge';
 import PostCard from '../components/posts/PostCard';
-import PostForm from '../components/posts/PostForm';
+import QuickPostForm from '../components/posts/QuickPostForm';
 import { PostCardSkeleton } from '../components/common/Skeleton';
 import Avatar from '../components/common/Avatar';
 import { formatDistanceToNow } from '../utils/timeFormat';
@@ -72,7 +72,10 @@ export default function DashboardPage() {
     <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
       {/* Main Feed */}
       <div className="lg:col-span-3 space-y-6">
-        <PostForm onSubmit={handleCreatePost} />
+        <QuickPostForm onSubmit={async (title, content, isDraft) => {
+          await createPost(title, content, undefined, undefined, isDraft);
+          await refetch();
+        }} />
 
         <div>
           <h2 className="section-heading">{t('dashboard.timeline')}</h2>


### PR DESCRIPTION
## 概要
ダッシュボードに簡易的な投稿ができるクイック投稿フォームを追加しました。

## 変更内容
- **QuickPostForm**コンポーネント新規作成
  - フォーカス時に自動展開（60px → 120px）
  - タイトル自動生成（本文の最初の50文字）
  - 投稿/下書き保存ボタン
  - アバター表示

- DashboardPageの更新
  - PostFormからQuickPostFormへ置き換え

## 改善効果
- 投稿のハードルが下がり、投稿頻度向上
- ユーザーエンゲージメント向上

Closes #191

@github-copilot[bot] レビューをお願いします