### PR TITLE
feat: 削除確認をブラウザconfirm()からConfirmDialogに統一

### DIFF
--- a/frontend/src/hooks/useBookReviews.ts
+++ b/frontend/src/hooks/useBookReviews.ts
@@ -55,7 +55,6 @@ export function useBookReviews() {
   }, [t, reviews]);
 
   const handleDelete = useCallback(async (review: BookReview) => {
-    if (!confirm(t('bookReviews.confirmDelete'))) return false;
     try {
       await deleteBookReview(review.id);
       setLocalReviews(prev => (prev ?? reviews).filter(r => r.id !== review.id));

--- a/frontend/src/hooks/useGoals.ts
+++ b/frontend/src/hooks/useGoals.ts
@@ -79,7 +79,6 @@ export function useGoals() {
   }, [t, setGoals]);
 
   const handleDelete = useCallback(async (id: number) => {
-    if (!confirm(t('goals.confirmDelete'))) return false;
     try {
       await deleteGoal(id);
       setGoals(prev => prev.filter(g => g.id !== id));

--- a/frontend/src/hooks/usePosts.ts
+++ b/frontend/src/hooks/usePosts.ts
@@ -44,8 +44,6 @@ export function usePosts() {
   }, [refetch]);
 
   const handleDeletePost = useCallback(async (post: Post) => {
-    if (!confirm(`「${post.title}」を削除してもよろしいですか？`)) return false;
-
     try {
       await apiDeletePost(post.id);
       await refetch();

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -65,7 +65,6 @@ export function useProjects() {
   }, [t, projects]);
 
   const handleDelete = useCallback(async (project: Project) => {
-    if (!confirm(t('projects.confirmDelete'))) return false;
     try {
       await deleteProject(project.id);
       setLocalProjects(prev => (prev ?? projects).filter(p => p.id !== project.id));

--- a/frontend/src/hooks/useQuestions.ts
+++ b/frontend/src/hooks/useQuestions.ts
@@ -74,7 +74,6 @@ export function useQuestions() {
   }, [t, questions]);
 
   const handleDelete = useCallback(async (question: Question) => {
-    if (!confirm(t('qa.confirmDelete'))) return false;
     try {
       await deleteQuestion(question.id);
       setLocalQuestions(prev => (prev ?? questions).filter(q => q.id !== question.id));

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -70,6 +70,7 @@
     "findPeople": "Finde Personen zum Folgen",
     "yourProfile": "Dein Profil",
     "connectGitHub": "GitHub verbinden um zu starten",
+    "confirmDeletePost": "Möchten Sie diesen Beitrag wirklich löschen?",
     "goalsProgress": "Ziel-Fortschritt",
     "viewAll": "Alle anzeigen",
     "noActiveGoals": "Keine aktiven Ziele",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -70,6 +70,7 @@
     "findPeople": "Find people to follow",
     "yourProfile": "Your profile",
     "connectGitHub": "Connect GitHub to get started",
+    "confirmDeletePost": "Are you sure you want to delete this post?",
     "goalsProgress": "Goals Progress",
     "viewAll": "View all",
     "noActiveGoals": "No active goals",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -70,6 +70,7 @@
     "findPeople": "Encuentra personas para seguir",
     "yourProfile": "Tu perfil",
     "connectGitHub": "Conecta GitHub para comenzar",
+    "confirmDeletePost": "¿Estás seguro de que quieres eliminar esta publicación?",
     "goalsProgress": "Progreso de objetivos",
     "viewAll": "Ver todo",
     "noActiveGoals": "No hay objetivos activos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -70,6 +70,7 @@
     "findPeople": "Trouver des personnes à suivre",
     "yourProfile": "Votre profil",
     "connectGitHub": "Connectez GitHub pour commencer",
+    "confirmDeletePost": "Êtes-vous sûr de vouloir supprimer cette publication ?",
     "goalsProgress": "Progression des objectifs",
     "viewAll": "Tout voir",
     "noActiveGoals": "Aucun objectif actif",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -71,6 +71,7 @@
     "findPeople": "フォローする人を探す",
     "yourProfile": "あなたのプロフィール",
     "connectGitHub": "GitHubを連携して始めましょう",
+    "confirmDeletePost": "この投稿を削除してもよろしいですか？",
     "goalsProgress": "学習目標の進捗",
     "viewAll": "すべて見る",
     "noActiveGoals": "進行中の目標がありません",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -70,6 +70,7 @@
     "findPeople": "팔로우할 사람 찾기",
     "yourProfile": "내 프로필",
     "connectGitHub": "GitHub 연결하고 시작하기",
+    "confirmDeletePost": "이 게시물을 삭제하시겠습니까?",
     "goalsProgress": "학습 목표 진행률",
     "viewAll": "전체 보기",
     "noActiveGoals": "진행 중인 목표가 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -70,6 +70,7 @@
     "findPeople": "Encontrar pessoas para seguir",
     "yourProfile": "Seu perfil",
     "connectGitHub": "Conecte o GitHub para começar",
+    "confirmDeletePost": "Tem certeza de que deseja excluir esta publicação?",
     "goalsProgress": "Progresso das metas",
     "viewAll": "Ver tudo",
     "noActiveGoals": "Nenhuma meta ativa",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -70,6 +70,7 @@
     "findPeople": "Найти людей для подписки",
     "yourProfile": "Ваш профиль",
     "connectGitHub": "Подключите GitHub чтобы начать",
+    "confirmDeletePost": "Вы уверены, что хотите удалить эту публикацию?",
     "goalsProgress": "Прогресс целей",
     "viewAll": "Смотреть все",
     "noActiveGoals": "Нет активных целей",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -70,6 +70,7 @@
     "findPeople": "发现更多开发者",
     "yourProfile": "你的个人资料",
     "connectGitHub": "连接 GitHub 开始使用",
+    "confirmDeletePost": "确定要删除这篇帖子吗？",
     "goalsProgress": "学习目标进度",
     "viewAll": "查看全部",
     "noActiveGoals": "没有进行中的目标",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -70,6 +70,7 @@
     "findPeople": "尋找更多開發者",
     "yourProfile": "你的個人資料",
     "connectGitHub": "連接 GitHub 開始使用",
+    "confirmDeletePost": "確定要刪除這篇貼文嗎？",
     "goalsProgress": "學習目標進度",
     "viewAll": "查看全部",
     "noActiveGoals": "沒有進行中的目標",

--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -3,11 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { BookOpen } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import type { BookReview } from '../types/bookReview';
-import { useBookReviews } from '../hooks';
+import { useBookReviews, useConfirm } from '../hooks';
 import BookReviewCard from '../components/bookReviews/BookReviewCard';
 import BookReviewForm from '../components/bookReviews/BookReviewForm';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import { EmptyState, Modal, Pagination } from '../components/common';
+import ConfirmDialog from '../components/common/ConfirmDialog';
 
 export default function BookReviewsPage() {
   const { t } = useTranslation();
@@ -17,8 +18,15 @@ export default function BookReviewsPage() {
     createReview, updateReview, deleteReview,
   } = useBookReviews();
 
+  const { confirm, dialogProps } = useConfirm();
+
   const [showForm, setShowForm] = useState(false);
   const [editingReview, setEditingReview] = useState<BookReview | null>(null);
+
+  const handleDeleteReview = async (review: BookReview) => {
+    const ok = await confirm({ title: t('common.confirm'), message: t('bookReviews.confirmDelete'), variant: 'danger' });
+    if (ok) deleteReview(review);
+  };
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
@@ -86,7 +94,7 @@ export default function BookReviewsPage() {
                 isOwner={user?.id === review.user_id}
                 showUser={true}
                 onEdit={() => setEditingReview(review)}
-                onDelete={() => deleteReview(review)}
+                onDelete={() => handleDeleteReview(review)}
               />
             ))}
           </div>
@@ -99,6 +107,7 @@ export default function BookReviewsPage() {
           />
         </>
       )}
+      <ConfirmDialog {...dialogProps} />
     </div>
   );
 }

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Target, Bell, TrendingUp, CheckCircle2, Clock, ChevronRight } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
-import { usePosts, useDashboard, useBadgeNotifier } from '../hooks';
+import { usePosts, useDashboard, useBadgeNotifier, useConfirm } from '../hooks';
 import { getUserBadges } from '../api/badges';
 import { useAsyncData } from '../hooks/useAsyncData';
 import type { BadgeResult } from '../types/badge';
@@ -11,6 +11,7 @@ import type { Post } from '../types/post';
 import PostCard from '../components/posts/PostCard';
 import PostForm from '../components/posts/PostForm';
 import { Modal } from '../components/common';
+import ConfirmDialog from '../components/common/ConfirmDialog';
 import QuickPostForm from '../components/posts/QuickPostForm';
 import { PostCardSkeleton } from '../components/common/Skeleton';
 import Avatar from '../components/common/Avatar';
@@ -27,7 +28,13 @@ export default function DashboardPage() {
   const { t } = useTranslation();
   const user = useAuthStore((s) => s.user);
   const { posts, loading, tab, setTab, createPost, updatePost, deletePost, refetch } = usePosts();
+  const { confirm, dialogProps } = useConfirm();
   const [editingPost, setEditingPost] = useState<Post | null>(null);
+
+  const handleDeletePost = async (post: Post) => {
+    const ok = await confirm({ title: t('common.confirm'), message: t('dashboard.confirmDeletePost'), variant: 'danger' });
+    if (ok) deletePost(post);
+  };
   const {
     activeGoals,
     completedGoals,
@@ -146,7 +153,7 @@ export default function DashboardPage() {
                 post={post}
                 isOwner={user?.id === post.user_id}
                 onEdit={() => setEditingPost(post)}
-                onDelete={() => deletePost(post)}
+                onDelete={() => handleDeletePost(post)}
                 onUpdate={refetch}
               />
             ))}
@@ -396,6 +403,7 @@ export default function DashboardPage() {
           </div>
         </div>
       </div>
+      <ConfirmDialog {...dialogProps} />
     </div>
   );
 }

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -2,9 +2,10 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Monitor, Rocket, Target, FolderOpen, FileText, type LucideIcon } from 'lucide-react';
 import { type GoalCategory, type GoalStatus, type LearningGoal } from '../api/goals';
-import { useGoals } from '../hooks';
+import { useGoals, useConfirm } from '../hooks';
 import { Modal, PageLoader } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
+import ConfirmDialog from '../components/common/ConfirmDialog';
 
 const CATEGORIES: { value: GoalCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'goals.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -21,8 +22,15 @@ export default function GoalsPage() {
     createGoal, updateGoal, deleteGoal,
   } = useGoals();
 
+  const { confirm, dialogProps } = useConfirm();
+
   const [showForm, setShowForm] = useState(false);
   const [editingGoal, setEditingGoal] = useState<LearningGoal | null>(null);
+
+  const handleDeleteGoal = async (id: number) => {
+    const ok = await confirm({ title: t('common.confirm'), message: t('goals.confirmDelete'), variant: 'danger' });
+    if (ok) deleteGoal(id);
+  };
 
   // Form state
   const [title, setTitle] = useState('');
@@ -232,7 +240,7 @@ export default function GoalsPage() {
                     key={goal.id}
                     goal={goal}
                     onEdit={handleEdit}
-                    onDelete={deleteGoal}
+                    onDelete={handleDeleteGoal}
                     onProgressChange={handleProgressChange}
                     onStatusChange={handleStatusChange}
                     getCategoryInfo={getCategoryInfo}
@@ -255,7 +263,7 @@ export default function GoalsPage() {
                     key={goal.id}
                     goal={goal}
                     onEdit={handleEdit}
-                    onDelete={deleteGoal}
+                    onDelete={handleDeleteGoal}
                     onProgressChange={handleProgressChange}
                     onStatusChange={handleStatusChange}
                     getCategoryInfo={getCategoryInfo}
@@ -278,7 +286,7 @@ export default function GoalsPage() {
                     key={goal.id}
                     goal={goal}
                     onEdit={handleEdit}
-                    onDelete={deleteGoal}
+                    onDelete={handleDeleteGoal}
                     onProgressChange={handleProgressChange}
                     onStatusChange={handleStatusChange}
                     getCategoryInfo={getCategoryInfo}
@@ -291,6 +299,8 @@ export default function GoalsPage() {
           )}
         </div>
       )}
+
+      <ConfirmDialog {...dialogProps} />
     </div>
   );
 }

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -2,11 +2,12 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FolderOpen } from 'lucide-react';
 import type { Project } from '../types/project';
-import { useProjects } from '../hooks';
+import { useProjects, useConfirm } from '../hooks';
 import ProjectCard from '../components/projects/ProjectCard';
 import ProjectForm from '../components/projects/ProjectForm';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import EmptyState from '../components/common/EmptyState';
+import ConfirmDialog from '../components/common/ConfirmDialog';
 import { Modal } from '../components/common';
 
 export default function ProjectsPage() {
@@ -16,8 +17,15 @@ export default function ProjectsPage() {
     createProject, updateProject, deleteProject,
   } = useProjects();
 
+  const { confirm, dialogProps } = useConfirm();
+
   const [showForm, setShowForm] = useState(false);
   const [editingProject, setEditingProject] = useState<Project | null>(null);
+
+  const handleDeleteProject = async (project: Project) => {
+    const ok = await confirm({ title: t('common.confirm'), message: t('projects.confirmDelete'), variant: 'danger' });
+    if (ok) deleteProject(project);
+  };
 
   if (loading) {
     return (
@@ -87,11 +95,13 @@ export default function ProjectsPage() {
               project={project}
               isOwner
               onEdit={() => setEditingProject(project)}
-              onDelete={() => deleteProject(project)}
+              onDelete={() => handleDeleteProject(project)}
             />
           ))}
         </div>
       )}
+
+      <ConfirmDialog {...dialogProps} />
     </div>
   );
 }

--- a/frontend/src/pages/QAPage.tsx
+++ b/frontend/src/pages/QAPage.tsx
@@ -3,11 +3,12 @@ import { useTranslation } from 'react-i18next';
 import { HelpCircle } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import type { Question } from '../types/qa';
-import { useQuestions, useDebounce } from '../hooks';
+import { useQuestions, useDebounce, useConfirm } from '../hooks';
 import QuestionCard from '../components/qa/QuestionCard';
 import QuestionForm from '../components/qa/QuestionForm';
 import { QuestionCardSkeleton } from '../components/common/Skeleton';
 import { EmptyState, Modal, Pagination } from '../components/common';
+import ConfirmDialog from '../components/common/ConfirmDialog';
 
 export default function QAPage() {
   const { t } = useTranslation();
@@ -21,8 +22,15 @@ export default function QAPage() {
     createQuestion, updateQuestion, deleteQuestion,
   } = useQuestions();
 
+  const { confirm, dialogProps } = useConfirm();
+
   const [showForm, setShowForm] = useState(false);
   const [editingQuestion, setEditingQuestion] = useState<Question | null>(null);
+
+  const handleDeleteQuestion = async (question: Question) => {
+    const ok = await confirm({ title: t('common.confirm'), message: t('qa.confirmDelete'), variant: 'danger' });
+    if (ok) deleteQuestion(question);
+  };
 
   // デバウンス処理（300ms）
   const debouncedQuery = useDebounce(searchQuery, 300);
@@ -135,7 +143,7 @@ export default function QAPage() {
                 question={question}
                 isOwner={user?.id === question.user_id}
                 onEdit={() => setEditingQuestion(question)}
-                onDelete={() => deleteQuestion(question)}
+                onDelete={() => handleDeleteQuestion(question)}
               />
             ))}
           </div>
@@ -148,6 +156,7 @@ export default function QAPage() {
           />
         </>
       )}
+      <ConfirmDialog {...dialogProps} />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- 5つのフック（usePosts, useGoals, useProjects, useBookReviews, useQuestions）からブラウザネイティブの`confirm()`を削除
- 5つのページ（DashboardPage, GoalsPage, ProjectsPage, BookReviewsPage, QAPage）に`useConfirm` + `ConfirmDialog`パターンを導入
- 全10言語のi18nファイルに`dashboard.confirmDeletePost`キーを追加

## 変更内容
- **フック**: 各フックのdeleteハンドラから`confirm()`呼び出しを除去し、確認ロジックをページ層に移動
- **ページ**: `useConfirm`フックと`ConfirmDialog`コンポーネントで統一的な削除確認UIを提供
- **i18n**: 投稿削除の確認メッセージを全言語で追加

## テスト計画
- [x] TypeScriptビルドチェック通過
- [ ] 各ページの削除ボタンクリック時にConfirmDialogが表示されること
- [ ] ConfirmDialogのキャンセルで削除が中断されること
- [ ] ConfirmDialogの確認で削除が実行されること

Closes #284