### PR TITLE
学習ノート（Note）機能 - Service層とHandler層実装

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -49,6 +49,7 @@ type Container struct {
 	RecommendationHandler    *handler.RecommendationHandler
 	StudyCircleHandler       *handler.StudyCircleHandler
 	SearchHandler            *handler.SearchHandler
+	NoteHandler              *handler.NoteHandler
 
 	// ミドルウェア・コールバック用
 	AuthService      *service.AuthService
@@ -91,6 +92,7 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	badgeRepo := repository.NewBadgeRepository(db)
 	recommendationRepo := repository.NewRecommendationRepository(db)
 	studyCircleRepo := repository.NewStudyCircleRepository(db)
+	noteRepo := repository.NewNoteRepository(db)
 
 	c.GroupMessageRepo = groupMessageRepo
 
@@ -126,6 +128,7 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	analyticsService := service.NewLearningAnalyticsService(analyticsRepo)
 	recommendationService := service.NewRecommendationService(recommendationRepo, userRepo)
 	studyCircleService := service.NewStudyCircleService(studyCircleRepo)
+	noteService := service.NewNoteService(noteRepo)
 
 	// テンプレートロードマップの初期登録
 	go seedTemplateRoadmaps(db, roadmapService)
@@ -196,6 +199,7 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	c.RecommendationHandler = handler.NewRecommendationHandler(recommendationService)
 	c.StudyCircleHandler = handler.NewStudyCircleHandler(studyCircleService)
 	c.SearchHandler = handler.NewSearchHandler(postRepo, studyCircleRepo)
+	c.NoteHandler = handler.NewNoteHandler(noteService)
 
 	// HubのGetRoomMembersコールバックを設定
 	hub.GetRoomMembers = groupMessageRepo.GetMemberUserIDs

--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -1,0 +1,223 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// NoteServiceInterface はNoteServiceのインターフェース。
+// テスト時のモック化を容易にするため、インターフェースとして定義する。
+type NoteServiceInterface interface {
+	Create(note *model.Note) error
+	GetByID(id uint) (*model.Note, error)
+	GetByUserID(userID uint, page, limit int) ([]model.Note, error)
+	GetByFolderID(folderID uint) ([]model.Note, error)
+	Update(note *model.Note) error
+	Delete(id uint) error
+	Search(userID uint, query string, page, limit int) ([]model.Note, int64, error)
+	CountByUserID(userID uint) (int64, error)
+	ToggleFavorite(id uint) error
+}
+
+// NoteHandler は学習ノート関連のHTTPハンドラ。
+// ノートのCRUD・検索・お気に入り管理を処理する。
+type NoteHandler struct {
+	service NoteServiceInterface
+}
+
+// NewNoteHandler は新しいNoteHandlerインスタンスを生成する。
+func NewNoteHandler(s NoteServiceInterface) *NoteHandler {
+	return &NoteHandler{service: s}
+}
+
+// CreateNoteInput はノート作成のリクエストボディ。
+type CreateNoteInput struct {
+	Title    string `json:"title" binding:"required"`
+	Content  string `json:"content" binding:"required"`
+	Tags     string `json:"tags"`
+	FolderID *uint  `json:"folder_id"`
+}
+
+// Create は新しいノートを作成する。
+func (h *NoteHandler) Create(c *gin.Context) {
+	userID := c.GetUint("userID")
+	input := bindJSON[CreateNoteInput](c)
+	if input == nil {
+		return
+	}
+
+	note := &model.Note{
+		UserID:   userID,
+		Title:    input.Title,
+		Content:  input.Content,
+		Tags:     input.Tags,
+		FolderID: input.FolderID,
+	}
+
+	if err := h.service.Create(note); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, note)
+}
+
+// GetByID は指定IDのノートを取得する。
+func (h *NoteHandler) GetByID(c *gin.Context) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	note, err := h.service.GetByID(id)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, note)
+}
+
+// GetByUserID は現在のユーザーのノート一覧をページネーション付きで取得する。
+func (h *NoteHandler) GetByUserID(c *gin.Context) {
+	userID := c.GetUint("userID")
+	page, limit := parsePagination(c)
+
+	notes, err := h.service.GetByUserID(userID, page, limit)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	total, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondPaginated(c, notes, total, page, limit)
+}
+
+// GetByFolderID は指定フォルダ内のノート一覧を取得する。
+func (h *NoteHandler) GetByFolderID(c *gin.Context) {
+	folderID, ok := parseID(c, "folderId")
+	if !ok {
+		return
+	}
+
+	notes, err := h.service.GetByFolderID(folderID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, notes)
+}
+
+// UpdateNoteInput はノート更新のリクエストボディ。
+type UpdateNoteInput struct {
+	Title    string `json:"title"`
+	Content  string `json:"content"`
+	Tags     string `json:"tags"`
+	FolderID *uint  `json:"folder_id"`
+}
+
+// Update はノートを更新する。
+func (h *NoteHandler) Update(c *gin.Context) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	input := bindJSON[UpdateNoteInput](c)
+	if input == nil {
+		return
+	}
+
+	// 既存のノートを取得して所有者確認
+	note, err := h.service.GetByID(id)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	// 所有者チェック
+	if note.UserID != userID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "この操作を行う権限がありません"})
+		return
+	}
+
+	// 更新フィールドを適用（空でない場合のみ）
+	if input.Title != "" {
+		note.Title = input.Title
+	}
+	if input.Content != "" {
+		note.Content = input.Content
+	}
+	if input.Tags != "" {
+		note.Tags = input.Tags
+	}
+	if input.FolderID != nil {
+		note.FolderID = input.FolderID
+	}
+
+	if err := h.service.Update(note); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, note)
+}
+
+// Delete はノートを削除する。
+func (h *NoteHandler) Delete(c *gin.Context) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.Delete(id); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondDeleted(c)
+}
+
+// Search はキーワードでノートを検索する（ページネーション付き）。
+func (h *NoteHandler) Search(c *gin.Context) {
+	userID := c.GetUint("userID")
+	query := c.Query("q")
+	if query == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "検索キーワードが必要です"})
+		return
+	}
+
+	page, limit := parsePagination(c)
+
+	notes, total, err := h.service.Search(userID, query, page, limit)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondPaginated(c, notes, total, page, limit)
+}
+
+// ToggleFavorite はノートのお気に入り状態を切り替える。
+func (h *NoteHandler) ToggleFavorite(c *gin.Context) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.ToggleFavorite(id); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"message": "お気に入り状態を更新しました"})
+}

--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -1,0 +1,269 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockNoteService は NoteService のモック実装。
+type MockNoteService struct {
+	mock.Mock
+}
+
+func (m *MockNoteService) Create(note *model.Note) error {
+	return m.Called(note).Error(0)
+}
+
+func (m *MockNoteService) GetByID(id uint) (*model.Note, error) {
+	args := m.Called(id)
+	if note := args.Get(0); note != nil {
+		return note.(*model.Note), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockNoteService) GetByUserID(userID uint, page, limit int) ([]model.Note, error) {
+	args := m.Called(userID, page, limit)
+	return args.Get(0).([]model.Note), args.Error(1)
+}
+
+func (m *MockNoteService) GetByFolderID(folderID uint) ([]model.Note, error) {
+	args := m.Called(folderID)
+	return args.Get(0).([]model.Note), args.Error(1)
+}
+
+func (m *MockNoteService) Update(note *model.Note) error {
+	return m.Called(note).Error(0)
+}
+
+func (m *MockNoteService) Delete(id uint) error {
+	return m.Called(id).Error(0)
+}
+
+func (m *MockNoteService) Search(userID uint, query string, page, limit int) ([]model.Note, int64, error) {
+	args := m.Called(userID, query, page, limit)
+	return args.Get(0).([]model.Note), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockNoteService) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockNoteService) ToggleFavorite(id uint) error {
+	return m.Called(id).Error(0)
+}
+
+// newTestNoteHandler はテスト用のNoteHandlerを生成する。
+func newTestNoteHandler() (*NoteHandler, *MockNoteService) {
+	mockService := new(MockNoteService)
+	handler := NewNoteHandler(mockService)
+	return handler, mockService
+}
+
+// setupRouter はテスト用のGinルーターをセットアップする。
+func setupRouter() *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	return gin.New()
+}
+
+// ============================================================
+// Create テスト
+// ============================================================
+
+func TestNoteHandler_Create(t *testing.T) {
+	handler, mockService := newTestNoteHandler()
+	router := setupRouter()
+
+	router.POST("/notes", func(c *gin.Context) {
+		c.Set("userID", uint(1))
+		handler.Create(c)
+	})
+
+	input := CreateNoteInput{
+		Title:    "テストノート",
+		Content:  "これはテスト内容です",
+		Tags:     "Go,TDD",
+		FolderID: nil,
+	}
+	body, _ := json.Marshal(input)
+
+	mockService.On("Create", mock.AnythingOfType("*model.Note")).Return(nil)
+
+	req, _ := http.NewRequest("POST", "/notes", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+// ============================================================
+// GetByID テスト
+// ============================================================
+
+func TestNoteHandler_GetByID(t *testing.T) {
+	handler, mockService := newTestNoteHandler()
+	router := setupRouter()
+
+	router.GET("/notes/:id", handler.GetByID)
+
+	note := &model.Note{
+		ID:      1,
+		UserID:  1,
+		Title:   "テストノート",
+		Content: "内容",
+	}
+
+	mockService.On("GetByID", uint(1)).Return(note, nil)
+
+	req, _ := http.NewRequest("GET", "/notes/1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+// ============================================================
+// GetByUserID テスト
+// ============================================================
+
+func TestNoteHandler_GetByUserID(t *testing.T) {
+	handler, mockService := newTestNoteHandler()
+	router := setupRouter()
+
+	router.GET("/notes", func(c *gin.Context) {
+		c.Set("userID", uint(1))
+		handler.GetByUserID(c)
+	})
+
+	notes := []model.Note{
+		{ID: 1, UserID: 1, Title: "ノート1"},
+		{ID: 2, UserID: 1, Title: "ノート2"},
+	}
+
+	mockService.On("GetByUserID", uint(1), 1, 20).Return(notes, nil)
+	mockService.On("CountByUserID", uint(1)).Return(int64(2), nil)
+
+	req, _ := http.NewRequest("GET", "/notes?page=1&limit=20", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+// ============================================================
+// Update テスト
+// ============================================================
+
+func TestNoteHandler_Update(t *testing.T) {
+	handler, mockService := newTestNoteHandler()
+	router := setupRouter()
+
+	router.PUT("/notes/:id", func(c *gin.Context) {
+		c.Set("userID", uint(1))
+		handler.Update(c)
+	})
+
+	input := UpdateNoteInput{
+		Title:   "更新後タイトル",
+		Content: "更新後内容",
+	}
+	body, _ := json.Marshal(input)
+
+	updatedNote := &model.Note{
+		ID:      1,
+		UserID:  1,
+		Title:   "更新後タイトル",
+		Content: "更新後内容",
+	}
+
+	mockService.On("GetByID", uint(1)).Return(updatedNote, nil)
+	mockService.On("Update", mock.AnythingOfType("*model.Note")).Return(nil)
+
+	req, _ := http.NewRequest("PUT", "/notes/1", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+// ============================================================
+// Delete テスト
+// ============================================================
+
+func TestNoteHandler_Delete(t *testing.T) {
+	handler, mockService := newTestNoteHandler()
+	router := setupRouter()
+
+	router.DELETE("/notes/:id", handler.Delete)
+
+	mockService.On("Delete", uint(1)).Return(nil)
+
+	req, _ := http.NewRequest("DELETE", "/notes/1", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+// ============================================================
+// Search テスト
+// ============================================================
+
+func TestNoteHandler_Search(t *testing.T) {
+	handler, mockService := newTestNoteHandler()
+	router := setupRouter()
+
+	router.GET("/notes/search", func(c *gin.Context) {
+		c.Set("userID", uint(1))
+		handler.Search(c)
+	})
+
+	notes := []model.Note{
+		{ID: 1, UserID: 1, Title: "Go学習", Content: "Goを学習中"},
+	}
+
+	mockService.On("Search", uint(1), "Go", 1, 20).Return(notes, int64(1), nil)
+
+	req, _ := http.NewRequest("GET", "/notes/search?q=Go&page=1&limit=20", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+// ============================================================
+// ToggleFavorite テスト
+// ============================================================
+
+func TestNoteHandler_ToggleFavorite(t *testing.T) {
+	handler, mockService := newTestNoteHandler()
+	router := setupRouter()
+
+	router.PUT("/notes/:id/favorite", handler.ToggleFavorite)
+
+	mockService.On("ToggleFavorite", uint(1)).Return(nil)
+
+	req, _ := http.NewRequest("PUT", "/notes/1/favorite", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	mockService.AssertExpectations(t)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -280,6 +280,19 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		learningLogs.DELETE("/:id", c.LearningLogHandler.Delete)
 	}
 
+	// 学習ノート
+	notes := g.Group("/notes")
+	{
+		notes.POST("", c.NoteHandler.Create)
+		notes.GET("", c.NoteHandler.GetByUserID)
+		notes.GET("/search", c.NoteHandler.Search)
+		notes.GET("/folder/:folderId", c.NoteHandler.GetByFolderID)
+		notes.GET("/:id", c.NoteHandler.GetByID)
+		notes.PUT("/:id", c.NoteHandler.Update)
+		notes.DELETE("/:id", c.NoteHandler.Delete)
+		notes.PUT("/:id/favorite", c.NoteHandler.ToggleFavorite)
+	}
+
 	// メール配信設定
 	g.GET("/email-preferences", c.EmailPreferencesHandler.GetPreferences)
 	g.PUT("/email-preferences", c.EmailPreferencesHandler.UpdatePreferences)

--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// NoteService は学習ノートのビジネスロジックを提供する。
+type NoteService struct {
+	repo repository.NoteRepositoryInterface
+}
+
+// NewNoteService は新しいNoteServiceインスタンスを生成する。
+func NewNoteService(repo repository.NoteRepositoryInterface) *NoteService {
+	return &NoteService{repo: repo}
+}
+
+// Create は新しいノートを作成する。
+func (s *NoteService) Create(note *model.Note) error {
+	return s.repo.Create(note)
+}
+
+// GetByID は指定IDのノートを取得する。
+func (s *NoteService) GetByID(id uint) (*model.Note, error) {
+	return s.repo.FindByID(id)
+}
+
+// GetByUserID は指定ユーザーのノート一覧を取得する。
+func (s *NoteService) GetByUserID(userID uint, page, limit int) ([]model.Note, error) {
+	return s.repo.FindByUserID(userID, page, limit)
+}
+
+// GetByFolderID は指定フォルダ内のノート一覧を取得する。
+func (s *NoteService) GetByFolderID(folderID uint) ([]model.Note, error) {
+	return s.repo.FindByFolderID(folderID)
+}
+
+// Update はノートを更新する。
+func (s *NoteService) Update(note *model.Note) error {
+	return s.repo.Update(note)
+}
+
+// Delete はノートを削除する。
+func (s *NoteService) Delete(id uint) error {
+	return s.repo.Delete(id)
+}
+
+// Search はキーワードでノートを検索する。
+func (s *NoteService) Search(userID uint, query string, page, limit int) ([]model.Note, int64, error) {
+	offset := (page - 1) * limit
+	return s.repo.Search(userID, query, limit, offset)
+}
+
+// CountByUserID は指定ユーザーのノート総数を取得する。
+func (s *NoteService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}
+
+// ToggleFavorite はノートのお気に入り状態を切り替える。
+func (s *NoteService) ToggleFavorite(id uint) error {
+	return s.repo.ToggleFavorite(id)
+}

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -1,0 +1,183 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockNoteRepository はNoteRepositoryのモック実装。
+type MockNoteRepository struct {
+	mock.Mock
+}
+
+func (m *MockNoteRepository) Create(note *model.Note) error {
+	return m.Called(note).Error(0)
+}
+
+func (m *MockNoteRepository) FindByID(id uint) (*model.Note, error) {
+	args := m.Called(id)
+	if note := args.Get(0); note != nil {
+		return note.(*model.Note), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (m *MockNoteRepository) FindByUserID(userID uint, page, limit int) ([]model.Note, error) {
+	args := m.Called(userID, page, limit)
+	return args.Get(0).([]model.Note), args.Error(1)
+}
+
+func (m *MockNoteRepository) FindByFolderID(folderID uint) ([]model.Note, error) {
+	args := m.Called(folderID)
+	return args.Get(0).([]model.Note), args.Error(1)
+}
+
+func (m *MockNoteRepository) Update(note *model.Note) error {
+	return m.Called(note).Error(0)
+}
+
+func (m *MockNoteRepository) Delete(id uint) error {
+	return m.Called(id).Error(0)
+}
+
+func (m *MockNoteRepository) Search(userID uint, query string, limit, offset int) ([]model.Note, int64, error) {
+	args := m.Called(userID, query, limit, offset)
+	return args.Get(0).([]model.Note), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockNoteRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockNoteRepository) ToggleFavorite(id uint) error {
+	return m.Called(id).Error(0)
+}
+
+// newTestNoteService はテスト用のNoteServiceを生成する。
+func newTestNoteService() (*NoteService, *MockNoteRepository) {
+	repo := new(MockNoteRepository)
+	svc := NewNoteService(repo)
+	return svc, repo
+}
+
+// ============================================================
+// Create テスト
+// ============================================================
+
+func TestNoteService_Create(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	note := &model.Note{
+		UserID:  1,
+		Title:   "テストノート",
+		Content: "これはテストです",
+		Tags:    "Go,TDD",
+	}
+
+	repo.On("Create", note).Return(nil)
+
+	err := svc.Create(note)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// GetByID テスト
+// ============================================================
+
+func TestNoteService_GetByID(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	note := &model.Note{
+		ID:      1,
+		UserID:  1,
+		Title:   "テストノート",
+		Content: "内容",
+	}
+
+	repo.On("FindByID", uint(1)).Return(note, nil)
+
+	result, err := svc.GetByID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, note, result)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// GetByUserID テスト
+// ============================================================
+
+func TestNoteService_GetByUserID(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	notes := []model.Note{
+		{ID: 1, UserID: 1, Title: "ノート1"},
+		{ID: 2, UserID: 1, Title: "ノート2"},
+	}
+
+	repo.On("FindByUserID", uint(1), 1, 20).Return(notes, nil)
+
+	result, err := svc.GetByUserID(1, 1, 20)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(result))
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// Update テスト
+// ============================================================
+
+func TestNoteService_Update(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	note := &model.Note{
+		ID:      1,
+		UserID:  1,
+		Title:   "更新後タイトル",
+		Content: "更新後内容",
+	}
+
+	repo.On("Update", note).Return(nil)
+
+	err := svc.Update(note)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// Delete テスト
+// ============================================================
+
+func TestNoteService_Delete(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	repo.On("Delete", uint(1)).Return(nil)
+
+	err := svc.Delete(1)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// Search テスト
+// ============================================================
+
+func TestNoteService_Search(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	notes := []model.Note{
+		{ID: 1, UserID: 1, Title: "Go学習", Content: "Goを学習中"},
+	}
+
+	repo.On("Search", uint(1), "Go", 20, 0).Return(notes, int64(1), nil)
+
+	result, total, err := svc.Search(1, "Go", 1, 20)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), total)
+	assert.Equal(t, 1, len(result))
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
NoteService層とNoteHandler層をTDDアプローチで実装。
Repository層（#240）と統合し、完全なCRUD操作とAPI提供を実現。

## 実装内容

### Service層
- `internal/service/note.go` - ビジネスロジック層
  - Create, GetByID, GetByUserID, GetByFolderID
  - Update, Delete
  - Search（ページネーション付き）
  - CountByUserID, ToggleFavorite
- `internal/service/note_test.go` - 6つのテストケース

### Handler層
- `internal/handler/note.go` - HTTPエンドポイント実装
  - POST /notes - ノート作成
  - GET /notes - ユーザーのノート一覧
  - GET /notes/search - キーワード検索
  - GET /notes/folder/:folderId - フォルダ内ノート
  - GET /notes/:id - ノート取得
  - PUT /notes/:id - ノート更新
  - DELETE /notes/:id - ノート削除
  - PUT /notes/:id/favorite - お気に入り切り替え
- `internal/handler/note_test.go` - 7つのテストケース

### 統合
- DIコンテナにNoteHandler追加
- /api/v1/notes エンドポイント登録

## テスト結果
✅ Service層: 6/6 PASS
✅ Handler層: 7/7 PASS
✅ ビルド: 成功

## 技術詳細
- 所有者チェック: Update時にUserID照合
- 部分更新対応: 空値フィールドはスキップ
- インターフェース設計: テスト時のモック化を容易に
- エラーハンドリング: respondError統一化

## 関連PR
- #240 - Note Repository層実装

## API仕様
全エンドポイントは `/api/v1/notes` 配下に配置され、認証必須です。