### PR TITLE
README: Docker起動方法とトラブルシューティングを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,11 @@ cp frontend/.env.example frontend/.env
 #### 3. Docker Composeで起動
 
 ```bash
-docker-compose up -d
+# 初回起動 or コードを変更した場合は --build フラグを追加
+docker compose up -d --build
+
+# 2回目以降（コード変更がない場合）
+docker compose up -d
 ```
 
 #### 4. マイグレーション実行
@@ -307,6 +311,29 @@ make migrate-up
 - API: http://localhost:8080
 - Mailhog: http://localhost:8025（開発用メールUI）
 - Grafana: http://localhost:3000
+
+### トラブルシューティング
+
+#### フロントエンドがブラウザで表示されない場合
+
+1. **ブラウザのキャッシュをクリア**
+   - Chrome/Edge: Ctrl+Shift+Delete / Cmd+Shift+Delete
+   - ハードリロード: Ctrl+Shift+R / Cmd+Shift+R
+
+2. **Dockerコンテナを再起動**
+   ```bash
+   docker compose down
+   docker compose up -d --build
+   ```
+
+3. **フロントエンドのログを確認**
+   ```bash
+   docker compose logs frontend --tail=50
+   ```
+
+4. **Viteサーバーが正常に起動しているか確認**
+   - ログに `VITE v7.x.x  ready in XXX ms` と表示されていること
+   - `Network: http://172.x.x.x:5173/` のようなネットワークアドレスが表示されていること
 
 ### Kubernetesへのデプロイ
 


### PR DESCRIPTION
## 概要
README.mdにDocker Composeでの起動方法の改善とトラブルシューティングセクションを追加しました。

## 変更内容

### 1. Docker Composeでの起動方法を改善
- 初回起動時は `--build` フラグが必要であることを明記
- 2回目以降のコマンドも記載
- コメントで使い分けを説明

### 2. トラブルシューティングセクションを新設
- **フロントエンドが表示されない場合の対処法**
  - ブラウザキャッシュのクリア方法（Chrome/Edge対応）
  - Dockerコンテナの再起動手順
  - ログ確認方法
  - Viteサーバーの正常動作確認方法

## 改善効果
- 初めて開発環境をセットアップするユーザーがスムーズに起動可能
- フロントエンド表示問題のトラブルシューティングが容易に
- ドキュメントの充実により開発者体験が向上

## 関連Issue
#218