### PR TITLE
feat: HTTPレスポンス構造を統一

### DIFF
--- a/backend/internal/domain/response.go
+++ b/backend/internal/domain/response.go
@@ -1,0 +1,62 @@
+// Package domain provides core business logic and domain models.
+package domain
+
+// SuccessResponse は成功レスポンスの統一構造体。
+type SuccessResponse struct {
+	Data interface{} `json:"data,omitempty"`
+}
+
+// ErrorResponse はエラーレスポンスの統一構造体。
+type ErrorResponse struct {
+	Error string      `json:"error"`
+	Code  string      `json:"code,omitempty"`
+	Details interface{} `json:"details,omitempty"`
+}
+
+// PaginatedResponse はページネーション付きレスポンスの統一構造体。
+type PaginatedResponse struct {
+	Data       interface{} `json:"data"`
+	Total      int64       `json:"total"`
+	Page       int         `json:"page,omitempty"`
+	Limit      int         `json:"limit,omitempty"`
+	TotalPages int         `json:"total_pages,omitempty"`
+}
+
+// MessageResponse はメッセージのみのレスポンス構造体。
+type MessageResponse struct {
+	Message string `json:"message"`
+}
+
+// NewSuccessResponse は成功レスポンスを生成する。
+func NewSuccessResponse(data interface{}) SuccessResponse {
+	return SuccessResponse{Data: data}
+}
+
+// NewErrorResponse はエラーレスポンスを生成する。
+func NewErrorResponse(message string, code string, details interface{}) ErrorResponse {
+	return ErrorResponse{
+		Error:   message,
+		Code:    code,
+		Details: details,
+	}
+}
+
+// NewPaginatedResponse はページネーション付きレスポンスを生成する。
+func NewPaginatedResponse(data interface{}, total int64, page, limit int) PaginatedResponse {
+	totalPages := 0
+	if limit > 0 {
+		totalPages = int((total + int64(limit) - 1) / int64(limit))
+	}
+	return PaginatedResponse{
+		Data:       data,
+		Total:      total,
+		Page:       page,
+		Limit:      limit,
+		TotalPages: totalPages,
+	}
+}
+
+// NewMessageResponse はメッセージレスポンスを生成する。
+func NewMessageResponse(message string) MessageResponse {
+	return MessageResponse{Message: message}
+}

--- a/backend/internal/domain/response_test.go
+++ b/backend/internal/domain/response_test.go
@@ -1,0 +1,89 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSuccessResponse(t *testing.T) {
+	data := map[string]string{"key": "value"}
+	response := NewSuccessResponse(data)
+
+	assert.Equal(t, data, response.Data)
+}
+
+func TestNewErrorResponse(t *testing.T) {
+	message := "エラーメッセージ"
+	code := "VALIDATION_ERROR"
+	details := map[string]string{"field": "title"}
+
+	response := NewErrorResponse(message, code, details)
+
+	assert.Equal(t, message, response.Error)
+	assert.Equal(t, code, response.Code)
+	assert.Equal(t, details, response.Details)
+}
+
+func TestNewPaginatedResponse(t *testing.T) {
+	tests := []struct {
+		name       string
+		data       interface{}
+		total      int64
+		page       int
+		limit      int
+		wantPages  int
+	}{
+		{
+			name:      "10件中10件を1ページで取得",
+			data:      []string{"a", "b"},
+			total:     10,
+			page:      1,
+			limit:     10,
+			wantPages: 1,
+		},
+		{
+			name:      "100件を20件ずつ",
+			data:      []string{},
+			total:     100,
+			page:      1,
+			limit:     20,
+			wantPages: 5,
+		},
+		{
+			name:      "95件を20件ずつ（端数あり）",
+			data:      []string{},
+			total:     95,
+			page:      1,
+			limit:     20,
+			wantPages: 5,
+		},
+		{
+			name:      "0件",
+			data:      []string{},
+			total:     0,
+			page:      1,
+			limit:     10,
+			wantPages: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			response := NewPaginatedResponse(tt.data, tt.total, tt.page, tt.limit)
+
+			assert.Equal(t, tt.data, response.Data)
+			assert.Equal(t, tt.total, response.Total)
+			assert.Equal(t, tt.page, response.Page)
+			assert.Equal(t, tt.limit, response.Limit)
+			assert.Equal(t, tt.wantPages, response.TotalPages)
+		})
+	}
+}
+
+func TestNewMessageResponse(t *testing.T) {
+	message := "成功しました"
+	response := NewMessageResponse(message)
+
+	assert.Equal(t, message, response.Message)
+}

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -53,12 +53,14 @@ func bindJSON[T any](c *gin.Context) *T {
 func respondError(c *gin.Context, err error) {
 	// DomainError の場合
 	if domainErr := domain.GetDomainError(err); domainErr != nil {
-		c.JSON(domainErr.HTTPStatus(), gin.H{"error": domainErr.Message, "code": domainErr.Code})
+		response := domain.NewErrorResponse(domainErr.Message, string(domainErr.Code), nil)
+		c.JSON(domainErr.HTTPStatus(), response)
 		return
 	}
 
 	// DomainError でない場合は内部エラーとして扱う
-	c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+	response := domain.NewErrorResponse(err.Error(), "", nil)
+	c.JSON(http.StatusInternalServerError, response)
 }
 
 // respondOK は200 OKでデータを返す。
@@ -73,5 +75,12 @@ func respondCreated(c *gin.Context, data interface{}) {
 
 // respondDeleted は200 OKで削除メッセージを返す。
 func respondDeleted(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"message": "deleted"})
+	response := domain.NewMessageResponse("deleted")
+	c.JSON(http.StatusOK, response)
+}
+
+// respondPaginated はページネーション付きレスポンスを返す。
+func respondPaginated(c *gin.Context, data interface{}, total int64, page, limit int) {
+	response := domain.NewPaginatedResponse(data, total, page, limit)
+	c.JSON(http.StatusOK, response)
 }


### PR DESCRIPTION
## 概要
Issue #209 の実装として、HTTPレスポンス構造を統一しました。

## 変更内容

### domain/response.go の作成
統一レスポンス構造を定義：
- **SuccessResponse**: 成功時のデータレスポンス `{data}`
- **ErrorResponse**: エラーレスポンス `{error, code, details}`
- **PaginatedResponse**: ページネーション付きレスポンス `{data, total, page, limit, total_pages}`
- **MessageResponse**: メッセージのみのレスポンス `{message}`

### handler/helpers.go の更新
- `respondError`: domain.NewErrorResponse() を使用
- `respondDeleted`: domain.NewMessageResponse() を使用
- `respondPaginated`: domain.NewPaginatedResponse() を追加（新規）

### テスト
- domain/response_test.go で全レスポンス構造をテスト
- ページネーション計算のテストケースを追加

## メリット
- ✅ タイプセーフティ向上（gin.H{}の直接使用を削減）
- ✅ レスポンス構造の一貫性
- ✅ フロントエンドとのI/F明確化
- ✅ ドキュメント化しやすい

## テスト結果
- ✅ 全テストがパス
- ✅ ビルド成功

Closes #209