### PR TITLE
検索機能にデバウンスを実装（QAPage & ResourcesPage）

### DIFF
--- a/frontend/src/pages/QAPage.tsx
+++ b/frontend/src/pages/QAPage.tsx
@@ -1,8 +1,8 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../store/authStore';
 import type { Question } from '../types/qa';
-import { useQuestions } from '../hooks';
+import { useQuestions, useDebounce } from '../hooks';
 import QuestionCard from '../components/qa/QuestionCard';
 import QuestionForm from '../components/qa/QuestionForm';
 import { QuestionCardSkeleton } from '../components/common/Skeleton';
@@ -21,6 +21,16 @@ export default function QAPage() {
 
   const [showForm, setShowForm] = useState(false);
   const [editingQuestion, setEditingQuestion] = useState<Question | null>(null);
+
+  // デバウンス処理（300ms）
+  const debouncedQuery = useDebounce(searchQuery, 300);
+
+  // デバウンスされたクエリで自動検索
+  useEffect(() => {
+    if (debouncedQuery !== undefined) {
+      handleSearch();
+    }
+  }, [debouncedQuery, handleSearch]);
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BookOpen } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../types/resource';
-import { useResources } from '../hooks';
+import { useResources, useDebounce } from '../hooks';
 import ResourceCard from '../components/resources/ResourceCard';
 import ResourceForm from '../components/resources/ResourceForm';
 import { ResourceCardSkeleton } from '../components/common/Skeleton';
@@ -29,6 +29,16 @@ export default function ResourcesPage() {
 
   const [showForm, setShowForm] = useState(false);
   const [editingResource, setEditingResource] = useState<LearningResource | null>(null);
+
+  // デバウンス処理（300ms）
+  const debouncedQuery = useDebounce(searchQuery, 300);
+
+  // デバウンスされたクエリで自動検索
+  useEffect(() => {
+    if (debouncedQuery !== undefined) {
+      handleSearch();
+    }
+  }, [debouncedQuery, handleSearch]);
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">


### PR DESCRIPTION
## 概要
QAPage と ResourcesPage の検索機能にデバウンス処理を実装し、パフォーマンスとUXを向上させました。

## 実装内容

### 変更ファイル
- `frontend/src/pages/QAPage.tsx`
- `frontend/src/pages/ResourcesPage.tsx`

### 実装詳細
1. `useDebounce` フックをインポート
2. 検索クエリに300msのデバウンスを適用
3. デバウンスされたクエリが変更されたときに自動的に検索を実行

### コード例
```typescript
// デバウンス処理（300ms）
const debouncedQuery = useDebounce(searchQuery, 300);

// デバウンスされたクエリで自動検索
useEffect(() => {
  if (debouncedQuery !== undefined) {
    handleSearch();
  }
}, [debouncedQuery, handleSearch]);
```

## 効果

### パフォーマンス改善
- APIリクエスト数の削減（入力のたびではなく、入力停止後に1回だけリクエスト）
- サーバー負荷の軽減

### UX向上
- ユーザーが入力中に不要な検索結果が表示されない
- よりスムーズな入力体験
- 最終的な入力が確定してから検索が実行される

## テスト
- [x] QAPage で検索入力時にデバウンスが動作することを確認
- [x] ResourcesPage で検索入力時にデバウンスが動作することを確認
- [x] 300ms待機後に検索が実行されることを確認
- [x] 既存の検索機能が正常に動作することを確認

Closes #207