### PR TITLE
Phase 7.6: HTTPレスポンス構造の統一

### DIFF
--- a/backend/internal/dto/response.go
+++ b/backend/internal/dto/response.go
@@ -15,3 +15,16 @@ type MessageResponse struct {
 type URLResponse struct {
 	URL string `json:"url"`
 }
+
+// DataResponse は汎用データレスポンス
+type DataResponse[T any] struct {
+	Data T `json:"data"`
+}
+
+// ListResponse はリストデータレスポンス（ページネーション情報付き）
+type ListResponse[T any] struct {
+	Data  []T `json:"data"`
+	Total int `json:"total,omitempty"`
+	Page  int `json:"page,omitempty"`
+	Limit int `json:"limit,omitempty"`
+}

--- a/backend/internal/handler/response_helpers.go
+++ b/backend/internal/handler/response_helpers.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
+)
+
+// RespondSuccess は成功レスポンスを返す（200 OK）
+func RespondSuccess[T any](c *gin.Context, data T) {
+	c.JSON(http.StatusOK, data)
+}
+
+// RespondCreated は作成成功レスポンスを返す（201 Created）
+func RespondCreated[T any](c *gin.Context, data T) {
+	c.JSON(http.StatusCreated, data)
+}
+
+// RespondMessage はメッセージレスポンスを返す（200 OK）
+func RespondMessage(c *gin.Context, message string) {
+	c.JSON(http.StatusOK, dto.MessageResponse{Message: message})
+}
+
+// RespondData はデータレスポンスを返す（200 OK）
+func RespondData[T any](c *gin.Context, data T) {
+	c.JSON(http.StatusOK, dto.DataResponse[T]{Data: data})
+}
+
+// RespondList はリストレスポンスを返す（200 OK）
+func RespondList[T any](c *gin.Context, data []T, total int) {
+	c.JSON(http.StatusOK, dto.ListResponse[T]{
+		Data:  data,
+		Total: total,
+	})
+}
+
+// RespondListWithPagination はページネーション付きリストレスポンスを返す（200 OK）
+func RespondListWithPagination[T any](c *gin.Context, data []T, total, page, limit int) {
+	c.JSON(http.StatusOK, dto.ListResponse[T]{
+		Data:  data,
+		Total: total,
+		Page:  page,
+		Limit: limit,
+	})
+}


### PR DESCRIPTION
## 変更内容

handler層のレスポンス構造を統一し、一貫性とタイプセーフティを向上させました。

### 主な変更

1. **dto/response.go** - レスポンス構造体拡張
   - DataResponse[T] - 汎用データレスポンス
   - ListResponse[T] - リストデータ（ページネーション付き）
   - ジェネリクス活用でタイプセーフティ向上

2. **handler/response_helpers.go** - レスポンスヘルパー関数
   - RespondSuccess[T] - 成功レスポンス（200）
   - RespondCreated[T] - 作成成功（201）
   - RespondMessage - メッセージレスポンス
   - RespondData[T] - データレスポンス
   - RespondList[T] - リストレスポンス
   - RespondListWithPagination[T] - ページネーション付き

### 技術的特徴

- Go 1.18+ ジェネリクスを活用
- 型安全なレスポンス生成
- 一貫したレスポンス構造
- 再利用可能なヘルパー関数

### 使用例

```go
// Before
c.JSON(http.StatusOK, gin.H{"user": user})

// After
RespondSuccess(c, user)
// または
RespondData(c, user)
```

### 効果

- ✅ タイプセーフティ向上
- ✅ レスポンス構造の一貫性
- ✅ コード可読性向上
- ✅ フロントエンドとのI/F明確化

Related to #209