### PR TITLE
refactor: Handler層のparsePaginationを改善

### DIFF
--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -22,6 +22,7 @@ func parseID(c *gin.Context, param string) (uint, bool) {
 
 // parsePagination はクエリパラメータからpage/limitを取得する。
 // デフォルト: page=1, limit=20。limitの上限は100。
+// domain.ValidatePaginationを使用してlimitの上限を正規化する。
 func parsePagination(c *gin.Context) (page, limit int) {
 	page, _ = strconv.Atoi(c.DefaultQuery("page", "1"))
 	limit, _ = strconv.Atoi(c.DefaultQuery("limit", "20"))
@@ -31,9 +32,11 @@ func parsePagination(c *gin.Context) (page, limit int) {
 	if limit < 1 {
 		limit = 20
 	}
-	if limit > 100 {
-		limit = 100
-	}
+
+	// domain.ValidatePaginationでlimitの上限（100）を正規化（エラーは無視）
+	offset := (page - 1) * limit
+	limit, _, _ = domain.ValidatePagination(limit, offset)
+
 	return page, limit
 }
 


### PR DESCRIPTION
## 概要
バリデーション層統合計画（Phase 4）の一環として、Handler層の`parsePagination`関数を改善しました。

## 主な変更内容
- **parsePagination関数の改善**: `backend/internal/handler/helpers.go`
  - `domain.ValidatePagination`を使用してlimitの上限（100）を正規化
  - コード重複を削減し、バリデーション層の統一性を向上
  - 既存のデフォルト値（page=1, limit=20）を維持

## テスト結果
✅ 全parsePaginationテストPASS
✅ ビルド成功

## 関連PR
- #246 (NoteValidator実装)