### PR TITLE
refactor: project/roadmap/study_circle ハンドラをインターフェースに置換

### DIFF
--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
 
 // parseDate は日付文字列を "2006-01-02" 形式でパースする。
@@ -14,14 +13,26 @@ func parseDate(dateStr string) (time.Time, error) {
 	return time.Parse("2006-01-02", dateStr)
 }
 
+// ProjectServiceInterface はProjectHandlerが依存するサービスメソッドを定義する。
+type ProjectServiceInterface interface {
+	Create(project *model.Project) error
+	GetByID(id uint) (*model.Project, error)
+	GetByUserID(userID uint) ([]model.Project, error)
+	GetFeaturedByUserID(userID uint) ([]model.Project, error)
+	GetAll(limit, offset int) ([]model.Project, int64, error)
+	Update(id, userID uint, updates *model.Project) (*model.Project, error)
+	UpdateFeatured(id, userID uint, featured bool) (*model.Project, error)
+	Delete(id, userID uint) error
+}
+
 // ProjectHandler はプロジェクト関連のHTTPハンドラ。
 // プロジェクトのCRUD・注目プロジェクト取得・一覧取得を処理する。
 type ProjectHandler struct {
-	service *service.ProjectService
+	service ProjectServiceInterface
 }
 
 // NewProjectHandler は新しいProjectHandlerインスタンスを生成する。
-func NewProjectHandler(s *service.ProjectService) *ProjectHandler {
+func NewProjectHandler(s ProjectServiceInterface) *ProjectHandler {
 	return &ProjectHandler{service: s}
 }
 

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -9,14 +9,33 @@ import (
 	"github.com/norman6464/devsync/backend/internal/service"
 )
 
+// RoadmapServiceInterface はRoadmapHandlerが依存するサービスメソッドを定義する。
+type RoadmapServiceInterface interface {
+	Create(roadmap *model.Roadmap) error
+	GetByID(id, userID uint) (*model.Roadmap, error)
+	GetByUserID(userID uint) ([]model.Roadmap, error)
+	GetPublicRoadmaps(limit, offset int) ([]model.Roadmap, int64, error)
+	Update(id, userID uint, updates *model.Roadmap) (*model.Roadmap, error)
+	UpdateVisibility(id, userID uint, isPublic bool) (*model.Roadmap, error)
+	Delete(id, userID uint) error
+	CopyRoadmap(roadmapID, userID uint) (*model.Roadmap, error)
+	GetTemplates() ([]model.Roadmap, error)
+	CreateFromTemplate(templateID, userID uint) (*model.Roadmap, error)
+	CreateStep(roadmapID, userID uint, step *model.RoadmapStep) error
+	UpdateStep(roadmapID, stepID, userID uint, updates *model.RoadmapStep) (*model.RoadmapStep, error)
+	UpdateStepCompletion(roadmapID, stepID, userID uint, isCompleted bool) (*model.RoadmapStep, error)
+	DeleteStep(roadmapID, stepID, userID uint) error
+	ReorderSteps(roadmapID, userID uint, orders []service.StepOrder) error
+}
+
 // RoadmapHandler はロードマップ関連のHTTPハンドラ。
 // ロードマップとステップのCRUD・公開一覧・コピー・並べ替えを処理する。
 type RoadmapHandler struct {
-	service *service.RoadmapService
+	service RoadmapServiceInterface
 }
 
 // NewRoadmapHandler は新しいRoadmapHandlerインスタンスを生成する。
-func NewRoadmapHandler(s *service.RoadmapService) *RoadmapHandler {
+func NewRoadmapHandler(s RoadmapServiceInterface) *RoadmapHandler {
 	return &RoadmapHandler{service: s}
 }
 

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -6,16 +6,36 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// StudyCircleServiceInterface はStudyCircleHandlerが依存するサービスメソッドを定義する。
+type StudyCircleServiceInterface interface {
+	Create(circle *model.StudyCircle, memberIDs []uint) error
+	GetMyCircles(userID uint) ([]model.StudyCircle, error)
+	GetByID(id, userID uint) (*model.StudyCircle, error)
+	Update(id, userID uint, name, topic, description *string) (*model.StudyCircle, error)
+	Delete(id, userID uint) error
+	GetMembers(circleID, userID uint) ([]model.StudyCircleMember, error)
+	AddMember(circleID, userID, targetUserID uint) error
+	RemoveMember(circleID, userID, targetUserID uint) error
+	CreateStep(circleID, userID uint, step *model.StudyCircleStep) error
+	UpdateStep(circleID, userID, stepID uint, title, description *string) (*model.StudyCircleStep, error)
+	DeleteStep(circleID, userID, stepID uint) error
+	ReorderSteps(circleID, userID uint, orders []repository.StepOrder) error
+	UpdateProgress(circleID, userID, stepID uint, isCompleted bool) error
+	GetProgress(circleID, userID uint) ([]model.StudyCircleMemberProgress, error)
+	CreateCheckin(circleID, userID uint, content string) (*model.StudyCircleCheckin, error)
+	GetCheckins(circleID, userID uint) ([]model.StudyCircleCheckin, error)
+	GetStreakRanking(circleID, userID uint) ([]model.CircleMemberStreak, error)
+}
 
 // StudyCircleHandler はスタディサークル関連のHTTPリクエストを処理する。
 type StudyCircleHandler struct {
-	service *service.StudyCircleService
+	service StudyCircleServiceInterface
 }
 
 // NewStudyCircleHandler は新しいStudyCircleHandlerインスタンスを生成する。
-func NewStudyCircleHandler(svc *service.StudyCircleService) *StudyCircleHandler {
+func NewStudyCircleHandler(svc StudyCircleServiceInterface) *StudyCircleHandler {
 	return &StudyCircleHandler{service: svc}
 }
 


### PR DESCRIPTION
## 概要
3つのハンドラの具象サービス型をインターフェースに置換し、テスタビリティと疎結合化を推進。

## 変更内容
- **ProjectHandler**: `*service.ProjectService` → `ProjectServiceInterface` (8メソッド)
- **RoadmapHandler**: `*service.RoadmapService` → `RoadmapServiceInterface` (15メソッド)
- **StudyCircleHandler**: `*service.StudyCircleService` → `StudyCircleServiceInterface` (17メソッド)

## テスト計画
- [x] `go build ./...` 通過
- [x] 既存テスト影響なし（既知の3件の失敗は変更前と同一）

Closes #286