### PR TITLE
feat: 共有Modalコンポーネントを作成し7ページの手書きモーダルを統一

### DIFF
--- a/frontend/src/components/common/Modal.tsx
+++ b/frontend/src/components/common/Modal.tsx
@@ -1,0 +1,47 @@
+import { useEffect, type ReactNode } from 'react';
+
+interface ModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title?: string;
+  maxWidth?: string;
+  children: ReactNode;
+}
+
+export default function Modal({
+  isOpen,
+  onClose,
+  title,
+  maxWidth = 'max-w-2xl',
+  children,
+}: ModalProps) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      data-testid="modal-overlay"
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        className={`bg-gray-800 rounded-md p-6 w-full ${maxWidth} max-h-[90vh] overflow-y-auto`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {title && (
+          <h2 className="text-xl font-semibold text-white mb-4">{title}</h2>
+        )}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Modal.test.tsx
+++ b/frontend/src/components/common/__tests__/Modal.test.tsx
@@ -1,0 +1,82 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import Modal from '../Modal';
+
+describe('Modal', () => {
+  const onClose = vi.fn();
+
+  afterEach(() => {
+    onClose.mockClear();
+  });
+
+  it('isOpen=trueの場合にモーダルが表示される', () => {
+    render(
+      <Modal isOpen={true} onClose={onClose} title="テストモーダル">
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    expect(screen.getByText('テストモーダル')).toBeInTheDocument();
+    expect(screen.getByText('コンテンツ')).toBeInTheDocument();
+  });
+
+  it('isOpen=falseの場合にモーダルが表示されない', () => {
+    render(
+      <Modal isOpen={false} onClose={onClose} title="テストモーダル">
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    expect(screen.queryByText('テストモーダル')).toBeNull();
+  });
+
+  it('背景クリックでonCloseが呼ばれる', () => {
+    render(
+      <Modal isOpen={true} onClose={onClose} title="テスト">
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    // 背景（overlay）をクリック
+    const overlay = screen.getByTestId('modal-overlay');
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('モーダル内部のクリックでは閉じない', () => {
+    render(
+      <Modal isOpen={true} onClose={onClose} title="テスト">
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    fireEvent.click(screen.getByText('コンテンツ'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('Escapeキーでoncloseが呼ばれる', () => {
+    render(
+      <Modal isOpen={true} onClose={onClose} title="テスト">
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('titleが未指定の場合はヘッダーが表示されない', () => {
+    render(
+      <Modal isOpen={true} onClose={onClose}>
+        <p>コンテンツのみ</p>
+      </Modal>
+    );
+    expect(screen.queryByRole('heading')).toBeNull();
+    expect(screen.getByText('コンテンツのみ')).toBeInTheDocument();
+  });
+
+  it('maxWidthクラスが適用される', () => {
+    render(
+      <Modal isOpen={true} onClose={onClose} title="テスト" maxWidth="max-w-lg">
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toContain('max-w-lg');
+  });
+});

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -3,4 +3,5 @@ export { default as PageLoader } from './PageLoader';
 export { default as InlineLoader } from './InlineLoader';
 export { Skeleton, PostCardSkeleton, UserCardSkeleton } from './Skeleton';
 export { default as EmptyState } from './EmptyState';
+export { default as Modal } from './Modal';
 export { default as Pagination } from './Pagination';

--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -7,7 +7,7 @@ import { useBookReviews } from '../hooks';
 import BookReviewCard from '../components/bookReviews/BookReviewCard';
 import BookReviewForm from '../components/bookReviews/BookReviewForm';
 import LoadingSpinner from '../components/common/LoadingSpinner';
-import { EmptyState, Pagination } from '../components/common';
+import { EmptyState, Modal, Pagination } from '../components/common';
 
 export default function BookReviewsPage() {
   const { t } = useTranslation();
@@ -39,32 +39,30 @@ export default function BookReviewsPage() {
       </div>
 
       {/* Form Modal */}
-      {(showForm || editingReview) && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-md p-6 w-full max-w-lg max-h-[90vh] overflow-y-auto">
-            <h2 className="text-xl font-semibold text-white mb-4">
-              {editingReview ? t('bookReviews.editReview') : t('bookReviews.newReview')}
-            </h2>
-            <BookReviewForm
-              review={editingReview || undefined}
-              onSubmit={async (data) => {
-                if (editingReview) {
-                  const result = await updateReview(editingReview.id, data);
-                  if (result) setEditingReview(null);
-                } else {
-                  const result = await createReview(data);
-                  if (result) setShowForm(false);
-                }
-              }}
-              onCancel={() => {
-                setShowForm(false);
-                setEditingReview(null);
-              }}
-              loading={saving}
-            />
-          </div>
-        </div>
-      )}
+      <Modal
+        isOpen={showForm || !!editingReview}
+        onClose={() => { setShowForm(false); setEditingReview(null); }}
+        title={editingReview ? t('bookReviews.editReview') : t('bookReviews.newReview')}
+        maxWidth="max-w-lg"
+      >
+        <BookReviewForm
+          review={editingReview || undefined}
+          onSubmit={async (data) => {
+            if (editingReview) {
+              const result = await updateReview(editingReview.id, data);
+              if (result) setEditingReview(null);
+            } else {
+              const result = await createReview(data);
+              if (result) setShowForm(false);
+            }
+          }}
+          onCancel={() => {
+            setShowForm(false);
+            setEditingReview(null);
+          }}
+          loading={saving}
+        />
+      </Modal>
 
       {/* Content */}
       {loading ? (

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import type { BadgeResult } from '../types/badge';
 import type { Post } from '../types/post';
 import PostCard from '../components/posts/PostCard';
 import PostForm from '../components/posts/PostForm';
+import { Modal } from '../components/common';
 import QuickPostForm from '../components/posts/QuickPostForm';
 import { PostCardSkeleton } from '../components/common/Skeleton';
 import Avatar from '../components/common/Avatar';
@@ -154,21 +155,22 @@ export default function DashboardPage() {
         </div>
 
         {/* Edit Modal */}
-        {editingPost && (
-          <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-            <div className="bg-gray-800 rounded-md p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-              <h2 className="text-xl font-semibold text-white mb-4">投稿を編集</h2>
-              <PostForm
-                post={editingPost}
-                onSubmit={async (title, content, imageUrls) => {
-                  const result = await updatePost(editingPost.id, title, content, imageUrls);
-                  if (result) setEditingPost(null);
-                }}
-                onCancel={() => setEditingPost(null)}
-              />
-            </div>
-          </div>
-        )}
+        <Modal
+          isOpen={!!editingPost}
+          onClose={() => setEditingPost(null)}
+          title="投稿を編集"
+        >
+          {editingPost && (
+            <PostForm
+              post={editingPost}
+              onSubmit={async (title, content, imageUrls) => {
+                const result = await updatePost(editingPost.id, title, content, imageUrls);
+                if (result) setEditingPost(null);
+              }}
+              onCancel={() => setEditingPost(null)}
+            />
+          )}
+        </Modal>
       </div>
 
       {/* Sidebar */}

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Monitor, Rocket, Target, FolderOpen, FileText, type LucideIcon } from 'lucide-react';
 import { type GoalCategory, type GoalStatus, type LearningGoal } from '../api/goals';
 import { useGoals } from '../hooks';
-import { PageLoader } from '../components/common';
+import { Modal, PageLoader } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 
 const CATEGORIES: { value: GoalCategory; label: string; icon: string; Icon: LucideIcon }[] = [
@@ -131,85 +131,83 @@ export default function GoalsPage() {
       </div>
 
       {/* Create/Edit Form Modal */}
-      {showForm && (
-        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 px-4">
-          <div className="bg-gray-900 border border-gray-700 rounded-md max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold mb-4">
-              {editingGoal ? t('goals.editGoal') : t('goals.addGoal')}
-            </h3>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                  {t('goals.goalTitle')}
-                </label>
-                <input
-                  type="text"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  placeholder={t('goals.titlePlaceholder')}
-                  className={inputClass}
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                  {t('goals.description')}
-                </label>
-                <textarea
-                  value={description}
-                  onChange={(e) => setDescription(e.target.value)}
-                  placeholder={t('goals.descriptionPlaceholder')}
-                  rows={3}
-                  className={`${inputClass} resize-none`}
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                  {t('goals.category')}
-                </label>
-                <select
-                  value={category}
-                  onChange={(e) => setCategory(e.target.value as GoalCategory)}
-                  className={inputClass}
-                >
-                  {CATEGORIES.map((cat) => (
-                    <option key={cat.value} value={cat.value}>
-                      {cat.icon} {t(cat.label)}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                  {t('goals.targetDate')}
-                </label>
-                <input
-                  type="date"
-                  value={targetDate}
-                  onChange={(e) => setTargetDate(e.target.value)}
-                  className={inputClass}
-                />
-              </div>
-              <div className="flex gap-3 justify-end pt-2">
-                <button
-                  type="button"
-                  onClick={resetForm}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  type="submit"
-                  disabled={saving || !title.trim()}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
-                >
-                  {saving ? t('common.loading') : editingGoal ? t('common.save') : t('goals.create')}
-                </button>
-              </div>
-            </form>
+      <Modal
+        isOpen={showForm}
+        onClose={resetForm}
+        title={editingGoal ? t('goals.editGoal') : t('goals.addGoal')}
+        maxWidth="max-w-md"
+      >
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              {t('goals.goalTitle')}
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={t('goals.titlePlaceholder')}
+              className={inputClass}
+              required
+            />
           </div>
-        </div>
-      )}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              {t('goals.description')}
+            </label>
+            <textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t('goals.descriptionPlaceholder')}
+              rows={3}
+              className={`${inputClass} resize-none`}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              {t('goals.category')}
+            </label>
+            <select
+              value={category}
+              onChange={(e) => setCategory(e.target.value as GoalCategory)}
+              className={inputClass}
+            >
+              {CATEGORIES.map((cat) => (
+                <option key={cat.value} value={cat.value}>
+                  {cat.icon} {t(cat.label)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              {t('goals.targetDate')}
+            </label>
+            <input
+              type="date"
+              value={targetDate}
+              onChange={(e) => setTargetDate(e.target.value)}
+              className={inputClass}
+            />
+          </div>
+          <div className="flex gap-3 justify-end pt-2">
+            <button
+              type="button"
+              onClick={resetForm}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={saving || !title.trim()}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+            >
+              {saving ? t('common.loading') : editingGoal ? t('common.save') : t('goals.create')}
+            </button>
+          </div>
+        </form>
+      </Modal>
 
       {/* Goals List */}
       {goals.length === 0 ? (

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -7,6 +7,7 @@ import ProjectCard from '../components/projects/ProjectCard';
 import ProjectForm from '../components/projects/ProjectForm';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import EmptyState from '../components/common/EmptyState';
+import { Modal } from '../components/common';
 
 export default function ProjectsPage() {
   const { t } = useTranslation();
@@ -45,33 +46,30 @@ export default function ProjectsPage() {
       </div>
 
       {/* Form Modal */}
-      {(showForm || editingProject) && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-md p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <h2 className="text-xl font-semibold text-white mb-4">
-              {editingProject ? t('projects.editProject') : t('projects.newProject')}
-            </h2>
-            <ProjectForm
-              project={editingProject || undefined}
-              repos={repos}
-              onSubmit={async (data) => {
-                if (editingProject) {
-                  const result = await updateProject(editingProject.id, data);
-                  if (result) setEditingProject(null);
-                } else {
-                  const result = await createProject(data);
-                  if (result) setShowForm(false);
-                }
-              }}
-              onCancel={() => {
-                setShowForm(false);
-                setEditingProject(null);
-              }}
-              loading={saving}
-            />
-          </div>
-        </div>
-      )}
+      <Modal
+        isOpen={showForm || !!editingProject}
+        onClose={() => { setShowForm(false); setEditingProject(null); }}
+        title={editingProject ? t('projects.editProject') : t('projects.newProject')}
+      >
+        <ProjectForm
+          project={editingProject || undefined}
+          repos={repos}
+          onSubmit={async (data) => {
+            if (editingProject) {
+              const result = await updateProject(editingProject.id, data);
+              if (result) setEditingProject(null);
+            } else {
+              const result = await createProject(data);
+              if (result) setShowForm(false);
+            }
+          }}
+          onCancel={() => {
+            setShowForm(false);
+            setEditingProject(null);
+          }}
+          loading={saving}
+        />
+      </Modal>
 
       {/* Projects Grid */}
       {projects.length === 0 ? (

--- a/frontend/src/pages/QAPage.tsx
+++ b/frontend/src/pages/QAPage.tsx
@@ -7,7 +7,7 @@ import { useQuestions, useDebounce } from '../hooks';
 import QuestionCard from '../components/qa/QuestionCard';
 import QuestionForm from '../components/qa/QuestionForm';
 import { QuestionCardSkeleton } from '../components/common/Skeleton';
-import { EmptyState, Pagination } from '../components/common';
+import { EmptyState, Modal, Pagination } from '../components/common';
 
 export default function QAPage() {
   const { t } = useTranslation();
@@ -88,32 +88,29 @@ export default function QAPage() {
       </div>
 
       {/* Form Modal */}
-      {(showForm || editingQuestion) && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-md p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <h2 className="text-xl font-semibold text-white mb-4">
-              {editingQuestion ? t('qa.editQuestion') : t('qa.newQuestion')}
-            </h2>
-            <QuestionForm
-              question={editingQuestion || undefined}
-              onSubmit={async (data) => {
-                if (editingQuestion) {
-                  const result = await updateQuestion(editingQuestion.id, data);
-                  if (result) setEditingQuestion(null);
-                } else {
-                  const result = await createQuestion(data);
-                  if (result) setShowForm(false);
-                }
-              }}
-              onCancel={() => {
-                setShowForm(false);
-                setEditingQuestion(null);
-              }}
-              loading={saving}
-            />
-          </div>
-        </div>
-      )}
+      <Modal
+        isOpen={showForm || !!editingQuestion}
+        onClose={() => { setShowForm(false); setEditingQuestion(null); }}
+        title={editingQuestion ? t('qa.editQuestion') : t('qa.newQuestion')}
+      >
+        <QuestionForm
+          question={editingQuestion || undefined}
+          onSubmit={async (data) => {
+            if (editingQuestion) {
+              const result = await updateQuestion(editingQuestion.id, data);
+              if (result) setEditingQuestion(null);
+            } else {
+              const result = await createQuestion(data);
+              if (result) setShowForm(false);
+            }
+          }}
+          onCancel={() => {
+            setShowForm(false);
+            setEditingQuestion(null);
+          }}
+          loading={saving}
+        />
+      </Modal>
 
       {/* Content */}
       {loading ? (

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -6,6 +6,7 @@ import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
 import { useRoadmaps, useRoadmapTemplates } from '../hooks';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import EmptyState from '../components/common/EmptyState';
+import { Modal } from '../components/common';
 
 const CATEGORIES: { value: RoadmapCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'roadmaps.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -235,78 +236,76 @@ export default function RoadmapsPage() {
       )}
 
       {/* Form Modal */}
-      {showForm && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-md p-6 w-full max-w-md">
-            <h2 className="text-xl font-semibold text-white mb-4">
-              {editingRoadmap ? t('roadmaps.editRoadmap') : t('roadmaps.addRoadmap')}
-            </h2>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.roadmapTitle')}</label>
-                <input
-                  type="text"
-                  value={title}
-                  onChange={e => setTitle(e.target.value)}
-                  placeholder={t('roadmaps.titlePlaceholder')}
-                  className={inputClass}
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.descriptionLabel')}</label>
-                <textarea
-                  value={description}
-                  onChange={e => setDescription(e.target.value)}
-                  placeholder={t('roadmaps.descriptionPlaceholder')}
-                  rows={3}
-                  className={`${inputClass} resize-none`}
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.category')}</label>
-                <select
-                  value={category}
-                  onChange={e => setCategory(e.target.value as RoadmapCategory)}
-                  className={inputClass}
-                >
-                  {CATEGORIES.map(cat => (
-                    <option key={cat.value} value={cat.value}>
-                      {cat.icon} {t(cat.label)}
-                    </option>
-                  ))}
-                </select>
-              </div>
-              <div className="flex items-center gap-2">
-                <input
-                  type="checkbox"
-                  id="is_public"
-                  checked={isPublic}
-                  onChange={e => setIsPublic(e.target.checked)}
-                  className="w-4 h-4 rounded border-gray-600 bg-gray-700"
-                />
-                <label htmlFor="is_public" className="text-sm text-gray-300">{t('roadmaps.makePublic')}</label>
-              </div>
-              <div className="flex gap-3 justify-end pt-2">
-                <button
-                  type="button"
-                  onClick={resetForm}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  type="submit"
-                  disabled={saving || !title.trim()}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
-                >
-                  {saving ? t('common.saving') : editingRoadmap ? t('common.save') : t('roadmaps.create')}
-                </button>
-              </div>
-            </form>
+      <Modal
+        isOpen={showForm}
+        onClose={resetForm}
+        title={editingRoadmap ? t('roadmaps.editRoadmap') : t('roadmaps.addRoadmap')}
+        maxWidth="max-w-md"
+      >
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.roadmapTitle')}</label>
+            <input
+              type="text"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              placeholder={t('roadmaps.titlePlaceholder')}
+              className={inputClass}
+              required
+            />
           </div>
-        </div>
-      )}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.descriptionLabel')}</label>
+            <textarea
+              value={description}
+              onChange={e => setDescription(e.target.value)}
+              placeholder={t('roadmaps.descriptionPlaceholder')}
+              rows={3}
+              className={`${inputClass} resize-none`}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.category')}</label>
+            <select
+              value={category}
+              onChange={e => setCategory(e.target.value as RoadmapCategory)}
+              className={inputClass}
+            >
+              {CATEGORIES.map(cat => (
+                <option key={cat.value} value={cat.value}>
+                  {cat.icon} {t(cat.label)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              id="is_public"
+              checked={isPublic}
+              onChange={e => setIsPublic(e.target.checked)}
+              className="w-4 h-4 rounded border-gray-600 bg-gray-700"
+            />
+            <label htmlFor="is_public" className="text-sm text-gray-300">{t('roadmaps.makePublic')}</label>
+          </div>
+          <div className="flex gap-3 justify-end pt-2">
+            <button
+              type="button"
+              onClick={resetForm}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={saving || !title.trim()}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+            >
+              {saving ? t('common.saving') : editingRoadmap ? t('common.save') : t('roadmaps.create')}
+            </button>
+          </div>
+        </form>
+      </Modal>
 
       {/* Content */}
       {roadmaps.length === 0 ? (

--- a/frontend/src/pages/StudyCirclesPage.tsx
+++ b/frontend/src/pages/StudyCirclesPage.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Users, Plus, X, Crown } from 'lucide-react';
+import { Users, Plus, Crown } from 'lucide-react';
 import { useStudyCircles } from '../hooks';
 import { useAuthStore } from '../store/authStore';
 import Avatar from '../components/common/Avatar';
+import { Modal } from '../components/common';
 
 export default function StudyCirclesPage() {
   const { t } = useTranslation();
@@ -118,74 +119,69 @@ export default function StudyCirclesPage() {
       )}
 
       {/* Create Modal */}
-      {showModal && (
-        <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-900 border border-gray-800 rounded-md p-6 w-full max-w-md">
-            <div className="flex items-center justify-between mb-4">
-              <h2 className="text-lg font-bold text-white">{t('studyCircle.create')}</h2>
-              <button onClick={() => setShowModal(false)} className="text-gray-400 hover:text-white">
-                <X className="w-5 h-5" />
-              </button>
-            </div>
-            <div className="space-y-3">
-              <div>
-                <label className="text-xs text-gray-400 block mb-1">{t('studyCircle.name')}</label>
-                <input
-                  type="text"
-                  value={form.name}
-                  onChange={(e) => setForm({ ...form, name: e.target.value })}
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
-                  placeholder="React学習会"
-                />
-              </div>
-              <div>
-                <label className="text-xs text-gray-400 block mb-1">{t('studyCircle.topic')}</label>
-                <input
-                  type="text"
-                  value={form.topic}
-                  onChange={(e) => setForm({ ...form, topic: e.target.value })}
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
-                  placeholder="React入門を1ヶ月で"
-                />
-              </div>
-              <div>
-                <label className="text-xs text-gray-400 block mb-1">{t('studyCircle.description')}</label>
-                <textarea
-                  value={form.description}
-                  onChange={(e) => setForm({ ...form, description: e.target.value })}
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500 h-20 resize-none"
-                />
-              </div>
-              <div>
-                <label className="text-xs text-gray-400 block mb-1">{t('studyCircle.maxMembers')}</label>
-                <input
-                  type="number"
-                  min={3}
-                  max={10}
-                  value={form.max_members}
-                  onChange={(e) => setForm({ ...form, max_members: parseInt(e.target.value) || 5 })}
-                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
-                />
-              </div>
-            </div>
-            <div className="flex justify-end gap-2 mt-5">
-              <button
-                onClick={() => setShowModal(false)}
-                className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={handleCreate}
-                disabled={saving || !form.name || !form.topic}
-                className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
-              >
-                {saving ? '...' : t('studyCircle.create')}
-              </button>
-            </div>
+      <Modal
+        isOpen={showModal}
+        onClose={() => setShowModal(false)}
+        title={t('studyCircle.create')}
+        maxWidth="max-w-md"
+      >
+        <div className="space-y-3">
+          <div>
+            <label className="text-xs text-gray-400 block mb-1">{t('studyCircle.name')}</label>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
+              placeholder="React学習会"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-gray-400 block mb-1">{t('studyCircle.topic')}</label>
+            <input
+              type="text"
+              value={form.topic}
+              onChange={(e) => setForm({ ...form, topic: e.target.value })}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
+              placeholder="React入門を1ヶ月で"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-gray-400 block mb-1">{t('studyCircle.description')}</label>
+            <textarea
+              value={form.description}
+              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500 h-20 resize-none"
+            />
+          </div>
+          <div>
+            <label className="text-xs text-gray-400 block mb-1">{t('studyCircle.maxMembers')}</label>
+            <input
+              type="number"
+              min={3}
+              max={10}
+              value={form.max_members}
+              onChange={(e) => setForm({ ...form, max_members: parseInt(e.target.value) || 5 })}
+              className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
+            />
           </div>
         </div>
-      )}
+        <div className="flex justify-end gap-2 mt-5">
+          <button
+            onClick={() => setShowModal(false)}
+            className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={handleCreate}
+            disabled={saving || !form.name || !form.topic}
+            className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            {saving ? '...' : t('studyCircle.create')}
+          </button>
+        </div>
+      </Modal>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- Escapeキー・背景クリック対応の共有 `Modal` コンポーネントを TDD で作成
- 7ページ（QA・BookReviews・Dashboard・Goals・Projects・StudyCircles・Roadmaps）の手書きモーダルを `Modal` コンポーネントに置き換え
- 不要になった `X` アイコンインポートを削除

## テスト
- Modal コンポーネントの単体テスト 7件（表示/非表示、背景クリック、内部クリック伝播停止、Escapeキー、タイトル有無、maxWidth）
- TypeScript 型チェック通過

closes #278