### PR TITLE
test: FollowHandler・NotificationHandler のユニットテスト追加

### DIFF
--- a/backend/internal/handler/follow_test.go
+++ b/backend/internal/handler/follow_test.go
@@ -1,0 +1,131 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/assert"
+)
+
+// ---------- Follow ----------
+
+func TestFollow_Success(t *testing.T) {
+	h, svc := setupFollowHandler()
+	svc.On("Follow", uint(1), uint(2)).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/users/:id/follow", h.Follow)
+	w := doRequest(r, "POST", "/users/2/follow", nil)
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestFollow_InvalidID(t *testing.T) {
+	h, _ := setupFollowHandler()
+
+	r := newRouter(1)
+	r.POST("/users/:id/follow", h.Follow)
+	w := doRequest(r, "POST", "/users/abc/follow", nil)
+	assertStatus(t, w, 400)
+}
+
+func TestFollow_ServiceError(t *testing.T) {
+	h, svc := setupFollowHandler()
+	svc.On("Follow", uint(1), uint(2)).Return(service.ErrBadRequest)
+
+	r := newRouter(1)
+	r.POST("/users/:id/follow", h.Follow)
+	w := doRequest(r, "POST", "/users/2/follow", nil)
+	assertStatus(t, w, 400)
+}
+
+// ---------- Unfollow ----------
+
+func TestUnfollow_Success(t *testing.T) {
+	h, svc := setupFollowHandler()
+	svc.On("Unfollow", uint(1), uint(2)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/users/:id/follow", h.Unfollow)
+	w := doRequest(r, "DELETE", "/users/2/follow", nil)
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestUnfollow_ServiceError(t *testing.T) {
+	h, svc := setupFollowHandler()
+	svc.On("Unfollow", uint(1), uint(2)).Return(service.ErrNotFound)
+
+	r := newRouter(1)
+	r.DELETE("/users/:id/follow", h.Unfollow)
+	w := doRequest(r, "DELETE", "/users/2/follow", nil)
+	assertStatus(t, w, 404)
+}
+
+// ---------- GetFollowers ----------
+
+func TestGetFollowers_Success(t *testing.T) {
+	h, svc := setupFollowHandler()
+	users := []model.User{{Name: "alice"}, {Name: "bob"}}
+	svc.On("GetFollowers", uint(2)).Return(users, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:id/followers", h.GetFollowers)
+	w := doRequest(r, "GET", "/users/2/followers", nil)
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestGetFollowers_Empty(t *testing.T) {
+	h, svc := setupFollowHandler()
+	var empty []model.User
+	svc.On("GetFollowers", uint(2)).Return(empty, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:id/followers", h.GetFollowers)
+	w := doRequest(r, "GET", "/users/2/followers", nil)
+	assertStatus(t, w, 200)
+	// nilの場合は空配列を返すことを確認
+	body := w.Body.String()
+	assert.Contains(t, body, "[]")
+}
+
+func TestGetFollowers_ServiceError(t *testing.T) {
+	h, svc := setupFollowHandler()
+	var empty []model.User
+	svc.On("GetFollowers", uint(2)).Return(empty, fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/users/:id/followers", h.GetFollowers)
+	w := doRequest(r, "GET", "/users/2/followers", nil)
+	assertStatus(t, w, 500)
+}
+
+// ---------- GetFollowing ----------
+
+func TestGetFollowing_Success(t *testing.T) {
+	h, svc := setupFollowHandler()
+	users := []model.User{{Name: "charlie"}}
+	svc.On("GetFollowing", uint(2)).Return(users, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:id/following", h.GetFollowing)
+	w := doRequest(r, "GET", "/users/2/following", nil)
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestGetFollowing_Empty(t *testing.T) {
+	h, svc := setupFollowHandler()
+	var empty []model.User
+	svc.On("GetFollowing", uint(2)).Return(empty, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:id/following", h.GetFollowing)
+	w := doRequest(r, "GET", "/users/2/following", nil)
+	assertStatus(t, w, 200)
+	body := w.Body.String()
+	assert.Contains(t, body, "[]")
+}

--- a/backend/internal/handler/notification_test.go
+++ b/backend/internal/handler/notification_test.go
@@ -1,0 +1,169 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+)
+
+// ---------- GetAll ----------
+
+func TestNotificationGetAll_Success(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	notifs := []model.Notification{{ID: 1, UserID: 1}}
+	svc.On("GetByUserID", uint(1), 1, 20, "").Return(notifs, nil)
+	svc.On("CountByUserID", uint(1), "").Return(int64(1), nil)
+
+	r := newRouter(1)
+	r.GET("/notifications", h.GetAll)
+	w := doRequest(r, "GET", "/notifications", nil)
+	assertStatus(t, w, 200)
+
+	body := parseJSON(t, w)
+	_, hasNotifs := body["notifications"]
+	if !hasNotifs {
+		t.Error("レスポンスに notifications フィールドがない")
+	}
+	svc.AssertExpectations(t)
+}
+
+func TestNotificationGetAll_WithTypeFilter(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	notifs := []model.Notification{}
+	svc.On("GetByUserID", uint(1), 1, 20, "follow").Return(notifs, nil)
+	svc.On("CountByUserID", uint(1), "follow").Return(int64(0), nil)
+
+	r := newRouter(1)
+	r.GET("/notifications", h.GetAll)
+	w := doRequest(r, "GET", "/notifications?type=follow", nil)
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestNotificationGetAll_ServiceError(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	notifs := []model.Notification{}
+	svc.On("GetByUserID", uint(1), 1, 20, "").Return(notifs, fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/notifications", h.GetAll)
+	w := doRequest(r, "GET", "/notifications", nil)
+	assertStatus(t, w, 500)
+}
+
+// ---------- GetUnreadCount ----------
+
+func TestNotificationGetUnreadCount_Success(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	svc.On("CountUnread", uint(1)).Return(int64(5), nil)
+
+	r := newRouter(1)
+	r.GET("/notifications/unread", h.GetUnreadCount)
+	w := doRequest(r, "GET", "/notifications/unread", nil)
+	assertStatus(t, w, 200)
+
+	body := parseJSON(t, w)
+	count, ok := body["count"].(float64)
+	if !ok || count != 5 {
+		t.Errorf("count should be 5, got %v", body["count"])
+	}
+}
+
+func TestNotificationGetUnreadCount_Error(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	svc.On("CountUnread", uint(1)).Return(int64(0), fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/notifications/unread", h.GetUnreadCount)
+	w := doRequest(r, "GET", "/notifications/unread", nil)
+	assertStatus(t, w, 500)
+}
+
+// ---------- MarkAsRead ----------
+
+func TestNotificationMarkAsRead_Success(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	svc.On("MarkAsRead", uint(10), uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.PATCH("/notifications/:id/read", h.MarkAsRead)
+	w := doRequest(r, "PATCH", "/notifications/10/read", nil)
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestNotificationMarkAsRead_InvalidID(t *testing.T) {
+	h, _ := setupNotificationHandler()
+
+	r := newRouter(1)
+	r.PATCH("/notifications/:id/read", h.MarkAsRead)
+	w := doRequest(r, "PATCH", "/notifications/abc/read", nil)
+	assertStatus(t, w, 400)
+}
+
+func TestNotificationMarkAsRead_NotFound(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	svc.On("MarkAsRead", uint(999), uint(1)).Return(service.ErrNotFound)
+
+	r := newRouter(1)
+	r.PATCH("/notifications/:id/read", h.MarkAsRead)
+	w := doRequest(r, "PATCH", "/notifications/999/read", nil)
+	assertStatus(t, w, 404)
+}
+
+// ---------- MarkAllAsRead ----------
+
+func TestNotificationMarkAllAsRead_Success(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	svc.On("MarkAllAsRead", uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.PATCH("/notifications/read-all", h.MarkAllAsRead)
+	w := doRequest(r, "PATCH", "/notifications/read-all", nil)
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestNotificationMarkAllAsRead_Error(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	svc.On("MarkAllAsRead", uint(1)).Return(fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.PATCH("/notifications/read-all", h.MarkAllAsRead)
+	w := doRequest(r, "PATCH", "/notifications/read-all", nil)
+	assertStatus(t, w, 500)
+}
+
+// ---------- Delete ----------
+
+func TestNotificationDelete_Success(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	svc.On("Delete", uint(10), uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/notifications/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/notifications/10", nil)
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestNotificationDelete_NotFound(t *testing.T) {
+	h, svc := setupNotificationHandler()
+	svc.On("Delete", uint(999), uint(1)).Return(service.ErrNotFound)
+
+	r := newRouter(1)
+	r.DELETE("/notifications/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/notifications/999", nil)
+	assertStatus(t, w, 404)
+}
+
+func TestNotificationDelete_InvalidID(t *testing.T) {
+	h, _ := setupNotificationHandler()
+
+	r := newRouter(1)
+	r.DELETE("/notifications/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/notifications/abc", nil)
+	assertStatus(t, w, 400)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -687,3 +687,60 @@ func setupAnswerHandler() (*AnswerHandler, *MockAnswerService) {
 	h := NewAnswerHandler(svc)
 	return h, svc
 }
+
+// MockFollowService は FollowServiceInterface のモック実装。
+type MockFollowService struct{ mock.Mock }
+
+func (m *MockFollowService) Follow(followerID, followeeID uint) error {
+	return m.Called(followerID, followeeID).Error(0)
+}
+func (m *MockFollowService) Unfollow(followerID, followeeID uint) error {
+	return m.Called(followerID, followeeID).Error(0)
+}
+func (m *MockFollowService) GetFollowers(userID uint) ([]model.User, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.User), args.Error(1)
+}
+func (m *MockFollowService) GetFollowing(userID uint) ([]model.User, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.User), args.Error(1)
+}
+
+// setupFollowHandler はFollowHandlerテスト用のセットアップを行う。
+func setupFollowHandler() (*FollowHandler, *MockFollowService) {
+	svc := new(MockFollowService)
+	h := NewFollowHandler(svc)
+	return h, svc
+}
+
+// MockNotificationService は NotificationServiceInterface のモック実装。
+type MockNotificationService struct{ mock.Mock }
+
+func (m *MockNotificationService) GetByUserID(userID uint, page, limit int, notificationType string) ([]model.Notification, error) {
+	args := m.Called(userID, page, limit, notificationType)
+	return args.Get(0).([]model.Notification), args.Error(1)
+}
+func (m *MockNotificationService) CountByUserID(userID uint, notificationType string) (int64, error) {
+	args := m.Called(userID, notificationType)
+	return args.Get(0).(int64), args.Error(1)
+}
+func (m *MockNotificationService) CountUnread(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+func (m *MockNotificationService) MarkAsRead(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+func (m *MockNotificationService) MarkAllAsRead(userID uint) error {
+	return m.Called(userID).Error(0)
+}
+func (m *MockNotificationService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+
+// setupNotificationHandler はNotificationHandlerテスト用のセットアップを行う。
+func setupNotificationHandler() (*NotificationHandler, *MockNotificationService) {
+	svc := new(MockNotificationService)
+	h := NewNotificationHandler(svc)
+	return h, svc
+}


### PR DESCRIPTION
## 概要
- FollowHandler の全4エンドポイント（Follow/Unfollow/GetFollowers/GetFollowing）に10テスト追加
- NotificationHandler の全5エンドポイント（GetAll/GetUnreadCount/MarkAsRead/MarkAllAsRead/Delete）に13テスト追加
- MockFollowService・MockNotificationService を testutil_test.go に追加

## テスト
- 新規23テスト全て GREEN
- 既存テスト影響なし

closes #282