### PR TITLE
refactor: BadgeHandler・RankingHandler・LevelHandlerのインターフェース化

### DIFF
--- a/backend/internal/handler/badge.go
+++ b/backend/internal/handler/badge.go
@@ -7,14 +7,20 @@ import (
 	"github.com/norman6464/devsync/backend/internal/service"
 )
 
+// BadgeServiceInterface はBadgeHandlerが依存するサービスメソッドを定義する。
+type BadgeServiceInterface interface {
+	GetUserBadges(userID uint) ([]service.BadgeResult, error)
+	NotifyBadgeEarned(userID uint, badgeID string) error
+}
+
 // BadgeHandler はバッジ関連のHTTPハンドラ。
 // ユーザーバッジの取得・バッジ獲得通知の作成を処理する。
 type BadgeHandler struct {
-	service *service.BadgeService
+	service BadgeServiceInterface
 }
 
 // NewBadgeHandler は新しいBadgeHandlerインスタンスを生成する。
-func NewBadgeHandler(s *service.BadgeService) *BadgeHandler {
+func NewBadgeHandler(s BadgeServiceInterface) *BadgeHandler {
 	return &BadgeHandler{service: s}
 }
 

--- a/backend/internal/handler/level.go
+++ b/backend/internal/handler/level.go
@@ -2,17 +2,23 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
+
+// LevelServiceInterface はLevelHandlerが依存するサービスメソッドを定義する。
+type LevelServiceInterface interface {
+	GetLevelInfo(userID uint) (*model.LevelInfo, error)
+	GetXPBreakdown(userID uint) (*model.XPBreakdown, error)
+}
 
 // LevelHandler はレベルシステム関連のHTTPハンドラ。
 // ユーザーのレベル情報とXP内訳の取得を処理する。
 type LevelHandler struct {
-	service *service.LevelService
+	service LevelServiceInterface
 }
 
 // NewLevelHandler は新しいLevelHandlerインスタンスを生成する。
-func NewLevelHandler(s *service.LevelService) *LevelHandler {
+func NewLevelHandler(s LevelServiceInterface) *LevelHandler {
 	return &LevelHandler{service: s}
 }
 

--- a/backend/internal/handler/ranking.go
+++ b/backend/internal/handler/ranking.go
@@ -2,17 +2,25 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/repository"
 )
+
+// RankingServiceInterface はRankingHandlerが依存するサービスメソッドを定義する。
+type RankingServiceInterface interface {
+	ContributionRanking(period string) ([]repository.RankingEntry, error)
+	LanguageRanking(language, period string) ([]repository.RankingEntry, error)
+	LevelRanking() ([]repository.RankingEntry, error)
+	AvailableLanguages() ([]string, error)
+}
 
 // RankingHandler はランキング関連のHTTPハンドラ。
 // コントリビューションランキング・言語別ランキングの取得を処理する。
 type RankingHandler struct {
-	service *service.RankingService
+	service RankingServiceInterface
 }
 
 // NewRankingHandler は新しいRankingHandlerインスタンスを生成する。
-func NewRankingHandler(s *service.RankingService) *RankingHandler {
+func NewRankingHandler(s RankingServiceInterface) *RankingHandler {
 	return &RankingHandler{service: s}
 }
 


### PR DESCRIPTION
## 概要
BadgeHandler・RankingHandler・LevelHandlerのサービス依存を具象型からインターフェースに変更。

## 変更内容
- BadgeServiceInterface (2メソッド: GetUserBadges, NotifyBadgeEarned)
- RankingServiceInterface (4メソッド: ContributionRanking, LanguageRanking, LevelRanking, AvailableLanguages)
- LevelServiceInterface (2メソッド: GetLevelInfo, GetXPBreakdown)

Closes #292