### PR TITLE
test: BookReviewHandlerテスト17件追加

### DIFF
--- a/backend/internal/handler/book_review_test.go
+++ b/backend/internal/handler/book_review_test.go
@@ -1,0 +1,266 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// ============================================================
+// Create テスト
+// ============================================================
+
+func TestBookReviewCreate_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.POST("/book-reviews", h.Create)
+
+	svc.On("Create", mock.AnythingOfType("*model.BookReview")).Return(nil)
+
+	w := doRequest(r, http.MethodPost, "/book-reviews", map[string]interface{}{
+		"title":  "Go言語入門",
+		"author": "テスト著者",
+		"rating": 5,
+		"review": "とても良い本です",
+	})
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewCreate_ValidationError(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.POST("/book-reviews", h.Create)
+
+	// title と rating は required
+	w := doRequest(r, http.MethodPost, "/book-reviews", map[string]interface{}{
+		"review": "レビューのみ",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookReviewCreate_InvalidJSON(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.POST("/book-reviews", h.Create)
+
+	w := doRequestRaw(r, http.MethodPost, "/book-reviews", "not json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookReviewCreate_ServiceError(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.POST("/book-reviews", h.Create)
+
+	svc.On("Create", mock.AnythingOfType("*model.BookReview")).Return(errors.New("db error"))
+
+	w := doRequest(r, http.MethodPost, "/book-reviews", map[string]interface{}{
+		"title":  "Go言語入門",
+		"rating": 5,
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetByID テスト
+// ============================================================
+
+func TestBookReviewGetByID_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/:id", h.GetByID)
+
+	review := &model.BookReview{Title: "Go言語入門", Rating: 5}
+	review.ID = 1
+	svc.On("GetByID", uint(1)).Return(review, nil)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/1", nil)
+	assertStatus(t, w, http.StatusOK)
+
+	body := parseJSON(t, w)
+	assert.Equal(t, "Go言語入門", body["title"])
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewGetByID_NotFound(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/:id", h.GetByID)
+
+	svc.On("GetByID", uint(999)).Return(nil, service.ErrNotFound)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/999", nil)
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewGetByID_InvalidID(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/:id", h.GetByID)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// GetAll テスト
+// ============================================================
+
+func TestBookReviewGetAll_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews", h.GetAll)
+
+	reviews := []model.BookReview{
+		{Title: "Go言語入門", Rating: 5},
+		{Title: "Rust入門", Rating: 4},
+	}
+	svc.On("GetAll", 20, 0).Return(reviews, int64(2), nil)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews", nil)
+	assertStatus(t, w, http.StatusOK)
+
+	body := parseJSON(t, w)
+	assert.Equal(t, float64(2), body["total"])
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewGetAll_WithPagination(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews", h.GetAll)
+
+	svc.On("GetAll", 10, 5).Return([]model.BookReview{}, int64(0), nil)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews?limit=10&offset=5", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewGetAll_LimitCap(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews", h.GetAll)
+
+	// limit=200 は 100 に制限される
+	svc.On("GetAll", 100, 0).Return([]model.BookReview{}, int64(0), nil)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews?limit=200", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetByUserID テスト
+// ============================================================
+
+func TestBookReviewGetByUserID_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/book-reviews", h.GetByUserID)
+
+	reviews := []model.BookReview{
+		{Title: "Go言語入門", Rating: 5},
+	}
+	svc.On("GetByUserID", uint(1)).Return(reviews, nil)
+
+	w := doRequest(r, http.MethodGet, "/users/1/book-reviews", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// Update テスト
+// ============================================================
+
+func TestBookReviewUpdate_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id", h.Update)
+
+	updated := &model.BookReview{Title: "更新後タイトル", Rating: 4}
+	updated.ID = 1
+	svc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.BookReview")).Return(updated, nil)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/1", map[string]interface{}{
+		"title": "更新後タイトル",
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewUpdate_Forbidden(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id", h.Update)
+
+	svc.On("Update", uint(5), uint(1), mock.AnythingOfType("*model.BookReview")).Return(nil, service.ErrForbidden)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/5", map[string]interface{}{
+		"title": "不正更新",
+	})
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewUpdate_NotFound(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id", h.Update)
+
+	svc.On("Update", uint(999), uint(1), mock.AnythingOfType("*model.BookReview")).Return(nil, service.ErrNotFound)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/999", map[string]interface{}{
+		"title": "存在しない",
+	})
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// Delete テスト
+// ============================================================
+
+func TestBookReviewDelete_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.DELETE("/book-reviews/:id", h.Delete)
+
+	svc.On("Delete", uint(1), uint(1)).Return(nil)
+
+	w := doRequest(r, http.MethodDelete, "/book-reviews/1", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewDelete_Forbidden(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.DELETE("/book-reviews/:id", h.Delete)
+
+	svc.On("Delete", uint(5), uint(1)).Return(service.ErrForbidden)
+
+	w := doRequest(r, http.MethodDelete, "/book-reviews/5", nil)
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewDelete_NotFound(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.DELETE("/book-reviews/:id", h.Delete)
+
+	svc.On("Delete", uint(999), uint(1)).Return(service.ErrNotFound)
+
+	w := doRequest(r, http.MethodDelete, "/book-reviews/999", nil)
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -611,3 +611,42 @@ func setupStudyCircleHandler() (*StudyCircleHandler, *MockStudyCircleRepository)
 	h := NewStudyCircleHandler(svc)
 	return h, repo
 }
+
+// MockBookReviewService は BookReviewServiceInterface のモック実装。
+type MockBookReviewService struct{ mock.Mock }
+
+func (m *MockBookReviewService) Create(review *model.BookReview) error {
+	return m.Called(review).Error(0)
+}
+func (m *MockBookReviewService) GetByID(id uint) (*model.BookReview, error) {
+	args := m.Called(id)
+	if r := args.Get(0); r != nil {
+		return r.(*model.BookReview), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockBookReviewService) GetByUserID(userID uint) ([]model.BookReview, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.BookReview), args.Error(1)
+}
+func (m *MockBookReviewService) GetAll(limit, offset int) ([]model.BookReview, int64, error) {
+	args := m.Called(limit, offset)
+	return args.Get(0).([]model.BookReview), args.Get(1).(int64), args.Error(2)
+}
+func (m *MockBookReviewService) Update(id, userID uint, updates *model.BookReview) (*model.BookReview, error) {
+	args := m.Called(id, userID, updates)
+	if r := args.Get(0); r != nil {
+		return r.(*model.BookReview), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockBookReviewService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+
+// setupBookReviewHandler はBookReviewHandlerテスト用のセットアップを行う。
+func setupBookReviewHandler() (*BookReviewHandler, *MockBookReviewService) {
+	mockService := new(MockBookReviewService)
+	h := NewBookReviewHandler(mockService)
+	return h, mockService
+}


### PR DESCRIPTION
## 概要
- インターフェース化されたBookReviewHandlerに対する包括的なユニットテストを追加
- MockBookReviewServiceを用いてサービス層をモック化

## テスト一覧（17件）
- **Create**: 正常作成、バリデーションエラー、不正JSON、サービスエラー
- **GetByID**: 正常取得、Not Found、無効なID
- **GetAll**: 正常取得、ページネーション指定、limit上限キャップ
- **GetByUserID**: 正常取得
- **Update**: 正常更新、Forbidden（他人のレビュー）、Not Found
- **Delete**: 正常削除、Forbidden、Not Found

## テスト計画
- [x] BookReviewテスト17件全通過
- [x] Goビルド成功

Closes #270