### PR TITLE
Phase 7.7: bindJSONヘルパーの統一的な適用

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -20,19 +20,20 @@ func NewLearningGoalHandler(s *service.LearningGoalService) *LearningGoalHandler
 	return &LearningGoalHandler{service: s}
 }
 
+// CreateGoalInput は学習目標作成のリクエストボディ。
+type CreateGoalInput struct {
+	Title       string `json:"title" binding:"required"`
+	Description string `json:"description"`
+	Category    string `json:"category"`
+	TargetDate  string `json:"target_date"`
+}
+
 // Create は新しい学習目標を作成する。
 func (h *LearningGoalHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req struct {
-		Title       string `json:"title" binding:"required"`
-		Description string `json:"description"`
-		Category    string `json:"category"`
-		TargetDate  string `json:"target_date"`
-	}
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "title is required"})
+	req := bindJSON[CreateGoalInput](c)
+	if req == nil {
 		return
 	}
 
@@ -66,6 +67,16 @@ func (h *LearningGoalHandler) Create(c *gin.Context) {
 	respondCreated(c, goal)
 }
 
+// UpdateGoalInput は学習目標更新のリクエストボディ。
+type UpdateGoalInput struct {
+	Title       *string `json:"title"`
+	Description *string `json:"description"`
+	Category    *string `json:"category"`
+	TargetDate  *string `json:"target_date"`
+	Progress    *int    `json:"progress"`
+	Status      *string `json:"status"`
+}
+
 // Update は指定された学習目標を更新する。
 func (h *LearningGoalHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
@@ -74,17 +85,8 @@ func (h *LearningGoalHandler) Update(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Title       *string `json:"title"`
-		Description *string `json:"description"`
-		Category    *string `json:"category"`
-		TargetDate  *string `json:"target_date"`
-		Progress    *int    `json:"progress"`
-		Status      *string `json:"status"`
-	}
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+	req := bindJSON[UpdateGoalInput](c)
+	if req == nil {
 		return
 	}
 

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -20,22 +18,24 @@ func NewPostHandler(s *service.PostService, snippetService *service.CodeSnippetS
 	return &PostHandler{service: s, snippetService: snippetService}
 }
 
+// CreatePostInput は投稿作成のリクエストボディ。
+type CreatePostInput struct {
+	Title     string `json:"title" binding:"required"`
+	Content   string `json:"content" binding:"required"`
+	ImageURLs string `json:"image_urls"`
+	IsDraft   bool   `json:"is_draft"`
+	CodeSnippets []struct {
+		Language string `json:"language"`
+		FileName string `json:"file_name"`
+		Code     string `json:"code"`
+	} `json:"code_snippets"`
+}
+
 // Create は新しい投稿を作成する。
 func (h *PostHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
-	var input struct {
-		Title     string `json:"title" binding:"required"`
-		Content   string `json:"content" binding:"required"`
-		ImageURLs string `json:"image_urls"`
-		IsDraft   bool   `json:"is_draft"`
-		CodeSnippets []struct {
-			Language string `json:"language"`
-			FileName string `json:"file_name"`
-			Code     string `json:"code"`
-		} `json:"code_snippets"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	input := bindJSON[CreatePostInput](c)
+	if input == nil {
 		return
 	}
 
@@ -112,6 +112,13 @@ func (h *PostHandler) GetByID(c *gin.Context) {
 	})
 }
 
+// UpdatePostInput は投稿更新のリクエストボディ。
+type UpdatePostInput struct {
+	Title     string `json:"title"`
+	Content   string `json:"content"`
+	ImageURLs string `json:"image_urls"`
+}
+
 // Update は投稿を更新する。所有者のみ更新可能。
 func (h *PostHandler) Update(c *gin.Context) {
 	id, ok := parseID(c, "id")
@@ -120,13 +127,8 @@ func (h *PostHandler) Update(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	var input struct {
-		Title     string `json:"title"`
-		Content   string `json:"content"`
-		ImageURLs string `json:"image_urls"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	input := bindJSON[UpdatePostInput](c)
+	if input == nil {
 		return
 	}
 
@@ -225,6 +227,11 @@ func (h *PostHandler) GetComments(c *gin.Context) {
 	respondOK(c, comments)
 }
 
+// CreateCommentInput はコメント作成のリクエストボディ。
+type CreateCommentInput struct {
+	Content string `json:"content" binding:"required"`
+}
+
 // CreateComment は投稿にコメントを作成する。
 func (h *PostHandler) CreateComment(c *gin.Context) {
 	id, ok := parseID(c, "id")
@@ -233,11 +240,8 @@ func (h *PostHandler) CreateComment(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	var input struct {
-		Content string `json:"content" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+	input := bindJSON[CreateCommentInput](c)
+	if input == nil {
 		return
 	}
 


### PR DESCRIPTION
## 概要
既存の`bindJSON`ヘルパー関数を活用し、handler層でのJSONバインド処理を統一しました。

## 変更内容

### post.go
- ✅ `Create`, `Update`, `CreateComment` メソッドでbindJSON使用
- ✅ 名前付き型を定義: `CreatePostInput`, `UpdatePostInput`, `CreateCommentInput`
- ✅ `net/http` importを削除（不要になったため）
- **削減**: 12行のコード重複を削除

### learning_goal.go
- ✅ `Create`, `Update` メソッドでbindJSON使用
- ✅ 名前付き型を定義: `CreateGoalInput`, `UpdateGoalInput`
- **削減**: 8行のコード重複を削除

### question.go（参考）
- 既に理想的な実装（変更不要）
- `Create`, `Update`, `Vote` メソッドで既にbindJSON使用
- 他のhandlerの良い実装例として機能

## 改善効果
- **コードの重複削減**: 合計20行の重複コードを削除
- **エラーハンドリングの統一**: bindJSONヘルパーで一元管理
- **型安全性の向上**: 名前付き型による明示的な型定義
- **可読性の向上**: 入力型が明確に定義される
- **保守性の向上**: 1箇所でバインドロジックを管理

## テスト結果
- ✅ post_test.go: 全26テストPASS
- ✅ 既存のテストに影響なし

Closes #215