### PR TITLE
feat: 投稿の編集・削除機能を実装

### DIFF
--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -14,10 +14,13 @@ import { Code2 } from 'lucide-react';
 
 interface PostCardProps {
   post: Post;
+  isOwner?: boolean;
+  onEdit?: () => void;
+  onDelete?: () => void;
   onUpdate?: () => void;
 }
 
-export default function PostCard({ post, onUpdate }: PostCardProps) {
+export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUpdate }: PostCardProps) {
   const { t } = useTranslation();
   const [liked, setLiked] = useState(post.liked || false);
   const [likeCount, setLikeCount] = useState(post.like_count);
@@ -65,8 +68,36 @@ export default function PostCard({ post, onUpdate }: PostCardProps) {
         </div>
       </div>
 
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <Link to={`/posts/${post.id}`} className="flex-1 group">
+          <h3 className="text-base font-semibold group-hover:text-blue-400 transition-colors">{post.title}</h3>
+        </Link>
+
+        {isOwner && (
+          <div className="flex gap-1 flex-shrink-0">
+            <button
+              onClick={onEdit}
+              className="p-1.5 text-gray-400 hover:text-white transition-colors"
+              title={t('common.edit')}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
+              </svg>
+            </button>
+            <button
+              onClick={onDelete}
+              className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+              title={t('common.delete')}
+            >
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
+              </svg>
+            </button>
+          </div>
+        )}
+      </div>
+
       <Link to={`/posts/${post.id}`} className="block group">
-        <h3 className="text-base font-semibold mb-1.5 group-hover:text-blue-400 transition-colors">{post.title}</h3>
         <div className="text-gray-400 text-sm leading-relaxed prose prose-sm prose-invert max-w-none line-clamp-4">
           <ReactMarkdown
             remarkPlugins={[remarkGfm]}

--- a/frontend/src/components/posts/PostForm.tsx
+++ b/frontend/src/components/posts/PostForm.tsx
@@ -6,6 +6,7 @@ import MarkdownEditor from './MarkdownEditor';
 import CodeSnippetInput, { type SnippetInputData } from './CodeSnippetInput';
 
 interface PostFormProps {
+  post?: { id: number; title: string; content: string; image_urls?: string };
   onSubmit: (
     title: string,
     content: string,
@@ -13,16 +14,20 @@ interface PostFormProps {
     codeSnippets?: { language: string; file_name?: string; code: string }[],
     isDraft?: boolean
   ) => Promise<void>;
+  onCancel?: () => void;
+  loading?: boolean;
 }
 
-export default function PostForm({ onSubmit }: PostFormProps) {
+export default function PostForm({ post, onSubmit, onCancel, loading: externalLoading }: PostFormProps) {
   const { t } = useTranslation();
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [imageUrls, setImageUrls] = useState<string[]>([]);
+  const [title, setTitle] = useState(post?.title || '');
+  const [content, setContent] = useState(post?.content || '');
+  const [imageUrls, setImageUrls] = useState<string[]>(
+    post?.image_urls ? JSON.parse(post.image_urls) : []
+  );
   const [snippets, setSnippets] = useState<SnippetInputData[]>([]);
   const [loading, setLoading] = useState(false);
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(!!post);
 
   const addSnippet = () => {
     setSnippets([...snippets, { language: '', file_name: '', code: '' }]);
@@ -52,14 +57,16 @@ export default function PostForm({ onSubmit }: PostFormProps) {
           code: s.code,
         }));
       await onSubmit(title, content, imageUrlsJson, validSnippets.length > 0 ? validSnippets : undefined, isDraft);
-      setTitle('');
-      setContent('');
-      setImageUrls([]);
-      setSnippets([]);
-      setExpanded(false);
-      toast.success(isDraft ? t('post.draftSaved') : t('post.postCreated'));
+      if (!post) {
+        setTitle('');
+        setContent('');
+        setImageUrls([]);
+        setSnippets([]);
+        setExpanded(false);
+      }
+      toast.success(post ? '投稿を更新しました' : (isDraft ? '下書きを保存しました' : '投稿を作成しました'));
     } catch {
-      toast.error(isDraft ? t('post.draftFailed') : t('post.postFailed'));
+      toast.error(post ? '投稿の更新に失敗しました' : (isDraft ? '下書きの保存に失敗しました' : '投稿の作成に失敗しました'));
     } finally {
       setLoading(false);
     }
@@ -120,30 +127,36 @@ export default function PostForm({ onSubmit }: PostFormProps) {
               <button
                 type="button"
                 onClick={() => {
-                  setExpanded(false);
-                  setTitle('');
-                  setContent('');
-                  setImageUrls([]);
-                  setSnippets([]);
+                  if (onCancel) {
+                    onCancel();
+                  } else {
+                    setExpanded(false);
+                    setTitle('');
+                    setContent('');
+                    setImageUrls([]);
+                    setSnippets([]);
+                  }
                 }}
                 className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors rounded-lg"
               >
-                {t('common.cancel')}
+                キャンセル
               </button>
-              <button
-                type="button"
-                onClick={(e) => handleSubmit(e, true)}
-                disabled={loading || !title.trim() || !content.trim()}
-                className="px-4 py-2 text-sm text-gray-400 hover:text-white disabled:opacity-40 transition-colors rounded-lg border border-gray-700 hover:border-gray-600"
-              >
-                {t('post.saveDraft')}
-              </button>
+              {!post && (
+                <button
+                  type="button"
+                  onClick={(e) => handleSubmit(e, true)}
+                  disabled={(externalLoading || loading) || !title.trim() || !content.trim()}
+                  className="px-4 py-2 text-sm text-gray-400 hover:text-white disabled:opacity-40 transition-colors rounded-lg border border-gray-700 hover:border-gray-600"
+                >
+                  下書き保存
+                </button>
+              )}
               <button
                 type="submit"
-                disabled={loading || !title.trim() || !content.trim()}
+                disabled={(externalLoading || loading) || !title.trim() || !content.trim()}
                 className="px-5 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-40 disabled:hover:bg-gray-700 text-white rounded-lg font-medium text-sm transition-colors"
               >
-                {loading ? t('post.posting') : t('post.post')}
+                {(externalLoading || loading) ? (post ? '更新中...' : '投稿中...') : (post ? '更新' : '投稿')}
               </button>
             </div>
           </div>

--- a/frontend/src/hooks/usePostDetail.ts
+++ b/frontend/src/hooks/usePostDetail.ts
@@ -1,7 +1,8 @@
 import { useState, useCallback } from 'react';
-import { getPost, getComments, createComment } from '../api/posts';
+import { getPost, getComments, createComment, updatePost as apiUpdatePost } from '../api/posts';
 import type { Post, Comment } from '../types/post';
 import { useAsyncData } from './useAsyncData';
+import toast from 'react-hot-toast';
 
 export function usePostDetail(id: string | undefined) {
   const postId = id ? parseInt(id) : 0;
@@ -35,12 +36,33 @@ export function usePostDetail(id: string | undefined) {
     }
   }, [postId, refetch]);
 
+  const handleUpdatePost = useCallback(async (
+    title: string,
+    content: string,
+    imageUrls?: string
+  ) => {
+    if (!postId) return false;
+    setSubmitting(true);
+    try {
+      await apiUpdatePost(postId, { title, content, image_urls: imageUrls });
+      await refetch();
+      toast.success('投稿を更新しました');
+      return true;
+    } catch {
+      toast.error('投稿の更新に失敗しました');
+      return false;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [postId, refetch]);
+
   return {
     post: data?.post ?? null,
     comments: data?.comments ?? [],
     loading,
     submitting,
     submitComment: handleSubmitComment,
+    updatePost: handleUpdatePost,
     refetch,
   };
 }

--- a/frontend/src/hooks/usePosts.ts
+++ b/frontend/src/hooks/usePosts.ts
@@ -1,7 +1,8 @@
 import { useState, useCallback } from 'react';
-import { getTimeline, getPosts, createPost } from '../api/posts';
+import { getTimeline, getPosts, createPost, updatePost, deletePost as apiDeletePost } from '../api/posts';
 import type { Post } from '../types/post';
 import { useAsyncData } from './useAsyncData';
+import toast from 'react-hot-toast';
 
 export function usePosts() {
   const [tab, setTab] = useState<'timeline' | 'all'>('timeline');
@@ -25,12 +26,45 @@ export function usePosts() {
     refetch();
   }, [refetch]);
 
+  const handleUpdatePost = useCallback(async (
+    id: number,
+    title: string,
+    content: string,
+    imageUrls?: string
+  ) => {
+    try {
+      await updatePost(id, { title, content, image_urls: imageUrls });
+      await refetch();
+      toast.success('投稿を更新しました');
+      return true;
+    } catch {
+      toast.error('投稿の更新に失敗しました');
+      return false;
+    }
+  }, [refetch]);
+
+  const handleDeletePost = useCallback(async (post: Post) => {
+    if (!confirm(`「${post.title}」を削除してもよろしいですか？`)) return false;
+
+    try {
+      await apiDeletePost(post.id);
+      await refetch();
+      toast.success('投稿を削除しました');
+      return true;
+    } catch {
+      toast.error('投稿の削除に失敗しました');
+      return false;
+    }
+  }, [refetch]);
+
   return {
     posts,
     loading,
     tab,
     setTab,
     createPost: handleCreatePost,
+    updatePost: handleUpdatePost,
+    deletePost: handleDeletePost,
     refetch,
   };
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Target, Bell, TrendingUp, CheckCircle2, Clock, ChevronRight } from 'lucide-react';
@@ -6,7 +7,9 @@ import { usePosts, useDashboard, useBadgeNotifier } from '../hooks';
 import { getUserBadges } from '../api/badges';
 import { useAsyncData } from '../hooks/useAsyncData';
 import type { BadgeResult } from '../types/badge';
+import type { Post } from '../types/post';
 import PostCard from '../components/posts/PostCard';
+import PostForm from '../components/posts/PostForm';
 import QuickPostForm from '../components/posts/QuickPostForm';
 import { PostCardSkeleton } from '../components/common/Skeleton';
 import Avatar from '../components/common/Avatar';
@@ -22,7 +25,8 @@ import StudyCircleWidget from '../components/dashboard/StudyCircleWidget';
 export default function DashboardPage() {
   const { t } = useTranslation();
   const user = useAuthStore((s) => s.user);
-  const { posts, loading, tab, setTab, createPost, refetch } = usePosts();
+  const { posts, loading, tab, setTab, createPost, updatePost, deletePost, refetch } = usePosts();
+  const [editingPost, setEditingPost] = useState<Post | null>(null);
   const {
     activeGoals,
     completedGoals,
@@ -136,11 +140,35 @@ export default function DashboardPage() {
         ) : (
           <div className="space-y-4">
             {posts.map((post) => (
-              <PostCard key={post.id} post={post} onUpdate={refetch} />
+              <PostCard
+                key={post.id}
+                post={post}
+                isOwner={user?.id === post.user_id}
+                onEdit={() => setEditingPost(post)}
+                onDelete={() => deletePost(post)}
+                onUpdate={refetch}
+              />
             ))}
           </div>
         )}
         </div>
+
+        {/* Edit Modal */}
+        {editingPost && (
+          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+            <div className="bg-gray-800 rounded-md p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+              <h2 className="text-xl font-semibold text-white mb-4">投稿を編集</h2>
+              <PostForm
+                post={editingPost}
+                onSubmit={async (title, content, imageUrls) => {
+                  const result = await updatePost(editingPost.id, title, content, imageUrls);
+                  if (result) setEditingPost(null);
+                }}
+                onCancel={() => setEditingPost(null)}
+              />
+            </div>
+          </div>
+        )}
       </div>
 
       {/* Sidebar */}

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,18 +1,25 @@
 import { useState } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { usePostDetail } from '../hooks';
+import { deletePost } from '../api/posts';
+import { useAuthStore } from '../store/authStore';
 import PostCard from '../components/posts/PostCard';
+import PostForm from '../components/posts/PostForm';
 import CodeSnippetViewer from '../components/posts/CodeSnippetViewer';
 import Avatar from '../components/common/Avatar';
 import { PageLoader } from '../components/common';
 import { format } from 'date-fns';
+import toast from 'react-hot-toast';
 
 export default function PostDetailPage() {
   const { id } = useParams<{ id: string }>();
   const { t } = useTranslation();
-  const { post, comments, loading, submitting, submitComment, refetch } = usePostDetail(id);
+  const navigate = useNavigate();
+  const user = useAuthStore((s) => s.user);
+  const { post, comments, loading, submitting, submitComment, refetch, updatePost } = usePostDetail(id);
   const [newComment, setNewComment] = useState('');
+  const [editingPost, setEditingPost] = useState(false);
 
   const handleSubmitComment = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -21,12 +28,30 @@ export default function PostDetailPage() {
     if (success) setNewComment('');
   };
 
+  const handleDeletePost = async () => {
+    if (!post || !confirm(`「${post.title}」を削除してもよろしいですか？`)) return;
+
+    try {
+      await deletePost(post.id);
+      toast.success('投稿を削除しました');
+      navigate('/');
+    } catch {
+      toast.error('投稿の削除に失敗しました');
+    }
+  };
+
   if (loading) return <PageLoader />;
   if (!post) return <div className="text-center text-gray-400 py-12">Post not found</div>;
 
   return (
     <div className="max-w-2xl mx-auto space-y-6">
-      <PostCard post={post} onUpdate={refetch} />
+      <PostCard
+        post={post}
+        isOwner={user?.id === post.user_id}
+        onEdit={() => setEditingPost(true)}
+        onDelete={handleDeletePost}
+        onUpdate={refetch}
+      />
 
       {/* Code Snippets Section */}
       {post.code_snippets && post.code_snippets.length > 0 && (
@@ -103,6 +128,23 @@ export default function PostDetailPage() {
           </div>
         )}
       </div>
+
+      {/* Edit Modal */}
+      {editingPost && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-gray-800 rounded-md p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+            <h2 className="text-xl font-semibold text-white mb-4">投稿を編集</h2>
+            <PostForm
+              post={post}
+              onSubmit={async (title, content, imageUrls) => {
+                const result = await updatePost(title, content, imageUrls);
+                if (result) setEditingPost(false);
+              }}
+              onCancel={() => setEditingPost(false)}
+            />
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -329,7 +329,13 @@ export default function ProfilePage() {
         {posts.length === 0 ? (
           <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center text-gray-400 text-sm">{t('profile.noPosts')}</div>
         ) : (
-          <div className="space-y-3">{posts.map((post) => <PostCard key={post.id} post={post} />)}</div>
+          <div className="space-y-3">{posts.map((post) => (
+            <PostCard
+              key={post.id}
+              post={post}
+              isOwner={currentUser?.id === post.user_id}
+            />
+          ))}</div>
         )}
       </div>
 


### PR DESCRIPTION
## 概要
Issue #178 の投稿編集・削除機能を実装しました。

## 変更内容
- PostCard に編集・削除ボタンを追加（投稿者のみ表示）
- PostForm を新規作成と編集の両方に対応
- usePosts, usePostDetail フックに更新・削除関数を追加
- DashboardPage, PostDetailPage, ProfilePage に編集モダルを実装
- 全てのメッセージを日本語で統一

## テスト
- TypeScript 型チェック: ✅
- Docker ビルド: ✅

Closes #178