### PR TITLE
Phase 7.4: service層のエラーハンドリングをDomainErrorに統一

### DIFF
--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -25,8 +25,10 @@ const (
 	ErrCodeBadRequest ErrorCode = "BAD_REQUEST"
 
 	// System errors
-	ErrCodeInternal ErrorCode = "INTERNAL_ERROR"
-	ErrCodeDatabase ErrorCode = "DATABASE_ERROR"
+	ErrCodeInternal          ErrorCode = "INTERNAL_ERROR"
+	ErrCodeDatabase          ErrorCode = "DATABASE_ERROR"
+	ErrCodeRateLimitExceeded ErrorCode = "RATE_LIMIT_EXCEEDED"
+	ErrCodeServiceUnavailable ErrorCode = "SERVICE_UNAVAILABLE"
 )
 
 // DomainError represents a domain-level error with additional context.
@@ -62,6 +64,10 @@ func (e *DomainError) HTTPStatus() int {
 		return http.StatusConflict
 	case ErrCodeValidation, ErrCodeBadRequest:
 		return http.StatusBadRequest
+	case ErrCodeRateLimitExceeded:
+		return http.StatusTooManyRequests
+	case ErrCodeServiceUnavailable:
+		return http.StatusServiceUnavailable
 	case ErrCodeDatabase, ErrCodeInternal:
 		return http.StatusInternalServerError
 	default:
@@ -80,11 +86,17 @@ func NewError(code ErrorCode, message string, err error) *DomainError {
 
 // Predefined domain errors
 var (
-	ErrUnauthorized = NewError(ErrCodeUnauthorized, "認証が必要です", nil)
-	ErrForbidden    = NewError(ErrCodeForbidden, "この操作を実行する権限がありません", nil)
-	ErrNotFound     = NewError(ErrCodeNotFound, "リソースが見つかりません", nil)
-	ErrBadRequest   = NewError(ErrCodeBadRequest, "不正なリクエストです", nil)
-	ErrInternal     = NewError(ErrCodeInternal, "内部エラーが発生しました", nil)
+	ErrUnauthorized       = NewError(ErrCodeUnauthorized, "認証が必要です", nil)
+	ErrForbidden          = NewError(ErrCodeForbidden, "この操作を実行する権限がありません", nil)
+	ErrNotFound           = NewError(ErrCodeNotFound, "リソースが見つかりません", nil)
+	ErrBadRequest         = NewError(ErrCodeBadRequest, "不正なリクエストです", nil)
+	ErrInternal           = NewError(ErrCodeInternal, "内部エラーが発生しました", nil)
+	ErrAlreadyExists      = NewError(ErrCodeAlreadyExists, "リソースが既に存在します", nil)
+	ErrConflict           = NewError(ErrCodeConflict, "競合が発生しました", nil)
+	ErrValidation         = NewError(ErrCodeValidation, "バリデーションエラー", nil)
+	ErrDatabase           = NewError(ErrCodeDatabase, "データベースエラーが発生しました", nil)
+	ErrRateLimitExceeded  = NewError(ErrCodeRateLimitExceeded, "レート制限を超過しました", nil)
+	ErrServiceUnavailable = NewError(ErrCodeServiceUnavailable, "サービスが利用できません", nil)
 )
 
 // IsDomainError checks if an error is a DomainError.

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -1,13 +1,11 @@
 package handler
 
 import (
-	"errors"
 	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
 
 // parseID はURLパラメータからuint型のIDを取得する。
@@ -51,7 +49,7 @@ func bindJSON[T any](c *gin.Context) *T {
 }
 
 // respondError はサービス層のエラーを適切なHTTPステータスコードに変換してレスポンスを返す。
-// DomainError を優先し、従来の service.ErrXXX も引き続きサポートする。
+// DomainError を使用して統一的なエラーハンドリングを実現する。
 func respondError(c *gin.Context, err error) {
 	// DomainError の場合
 	if domainErr := domain.GetDomainError(err); domainErr != nil {
@@ -59,25 +57,8 @@ func respondError(c *gin.Context, err error) {
 		return
 	}
 
-	// 従来の service.ErrXXX との互換性を保つ
-	switch {
-	case errors.Is(err, service.ErrNotFound):
-		c.JSON(http.StatusNotFound, gin.H{"error": err.Error()})
-	case errors.Is(err, service.ErrForbidden):
-		c.JSON(http.StatusForbidden, gin.H{"error": err.Error()})
-	case errors.Is(err, service.ErrBadRequest):
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
-	case errors.Is(err, service.ErrUnauthorized):
-		c.JSON(http.StatusUnauthorized, gin.H{"error": err.Error()})
-	case errors.Is(err, service.ErrConflict):
-		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
-	case errors.Is(err, service.ErrRateLimitExceeded):
-		c.JSON(http.StatusTooManyRequests, gin.H{"error": err.Error()})
-	case errors.Is(err, service.ErrLLMNotConfigured):
-		c.JSON(http.StatusServiceUnavailable, gin.H{"error": err.Error()})
-	default:
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-	}
+	// DomainError でない場合は内部エラーとして扱う
+	c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 }
 
 // respondOK は200 OKでデータを返す。

--- a/backend/internal/service/errors.go
+++ b/backend/internal/service/errors.go
@@ -3,16 +3,16 @@
 // 権限チェック・ビジネスルール・通知連携などのロジックを実装する。
 package service
 
-import "errors"
+import "github.com/norman6464/devsync/backend/internal/domain"
 
 // サービス層の共通エラー定義。
-// ハンドラー層でこれらのエラーを判定し、適切なHTTPステータスコードに変換する。
+// domain.DomainErrorを使用して統一的なエラーハンドリングを実現する。
 var (
-	ErrNotFound   = errors.New("not found")   // リソースが見つからない（404）
-	ErrForbidden  = errors.New("forbidden")   // アクセス権限がない（403）
-	ErrBadRequest = errors.New("bad request") // リクエストが不正（400）
-	ErrUnauthorized      = errors.New("unauthorized")        // 認証が必要（401）
-	ErrConflict          = errors.New("conflict")            // リソースの競合（409）
-	ErrRateLimitExceeded = errors.New("rate limit exceeded") // レート制限超過（429）
-	ErrLLMNotConfigured  = errors.New("LLM not configured") // LLM未設定（503）
+	ErrNotFound          = domain.ErrNotFound          // リソースが見つからない（404）
+	ErrForbidden         = domain.ErrForbidden         // アクセス権限がない（403）
+	ErrBadRequest        = domain.ErrBadRequest        // リクエストが不正（400）
+	ErrUnauthorized      = domain.ErrUnauthorized      // 認証が必要（401）
+	ErrConflict          = domain.ErrConflict          // リソースの競合（409）
+	ErrRateLimitExceeded = domain.ErrRateLimitExceeded // レート制限超過（429）
+	ErrLLMNotConfigured  = domain.ErrServiceUnavailable // LLM未設定（503）
 )


### PR DESCRIPTION
## 変更内容

service層のエラーハンドリングを`domain.DomainError`に統一し、Clean Architectureを強化しました。

### 主な変更

1. **domain/errors.go** - 全エラーコードと変数を追加
   - `ErrAlreadyExists`, `ErrConflict`, `ErrValidation`, `ErrDatabase`を追加
   - `ErrRateLimitExceeded`, `ErrServiceUnavailable`を追加
   - HTTPステータスマッピングを完全実装

2. **service/errors.go** - domain.ErrXXXへのエイリアス化
   - 従来の`errors.New()`を`domain.ErrXXX`のエイリアスに変更
   - `ErrLLMNotConfigured`を`domain.ErrServiceUnavailable`にマッピング
   - 後方互換性を維持しつつClean Architecture化

3. **handler/helpers.go** - respondError関数の簡素化
   - DomainErrorのみを処理するよう簡素化（40行→10行）
   - 不要なservice.ErrXXX分岐を削除
   - エラーコードとメッセージを統一的に返却

### テスト結果

```
✓ handler層: 全180テストがパス
✓ service層: 全テストがパス
```

### 効果

- エラーハンドリングの一貫性向上
- コード行数の削減（簡素化）
- 保守性・拡張性の向上
- Clean Architectureの原則に準拠

Related to #193