### PR TITLE
feat: SearchInput共通コンポーネントを作成し検索UIを統一

### DIFF
--- a/frontend/src/components/common/SearchInput.tsx
+++ b/frontend/src/components/common/SearchInput.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next';
+import { Search } from 'lucide-react';
+
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSearch?: () => void;
+  placeholder?: string;
+  showButton?: boolean;
+}
+
+export default function SearchInput({ value, onChange, onSearch, placeholder, showButton = false }: SearchInputProps) {
+  const { t } = useTranslation();
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && onSearch) {
+      onSearch();
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      <div className="relative flex-1">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          className="w-full pl-10 pr-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+        />
+      </div>
+      {showButton && onSearch && (
+        <button
+          type="button"
+          onClick={onSearch}
+          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+        >
+          {t('common.search')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/SearchInput.test.tsx
+++ b/frontend/src/components/common/__tests__/SearchInput.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import SearchInput from '../SearchInput';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('SearchInput', () => {
+  it('入力フィールドが表示される', () => {
+    render(<SearchInput value="" onChange={() => {}} placeholder="検索..." />);
+    expect(screen.getByPlaceholderText('検索...')).toBeInTheDocument();
+  });
+
+  it('値の変更でonChangeが呼ばれる', () => {
+    const onChange = vi.fn();
+    render(<SearchInput value="" onChange={onChange} placeholder="検索..." />);
+    fireEvent.change(screen.getByPlaceholderText('検索...'), { target: { value: 'test' } });
+    expect(onChange).toHaveBeenCalledWith('test');
+  });
+
+  it('EnterキーでonSearchが呼ばれる', () => {
+    const onSearch = vi.fn();
+    render(<SearchInput value="query" onChange={() => {}} onSearch={onSearch} placeholder="検索..." />);
+    fireEvent.keyDown(screen.getByPlaceholderText('検索...'), { key: 'Enter' });
+    expect(onSearch).toHaveBeenCalledOnce();
+  });
+
+  it('onSearchが未指定の場合Enterキーでエラーにならない', () => {
+    render(<SearchInput value="query" onChange={() => {}} placeholder="検索..." />);
+    expect(() => {
+      fireEvent.keyDown(screen.getByPlaceholderText('検索...'), { key: 'Enter' });
+    }).not.toThrow();
+  });
+
+  it('showButton=trueで検索ボタンが表示される', () => {
+    const onSearch = vi.fn();
+    render(<SearchInput value="" onChange={() => {}} onSearch={onSearch} showButton />);
+    const button = screen.getByText('common.search');
+    expect(button).toBeInTheDocument();
+    fireEvent.click(button);
+    expect(onSearch).toHaveBeenCalledOnce();
+  });
+
+  it('showButton=falseの場合ボタンが表示されない', () => {
+    render(<SearchInput value="" onChange={() => {}} onSearch={() => {}} />);
+    expect(screen.queryByText('common.search')).toBeNull();
+  });
+
+  it('showButton=trueでもonSearch未指定の場合ボタンが表示されない', () => {
+    render(<SearchInput value="" onChange={() => {}} showButton />);
+    expect(screen.queryByText('common.search')).toBeNull();
+  });
+
+  it('検索アイコンが表示される', () => {
+    const { container } = render(<SearchInput value="" onChange={() => {}} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -5,3 +5,4 @@ export { Skeleton, PostCardSkeleton, UserCardSkeleton } from './Skeleton';
 export { default as EmptyState } from './EmptyState';
 export { default as Modal } from './Modal';
 export { default as Pagination } from './Pagination';
+export { default as SearchInput } from './SearchInput';

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BookOpen, Star, Search, Plus, Edit, Trash2 } from 'lucide-react';
+import { BookOpen, Star, Plus, Edit, Trash2 } from 'lucide-react';
 import { useNotes } from '../hooks';
-import { PageLoader } from '../components/common';
+import { PageLoader, SearchInput } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 import type { Note } from '../api/notes';
 
@@ -83,16 +83,11 @@ export default function NotesPage() {
 
       {/* Search Bar */}
       <div className="mb-6">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-          <input
-            type="text"
-            placeholder={t('notes.searchPlaceholder')}
-            value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
-            className="w-full pl-10 pr-4 py-2 bg-gray-800 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          />
-        </div>
+        <SearchInput
+          value={searchQuery}
+          onChange={setSearchQuery}
+          placeholder={t('notes.searchPlaceholder')}
+        />
       </div>
 
       {/* Create/Edit Form */}

--- a/frontend/src/pages/QAPage.tsx
+++ b/frontend/src/pages/QAPage.tsx
@@ -7,7 +7,7 @@ import { useQuestions, useDebounce, useConfirm } from '../hooks';
 import QuestionCard from '../components/qa/QuestionCard';
 import QuestionForm from '../components/qa/QuestionForm';
 import { QuestionCardSkeleton } from '../components/common/Skeleton';
-import { EmptyState, Modal, Pagination } from '../components/common';
+import { EmptyState, Modal, Pagination, SearchInput } from '../components/common';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 
 export default function QAPage() {
@@ -63,22 +63,13 @@ export default function QAPage() {
       {/* Search & Sort */}
       <div className="flex flex-wrap gap-4 mb-6">
         <div className="flex-1 min-w-[200px]">
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
-              placeholder={t('qa.searchPlaceholder')}
-              className="flex-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
-            />
-            <button
-              onClick={handleSearch}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-            >
-              {t('common.search')}
-            </button>
-          </div>
+          <SearchInput
+            value={searchQuery}
+            onChange={setSearchQuery}
+            onSearch={handleSearch}
+            placeholder={t('qa.searchPlaceholder')}
+            showButton
+          />
         </div>
         <div className="flex gap-2">
           {(['newest', 'votes', 'unanswered'] as const).map(s => (

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -8,7 +8,7 @@ import ResourceCard from '../components/resources/ResourceCard';
 import ResourceForm from '../components/resources/ResourceForm';
 import { ResourceCardSkeleton } from '../components/common/Skeleton';
 import EmptyState from '../components/common/EmptyState';
-import { Pagination } from '../components/common';
+import { Pagination, SearchInput } from '../components/common';
 
 const categories: (ResourceCategory | '')[] = ['', 'book', 'video', 'article', 'course', 'tutorial', 'podcast', 'tool', 'other'];
 const difficulties: (ResourceDifficulty | '')[] = ['', 'beginner', 'intermediate', 'advanced'];
@@ -91,22 +91,13 @@ export default function ResourcesPage() {
       {tab === 'explore' && (
         <div className="flex flex-wrap gap-4 mb-6">
           <div className="flex-1 min-w-[200px]">
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
-                placeholder={t('resources.searchPlaceholder')}
-                className="flex-1 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
-              />
-              <button
-                onClick={handleSearch}
-                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-              >
-                {t('common.search')}
-              </button>
-            </div>
+            <SearchInput
+              value={searchQuery}
+              onChange={setSearchQuery}
+              onSearch={handleSearch}
+              placeholder={t('resources.searchPlaceholder')}
+              showButton
+            />
           </div>
           <select
             value={categoryFilter}


### PR DESCRIPTION
## 概要
NotesPage・QAPage・ResourcesPageで重複していた検索入力UIを共通SearchInputコンポーネントに統一。

## 変更内容
- `SearchInput` コンポーネント新規作成（Searchアイコン + 入力 + オプション検索ボタン）
- NotesPage: 手書きSearch icon + inputをSearchInputに置換
- QAPage: 手書きinput + buttonをSearchInput(showButton)に置換
- ResourcesPage: 手書きinput + buttonをSearchInput(showButton)に置換
- バレルエクスポート追加
- テスト8件追加

Closes #290