### PR TITLE
test: ProjectHandlerのユニットテスト17件を追加

### DIFF
--- a/backend/internal/handler/project_test.go
+++ b/backend/internal/handler/project_test.go
@@ -1,0 +1,251 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/mock"
+)
+
+// ---------- Create ----------
+
+func TestProjectCreate_Success(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("Create", mock.AnythingOfType("*model.Project")).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/projects", h.Create)
+	w := doRequest(r, "POST", "/projects", map[string]interface{}{
+		"title":       "My Project",
+		"description": "A test project",
+		"tech_stack":  "Go, React",
+	})
+
+	assertStatus(t, w, 201)
+	svc.AssertExpectations(t)
+}
+
+func TestProjectCreate_ValidationError(t *testing.T) {
+	h, _ := setupProjectHandler()
+
+	r := newRouter(1)
+	r.POST("/projects", h.Create)
+	// title is required
+	w := doRequest(r, "POST", "/projects", map[string]interface{}{
+		"description": "missing title",
+	})
+
+	assertStatus(t, w, 400)
+}
+
+func TestProjectCreate_ServiceError(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("Create", mock.AnythingOfType("*model.Project")).Return(fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.POST("/projects", h.Create)
+	w := doRequest(r, "POST", "/projects", map[string]interface{}{
+		"title": "My Project",
+	})
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetByID ----------
+
+func TestProjectGetByID_Success(t *testing.T) {
+	h, svc := setupProjectHandler()
+	project := &model.Project{Title: "Test", UserID: 1}
+	project.ID = 1
+	svc.On("GetByID", uint(1)).Return(project, nil)
+
+	r := newRouter(1)
+	r.GET("/projects/:id", h.GetByID)
+	w := doRequest(r, "GET", "/projects/1", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestProjectGetByID_InvalidID(t *testing.T) {
+	h, _ := setupProjectHandler()
+
+	r := newRouter(1)
+	r.GET("/projects/:id", h.GetByID)
+	w := doRequest(r, "GET", "/projects/abc", nil)
+
+	assertStatus(t, w, 400)
+}
+
+func TestProjectGetByID_NotFound(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("GetByID", uint(999)).Return(nil, service.ErrNotFound)
+
+	r := newRouter(1)
+	r.GET("/projects/:id", h.GetByID)
+	w := doRequest(r, "GET", "/projects/999", nil)
+
+	assertStatus(t, w, 404)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetByUserID ----------
+
+func TestProjectGetByUserID_Success(t *testing.T) {
+	h, svc := setupProjectHandler()
+	projects := []model.Project{{Title: "P1"}, {Title: "P2"}}
+	svc.On("GetByUserID", uint(1)).Return(projects, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/projects", h.GetByUserID)
+	w := doRequest(r, "GET", "/users/1/projects", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestProjectGetByUserID_Empty(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("GetByUserID", uint(1)).Return([]model.Project{}, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/projects", h.GetByUserID)
+	w := doRequest(r, "GET", "/users/1/projects", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetFeatured ----------
+
+func TestProjectGetFeatured_Success(t *testing.T) {
+	h, svc := setupProjectHandler()
+	projects := []model.Project{{Title: "Featured"}}
+	svc.On("GetFeaturedByUserID", uint(1)).Return(projects, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/projects/featured", h.GetFeatured)
+	w := doRequest(r, "GET", "/users/1/projects/featured", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+// ---------- Update ----------
+
+func TestProjectUpdate_Success(t *testing.T) {
+	h, svc := setupProjectHandler()
+	updated := &model.Project{Title: "Updated"}
+	updated.ID = 1
+	svc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.Project")).Return(updated, nil)
+
+	r := newRouter(1)
+	r.PUT("/projects/:id", h.Update)
+	w := doRequest(r, "PUT", "/projects/1", map[string]interface{}{
+		"title": "Updated",
+	})
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestProjectUpdate_WithFeatured(t *testing.T) {
+	h, svc := setupProjectHandler()
+	updated := &model.Project{Title: "Updated"}
+	updated.ID = 1
+	featured := true
+	svc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.Project")).Return(updated, nil)
+	svc.On("UpdateFeatured", uint(1), uint(1), featured).Return(updated, nil)
+
+	r := newRouter(1)
+	r.PUT("/projects/:id", h.Update)
+	w := doRequest(r, "PUT", "/projects/1", map[string]interface{}{
+		"title":    "Updated",
+		"featured": true,
+	})
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestProjectUpdate_ServiceError(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.Project")).Return(nil, service.ErrNotFound)
+
+	r := newRouter(1)
+	r.PUT("/projects/:id", h.Update)
+	w := doRequest(r, "PUT", "/projects/1", map[string]interface{}{
+		"title": "Updated",
+	})
+
+	assertStatus(t, w, 404)
+	svc.AssertExpectations(t)
+}
+
+// ---------- Delete ----------
+
+func TestProjectDelete_Success(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("Delete", uint(1), uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/projects/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/projects/1", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestProjectDelete_NotFound(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("Delete", uint(999), uint(1)).Return(service.ErrNotFound)
+
+	r := newRouter(1)
+	r.DELETE("/projects/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/projects/999", nil)
+
+	assertStatus(t, w, 404)
+	svc.AssertExpectations(t)
+}
+
+func TestProjectDelete_Forbidden(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("Delete", uint(1), uint(2)).Return(service.ErrForbidden)
+
+	r := newRouter(2)
+	r.DELETE("/projects/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/projects/1", nil)
+
+	assertStatus(t, w, 403)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetAll ----------
+
+func TestProjectGetAll_Success(t *testing.T) {
+	h, svc := setupProjectHandler()
+	projects := []model.Project{{Title: "P1"}}
+	svc.On("GetAll", 20, 0).Return(projects, int64(1), nil)
+
+	r := newRouter(1)
+	r.GET("/projects", h.GetAll)
+	w := doRequest(r, "GET", "/projects", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestProjectGetAll_ServiceError(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("GetAll", 20, 0).Return([]model.Project{}, int64(0), fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/projects", h.GetAll)
+	w := doRequest(r, "GET", "/projects", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -744,3 +744,53 @@ func setupNotificationHandler() (*NotificationHandler, *MockNotificationService)
 	h := NewNotificationHandler(svc)
 	return h, svc
 }
+
+// MockProjectService は ProjectServiceInterface のモック実装。
+type MockProjectService struct{ mock.Mock }
+
+func (m *MockProjectService) Create(project *model.Project) error {
+	return m.Called(project).Error(0)
+}
+func (m *MockProjectService) GetByID(id uint) (*model.Project, error) {
+	args := m.Called(id)
+	if p := args.Get(0); p != nil {
+		return p.(*model.Project), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockProjectService) GetByUserID(userID uint) ([]model.Project, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.Project), args.Error(1)
+}
+func (m *MockProjectService) GetFeaturedByUserID(userID uint) ([]model.Project, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.Project), args.Error(1)
+}
+func (m *MockProjectService) GetAll(limit, offset int) ([]model.Project, int64, error) {
+	args := m.Called(limit, offset)
+	return args.Get(0).([]model.Project), args.Get(1).(int64), args.Error(2)
+}
+func (m *MockProjectService) Update(id, userID uint, updates *model.Project) (*model.Project, error) {
+	args := m.Called(id, userID, updates)
+	if p := args.Get(0); p != nil {
+		return p.(*model.Project), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockProjectService) UpdateFeatured(id, userID uint, featured bool) (*model.Project, error) {
+	args := m.Called(id, userID, featured)
+	if p := args.Get(0); p != nil {
+		return p.(*model.Project), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockProjectService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+
+// setupProjectHandler はProjectHandlerテスト用のセットアップを行う。
+func setupProjectHandler() (*ProjectHandler, *MockProjectService) {
+	svc := new(MockProjectService)
+	h := NewProjectHandler(svc)
+	return h, svc
+}


### PR DESCRIPTION
## 概要
ProjectHandlerの全メソッドに対するユニットテスト17件を追加。

## テスト内容
| メソッド | テストケース | 件数 |
|---------|------------|------|
| Create | 成功・バリデーションエラー・サービスエラー | 3 |
| GetByID | 成功・無効ID・NotFound | 3 |
| GetByUserID | 成功・空 | 2 |
| GetFeatured | 成功 | 1 |
| Update | 成功・Featured更新・サービスエラー | 3 |
| Delete | 成功・NotFound・Forbidden | 3 |
| GetAll | 成功・サービスエラー | 2 |

## テスト計画
- [x] 全17テスト GREEN
- [x] 既存テストへの影響なし

Closes #288