### PR TITLE
feat: ページネーション共通コンポーネントを実装

### DIFF
--- a/frontend/src/components/common/Pagination.tsx
+++ b/frontend/src/components/common/Pagination.tsx
@@ -1,0 +1,110 @@
+import { useTranslation } from 'react-i18next';
+
+interface PaginationProps {
+  currentPage: number;
+  totalItems: number;
+  itemsPerPage: number;
+  onPageChange: (page: number) => void;
+}
+
+/**
+ * Pagination - ページネーション共通コンポーネント
+ *
+ * @param currentPage - 現在のページ（0-indexed）
+ * @param totalItems - 総アイテム数
+ * @param itemsPerPage - 1ページあたりのアイテム数
+ * @param onPageChange - ページ変更コールバック（0-indexed）
+ */
+export default function Pagination({
+  currentPage,
+  totalItems,
+  itemsPerPage,
+  onPageChange,
+}: PaginationProps) {
+  const { t } = useTranslation();
+
+  const totalPages = Math.ceil(totalItems / itemsPerPage);
+
+  if (totalPages <= 1) return null;
+
+  const isFirstPage = currentPage === 0;
+  const isLastPage = currentPage >= totalPages - 1;
+
+  const getPageNumbers = (): (number | 'ellipsis')[] => {
+    const pages: (number | 'ellipsis')[] = [];
+
+    if (totalPages <= 7) {
+      for (let i = 0; i < totalPages; i++) pages.push(i);
+      return pages;
+    }
+
+    // Always show first page
+    pages.push(0);
+
+    if (currentPage > 2) {
+      pages.push('ellipsis');
+    }
+
+    // Pages around current
+    const start = Math.max(1, currentPage - 1);
+    const end = Math.min(totalPages - 2, currentPage + 1);
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+
+    if (currentPage < totalPages - 3) {
+      pages.push('ellipsis');
+    }
+
+    // Always show last page
+    pages.push(totalPages - 1);
+
+    return pages;
+  };
+
+  return (
+    <div className="flex justify-center items-center gap-2 mt-8">
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={isFirstPage}
+        className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+      >
+        {t('common.previous')}
+      </button>
+
+      <div className="flex items-center gap-1">
+        {getPageNumbers().map((page, idx) =>
+          page === 'ellipsis' ? (
+            <span key={`ellipsis-${idx}`} className="px-2 py-2 text-gray-400">
+              …
+            </span>
+          ) : (
+            <button
+              key={page}
+              onClick={() => onPageChange(page)}
+              className={`min-w-[36px] px-2 py-2 rounded-lg text-sm font-medium transition-colors ${
+                page === currentPage
+                  ? 'bg-gray-600 text-white'
+                  : 'bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-white'
+              }`}
+            >
+              {page + 1}
+            </button>
+          )
+        )}
+      </div>
+
+      <span className="px-4 py-2 text-gray-400">
+        {currentPage + 1} / {totalPages}
+      </span>
+
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={isLastPage}
+        className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+      >
+        {t('common.next')}
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Pagination.test.tsx
+++ b/frontend/src/components/common/__tests__/Pagination.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import Pagination from '../Pagination';
+
+describe('Pagination', () => {
+  const defaultProps = {
+    currentPage: 0,
+    totalItems: 100,
+    itemsPerPage: 10,
+    onPageChange: vi.fn(),
+  };
+
+  it('現在のページ番号と総ページ数を表示する', () => {
+    render(<Pagination {...defaultProps} />);
+    expect(screen.getByText('1 / 10')).toBeInTheDocument();
+  });
+
+  it('前へボタンと次へボタンを表示する', () => {
+    render(<Pagination {...defaultProps} />);
+    expect(screen.getByRole('button', { name: '前へ' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '次へ' })).toBeInTheDocument();
+  });
+
+  it('最初のページでは前へボタンが無効', () => {
+    render(<Pagination {...defaultProps} currentPage={0} />);
+    expect(screen.getByRole('button', { name: '前へ' })).toBeDisabled();
+  });
+
+  it('最後のページでは次へボタンが無効', () => {
+    render(<Pagination {...defaultProps} currentPage={9} />);
+    expect(screen.getByRole('button', { name: '次へ' })).toBeDisabled();
+  });
+
+  it('次へボタンクリックで次のページに遷移', async () => {
+    const onPageChange = vi.fn();
+    render(<Pagination {...defaultProps} currentPage={0} onPageChange={onPageChange} />);
+
+    await userEvent.click(screen.getByRole('button', { name: '次へ' }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it('前へボタンクリックで前のページに遷移', async () => {
+    const onPageChange = vi.fn();
+    render(<Pagination {...defaultProps} currentPage={5} onPageChange={onPageChange} />);
+
+    await userEvent.click(screen.getByRole('button', { name: '前へ' }));
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+
+  it('totalItemsがitemsPerPage以下の場合は表示しない', () => {
+    const { container } = render(
+      <Pagination {...defaultProps} totalItems={10} itemsPerPage={10} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('totalItemsが0の場合は表示しない', () => {
+    const { container } = render(
+      <Pagination {...defaultProps} totalItems={0} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('端数がある場合の総ページ数を正しく計算する', () => {
+    render(<Pagination {...defaultProps} totalItems={25} itemsPerPage={10} />);
+    expect(screen.getByText('1 / 3')).toBeInTheDocument();
+  });
+
+  it('中間ページで両方のボタンが有効', () => {
+    render(<Pagination {...defaultProps} currentPage={5} />);
+    expect(screen.getByRole('button', { name: '前へ' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: '次へ' })).not.toBeDisabled();
+  });
+
+  it('ページ番号リンクをクリックで直接遷移', async () => {
+    const onPageChange = vi.fn();
+    render(<Pagination {...defaultProps} currentPage={0} onPageChange={onPageChange} />);
+
+    // ページ番号ボタン「2」をクリック（0-indexedで1）
+    await userEvent.click(screen.getByRole('button', { name: '2' }));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it('現在のページ番号がアクティブスタイルで表示される', () => {
+    render(<Pagination {...defaultProps} currentPage={2} />);
+    const activeButton = screen.getByRole('button', { name: '3' });
+    expect(activeButton).toHaveClass('bg-gray-600');
+  });
+
+  it('ページ数が多い場合に省略記号を表示する', () => {
+    render(<Pagination {...defaultProps} currentPage={5} totalItems={200} itemsPerPage={10} />);
+    expect(screen.getAllByText('…').length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -3,3 +3,4 @@ export { default as PageLoader } from './PageLoader';
 export { default as InlineLoader } from './InlineLoader';
 export { Skeleton, PostCardSkeleton, UserCardSkeleton } from './Skeleton';
 export { default as EmptyState } from './EmptyState';
+export { default as Pagination } from './Pagination';

--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -6,6 +6,7 @@ import { useBookReviews } from '../hooks';
 import BookReviewCard from '../components/bookReviews/BookReviewCard';
 import BookReviewForm from '../components/bookReviews/BookReviewForm';
 import LoadingSpinner from '../components/common/LoadingSpinner';
+import { Pagination } from '../components/common';
 
 export default function BookReviewsPage() {
   const { t } = useTranslation();
@@ -99,28 +100,12 @@ export default function BookReviewsPage() {
             ))}
           </div>
 
-          {/* Pagination */}
-          {total > limit && (
-            <div className="flex justify-center gap-2 mt-8">
-              <button
-                onClick={() => setPage(p => Math.max(0, p - 1))}
-                disabled={page === 0}
-                className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
-              >
-                {t('common.previous')}
-              </button>
-              <span className="px-4 py-2 text-gray-400">
-                {page + 1} / {Math.ceil(total / limit)}
-              </span>
-              <button
-                onClick={() => setPage(p => p + 1)}
-                disabled={(page + 1) * limit >= total}
-                className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
-              >
-                {t('common.next')}
-              </button>
-            </div>
-          )}
+          <Pagination
+            currentPage={page}
+            totalItems={total}
+            itemsPerPage={limit}
+            onPageChange={setPage}
+          />
         </>
       )}
     </div>

--- a/frontend/src/pages/QAPage.tsx
+++ b/frontend/src/pages/QAPage.tsx
@@ -6,6 +6,7 @@ import { useQuestions, useDebounce } from '../hooks';
 import QuestionCard from '../components/qa/QuestionCard';
 import QuestionForm from '../components/qa/QuestionForm';
 import { QuestionCardSkeleton } from '../components/common/Skeleton';
+import { Pagination } from '../components/common';
 
 export default function QAPage() {
   const { t } = useTranslation();
@@ -149,28 +150,12 @@ export default function QAPage() {
             ))}
           </div>
 
-          {/* Pagination */}
-          {total > limit && (
-            <div className="flex justify-center gap-2 mt-8">
-              <button
-                onClick={() => setPage(p => Math.max(0, p - 1))}
-                disabled={page === 0}
-                className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
-              >
-                {t('common.previous')}
-              </button>
-              <span className="px-4 py-2 text-gray-400">
-                {page + 1} / {Math.ceil(total / limit)}
-              </span>
-              <button
-                onClick={() => setPage(p => p + 1)}
-                disabled={(page + 1) * limit >= total}
-                className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
-              >
-                {t('common.next')}
-              </button>
-            </div>
-          )}
+          <Pagination
+            currentPage={page}
+            totalItems={total}
+            itemsPerPage={limit}
+            onPageChange={setPage}
+          />
         </>
       )}
     </div>

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -8,6 +8,7 @@ import ResourceCard from '../components/resources/ResourceCard';
 import ResourceForm from '../components/resources/ResourceForm';
 import { ResourceCardSkeleton } from '../components/common/Skeleton';
 import EmptyState from '../components/common/EmptyState';
+import { Pagination } from '../components/common';
 
 const categories: (ResourceCategory | '')[] = ['', 'book', 'video', 'article', 'course', 'tutorial', 'podcast', 'tool', 'other'];
 const difficulties: (ResourceDifficulty | '')[] = ['', 'beginner', 'intermediate', 'advanced'];
@@ -199,28 +200,12 @@ export default function ResourcesPage() {
             ))}
           </div>
 
-          {/* Pagination */}
-          {total > limit && (
-            <div className="flex justify-center gap-2 mt-8">
-              <button
-                onClick={() => setPage(p => Math.max(0, p - 1))}
-                disabled={page === 0}
-                className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
-              >
-                {t('common.previous')}
-              </button>
-              <span className="px-4 py-2 text-gray-400">
-                {page + 1} / {Math.ceil(total / limit)}
-              </span>
-              <button
-                onClick={() => setPage(p => p + 1)}
-                disabled={(page + 1) * limit >= total}
-                className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
-              >
-                {t('common.next')}
-              </button>
-            </div>
-          )}
+          <Pagination
+            currentPage={page}
+            totalItems={total}
+            itemsPerPage={limit}
+            onPageChange={setPage}
+          />
         </>
       )}
     </div>


### PR DESCRIPTION
## 概要
- 3ページ（QAPage・ResourcesPage・BookReviewsPage）の重複ページネーションUIを`Pagination`共通コンポーネントに統一
- ページ番号直接クリック対応・省略記号表示（7ページ超）に対応
- Vitest + Testing Libraryで13テスト作成

## 変更内容
- `Pagination.tsx` — 0-indexedページ共通コンポーネント（前へ/次へボタン、ページ番号、省略記号）
- `QAPage.tsx` — 重複ページネーションUI → Paginationコンポーネントに置換
- `ResourcesPage.tsx` — 同上
- `BookReviewsPage.tsx` — 同上
- `index.ts` — バレルエクスポート追加

## テスト計画
- [x] Pagination コンポーネントテスト 13件通過
- [x] TypeScript型チェック通過（`npx tsc --noEmit`）

Closes #266