### PR TITLE
feat: NoteValidator実装（TDD）とService層統合

### DIFF
--- a/backend/internal/domain/validator/note.go
+++ b/backend/internal/domain/validator/note.go
@@ -1,0 +1,79 @@
+package validator
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+)
+
+// NoteValidator handles validation for Note entities.
+type NoteValidator struct{}
+
+// NewNoteValidator creates a new NoteValidator instance.
+func NewNoteValidator() *NoteValidator {
+	return &NoteValidator{}
+}
+
+// ValidateTitle validates the note title.
+// タイトルは1〜200文字、空文字・スペースのみは不可。
+func (v *NoteValidator) ValidateTitle(title string) error {
+	return domain.ValidateTitle(title)
+}
+
+// ValidateContent validates the note content.
+// 本文は0〜100,000文字（約100KB）。空文字OK（マークダウンエディタで空の場合あり）。
+func (v *NoteValidator) ValidateContent(content string) error {
+	return domain.ValidateStringLength(content, 0, 100000, "本文")
+}
+
+// ValidateTags validates the note tags.
+// タグは0〜500文字。空文字OK（タグなしノート可）。
+func (v *NoteValidator) ValidateTags(tags string) error {
+	return domain.ValidateStringLength(tags, 0, 500, "タグ")
+}
+
+// ValidateCreateNote validates inputs for creating a new note.
+func (v *NoteValidator) ValidateCreateNote(title, content, tags string) error {
+	// タイトルのバリデーション（必須）
+	if err := v.ValidateTitle(title); err != nil {
+		return err
+	}
+
+	// 本文のバリデーション（オプショナル）
+	if err := v.ValidateContent(content); err != nil {
+		return err
+	}
+
+	// タグのバリデーション（オプショナル）
+	if err := v.ValidateTags(tags); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateUpdateNote validates inputs for updating an existing note.
+// 更新では部分更新をサポートするため、各フィールドが空でない場合のみバリデーション。
+func (v *NoteValidator) ValidateUpdateNote(title, content, tags string) error {
+	// タイトルのバリデーション（空でない場合のみ）
+	if title != "" {
+		if err := v.ValidateTitle(title); err != nil {
+			return err
+		}
+	}
+
+	// 本文のバリデーション（空でない場合のみ）
+	// 注：部分更新時に明示的に空にする場合は、別途処理が必要
+	if content != "" {
+		if err := v.ValidateContent(content); err != nil {
+			return err
+		}
+	}
+
+	// タグのバリデーション（空でない場合のみ）
+	if tags != "" {
+		if err := v.ValidateTags(tags); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/backend/internal/domain/validator/note_test.go
+++ b/backend/internal/domain/validator/note_test.go
@@ -1,0 +1,146 @@
+package validator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNoteValidator_ValidateTitle(t *testing.T) {
+	v := NewNoteValidator()
+
+	tests := []struct {
+		name    string
+		title   string
+		wantErr bool
+	}{
+		{"有効（通常のタイトル）", "学習ノート", false},
+		{"有効（長いタイトル）", "TypeScriptの型システムについての学習ノート", false},
+		{"無効（空文字）", "", true},
+		{"無効（スペースのみ）", "   ", true},
+		{"無効（長すぎる）", string(make([]byte, 201)), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateTitle(tt.title)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNoteValidator_ValidateContent(t *testing.T) {
+	v := NewNoteValidator()
+
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{"有効（通常のマークダウン）", "# 見出し\n\n本文です", false},
+		{"有効（空文字）", "", false}, // 本文は空でもOK
+		{"無効（長すぎる）", string(make([]byte, 100001)), true}, // 100KB超
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateContent(tt.content)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNoteValidator_ValidateTags(t *testing.T) {
+	v := NewNoteValidator()
+
+	tests := []struct {
+		name    string
+		tags    string
+		wantErr bool
+	}{
+		{"有効（通常のタグ）", "Go,TypeScript,React", false},
+		{"有効（空文字）", "", false}, // タグは空でもOK
+		{"有効（スペース含む）", "Go, TypeScript, React", false},
+		{"無効（長すぎる）", string(make([]byte, 501)), true}, // 500文字超
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateTags(tt.tags)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNoteValidator_ValidateCreateNote(t *testing.T) {
+	v := NewNoteValidator()
+
+	tests := []struct {
+		name    string
+		title   string
+		content string
+		tags    string
+		wantErr bool
+	}{
+		{"有効（完全なノート）", "学習ノート", "# 見出し\n本文", "Go,TDD", false},
+		{"有効（タグなし）", "学習ノート", "本文", "", false},
+		{"無効（タイトル空）", "", "本文", "", true},
+		{"無効（タイトル長すぎ）", string(make([]byte, 201)), "本文", "", true},
+		{"無効（本文長すぎ）", "タイトル", string(make([]byte, 100001)), "", true},
+		{"無効（タグ長すぎ）", "タイトル", "本文", string(make([]byte, 501)), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateCreateNote(tt.title, tt.content, tt.tags)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestNoteValidator_ValidateUpdateNote(t *testing.T) {
+	v := NewNoteValidator()
+
+	tests := []struct {
+		name    string
+		title   string
+		content string
+		tags    string
+		wantErr bool
+	}{
+		{"有効（完全な更新）", "更新タイトル", "更新内容", "Go", false},
+		{"有効（タイトルのみ）", "更新タイトル", "", "", false}, // 部分更新OK
+		{"有効（本文のみ）", "", "更新内容", "", false},         // 部分更新OK
+		{"有効（タグのみ）", "", "", "React", false},          // 部分更新OK
+		{"無効（タイトル長すぎ）", string(make([]byte, 201)), "", "", true},
+		{"無効（本文長すぎ）", "", string(make([]byte, 100001)), "", true},
+		{"無効（タグ長すぎ）", "", "", string(make([]byte, 501)), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := v.ValidateUpdateNote(tt.title, tt.content, tt.tags)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -17,6 +18,12 @@ func NewNoteService(repo repository.NoteRepositoryInterface) *NoteService {
 
 // Create は新しいノートを作成する。
 func (s *NoteService) Create(note *model.Note) error {
+	// バリデーション
+	v := validator.NewNoteValidator()
+	if err := v.ValidateCreateNote(note.Title, note.Content, note.Tags); err != nil {
+		return err
+	}
+
 	return s.repo.Create(note)
 }
 
@@ -37,6 +44,12 @@ func (s *NoteService) GetByFolderID(folderID uint) ([]model.Note, error) {
 
 // Update はノートを更新する。
 func (s *NoteService) Update(note *model.Note) error {
+	// バリデーション（部分更新対応）
+	v := validator.NewNoteValidator()
+	if err := v.ValidateUpdateNote(note.Title, note.Content, note.Tags); err != nil {
+		return err
+	}
+
 	return s.repo.Update(note)
 }
 


### PR DESCRIPTION
## 概要
バリデーション層統合計画（Issue #180）の一環として、NoteValidator実装とService層への統合を実施しました。

## 主な変更内容
- **NoteValidator実装**: `backend/internal/domain/validator/note.go`
  - タイトル検証（1-200文字）
  - 本文検証（0-100,000文字）
  - タグ検証（0-500文字）
  - Create専用バリデーション（必須チェック）
  - Update専用バリデーション（部分更新対応）

- **NoteService統合**: `backend/internal/service/note.go`
  - Create時にバリデーション実行
  - Update時にバリデーション実行

- **テスト実装**: `backend/internal/domain/validator/note_test.go`
  - 正常系・異常系の全パターン実装
  - テストカバレッジ100%

## テスト結果
✅ 全テストPASS
✅ ビルド成功

## 関連Issue
Closes #180