### PR TITLE
学習ノート機能 - 基盤実装（API・フック・i18n）

### DIFF
--- a/frontend/src/api/notes.ts
+++ b/frontend/src/api/notes.ts
@@ -1,0 +1,66 @@
+import client from './client';
+
+export interface Note {
+  id: number;
+  user_id: number;
+  folder_id?: number | null;
+  title: string;
+  content: string;
+  tags: string;
+  is_favorite: boolean;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface NoteFolder {
+  id: number;
+  user_id: number;
+  name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateNoteRequest {
+  title: string;
+  content: string;
+  tags?: string;
+  folder_id?: number | null;
+}
+
+export interface UpdateNoteRequest {
+  title?: string;
+  content?: string;
+  tags?: string;
+  folder_id?: number | null;
+}
+
+export interface NotePaginatedResponse {
+  data: Note[];
+  total: number;
+  page: number;
+  limit: number;
+}
+
+export const createNote = (data: CreateNoteRequest) =>
+  client.post<Note>('/notes', data);
+
+export const updateNote = (id: number, data: UpdateNoteRequest) =>
+  client.put<Note>(`/notes/${id}`, data);
+
+export const deleteNote = (id: number) =>
+  client.delete(`/notes/${id}`);
+
+export const getNote = (id: number) =>
+  client.get<Note>(`/notes/${id}`);
+
+export const getMyNotes = (page = 1, limit = 20) =>
+  client.get<NotePaginatedResponse>(`/notes?page=${page}&limit=${limit}`);
+
+export const getNotesByFolder = (folderId: number) =>
+  client.get<Note[]>(`/notes/folder/${folderId}`);
+
+export const searchNotes = (query: string, page = 1, limit = 20) =>
+  client.get<NotePaginatedResponse>(`/notes/search?q=${encodeURIComponent(query)}&page=${page}&limit=${limit}`);
+
+export const toggleFavorite = (id: number) =>
+  client.put<{ message: string }>(`/notes/${id}/favorite`);

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -28,6 +28,7 @@ export { useSettings } from './useSettings';
 export { useChat } from './useChat';
 export { useRecommendedUsers, useTrendingPosts, useTrendingResources } from './useRecommendations';
 export { useStudyCircles, useStudyCircleDetail, useStudyCircleActivity } from './useStudyCircles';
+export { useNotes, useNoteSearch } from './useNotes';
 export { useToast } from './useToast';
 export { useDebounce } from './useDebounce';
 export { useAutoSave } from './useAutoSave';

--- a/frontend/src/hooks/useNotes.ts
+++ b/frontend/src/hooks/useNotes.ts
@@ -1,0 +1,134 @@
+import { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import {
+  getMyNotes,
+  createNote,
+  updateNote,
+  deleteNote,
+  toggleFavorite,
+  searchNotes,
+  type Note,
+  type CreateNoteRequest,
+  type UpdateNoteRequest,
+} from '../api/notes';
+import { useAsyncData } from './useAsyncData';
+
+export function useNotes(page = 1, limit = 20) {
+  const { t } = useTranslation();
+  const [saving, setSaving] = useState(false);
+
+  const { data: notesData, loading, refetch } = useAsyncData(
+    async () => {
+      const { data } = await getMyNotes(page, limit);
+      return data || { data: [], total: 0, page: 1, limit: 20 };
+    },
+    { initialData: { data: [], total: 0, page: 1, limit: 20 } }
+  );
+
+  const [localNotes, setLocalNotes] = useState<Note[] | null>(null);
+  const currentNotes = localNotes ?? notesData.data;
+
+  // Sync localNotes when remote data changes
+  const setNotes = useCallback((updater: Note[] | ((prev: Note[]) => Note[])) => {
+    setLocalNotes(prev => {
+      const current = prev ?? notesData.data;
+      return typeof updater === 'function' ? updater(current) : updater;
+    });
+  }, [notesData.data]);
+
+  const handleCreate = useCallback(async (data: CreateNoteRequest) => {
+    setSaving(true);
+    try {
+      const { data: newNote } = await createNote(data);
+      setNotes(prev => [newNote, ...prev]);
+      toast.success(t('notes.created'));
+      return newNote;
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [t, setNotes]);
+
+  const handleUpdate = useCallback(async (noteId: number, data: UpdateNoteRequest) => {
+    setSaving(true);
+    try {
+      const { data: updated } = await updateNote(noteId, data);
+      setNotes(prev => prev.map(n => n.id === updated.id ? updated : n));
+      toast.success(t('notes.updated'));
+      return updated;
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+      return null;
+    } finally {
+      setSaving(false);
+    }
+  }, [t, setNotes]);
+
+  const handleDelete = useCallback(async (id: number) => {
+    if (!confirm(t('notes.confirmDelete'))) return false;
+    try {
+      await deleteNote(id);
+      setNotes(prev => prev.filter(n => n.id !== id));
+      toast.success(t('notes.deleted'));
+      return true;
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+      return false;
+    }
+  }, [t, setNotes]);
+
+  const handleToggleFavorite = useCallback(async (id: number) => {
+    try {
+      await toggleFavorite(id);
+      setNotes(prev => prev.map(n =>
+        n.id === id ? { ...n, is_favorite: !n.is_favorite } : n
+      ));
+      toast.success(t('notes.favoriteToggled'));
+      return true;
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+      return false;
+    }
+  }, [t, setNotes]);
+
+  const favoriteNotes = currentNotes.filter(n => n.is_favorite);
+
+  return {
+    notes: currentNotes,
+    total: notesData.total,
+    page: notesData.page,
+    limit: notesData.limit,
+    loading,
+    saving,
+    favoriteNotes,
+    createNote: handleCreate,
+    updateNote: handleUpdate,
+    deleteNote: handleDelete,
+    toggleFavorite: handleToggleFavorite,
+    refetch,
+  };
+}
+
+export function useNoteSearch(query: string, page = 1, limit = 20) {
+  const { data: searchResults, loading } = useAsyncData(
+    async () => {
+      if (!query.trim()) {
+        return { data: [], total: 0, page: 1, limit: 20 };
+      }
+      const { data } = await searchNotes(query, page, limit);
+      return data || { data: [], total: 0, page: 1, limit: 20 };
+    },
+    { initialData: { data: [], total: 0, page: 1, limit: 20 }, deps: [query, page, limit] }
+  );
+
+  return {
+    notes: searchResults.data,
+    total: searchResults.total,
+    page: searchResults.page,
+    limit: searchResults.limit,
+    loading,
+  };
+}

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1129,5 +1129,28 @@
       "todayCheckin": "Today's Check-in",
       "viewAll": "View All"
     }
+  },
+  "notes": {
+    "title": "Learning Notes",
+    "myNotes": "My Notes",
+    "createNote": "New Note",
+    "editNote": "Edit Note",
+    "noteTitle": "Title",
+    "noteContent": "Content (Markdown supported)",
+    "tags": "Tags (comma separated)",
+    "folder": "Folder",
+    "noFolder": "No folder",
+    "favorites": "Favorites",
+    "searchNotes": "Search Notes",
+    "searchPlaceholder": "Search by title or content...",
+    "noNotes": "No notes yet",
+    "noSearchResults": "No search results found",
+    "created": "Note created successfully",
+    "updated": "Note updated successfully",
+    "deleted": "Note deleted successfully",
+    "confirmDelete": "Are you sure you want to delete this note?",
+    "favoriteToggled": "Favorite status updated",
+    "lastUpdated": "Last updated",
+    "createdAt": "Created at"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1029,5 +1029,28 @@
       "todayCheckin": "今日のチェックイン",
       "viewAll": "すべて見る"
     }
+  },
+  "notes": {
+    "title": "学習ノート",
+    "myNotes": "マイノート",
+    "createNote": "新規ノート",
+    "editNote": "ノート編集",
+    "noteTitle": "タイトル",
+    "noteContent": "内容（マークダウン対応）",
+    "tags": "タグ（カンマ区切り）",
+    "folder": "フォルダ",
+    "noFolder": "フォルダなし",
+    "favorites": "お気に入り",
+    "searchNotes": "ノートを検索",
+    "searchPlaceholder": "タイトルまたは本文で検索...",
+    "noNotes": "ノートがありません",
+    "noSearchResults": "検索結果が見つかりませんでした",
+    "created": "ノートを作成しました",
+    "updated": "ノートを更新しました",
+    "deleted": "ノートを削除しました",
+    "confirmDelete": "このノートを削除しますか？",
+    "favoriteToggled": "お気に入りを更新しました",
+    "lastUpdated": "最終更新",
+    "createdAt": "作成日時"
   }
 }


### PR DESCRIPTION
## 概要
フロントエンドの学習ノート機能の基盤を実装。
バックエンドAPI（#240, #241）と連携する準備が完了しました。

## 実装内容

### API層
- `frontend/src/api/notes.ts` - 型定義＋APIクライアント
  - Note, NoteFolder, CreateNoteRequest, UpdateNoteRequest型
  - CRUD操作: createNote, updateNote, deleteNote, getNote
  - 検索・取得: getMyNotes, searchNotes
  - お気に入り: toggleFavorite

### フック層
- `frontend/src/hooks/useNotes.ts` - カスタムフック
  - `useNotes`: ノート一覧取得・CRUD・お気に入り切り替え
  - `useNoteSearch`: ノート検索（ページネーション対応）
  - 楽観的UI更新（localNotes state）
- `frontend/src/hooks/index.ts` - バレルエクスポート更新

### i18n
- 日本語（ja.json）: notesセクション追加（20キー）
- 英語（en.json）: notesセクション追加（20キー）

## 技術詳細
- ✅ useAsyncDataパターンを継続（既存フックと一貫性）
- ✅ ページネーション対応（NotePaginatedResponse）
- ✅ 楽観的UI更新（ローカル状態管理）
- ✅ トースト通知統合
- ✅ マークダウンサポート準備完了

## 次のPR
- [ ] 残り8言語のi18n追加
- [ ] ページコンポーネント（NotesPage, NoteDetailPage）
- [ ] フォーム・リストコンポーネント
- [ ] ルート・ナビゲーション統合
- [ ] テスト実行・ビルド確認

## 関連PR
- #240 - Note Repository層実装
- #241 - Note Service/Handler層実装
- #242 - README更新

## 確認方法
```bash
# フロントエンド起動
docker compose up -d --build frontend

# ビルド確認
cd frontend && npm run build
```

このPRはフロントエンド基盤のみで、UIコンポーネントは次のPRで実装予定です。