### PR TITLE
フロントエンドがブラウザで表示されない問題を修正

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
## 概要
Dockerコンテナ内でViteサーバーがlocalhostにバインドされていたため、ホストマシンのブラウザからアクセスできない問題を修正しました。

## 変更内容
- `package.json`のdevスクリプトに`--host`フラグを追加
- Viteサーバーが`0.0.0.0`にバインドされ、外部からアクセス可能に

## 修正前
```json
"dev": "vite"
```

## 修正後
```json
"dev": "vite --host"
```

## 動作確認
- ✅ Dockerコンテナが正常に起動
- ✅ Viteサーバーが`--host`フラグ付きで起動
- ✅ ブラウザから http://localhost:5173/ でアクセス可能

## 効果
- ホストマシンのブラウザからフロントエンドにアクセス可能
- 開発体験の向上

Closes #218