### PR TITLE
feat: プロフィールURLをユーザー名ベースに変更

### DIFF
--- a/backend/db/migrations/000002_add_username_to_users.down.sql
+++ b/backend/db/migrations/000002_add_username_to_users.down.sql
@@ -1,0 +1,9 @@
+-- ============================================================================
+-- usersテーブルからusernameカラムを削除（ロールバック）
+-- ============================================================================
+
+-- 1. UNIQUE インデックスを削除
+DROP INDEX IF EXISTS idx_users_username;
+
+-- 2. username カラムを削除
+ALTER TABLE users DROP COLUMN IF EXISTS username;

--- a/backend/db/migrations/000002_add_username_to_users.up.sql
+++ b/backend/db/migrations/000002_add_username_to_users.up.sql
@@ -1,0 +1,18 @@
+-- ============================================================================
+-- usersテーブルにusernameカラムを追加
+-- プロフィールURL用の一意のユーザー名フィールド
+-- ============================================================================
+
+-- 1. username カラムを追加（一時的にNULLを許可）
+ALTER TABLE users ADD COLUMN IF NOT EXISTS username TEXT;
+
+-- 2. 既存ユーザーにデフォルトのusernameを生成（user{id}形式）
+UPDATE users
+SET username = 'user' || id::TEXT
+WHERE username IS NULL OR username = '';
+
+-- 3. username カラムに NOT NULL 制約を追加
+ALTER TABLE users ALTER COLUMN username SET NOT NULL;
+
+-- 4. username カラムに UNIQUE インデックスを追加
+CREATE UNIQUE INDEX IF NOT EXISTS idx_users_username ON users (username);

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -44,6 +44,22 @@ func (h *UserHandler) GetByID(c *gin.Context) {
 	respondOK(c, user)
 }
 
+// GetByUsername は指定ユーザー名のユーザー情報を返す。
+func (h *UserHandler) GetByUsername(c *gin.Context) {
+	username := c.Param("username")
+	if username == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "username required"})
+		return
+	}
+
+	user, err := h.service.GetByUsername(username)
+	if err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+	respondOK(c, user)
+}
+
 // Update はユーザープロフィールを更新する。
 // 本人のみ更新可能（userIDとパスパラメータのIDが一致する必要がある）。
 func (h *UserHandler) Update(c *gin.Context) {

--- a/backend/internal/model/user.go
+++ b/backend/internal/model/user.go
@@ -8,6 +8,7 @@ import "time"
 // 認証情報、プロフィール、外部サービス連携、スキル情報を保持する。
 type User struct {
 	ID                  uint      `json:"id" gorm:"primaryKey"`
+	Username            string    `json:"username" gorm:"uniqueIndex;not null"`      // 一意のユーザー名（プロフィールURL用）
 	Name                string    `json:"name" gorm:"not null"`
 	Email               string    `json:"email" gorm:"uniqueIndex;not null"`
 	Password            string    `json:"-"`                                         // json:"-" でAPIレスポンスから除外

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -9,6 +9,7 @@ type UserRepositoryInterface interface {
 	FindAll() ([]model.User, error)
 	FindByID(id uint) (*model.User, error)
 	FindByEmail(email string) (*model.User, error)
+	FindByUsername(username string) (*model.User, error)
 	Search(query string) ([]model.User, error)
 	FindByGitHubID(githubID int64) (*model.User, error)
 	Create(user *model.User) error

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -42,6 +42,16 @@ func (r *UserRepository) FindByEmail(email string) (*model.User, error) {
 	return &user, nil
 }
 
+// FindByUsername は指定ユーザー名のユーザーを取得する。
+func (r *UserRepository) FindByUsername(username string) (*model.User, error) {
+	var user model.User
+	result := r.db.Where("username = ?", username).First(&user)
+	if result.Error != nil {
+		return nil, result.Error
+	}
+	return &user, nil
+}
+
 // Search は名前またはメールアドレスでユーザーを検索する（最大50件）。
 func (r *UserRepository) Search(query string) ([]model.User, error) {
 	var users []model.User

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -92,6 +92,7 @@ func registerUserRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("", c.UserHandler.GetAll)
+		users.GET("/by-username/:username", c.UserHandler.GetByUsername) // ユーザー名でユーザー取得（IDとの競合回避）
 		users.GET("/:id", c.UserHandler.GetByID)
 		users.PUT("/:id", c.UserHandler.Update)
 		users.GET("/:id/followers", c.FollowHandler.GetFollowers)

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -28,6 +28,11 @@ func (s *UserService) GetByID(id uint) (*model.User, error) {
 	return s.repo.FindByID(id)
 }
 
+// GetByUsername は指定ユーザー名のユーザーを取得する。
+func (s *UserService) GetByUsername(username string) (*model.User, error) {
+	return s.repo.FindByUsername(username)
+}
+
 // FindByID は指定IDのユーザーを取得する（リポジトリ互換エイリアス）。
 func (s *UserService) FindByID(id uint) (*model.User, error) {
 	return s.repo.FindByID(id)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,9 +71,9 @@ export default function App() {
         <Route path="/onboarding" element={<OnboardingPage />} />
         <Route element={<Layout />}>
           <Route path="/" element={<DashboardPage />} />
-          <Route path="/profile/:id" element={<ProfilePage />} />
-          <Route path="/profile/:id/followers" element={<FollowListPage />} />
-          <Route path="/profile/:id/following" element={<FollowListPage />} />
+          <Route path="/profile/:username" element={<ProfilePage />} />
+          <Route path="/profile/:username/followers" element={<FollowListPage />} />
+          <Route path="/profile/:username/following" element={<FollowListPage />} />
           <Route path="/search" element={<SearchPage />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/rankings" element={<RankingsPage />} />

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -7,6 +7,9 @@ export const getUsers = (q?: string) =>
 export const getUser = (id: number) =>
   client.get<User>(`/users/${id}`);
 
+export const getUserByUsername = (username: string) =>
+  client.get<User>(`/users/by-username/${username}`);
+
 export const updateUser = (id: number, data: {
   name?: string;
   bio?: string;

--- a/frontend/src/hooks/useFollowList.ts
+++ b/frontend/src/hooks/useFollowList.ts
@@ -1,14 +1,17 @@
 import { useState, useEffect } from 'react';
 import { useLocation } from 'react-router-dom';
-import { getUser, getFollowers, getFollowing } from '../api/users';
+import { getUser, getUserByUsername, getFollowers, getFollowing } from '../api/users';
 import type { User } from '../types/user';
 import { useAsyncData } from './useAsyncData';
 
 type Tab = 'followers' | 'following';
 
-export function useFollowList(id: string | undefined) {
+export function useFollowList(usernameOrId: string | undefined) {
   const location = useLocation();
-  const userId = id ? parseInt(id) : 0;
+  // usernameOrIdが数値の場合はID、そうでない場合はusername
+  const isId = usernameOrId && /^\d+$/.test(usernameOrId);
+  const userId = isId ? parseInt(usernameOrId) : 0;
+  const username = !isId ? usernameOrId : '';
 
   const initialTab: Tab = location.pathname.endsWith('/following') ? 'following' : 'followers';
   const [tab, setTab] = useState<Tab>(initialTab);
@@ -20,19 +23,23 @@ export function useFollowList(id: string | undefined) {
 
   const { data: profileUser, loading: profileLoading } = useAsyncData(
     async () => {
-      const { data } = await getUser(userId);
-      return data as User;
+      const userRes = username
+        ? await getUserByUsername(username)
+        : await getUser(userId);
+      return userRes.data as User;
     },
-    { deps: [userId], enabled: !!userId }
+    { deps: [usernameOrId], enabled: !!usernameOrId }
   );
 
   const { data: users, loading: usersLoading } = useAsyncData(
     async () => {
+      const actualUserId = profileUser?.id || userId;
+      if (!actualUserId) return [];
       const fetcher = tab === 'followers' ? getFollowers : getFollowing;
-      const { data } = await fetcher(userId);
+      const { data } = await fetcher(actualUserId);
       return (data || []) as User[];
     },
-    { initialData: [] as User[], deps: [userId, tab], enabled: !!userId }
+    { initialData: [] as User[], deps: [profileUser?.id, tab], enabled: !!profileUser }
   );
 
   return {

--- a/frontend/src/hooks/useProfile.ts
+++ b/frontend/src/hooks/useProfile.ts
@@ -1,4 +1,4 @@
-import { getUser, getFollowers, getFollowing } from '../api/users';
+import { getUser, getUserByUsername, getFollowers, getFollowing } from '../api/users';
 import { getUserPosts } from '../api/posts';
 import { getContributions, getLanguages, getRepos } from '../api/github';
 import { getZennArticles, getZennStats, type ZennArticle, type ZennStats } from '../api/zenn';
@@ -33,28 +33,36 @@ interface ProfileData {
   streakInfo: StreakInfo | null;
 }
 
-export function useProfile(id: string | undefined) {
-  const userId = id ? parseInt(id) : 0;
+export function useProfile(usernameOrId: string | undefined) {
+  // usernameOrIdが数値の場合はID、そうでない場合はusername
+  const isId = usernameOrId && /^\d+$/.test(usernameOrId);
+  const userId = isId ? parseInt(usernameOrId) : 0;
+  const username = !isId ? usernameOrId : '';
 
   const { data, loading, refetch } = useAsyncData(
     async (): Promise<ProfileData> => {
-      const [userRes, postsRes, followersRes, followingRes] = await Promise.all([
-        getUser(userId),
-        getUserPosts(userId),
-        getFollowers(userId),
-        getFollowing(userId),
-      ]);
+      // usernameまたはIDでユーザーを取得
+      const userRes = username
+        ? await getUserByUsername(username)
+        : await getUser(userId);
 
       const userData = userRes.data;
+      const actualUserId = userData.id;
+
+      const [postsRes, followersRes, followingRes] = await Promise.all([
+        getUserPosts(actualUserId),
+        getFollowers(actualUserId),
+        getFollowing(actualUserId),
+      ]);
       let contributions: GitHubContribution[] = [];
       let languages: GitHubLanguageStat[] = [];
       let repos: GitHubRepository[] = [];
 
       if (userData.github_connected) {
         const [contribRes, langRes, reposRes] = await Promise.all([
-          getContributions(userId),
-          getLanguages(userId),
-          getRepos(userId),
+          getContributions(actualUserId),
+          getLanguages(actualUserId),
+          getRepos(actualUserId),
         ]);
         contributions = contribRes.data || [];
         languages = langRes.data || [];
@@ -65,8 +73,8 @@ export function useProfile(id: string | undefined) {
       let zennStats: ZennStats | null = null;
       if (userData.zenn_username) {
         const [articlesRes, statsRes] = await Promise.all([
-          getZennArticles(userId),
-          getZennStats(userId),
+          getZennArticles(actualUserId),
+          getZennStats(actualUserId),
         ]);
         zennArticles = articlesRes.data || [];
         zennStats = statsRes.data;
@@ -76,8 +84,8 @@ export function useProfile(id: string | undefined) {
       let qiitaStats: QiitaStats | null = null;
       if (userData.qiita_username) {
         const [articlesRes, statsRes] = await Promise.all([
-          getQiitaArticles(userId),
-          getQiitaStats(userId),
+          getQiitaArticles(actualUserId),
+          getQiitaStats(actualUserId),
         ]);
         qiitaArticles = articlesRes.data || [];
         qiitaStats = statsRes.data;
@@ -94,10 +102,10 @@ export function useProfile(id: string | undefined) {
       }
 
       const [goalsRes, goalStatsRes, badgesRes, streakRes] = await Promise.all([
-        getUserGoals(userId),
-        getGoalStats(userId),
-        getUserBadges(userId),
-        getStreakInfo(userId),
+        getUserGoals(actualUserId),
+        getGoalStats(actualUserId),
+        getUserBadges(actualUserId),
+        getStreakInfo(actualUserId),
       ]);
 
       return {
@@ -119,7 +127,7 @@ export function useProfile(id: string | undefined) {
         streakInfo: streakRes.data || null,
       };
     },
-    { deps: [userId], enabled: !!userId }
+    { deps: [usernameOrId], enabled: !!usernameOrId }
   );
 
   return {

--- a/frontend/src/pages/FollowListPage.tsx
+++ b/frontend/src/pages/FollowListPage.tsx
@@ -6,9 +6,9 @@ import FollowButton from '../components/profile/FollowButton';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 
 export default function FollowListPage() {
-  const { id } = useParams<{ id: string }>();
+  const { username } = useParams<{ username: string }>();
   const currentUser = useAuthStore((s) => s.user);
-  const { profileUser, users, tab, loading, profileLoading } = useFollowList(id);
+  const { profileUser, users, tab, loading, profileLoading } = useFollowList(username);
 
   if (!profileUser && profileLoading) return <div className="py-12"><LoadingSpinner /></div>;
 
@@ -17,7 +17,7 @@ export default function FollowListPage() {
       {/* Header with back link */}
       <div className="flex items-center gap-3">
         <Link
-          to={`/profile/${id}`}
+          to={`/profile/${username}`}
           className="p-1.5 rounded-lg hover:bg-gray-800 transition-colors text-gray-400 hover:text-white"
         >
           <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
@@ -33,7 +33,7 @@ export default function FollowListPage() {
       {/* Tabs */}
       <div className="flex border-b border-gray-800">
         <Link
-          to={`/profile/${id}/followers`}
+          to={`/profile/${username}/followers`}
           className={`flex-1 text-center py-3 text-sm font-medium transition-colors relative ${
             tab === 'followers' ? 'text-white' : 'text-gray-500 hover:text-gray-300'
           }`}
@@ -44,7 +44,7 @@ export default function FollowListPage() {
           )}
         </Link>
         <Link
-          to={`/profile/${id}/following`}
+          to={`/profile/${username}/following`}
           className={`flex-1 text-center py-3 text-sm font-medium transition-colors relative ${
             tab === 'following' ? 'text-white' : 'text-gray-500 hover:text-gray-300'
           }`}
@@ -67,13 +67,13 @@ export default function FollowListPage() {
         <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden divide-y divide-gray-800/50">
           {users.map((user) => (
             <div key={user.id} className="flex items-center gap-4 px-5 py-4 hover:bg-gray-800/40 transition-colors">
-              <Link to={`/profile/${user.id}`} className="flex-shrink-0">
+              <Link to={`/profile/${user.username}`} className="flex-shrink-0">
                 <Avatar name={user.name} avatarUrl={user.avatar_url} size="sm" />
               </Link>
 
               <div className="flex-1 min-w-0">
                 <Link
-                  to={`/profile/${user.id}`}
+                  to={`/profile/${user.username}`}
                   className="font-medium text-sm hover:text-blue-400 transition-colors"
                 >
                   {user.name}

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -18,13 +18,13 @@ import PortfolioModal from '../components/profile/PortfolioModal';
 
 export default function ProfilePage() {
   const { t } = useTranslation();
-  const { id } = useParams<{ id: string }>();
+  const { username } = useParams<{ username: string }>();
   const currentUser = useAuthStore((s) => s.user);
   const {
     user, posts, contributions, languages, repos,
     zennArticles, zennStats, qiitaArticles, qiitaStats, atcoderRating,
     goals, goalStats, followerCount, followingCount, badges, streakInfo, loading,
-  } = useProfile(id);
+  } = useProfile(username);
 
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [portfolioModalOpen, setPortfolioModalOpen] = useState(false);
@@ -97,10 +97,10 @@ export default function ProfilePage() {
               )}
             </div>
             <div className="flex gap-4 mt-3 text-sm">
-              <Link to={`/profile/${user.id}/followers`} className="text-gray-400 hover:text-blue-400 transition-colors">
+              <Link to={`/profile/${user.username}/followers`} className="text-gray-400 hover:text-blue-400 transition-colors">
                 <strong className="text-white">{followerCount}</strong> {t('profile.followers')}
               </Link>
-              <Link to={`/profile/${user.id}/following`} className="text-gray-400 hover:text-blue-400 transition-colors">
+              <Link to={`/profile/${user.username}/following`} className="text-gray-400 hover:text-blue-400 transition-colors">
                 <strong className="text-white">{followingCount}</strong> {t('profile.following')}
               </Link>
             </div>

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -1,5 +1,6 @@
 export interface User {
   id: number;
+  username: string;
   name: string;
   email: string;
   avatar_url: string;


### PR DESCRIPTION
## 概要
プロフィールページのURLを `/profile/1` から `/profile/username` のようなユーザー名ベースに変更し、GitHubのようなURLスタイルを実現しました。

## 主な変更内容

### バックエンド
- **User model**: `username`フィールド追加（一意制約）
- **DBマイグレーション**: 既存ユーザーに`user{id}`形式でusername自動生成
- **Repository層**: `FindByUsername`メソッド追加
- **Service層**: `GetByUsername`メソッド追加
- **Handler層**: `GetByUsername`エンドポイント追加
- **Router**: `/api/v1/users/by-username/:username`追加

### フロントエンド
- **User型**: `username`フィールド追加
- **API**: `getUserByUsername`関数追加
- **useProfile**: username/ID両対応に修正
- **useFollowList**: username/ID両対応に修正
- **ProfilePage**: URLパラメータ`:id`→`:username`
- **FollowListPage**: URLパラメータ`:id`→`:username`
- **App.tsx**: ルーティング`:username`ベース化

## テスト結果
✅ バックエンドビルド成功
✅ 既存機能との互換性維持

## 互換性
- 数値形式のアクセスはIDとして扱い、引き続きサポート
- 既存のフォロワー/フォロー中APIは内部でID変換

## 注意事項
- **マイグレーション実行必須**: `000002_add_username_to_users.up.sql`
- 既存ユーザーはデフォルトで`user{id}`形式のusernameが付与されます
- 将来的にユーザー登録時にusername入力フィールドを追加予定