### PR TITLE
refactor: follow/notification/learning_goal ハンドラをインターフェース化

### DIFF
--- a/backend/internal/handler/follow.go
+++ b/backend/internal/handler/follow.go
@@ -3,17 +3,24 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// FollowServiceInterface はFollowServiceが実装すべきインターフェース。
+type FollowServiceInterface interface {
+	Follow(followerID, followeeID uint) error
+	Unfollow(followerID, followeeID uint) error
+	GetFollowers(userID uint) ([]model.User, error)
+	GetFollowing(userID uint) ([]model.User, error)
+}
 
 // FollowHandler はフォロー関連のHTTPハンドラ。
 // フォロー・アンフォロー・フォロワー/フォロー中一覧の取得を処理する。
 type FollowHandler struct {
-	service *service.FollowService
+	service FollowServiceInterface
 }
 
 // NewFollowHandler は新しいFollowHandlerインスタンスを生成する。
-func NewFollowHandler(s *service.FollowService) *FollowHandler {
+func NewFollowHandler(s FollowServiceInterface) *FollowHandler {
 	return &FollowHandler{service: s}
 }
 

--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -6,17 +6,26 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// LearningGoalServiceInterface はLearningGoalServiceが実装すべきインターフェース。
+type LearningGoalServiceInterface interface {
+	Create(goal *model.LearningGoal) error
+	GetByID(id uint) (*model.LearningGoal, error)
+	GetByUserID(userID uint) ([]model.LearningGoal, error)
+	GetStats(userID uint) (*model.LearningGoalStats, error)
+	Update(id, userID uint, updates *model.LearningGoal) (*model.LearningGoal, error)
+	Delete(id, userID uint) error
+}
 
 // LearningGoalHandler は学習目標関連のHTTPハンドラ。
 // 学習目標のCRUD・統計情報の取得を処理する。
 type LearningGoalHandler struct {
-	service *service.LearningGoalService
+	service LearningGoalServiceInterface
 }
 
 // NewLearningGoalHandler は新しいLearningGoalHandlerインスタンスを生成する。
-func NewLearningGoalHandler(s *service.LearningGoalService) *LearningGoalHandler {
+func NewLearningGoalHandler(s LearningGoalServiceInterface) *LearningGoalHandler {
 	return &LearningGoalHandler{service: s}
 }
 

--- a/backend/internal/handler/notification.go
+++ b/backend/internal/handler/notification.go
@@ -2,17 +2,27 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
+
+// NotificationServiceInterface はNotificationServiceが実装すべきインターフェース。
+type NotificationServiceInterface interface {
+	GetByUserID(userID uint, page, limit int, notificationType string) ([]model.Notification, error)
+	CountByUserID(userID uint, notificationType string) (int64, error)
+	CountUnread(userID uint) (int64, error)
+	MarkAsRead(id, userID uint) error
+	MarkAllAsRead(userID uint) error
+	Delete(id, userID uint) error
+}
 
 // NotificationHandler は通知関連のHTTPハンドラ。
 // 通知の取得・既読処理・削除を処理する。
 type NotificationHandler struct {
-	service *service.NotificationService
+	service NotificationServiceInterface
 }
 
 // NewNotificationHandler は新しいNotificationHandlerインスタンスを生成する。
-func NewNotificationHandler(s *service.NotificationService) *NotificationHandler {
+func NewNotificationHandler(s NotificationServiceInterface) *NotificationHandler {
 	return &NotificationHandler{service: s}
 }
 


### PR DESCRIPTION
## 概要
- FollowHandler: FollowServiceInterface（4メソッド）を定義し具体型を置き換え
- NotificationHandler: NotificationServiceInterface（6メソッド）を定義し具体型を置き換え
- LearningGoalHandler: LearningGoalServiceInterface（6メソッド）を定義し具体型を置き換え
- 各ハンドラから `service` パッケージインポートを削除

## テスト
- `go build ./...` 通過
- 既存テスト通過（既知の失敗3件は変更と無関係）

closes #280