### PR TITLE
test: Badge・Ranking・LevelHandlerテスト20件追加

### DIFF
--- a/backend/internal/handler/badge_test.go
+++ b/backend/internal/handler/badge_test.go
@@ -1,0 +1,85 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/service"
+)
+
+// ---------- GetUserBadges ----------
+
+func TestBadgeGetUserBadges_Success(t *testing.T) {
+	h, svc := setupBadgeHandler()
+	badges := []service.BadgeResult{{ID: "streak_3", Name: "3 Day Streak", Earned: true}}
+	svc.On("GetUserBadges", uint(1)).Return(badges, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/badges", h.GetUserBadges)
+	w := doRequest(r, "GET", "/users/1/badges", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestBadgeGetUserBadges_InvalidID(t *testing.T) {
+	h, _ := setupBadgeHandler()
+
+	r := newRouter(1)
+	r.GET("/users/:userId/badges", h.GetUserBadges)
+	w := doRequest(r, "GET", "/users/abc/badges", nil)
+
+	assertStatus(t, w, 400)
+}
+
+func TestBadgeGetUserBadges_ServiceError(t *testing.T) {
+	h, svc := setupBadgeHandler()
+	svc.On("GetUserBadges", uint(1)).Return([]service.BadgeResult{}, fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/users/:userId/badges", h.GetUserBadges)
+	w := doRequest(r, "GET", "/users/1/badges", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}
+
+// ---------- NotifyBadgeEarned ----------
+
+func TestBadgeNotifyBadgeEarned_Success(t *testing.T) {
+	h, svc := setupBadgeHandler()
+	svc.On("NotifyBadgeEarned", uint(1), "streak_3").Return(nil)
+
+	r := newRouter(1)
+	r.POST("/badges/notify", h.NotifyBadgeEarned)
+	w := doRequest(r, "POST", "/badges/notify", map[string]interface{}{
+		"badge_id": "streak_3",
+	})
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestBadgeNotifyBadgeEarned_ValidationError(t *testing.T) {
+	h, _ := setupBadgeHandler()
+
+	r := newRouter(1)
+	r.POST("/badges/notify", h.NotifyBadgeEarned)
+	w := doRequest(r, "POST", "/badges/notify", map[string]interface{}{})
+
+	assertStatus(t, w, 400)
+}
+
+func TestBadgeNotifyBadgeEarned_ServiceError(t *testing.T) {
+	h, svc := setupBadgeHandler()
+	svc.On("NotifyBadgeEarned", uint(1), "invalid").Return(fmt.Errorf("badge not found"))
+
+	r := newRouter(1)
+	r.POST("/badges/notify", h.NotifyBadgeEarned)
+	w := doRequest(r, "POST", "/badges/notify", map[string]interface{}{
+		"badge_id": "invalid",
+	})
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/level_test.go
+++ b/backend/internal/handler/level_test.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// ---------- GetMyLevelInfo ----------
+
+func TestLevelGetMyLevelInfo_Success(t *testing.T) {
+	h, svc := setupLevelHandler()
+	info := &model.LevelInfo{Level: 5, TotalXP: 1200}
+	svc.On("GetLevelInfo", uint(1)).Return(info, nil)
+
+	r := newRouter(1)
+	r.GET("/levels/me", h.GetMyLevelInfo)
+	w := doRequest(r, "GET", "/levels/me", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestLevelGetMyLevelInfo_ServiceError(t *testing.T) {
+	h, svc := setupLevelHandler()
+	svc.On("GetLevelInfo", uint(1)).Return(nil, fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/levels/me", h.GetMyLevelInfo)
+	w := doRequest(r, "GET", "/levels/me", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetLevelInfo ----------
+
+func TestLevelGetLevelInfo_Success(t *testing.T) {
+	h, svc := setupLevelHandler()
+	info := &model.LevelInfo{Level: 3, TotalXP: 600}
+	svc.On("GetLevelInfo", uint(5)).Return(info, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/level", h.GetLevelInfo)
+	w := doRequest(r, "GET", "/users/5/level", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestLevelGetLevelInfo_InvalidID(t *testing.T) {
+	h, _ := setupLevelHandler()
+
+	r := newRouter(1)
+	r.GET("/users/:userId/level", h.GetLevelInfo)
+	w := doRequest(r, "GET", "/users/abc/level", nil)
+
+	assertStatus(t, w, 400)
+}
+
+// ---------- GetXPBreakdown ----------
+
+func TestLevelGetXPBreakdown_Success(t *testing.T) {
+	h, svc := setupLevelHandler()
+	breakdown := &model.XPBreakdown{Total: 1200}
+	svc.On("GetXPBreakdown", uint(5)).Return(breakdown, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/xp", h.GetXPBreakdown)
+	w := doRequest(r, "GET", "/users/5/xp", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestLevelGetXPBreakdown_InvalidID(t *testing.T) {
+	h, _ := setupLevelHandler()
+
+	r := newRouter(1)
+	r.GET("/users/:userId/xp", h.GetXPBreakdown)
+	w := doRequest(r, "GET", "/users/abc/xp", nil)
+
+	assertStatus(t, w, 400)
+}
+
+func TestLevelGetXPBreakdown_ServiceError(t *testing.T) {
+	h, svc := setupLevelHandler()
+	svc.On("GetXPBreakdown", uint(5)).Return(nil, fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/users/:userId/xp", h.GetXPBreakdown)
+	w := doRequest(r, "GET", "/users/5/xp", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/ranking_test.go
+++ b/backend/internal/handler/ranking_test.go
@@ -1,0 +1,105 @@
+package handler
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// ---------- ContributionRanking ----------
+
+func TestRankingContribution_Success(t *testing.T) {
+	h, svc := setupRankingHandler()
+	entries := []repository.RankingEntry{{UserID: 1, Score: 100}}
+	svc.On("ContributionRanking", "weekly").Return(entries, nil)
+
+	r := newRouter(1)
+	r.GET("/rankings/contributions", h.ContributionRanking)
+	w := doRequest(r, "GET", "/rankings/contributions", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestRankingContribution_WithPeriod(t *testing.T) {
+	h, svc := setupRankingHandler()
+	entries := []repository.RankingEntry{{UserID: 1, Score: 50}}
+	svc.On("ContributionRanking", "monthly").Return(entries, nil)
+
+	r := newRouter(1)
+	r.GET("/rankings/contributions", h.ContributionRanking)
+	w := doRequest(r, "GET", "/rankings/contributions?period=monthly", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestRankingContribution_ServiceError(t *testing.T) {
+	h, svc := setupRankingHandler()
+	svc.On("ContributionRanking", "weekly").Return([]repository.RankingEntry{}, fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/rankings/contributions", h.ContributionRanking)
+	w := doRequest(r, "GET", "/rankings/contributions", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}
+
+// ---------- LanguageRanking ----------
+
+func TestRankingLanguage_Success(t *testing.T) {
+	h, svc := setupRankingHandler()
+	entries := []repository.RankingEntry{{UserID: 1, Score: 80}}
+	svc.On("LanguageRanking", "Go", "weekly").Return(entries, nil)
+
+	r := newRouter(1)
+	r.GET("/rankings/languages/:lang", h.LanguageRanking)
+	w := doRequest(r, "GET", "/rankings/languages/Go", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+// ---------- LevelRanking ----------
+
+func TestRankingLevel_Success(t *testing.T) {
+	h, svc := setupRankingHandler()
+	entries := []repository.RankingEntry{{UserID: 1, Score: 500}}
+	svc.On("LevelRanking").Return(entries, nil)
+
+	r := newRouter(1)
+	r.GET("/rankings/levels", h.LevelRanking)
+	w := doRequest(r, "GET", "/rankings/levels", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+// ---------- AvailableLanguages ----------
+
+func TestRankingAvailableLanguages_Success(t *testing.T) {
+	h, svc := setupRankingHandler()
+	languages := []string{"Go", "TypeScript", "Python"}
+	svc.On("AvailableLanguages").Return(languages, nil)
+
+	r := newRouter(1)
+	r.GET("/rankings/languages", h.AvailableLanguages)
+	w := doRequest(r, "GET", "/rankings/languages", nil)
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+func TestRankingAvailableLanguages_ServiceError(t *testing.T) {
+	h, svc := setupRankingHandler()
+	svc.On("AvailableLanguages").Return([]string{}, fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/rankings/languages", h.AvailableLanguages)
+	w := doRequest(r, "GET", "/rankings/languages", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -794,3 +794,160 @@ func setupProjectHandler() (*ProjectHandler, *MockProjectService) {
 	h := NewProjectHandler(svc)
 	return h, svc
 }
+
+// MockRoadmapService は RoadmapServiceInterface のモック実装。
+type MockRoadmapService struct{ mock.Mock }
+
+func (m *MockRoadmapService) Create(roadmap *model.Roadmap) error {
+	return m.Called(roadmap).Error(0)
+}
+func (m *MockRoadmapService) GetByID(id, userID uint) (*model.Roadmap, error) {
+	args := m.Called(id, userID)
+	if r := args.Get(0); r != nil {
+		return r.(*model.Roadmap), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockRoadmapService) GetByUserID(userID uint) ([]model.Roadmap, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.Roadmap), args.Error(1)
+}
+func (m *MockRoadmapService) GetPublicRoadmaps(limit, offset int) ([]model.Roadmap, int64, error) {
+	args := m.Called(limit, offset)
+	return args.Get(0).([]model.Roadmap), args.Get(1).(int64), args.Error(2)
+}
+func (m *MockRoadmapService) Update(id, userID uint, updates *model.Roadmap) (*model.Roadmap, error) {
+	args := m.Called(id, userID, updates)
+	if r := args.Get(0); r != nil {
+		return r.(*model.Roadmap), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockRoadmapService) UpdateVisibility(id, userID uint, isPublic bool) (*model.Roadmap, error) {
+	args := m.Called(id, userID, isPublic)
+	if r := args.Get(0); r != nil {
+		return r.(*model.Roadmap), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockRoadmapService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+func (m *MockRoadmapService) CopyRoadmap(roadmapID, userID uint) (*model.Roadmap, error) {
+	args := m.Called(roadmapID, userID)
+	if r := args.Get(0); r != nil {
+		return r.(*model.Roadmap), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockRoadmapService) GetTemplates() ([]model.Roadmap, error) {
+	args := m.Called()
+	return args.Get(0).([]model.Roadmap), args.Error(1)
+}
+func (m *MockRoadmapService) CreateFromTemplate(templateID, userID uint) (*model.Roadmap, error) {
+	args := m.Called(templateID, userID)
+	if r := args.Get(0); r != nil {
+		return r.(*model.Roadmap), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockRoadmapService) CreateStep(roadmapID, userID uint, step *model.RoadmapStep) error {
+	return m.Called(roadmapID, userID, step).Error(0)
+}
+func (m *MockRoadmapService) UpdateStep(roadmapID, stepID, userID uint, updates *model.RoadmapStep) (*model.RoadmapStep, error) {
+	args := m.Called(roadmapID, stepID, userID, updates)
+	if s := args.Get(0); s != nil {
+		return s.(*model.RoadmapStep), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockRoadmapService) UpdateStepCompletion(roadmapID, stepID, userID uint, isCompleted bool) (*model.RoadmapStep, error) {
+	args := m.Called(roadmapID, stepID, userID, isCompleted)
+	if s := args.Get(0); s != nil {
+		return s.(*model.RoadmapStep), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockRoadmapService) DeleteStep(roadmapID, stepID, userID uint) error {
+	return m.Called(roadmapID, stepID, userID).Error(0)
+}
+func (m *MockRoadmapService) ReorderSteps(roadmapID, userID uint, orders []service.StepOrder) error {
+	return m.Called(roadmapID, userID, orders).Error(0)
+}
+
+// setupRoadmapHandlerMock はRoadmapHandlerテスト用のモックセットアップを行う。
+func setupRoadmapHandlerMock() (*RoadmapHandler, *MockRoadmapService) {
+	svc := new(MockRoadmapService)
+	h := NewRoadmapHandler(svc)
+	return h, svc
+}
+
+// MockBadgeService は BadgeServiceInterface のモック実装。
+type MockBadgeService struct{ mock.Mock }
+
+func (m *MockBadgeService) GetUserBadges(userID uint) ([]service.BadgeResult, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]service.BadgeResult), args.Error(1)
+}
+func (m *MockBadgeService) NotifyBadgeEarned(userID uint, badgeID string) error {
+	return m.Called(userID, badgeID).Error(0)
+}
+
+// setupBadgeHandler はBadgeHandlerテスト用のセットアップを行う。
+func setupBadgeHandler() (*BadgeHandler, *MockBadgeService) {
+	svc := new(MockBadgeService)
+	h := NewBadgeHandler(svc)
+	return h, svc
+}
+
+// MockRankingService は RankingServiceInterface のモック実装。
+type MockRankingService struct{ mock.Mock }
+
+func (m *MockRankingService) ContributionRanking(period string) ([]repository.RankingEntry, error) {
+	args := m.Called(period)
+	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+}
+func (m *MockRankingService) LanguageRanking(language, period string) ([]repository.RankingEntry, error) {
+	args := m.Called(language, period)
+	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+}
+func (m *MockRankingService) LevelRanking() ([]repository.RankingEntry, error) {
+	args := m.Called()
+	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+}
+func (m *MockRankingService) AvailableLanguages() ([]string, error) {
+	args := m.Called()
+	return args.Get(0).([]string), args.Error(1)
+}
+
+// setupRankingHandler はRankingHandlerテスト用のセットアップを行う。
+func setupRankingHandler() (*RankingHandler, *MockRankingService) {
+	svc := new(MockRankingService)
+	h := NewRankingHandler(svc)
+	return h, svc
+}
+
+// MockLevelService は LevelServiceInterface のモック実装。
+type MockLevelService struct{ mock.Mock }
+
+func (m *MockLevelService) GetLevelInfo(userID uint) (*model.LevelInfo, error) {
+	args := m.Called(userID)
+	if l := args.Get(0); l != nil {
+		return l.(*model.LevelInfo), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockLevelService) GetXPBreakdown(userID uint) (*model.XPBreakdown, error) {
+	args := m.Called(userID)
+	if x := args.Get(0); x != nil {
+		return x.(*model.XPBreakdown), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// setupLevelHandler はLevelHandlerテスト用のセットアップを行う。
+func setupLevelHandler() (*LevelHandler, *MockLevelService) {
+	svc := new(MockLevelService)
+	h := NewLevelHandler(svc)
+	return h, svc
+}


### PR DESCRIPTION
## 概要
サイクル6-2でインターフェース化したBadge・Ranking・LevelHandlerに対するユニットテストを追加。

## テスト内容
- **BadgeHandler**: 6件（GetUserBadges 3件・NotifyBadgeEarned 3件）
- **RankingHandler**: 6件（ContributionRanking 3件・LanguageRanking 1件・LevelRanking 1件・AvailableLanguages 1件）
- **LevelHandler**: 7件（GetMyLevelInfo 2件・GetLevelInfo 2件・GetXPBreakdown 3件）
- MockBadgeService・MockRankingService・MockLevelServiceをtestutil_test.goに追加

Closes #294