### PR TITLE
refactor: AnswerHandler・PostHandlerのインターフェース化

### DIFF
--- a/backend/internal/handler/answer.go
+++ b/backend/internal/handler/answer.go
@@ -3,17 +3,27 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// AnswerServiceInterface はAnswerServiceが実装すべきインターフェース。
+type AnswerServiceInterface interface {
+	GetByQuestionID(questionID uint) ([]model.Answer, error)
+	Create(answer *model.Answer) error
+	Update(answerID, userID uint, body string) (*model.Answer, error)
+	Delete(answerID, userID uint) error
+	SetBestAnswer(questionID, answerID, userID uint) error
+	Vote(userID, answerID uint, value int) error
+	RemoveVote(userID, answerID uint) error
+}
 
 // AnswerHandler は回答関連のHTTPハンドラ。
 // 回答のCRUD・ベストアンサー選定・投票を処理する。
 type AnswerHandler struct {
-	service *service.AnswerService
+	service AnswerServiceInterface
 }
 
 // NewAnswerHandler は新しいAnswerHandlerインスタンスを生成する。
-func NewAnswerHandler(s *service.AnswerService) *AnswerHandler {
+func NewAnswerHandler(s AnswerServiceInterface) *AnswerHandler {
 	return &AnswerHandler{service: s}
 }
 

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -3,18 +3,41 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// PostServiceInterface はPostServiceが実装すべきインターフェース。
+type PostServiceInterface interface {
+	Create(post *model.Post) (*model.Post, error)
+	GetByID(id uint) (*model.Post, error)
+	GetAll(page, limit int) ([]model.Post, error)
+	GetByUserID(userID uint) ([]model.Post, error)
+	GetDrafts(userID uint) ([]model.Post, error)
+	Timeline(userID uint, page, limit int) ([]model.Post, error)
+	Update(id, userID uint, title, content, imageUrls string) (*model.Post, error)
+	Delete(id, userID uint) error
+	Like(userID, postID uint) error
+	Unlike(userID, postID uint) error
+	HasLiked(userID, postID uint) bool
+	CreateComment(comment *model.Comment) error
+	GetComments(postID uint) ([]model.Comment, error)
+	DeleteComment(id, userID uint) error
+	Publish(id, userID uint) (*model.Post, error)
+}
+
+// CodeSnippetServiceInterface はCodeSnippetServiceが実装すべきインターフェース。
+type CodeSnippetServiceInterface interface {
+	Create(snippet *model.CodeSnippet) (*model.CodeSnippet, error)
+}
 
 // PostHandler は投稿関連のHTTPハンドラ。
 // 投稿のCRUD・いいね・コメント・タイムラインを処理する。
 type PostHandler struct {
-	service        *service.PostService
-	snippetService *service.CodeSnippetService
+	service        PostServiceInterface
+	snippetService CodeSnippetServiceInterface
 }
 
 // NewPostHandler は新しいPostHandlerインスタンスを生成する。
-func NewPostHandler(s *service.PostService, snippetService *service.CodeSnippetService) *PostHandler {
+func NewPostHandler(s PostServiceInterface, snippetService CodeSnippetServiceInterface) *PostHandler {
 	return &PostHandler{service: s, snippetService: snippetService}
 }
 


### PR DESCRIPTION
## 概要
- AnswerHandlerとPostHandlerのサービス依存を具体型からインターフェースに置換
- service パッケージへの直接importを排除し、handler層の独立性を向上

## 変更内容
- `AnswerHandler`: `*service.AnswerService` → `AnswerServiceInterface`（7メソッド）
- `PostHandler`: `*service.PostService` → `PostServiceInterface`（15メソッド）
- `PostHandler`: `*service.CodeSnippetService` → `CodeSnippetServiceInterface`（1メソッド）

## テスト計画
- [x] Goビルド成功（`go build ./...`）
- [x] 既存ハンドラテスト通過

Closes #274