### PR TITLE
Phase 6.9: スケルトンスクリーンでローディング状態を統一

### DIFF
--- a/frontend/src/components/common/Skeleton.tsx
+++ b/frontend/src/components/common/Skeleton.tsx
@@ -49,3 +49,87 @@ export function UserCardSkeleton() {
     </div>
   );
 }
+
+export function QuestionCardSkeleton() {
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-md p-5">
+      <div className="flex items-start gap-3 mb-3">
+        <div className="flex flex-col items-center gap-1">
+          <Skeleton className="w-6 h-6" />
+          <Skeleton className="w-8 h-4" />
+        </div>
+        <div className="flex-1">
+          <Skeleton className="h-5 w-3/4 mb-2" />
+          <Skeleton className="h-4 w-full mb-1.5" />
+          <Skeleton className="h-4 w-5/6" />
+          <div className="flex gap-2 mt-3">
+            <Skeleton className="h-5 w-16 rounded-full" />
+            <Skeleton className="h-5 w-20 rounded-full" />
+          </div>
+        </div>
+      </div>
+      <div className="flex items-center gap-3 text-xs">
+        <Skeleton className="w-8 h-8 rounded-full" />
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="h-3 w-16" />
+      </div>
+    </div>
+  );
+}
+
+export function ResourceCardSkeleton() {
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-md p-5">
+      <div className="flex items-start justify-between mb-3">
+        <Skeleton className="h-6 w-2/3" />
+        <Skeleton className="h-6 w-12" />
+      </div>
+      <Skeleton className="h-4 w-full mb-2" />
+      <Skeleton className="h-4 w-4/5 mb-4" />
+      <div className="flex gap-2 mb-3">
+        <Skeleton className="h-5 w-16 rounded-full" />
+        <Skeleton className="h-5 w-20 rounded-full" />
+        <Skeleton className="h-5 w-14 rounded-full" />
+      </div>
+      <div className="border-t border-gray-800 pt-3 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Skeleton className="w-6 h-6 rounded-full" />
+          <Skeleton className="h-3 w-20" />
+        </div>
+        <div className="flex gap-3">
+          <Skeleton className="h-4 w-12" />
+          <Skeleton className="h-4 w-12" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ListSkeleton({ count = 3 }: { count?: number }) {
+  return (
+    <>
+      {Array.from({ length: count }).map((_, i) => (
+        <Skeleton key={i} className="h-16 w-full mb-3" />
+      ))}
+    </>
+  );
+}
+
+export function TableSkeleton({ rows = 5, cols = 4 }: { rows?: number; cols?: number }) {
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+      <div className="bg-gray-800 p-4 flex gap-4">
+        {Array.from({ length: cols }).map((_, i) => (
+          <Skeleton key={i} className="h-4 flex-1" />
+        ))}
+      </div>
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="p-4 flex gap-4 border-t border-gray-800">
+          {Array.from({ length: cols }).map((_, j) => (
+            <Skeleton key={j} className="h-4 flex-1" />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/QAPage.tsx
+++ b/frontend/src/pages/QAPage.tsx
@@ -5,7 +5,7 @@ import type { Question } from '../types/qa';
 import { useQuestions } from '../hooks';
 import QuestionCard from '../components/qa/QuestionCard';
 import QuestionForm from '../components/qa/QuestionForm';
-import LoadingSpinner from '../components/common/LoadingSpinner';
+import { QuestionCardSkeleton } from '../components/common/Skeleton';
 
 export default function QAPage() {
   const { t } = useTranslation();
@@ -105,8 +105,10 @@ export default function QAPage() {
 
       {/* Content */}
       {loading ? (
-        <div className="flex justify-center items-center min-h-[400px]">
-          <LoadingSpinner />
+        <div className="space-y-4">
+          <QuestionCardSkeleton />
+          <QuestionCardSkeleton />
+          <QuestionCardSkeleton />
         </div>
       ) : questions.length === 0 ? (
         <div className="text-center py-12">

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -5,7 +5,7 @@ import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../
 import { useResources } from '../hooks';
 import ResourceCard from '../components/resources/ResourceCard';
 import ResourceForm from '../components/resources/ResourceForm';
-import LoadingSpinner from '../components/common/LoadingSpinner';
+import { ResourceCardSkeleton } from '../components/common/Skeleton';
 
 const categories: (ResourceCategory | '')[] = ['', 'book', 'video', 'article', 'course', 'tutorial', 'podcast', 'tool', 'other'];
 const difficulties: (ResourceDifficulty | '')[] = ['', 'beginner', 'intermediate', 'advanced'];
@@ -152,8 +152,10 @@ export default function ResourcesPage() {
 
       {/* Content */}
       {loading ? (
-        <div className="flex justify-center items-center min-h-[400px]">
-          <LoadingSpinner />
+        <div className="space-y-4">
+          <ResourceCardSkeleton />
+          <ResourceCardSkeleton />
+          <ResourceCardSkeleton />
         </div>
       ) : resources.length === 0 ? (
         <div className="text-center py-12">


### PR DESCRIPTION
## 変更内容

データ取得中のローディング状態を視覚的に改善し、UXを向上させました。

### 主な変更

1. **components/common/Skeleton.tsx** - スケルトンコンポーネント拡張
   - QuestionCardSkeleton追加
   - ResourceCardSkeleton追加
   - ListSkeleton追加（汎用リスト用）
   - TableSkeleton追加（テーブル用）

2. **pages/QAPage.tsx** - スケルトンスクリーン適用
   - LoadingSpinner → QuestionCardSkeleton（3枚表示）
   - コンテンツ構造の事前表示

3. **pages/ResourcesPage.tsx** - スケルトンスクリーン適用
   - LoadingSpinner → ResourceCardSkeleton（3枚表示）
   - リソースカード形状を再現

### UX改善効果

- ローディング中の体感速度改善
- スピナーよりプロフェッショナルな印象
- コンテンツ構造の視覚的ヒント
- ユーザーエンゲージメント向上

### 備考

- DashboardPageは既にPostCardSkeletonを使用済み
- パルスアニメーション（animate-pulse）対応
- ライト/ダークモード対応

Related to #199