### PR TITLE
refactor: QuestionHandler・BookReviewHandlerをインターフェース依存に変更

### DIFF
--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -5,17 +5,26 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// BookReviewServiceInterface はBookReviewServiceが実装すべきインターフェース。
+type BookReviewServiceInterface interface {
+	Create(review *model.BookReview) error
+	GetByID(id uint) (*model.BookReview, error)
+	GetByUserID(userID uint) ([]model.BookReview, error)
+	GetAll(limit, offset int) ([]model.BookReview, int64, error)
+	Update(id, userID uint, updates *model.BookReview) (*model.BookReview, error)
+	Delete(id, userID uint) error
+}
 
 // BookReviewHandler は書籍レビュー関連のHTTPハンドラ。
 // 書籍レビューのCRUD・一覧取得を処理する。
 type BookReviewHandler struct {
-	service *service.BookReviewService
+	service BookReviewServiceInterface
 }
 
 // NewBookReviewHandler は新しいBookReviewHandlerインスタンスを生成する。
-func NewBookReviewHandler(s *service.BookReviewService) *BookReviewHandler {
+func NewBookReviewHandler(s BookReviewServiceInterface) *BookReviewHandler {
 	return &BookReviewHandler{service: s}
 }
 

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -82,6 +82,12 @@ func respondDeleted(c *gin.Context) {
 	c.JSON(http.StatusOK, response)
 }
 
+// respondBadRequest は400 Bad Requestでエラーメッセージを返す。
+func respondBadRequest(c *gin.Context, message string) {
+	response := domain.NewErrorResponse(message, string(domain.ErrCodeValidation), nil)
+	c.JSON(http.StatusBadRequest, response)
+}
+
 // respondPaginated はページネーション付きレスポンスを返す。
 func respondPaginated(c *gin.Context, data interface{}, total int64, page, limit int) {
 	response := domain.NewPaginatedResponse(data, total, page, limit)

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -1,22 +1,34 @@
 package handler
 
 import (
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// QuestionServiceInterface はQuestionServiceが実装すべきインターフェース。
+type QuestionServiceInterface interface {
+	Create(question *model.Question) error
+	GetAll(limit, offset int, tag, sort string) ([]model.Question, int64, error)
+	Search(q string, limit, offset int) ([]model.Question, int64, error)
+	GetByID(id uint) (*model.Question, error)
+	GetByUserID(userID uint) ([]model.Question, error)
+	GetUserVote(userID, questionID uint) (int, error)
+	Update(id, userID uint, title, body, tags string) (*model.Question, error)
+	Delete(id, userID uint) error
+	Vote(userID, questionID uint, value int) error
+	RemoveVote(userID, questionID uint) error
+}
 
 // QuestionHandler は質問関連のHTTPハンドラ。
 // 質問のCRUD・検索・投票を処理する。
 type QuestionHandler struct {
-	service *service.QuestionService
+	service QuestionServiceInterface
 }
 
 // NewQuestionHandler は新しいQuestionHandlerインスタンスを生成する。
-func NewQuestionHandler(s *service.QuestionService) *QuestionHandler {
+func NewQuestionHandler(s QuestionServiceInterface) *QuestionHandler {
 	return &QuestionHandler{service: s}
 }
 
@@ -92,7 +104,7 @@ func (h *QuestionHandler) GetAll(c *gin.Context) {
 func (h *QuestionHandler) Search(c *gin.Context) {
 	q := c.Query("q")
 	if q == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Search query is required"})
+		respondBadRequest(c, "search query is required")
 		return
 	}
 


### PR DESCRIPTION
## 概要
- QuestionHandler・BookReviewHandlerの具体型依存（`*service.XxxService`）をインターフェース依存に変更
- `respondBadRequest`ヘルパー関数を追加し、エラーハンドリングを統一

## 変更内容
- `question.go` — `QuestionServiceInterface`導入、`service`パッケージimport除去、Search()のハードコードされたc.JSON→respondBadRequestに置換
- `book_review.go` — `BookReviewServiceInterface`導入、`service`パッケージimport除去
- `helpers.go` — `respondBadRequest`ヘルパー関数追加

## テスト計画
- [x] Questionテスト17件全通過
- [x] Goビルド成功（`go build ./...`）
- [x] 既存テストの退行なし（TestRegister_SetsCookie, TestDeleteAccount_WrongPassword, TestResourceCreate_Successは既知のfail）

Closes #268