### PR TITLE
test: AnswerHandlerのユニットテスト18件追加

### DIFF
--- a/backend/internal/handler/answer_test.go
+++ b/backend/internal/handler/answer_test.go
@@ -1,0 +1,268 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// ============================================================
+// GetByQuestionID テスト
+// ============================================================
+
+func TestAnswerGetByQuestionID_Success(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.GET("/questions/:id/answers", h.GetByQuestionID)
+
+	answers := []model.Answer{
+		{Body: "回答1"},
+		{Body: "回答2"},
+	}
+	svc.On("GetByQuestionID", uint(1)).Return(answers, nil)
+
+	w := doRequest(r, http.MethodGet, "/questions/1/answers", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerGetByQuestionID_InvalidID(t *testing.T) {
+	h, _ := setupAnswerHandler()
+	r := newRouter(1)
+	r.GET("/questions/:id/answers", h.GetByQuestionID)
+
+	w := doRequest(r, http.MethodGet, "/questions/abc/answers", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// Create テスト
+// ============================================================
+
+func TestAnswerCreate_Success(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.POST("/questions/:id/answers", h.Create)
+
+	svc.On("Create", mock.AnythingOfType("*model.Answer")).Return(nil)
+
+	w := doRequest(r, http.MethodPost, "/questions/1/answers", map[string]interface{}{
+		"body": "これは回答です",
+	})
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerCreate_ValidationError(t *testing.T) {
+	h, _ := setupAnswerHandler()
+	r := newRouter(1)
+	r.POST("/questions/:id/answers", h.Create)
+
+	// body は required
+	w := doRequest(r, http.MethodPost, "/questions/1/answers", map[string]interface{}{})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestAnswerCreate_InvalidJSON(t *testing.T) {
+	h, _ := setupAnswerHandler()
+	r := newRouter(1)
+	r.POST("/questions/:id/answers", h.Create)
+
+	w := doRequestRaw(r, http.MethodPost, "/questions/1/answers", "not json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestAnswerCreate_ServiceError(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.POST("/questions/:id/answers", h.Create)
+
+	svc.On("Create", mock.AnythingOfType("*model.Answer")).Return(errors.New("db error"))
+
+	w := doRequest(r, http.MethodPost, "/questions/1/answers", map[string]interface{}{
+		"body": "回答",
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// Update テスト
+// ============================================================
+
+func TestAnswerUpdate_Success(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.PUT("/questions/:id/answers/:answerId", h.Update)
+
+	updated := &model.Answer{Body: "更新後の回答"}
+	updated.ID = 10
+	svc.On("Update", uint(10), uint(1), "更新後の回答").Return(updated, nil)
+
+	w := doRequest(r, http.MethodPut, "/questions/1/answers/10", map[string]interface{}{
+		"body": "更新後の回答",
+	})
+	assertStatus(t, w, http.StatusOK)
+
+	body := parseJSON(t, w)
+	assert.Equal(t, "更新後の回答", body["body"])
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerUpdate_Forbidden(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.PUT("/questions/:id/answers/:answerId", h.Update)
+
+	svc.On("Update", uint(10), uint(1), "不正な更新").Return(nil, service.ErrForbidden)
+
+	w := doRequest(r, http.MethodPut, "/questions/1/answers/10", map[string]interface{}{
+		"body": "不正な更新",
+	})
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerUpdate_NotFound(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.PUT("/questions/:id/answers/:answerId", h.Update)
+
+	svc.On("Update", uint(999), uint(1), "存在しない").Return(nil, service.ErrNotFound)
+
+	w := doRequest(r, http.MethodPut, "/questions/1/answers/999", map[string]interface{}{
+		"body": "存在しない",
+	})
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerUpdate_InvalidID(t *testing.T) {
+	h, _ := setupAnswerHandler()
+	r := newRouter(1)
+	r.PUT("/questions/:id/answers/:answerId", h.Update)
+
+	w := doRequest(r, http.MethodPut, "/questions/1/answers/abc", map[string]interface{}{
+		"body": "テスト",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// Delete テスト
+// ============================================================
+
+func TestAnswerDelete_Success(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.DELETE("/questions/:id/answers/:answerId", h.Delete)
+
+	svc.On("Delete", uint(10), uint(1)).Return(nil)
+
+	w := doRequest(r, http.MethodDelete, "/questions/1/answers/10", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerDelete_Forbidden(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.DELETE("/questions/:id/answers/:answerId", h.Delete)
+
+	svc.On("Delete", uint(10), uint(1)).Return(service.ErrForbidden)
+
+	w := doRequest(r, http.MethodDelete, "/questions/1/answers/10", nil)
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerDelete_NotFound(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.DELETE("/questions/:id/answers/:answerId", h.Delete)
+
+	svc.On("Delete", uint(999), uint(1)).Return(service.ErrNotFound)
+
+	w := doRequest(r, http.MethodDelete, "/questions/1/answers/999", nil)
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// SetBestAnswer テスト
+// ============================================================
+
+func TestAnswerSetBestAnswer_Success(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.PUT("/questions/:id/answers/:answerId/best", h.SetBestAnswer)
+
+	svc.On("SetBestAnswer", uint(1), uint(10), uint(1)).Return(nil)
+
+	w := doRequest(r, http.MethodPut, "/questions/1/answers/10/best", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerSetBestAnswer_Forbidden(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.PUT("/questions/:id/answers/:answerId/best", h.SetBestAnswer)
+
+	svc.On("SetBestAnswer", uint(1), uint(10), uint(1)).Return(service.ErrForbidden)
+
+	w := doRequest(r, http.MethodPut, "/questions/1/answers/10/best", nil)
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// Vote テスト
+// ============================================================
+
+func TestAnswerVote_Success(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.POST("/questions/:id/answers/:answerId/vote", h.Vote)
+
+	svc.On("Vote", uint(1), uint(10), 1).Return(nil)
+
+	w := doRequest(r, http.MethodPost, "/questions/1/answers/10/vote", map[string]interface{}{
+		"value": 1,
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerVote_ValidationError(t *testing.T) {
+	h, _ := setupAnswerHandler()
+	r := newRouter(1)
+	r.POST("/questions/:id/answers/:answerId/vote", h.Vote)
+
+	// value は required で 1 or -1 のみ許可
+	w := doRequest(r, http.MethodPost, "/questions/1/answers/10/vote", map[string]interface{}{
+		"value": 0,
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// RemoveVote テスト
+// ============================================================
+
+func TestAnswerRemoveVote_Success(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.DELETE("/questions/:id/answers/:answerId/vote", h.RemoveVote)
+
+	svc.On("RemoveVote", uint(1), uint(10)).Return(nil)
+
+	w := doRequest(r, http.MethodDelete, "/questions/1/answers/10/vote", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -650,3 +650,40 @@ func setupBookReviewHandler() (*BookReviewHandler, *MockBookReviewService) {
 	h := NewBookReviewHandler(mockService)
 	return h, mockService
 }
+
+// MockAnswerService は AnswerServiceInterface のモック実装。
+type MockAnswerService struct{ mock.Mock }
+
+func (m *MockAnswerService) GetByQuestionID(questionID uint) ([]model.Answer, error) {
+	args := m.Called(questionID)
+	return args.Get(0).([]model.Answer), args.Error(1)
+}
+func (m *MockAnswerService) Create(answer *model.Answer) error {
+	return m.Called(answer).Error(0)
+}
+func (m *MockAnswerService) Update(answerID, userID uint, body string) (*model.Answer, error) {
+	args := m.Called(answerID, userID, body)
+	if a := args.Get(0); a != nil {
+		return a.(*model.Answer), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockAnswerService) Delete(answerID, userID uint) error {
+	return m.Called(answerID, userID).Error(0)
+}
+func (m *MockAnswerService) SetBestAnswer(questionID, answerID, userID uint) error {
+	return m.Called(questionID, answerID, userID).Error(0)
+}
+func (m *MockAnswerService) Vote(userID, answerID uint, value int) error {
+	return m.Called(userID, answerID, value).Error(0)
+}
+func (m *MockAnswerService) RemoveVote(userID, answerID uint) error {
+	return m.Called(userID, answerID).Error(0)
+}
+
+// setupAnswerHandler はAnswerHandlerテスト用のセットアップを行う。
+func setupAnswerHandler() (*AnswerHandler, *MockAnswerService) {
+	svc := new(MockAnswerService)
+	h := NewAnswerHandler(svc)
+	return h, svc
+}


### PR DESCRIPTION
## 概要
AnswerHandlerの全7エンドポイントに対するユニットテスト18件を追加。

## 変更内容
- `backend/internal/handler/answer_test.go` — テスト18件新規作成
- `backend/internal/handler/testutil_test.go` — MockAnswerService・setupAnswerHelper追加

## テストカバレッジ
| エンドポイント | テスト数 |
|---|---|
| GetByQuestionID | 2（成功、不正ID） |
| Create | 4（成功、バリデーション、不正JSON、サービスエラー） |
| Update | 4（成功、権限、NotFound、不正ID） |
| Delete | 3（成功、権限、NotFound） |
| SetBestAnswer | 2（成功、権限） |
| Vote | 2（成功、バリデーション） |
| RemoveVote | 1（成功） |

## テスト計画
- [x] 18テスト全てPASS
- [x] Goビルド成功

Closes #276