### PR TITLE
feat: 手書きEmptyStateを共通コンポーネントに統一

### DIFF
--- a/frontend/src/components/common/__tests__/EmptyState.test.tsx
+++ b/frontend/src/components/common/__tests__/EmptyState.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import EmptyState from '../EmptyState';
+import { HelpCircle } from 'lucide-react';
+
+describe('EmptyState', () => {
+  it('アイコンとメッセージが表示される', () => {
+    render(<EmptyState icon={HelpCircle} message="データがありません" />);
+    expect(screen.getByText('データがありません')).toBeInTheDocument();
+  });
+
+  it('titleが指定された場合に見出しが表示される', () => {
+    render(<EmptyState icon={HelpCircle} title="空の状態" message="データがありません" />);
+    expect(screen.getByText('空の状態')).toBeInTheDocument();
+    expect(screen.getByText('データがありません')).toBeInTheDocument();
+  });
+
+  it('titleが未指定の場合は見出しが表示されない', () => {
+    render(<EmptyState icon={HelpCircle} message="データがありません" />);
+    expect(screen.queryByRole('heading')).toBeNull();
+  });
+
+  it('actionLabelとonActionが指定された場合にボタンが表示される', () => {
+    const onAction = vi.fn();
+    render(
+      <EmptyState icon={HelpCircle} message="データがありません" actionLabel="追加する" onAction={onAction} />
+    );
+    const button = screen.getByText('追加する');
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(onAction).toHaveBeenCalledOnce();
+  });
+
+  it('actionLabelのみ指定された場合はボタンが表示されない', () => {
+    render(<EmptyState icon={HelpCircle} message="データがありません" actionLabel="追加する" />);
+    expect(screen.queryByText('追加する')).toBeNull();
+  });
+
+  it('onActionのみ指定された場合はボタンが表示されない', () => {
+    render(<EmptyState icon={HelpCircle} message="データがありません" onAction={() => {}} />);
+    // ボタン要素がないことを確認
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+});

--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { BookOpen } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import type { BookReview } from '../types/bookReview';
 import { useBookReviews } from '../hooks';
 import BookReviewCard from '../components/bookReviews/BookReviewCard';
 import BookReviewForm from '../components/bookReviews/BookReviewForm';
 import LoadingSpinner from '../components/common/LoadingSpinner';
-import { Pagination } from '../components/common';
+import { EmptyState, Pagination } from '../components/common';
 
 export default function BookReviewsPage() {
   const { t } = useTranslation();
@@ -71,20 +72,12 @@ export default function BookReviewsPage() {
           <LoadingSpinner />
         </div>
       ) : reviews.length === 0 ? (
-        <div className="text-center py-12">
-          <div className="w-16 h-16 mx-auto mb-4 bg-gray-800 rounded-full flex items-center justify-center">
-            <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M12 6.042A8.967 8.967 0 0 0 6 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 0 1 6 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 0 1 6-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0 0 18 18a8.967 8.967 0 0 0-6 2.292m0-14.25v14.25" />
-            </svg>
-          </div>
-          <p className="text-gray-400">{t('bookReviews.noReviews')}</p>
-          <button
-            onClick={() => setShowForm(true)}
-            className="mt-4 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-          >
-            {t('bookReviews.addFirstReview')}
-          </button>
-        </div>
+        <EmptyState
+          icon={BookOpen}
+          message={t('bookReviews.noReviews')}
+          actionLabel={t('bookReviews.addFirstReview')}
+          onAction={() => setShowForm(true)}
+        />
       ) : (
         <>
           <div className="space-y-4">

--- a/frontend/src/pages/QAPage.tsx
+++ b/frontend/src/pages/QAPage.tsx
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { HelpCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import type { Question } from '../types/qa';
 import { useQuestions, useDebounce } from '../hooks';
 import QuestionCard from '../components/qa/QuestionCard';
 import QuestionForm from '../components/qa/QuestionForm';
 import { QuestionCardSkeleton } from '../components/common/Skeleton';
-import { Pagination } from '../components/common';
+import { EmptyState, Pagination } from '../components/common';
 
 export default function QAPage() {
   const { t } = useTranslation();
@@ -122,20 +123,12 @@ export default function QAPage() {
           <QuestionCardSkeleton />
         </div>
       ) : questions.length === 0 ? (
-        <div className="text-center py-12">
-          <div className="w-16 h-16 mx-auto mb-4 bg-gray-800 rounded-full flex items-center justify-center">
-            <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" />
-            </svg>
-          </div>
-          <p className="text-gray-400">{t('qa.noQuestions')}</p>
-          <button
-            onClick={() => setShowForm(true)}
-            className="mt-4 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-          >
-            {t('qa.askFirstQuestion')}
-          </button>
-        </div>
+        <EmptyState
+          icon={HelpCircle}
+          message={t('qa.noQuestions')}
+          actionLabel={t('qa.askFirstQuestion')}
+          onAction={() => setShowForm(true)}
+        />
       ) : (
         <>
           <div className="space-y-4">

--- a/frontend/src/pages/RoadmapDetailPage.tsx
+++ b/frontend/src/pages/RoadmapDetailPage.tsx
@@ -1,10 +1,12 @@
 import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { List } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { useRoadmapDetail } from '../hooks';
 import { type RoadmapStep } from '../api/roadmaps';
 import LoadingSpinner from '../components/common/LoadingSpinner';
+import EmptyState from '../components/common/EmptyState';
 
 export default function RoadmapDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -213,22 +215,12 @@ export default function RoadmapDetailPage() {
 
       {/* Steps List */}
       {roadmap.steps && roadmap.steps.length === 0 ? (
-        <div className="text-center py-12">
-          <div className="w-16 h-16 mx-auto mb-4 bg-gray-800 rounded-full flex items-center justify-center">
-            <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z" />
-            </svg>
-          </div>
-          <p className="text-gray-400">{t('roadmaps.noSteps')}</p>
-          {isOwner && (
-            <button
-              onClick={() => setShowStepForm(true)}
-              className="mt-4 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-            >
-              {t('roadmaps.addFirstStep')}
-            </button>
-          )}
-        </div>
+        <EmptyState
+          icon={List}
+          message={t('roadmaps.noSteps')}
+          actionLabel={isOwner ? t('roadmaps.addFirstStep') : undefined}
+          onAction={isOwner ? () => setShowStepForm(true) : undefined}
+        />
       ) : (
         <div className="space-y-3">
           {roadmap.steps?.map((step, index) => (

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Monitor, Rocket, Target, FolderOpen, FileText, BookOpen, ChevronDown, ChevronUp, type LucideIcon } from 'lucide-react';
+import { Monitor, Rocket, Target, FolderOpen, FileText, BookOpen, ChevronDown, ChevronUp, MapPin, type LucideIcon } from 'lucide-react';
 import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
 import { useRoadmaps, useRoadmapTemplates } from '../hooks';
 import LoadingSpinner from '../components/common/LoadingSpinner';
+import EmptyState from '../components/common/EmptyState';
 
 const CATEGORIES: { value: RoadmapCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'roadmaps.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -309,20 +310,12 @@ export default function RoadmapsPage() {
 
       {/* Content */}
       {roadmaps.length === 0 ? (
-        <div className="text-center py-12">
-          <div className="w-16 h-16 mx-auto mb-4 bg-gray-800 rounded-full flex items-center justify-center">
-            <svg className="w-8 h-8 text-gray-500" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M9 6.75V15m6-6v8.25m.503 3.498 4.875-2.437c.381-.19.622-.58.622-1.006V4.82c0-.836-.88-1.38-1.628-1.006l-3.869 1.934c-.317.159-.69.159-1.006 0L9.503 3.252a1.125 1.125 0 0 0-1.006 0L3.622 5.689C3.24 5.88 3 6.27 3 6.695V19.18c0 .836.88 1.38 1.628 1.006l3.869-1.934c.317-.159.69-.159 1.006 0l4.994 2.497c.317.158.69.158 1.006 0Z" />
-            </svg>
-          </div>
-          <p className="text-gray-400">{t('roadmaps.noRoadmaps')}</p>
-          <button
-            onClick={() => setShowForm(true)}
-            className="mt-4 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-          >
-            {t('roadmaps.createFirst')}
-          </button>
-        </div>
+        <EmptyState
+          icon={MapPin}
+          message={t('roadmaps.noRoadmaps')}
+          actionLabel={t('roadmaps.createFirst')}
+          onAction={() => setShowForm(true)}
+        />
       ) : (
         <div className="space-y-6">
           {activeRoadmaps.length > 0 && (


### PR DESCRIPTION
## 概要
- QAPage、BookReviewsPage、RoadmapsPage、RoadmapDetailPageの4ページで手書きだったEmptyState表示を共通`EmptyState`コンポーネントに統一
- EmptyStateコンポーネントのユニットテスト（6件）を追加
- lucide-reactアイコンを使用（HelpCircle, BookOpen, MapPin, List）

## 変更対象
- `frontend/src/pages/QAPage.tsx` — EmptyState + HelpCircle
- `frontend/src/pages/BookReviewsPage.tsx` — EmptyState + BookOpen
- `frontend/src/pages/RoadmapsPage.tsx` — EmptyState + MapPin
- `frontend/src/pages/RoadmapDetailPage.tsx` — EmptyState + List（isOwnerの場合のみCTAボタン表示）
- `frontend/src/components/common/__tests__/EmptyState.test.tsx` — 新規テスト6件

## テスト計画
- [x] EmptyStateコンポーネントテスト6件 GREEN
- [x] TypeScriptチェック通過（`npx tsc --noEmit`）

Closes #272