### PR TITLE
refactor: Handler層・DTO層のテストビルドエラーを修正

### DIFF
--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -3,30 +3,30 @@ package dto
 
 // RegisterRequest は新規ユーザー登録リクエスト
 type RegisterRequest struct {
-	Name            string `json:"name" binding:"required"`
-	Email           string `json:"email" binding:"required,email"`
-	Password        string `json:"password" binding:"required,min=6"`
-	ConfirmPassword string `json:"confirm_password" binding:"required"`
+	Name            string `json:"name" binding:"required" validate:"required"`
+	Email           string `json:"email" binding:"required,email" validate:"required,email"`
+	Password        string `json:"password" binding:"required,min=6" validate:"required,min=6"`
+	ConfirmPassword string `json:"confirm_password" binding:"required" validate:"required"`
 }
 
 // LoginRequest はログインリクエスト
 type LoginRequest struct {
-	Email    string `json:"email" binding:"required,email"`
-	Password string `json:"password" binding:"required"`
+	Email    string `json:"email" binding:"required,email" validate:"required,email"`
+	Password string `json:"password" binding:"required" validate:"required"`
 }
 
 // PasswordResetRequest はパスワードリセットリクエスト
 type PasswordResetRequest struct {
-	Email string `json:"email" binding:"required,email"`
+	Email string `json:"email" binding:"required,email" validate:"required,email"`
 }
 
 // ResetPasswordRequest はトークンによるパスワードリセットリクエスト
 type ResetPasswordRequest struct {
-	Token       string `json:"token" binding:"required"`
-	NewPassword string `json:"new_password" binding:"required,min=6"`
+	Token       string `json:"token" binding:"required" validate:"required"`
+	NewPassword string `json:"new_password" binding:"required,min=6" validate:"required,min=6"`
 }
 
 // DeleteAccountRequest はアカウント削除リクエスト
 type DeleteAccountRequest struct {
-	Password string `json:"password" binding:"required"`
+	Password string `json:"password" binding:"required" validate:"required"`
 }

--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -62,6 +62,32 @@ func (m *MockNoteService) ToggleFavorite(id uint) error {
 	return m.Called(id).Error(0)
 }
 
+func (m *MockNoteService) Archive(id uint) error {
+	return m.Called(id).Error(0)
+}
+
+func (m *MockNoteService) Unarchive(id uint) error {
+	return m.Called(id).Error(0)
+}
+
+func (m *MockNoteService) GetArchived(userID uint, page, limit int) ([]model.Note, error) {
+	args := m.Called(userID, page, limit)
+	return args.Get(0).([]model.Note), args.Error(1)
+}
+
+func (m *MockNoteService) CountArchivedByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockNoteService) Duplicate(id uint, userID uint) (*model.Note, error) {
+	args := m.Called(id, userID)
+	if note := args.Get(0); note != nil {
+		return note.(*model.Note), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 // newTestNoteHandler はテスト用のNoteHandlerを生成する。
 func newTestNoteHandler() (*NoteHandler, *MockNoteService) {
 	mockService := new(MockNoteService)


### PR DESCRIPTION
## 概要
- Handler層のMockNoteServiceのインターフェース不一致によるビルドエラーを修正
- DTO層のバリデーションタグ不一致によるテスト失敗を修正

## 変更内容
### Handler層（note_test.go）
MockNoteServiceに不足していた5メソッドを追加:
- `Archive`, `Unarchive`, `GetArchived`, `CountArchivedByUserID`, `Duplicate`

### DTO層（auth_dto.go）
`binding`タグと`validate`タグを併用する形に修正。Ginのリクエストバインディング（binding）とテスト用バリデータ（validate）の両方で検証可能に。

## テスト結果
- Handler層: 7テスト全パス
- DTO層: 16テスト全パス（修正前は19テスト失敗）

Closes #262