### PR TITLE
feat: PageHeader共通コンポーネントを作成し5ページで使用

### DIFF
--- a/frontend/src/components/common/PageHeader.tsx
+++ b/frontend/src/components/common/PageHeader.tsx
@@ -1,0 +1,28 @@
+import { Plus } from 'lucide-react';
+
+interface PageHeaderProps {
+  title: string;
+  subtitle?: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export default function PageHeader({ title, subtitle, actionLabel, onAction }: PageHeaderProps) {
+  return (
+    <div className="flex items-center justify-between mb-6">
+      <div>
+        <h1 className="text-2xl font-bold text-white">{title}</h1>
+        {subtitle && <p className="text-gray-400 text-sm mt-1">{subtitle}</p>}
+      </div>
+      {actionLabel && onAction && (
+        <button
+          onClick={onAction}
+          className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+        >
+          <Plus className="w-5 h-5" />
+          {actionLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/PageHeader.test.tsx
+++ b/frontend/src/components/common/__tests__/PageHeader.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import PageHeader from '../PageHeader';
+
+describe('PageHeader', () => {
+  it('タイトルが表示される', () => {
+    render(<PageHeader title="テストタイトル" />);
+    expect(screen.getByText('テストタイトル')).toBeInTheDocument();
+  });
+
+  it('サブタイトルが表示される', () => {
+    render(<PageHeader title="タイトル" subtitle="サブタイトル" />);
+    expect(screen.getByText('サブタイトル')).toBeInTheDocument();
+  });
+
+  it('サブタイトルが未指定の場合表示されない', () => {
+    render(<PageHeader title="タイトル" />);
+    expect(screen.queryByText('サブタイトル')).toBeNull();
+  });
+
+  it('アクションボタンが表示される', () => {
+    const onAction = vi.fn();
+    render(<PageHeader title="タイトル" actionLabel="追加" onAction={onAction} />);
+    const button = screen.getByText('追加');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('アクションボタンクリックでonActionが呼ばれる', () => {
+    const onAction = vi.fn();
+    render(<PageHeader title="タイトル" actionLabel="追加" onAction={onAction} />);
+    fireEvent.click(screen.getByText('追加'));
+    expect(onAction).toHaveBeenCalledOnce();
+  });
+
+  it('actionLabelのみでonActionが未指定の場合ボタンが表示されない', () => {
+    render(<PageHeader title="タイトル" actionLabel="追加" />);
+    expect(screen.queryByText('追加')).toBeNull();
+  });
+
+  it('onActionのみでactionLabelが未指定の場合ボタンが表示されない', () => {
+    render(<PageHeader title="タイトル" onAction={() => {}} />);
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('Plusアイコンが表示される', () => {
+    const { container } = render(
+      <PageHeader title="タイトル" actionLabel="追加" onAction={() => {}} />
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -6,3 +6,4 @@ export { default as EmptyState } from './EmptyState';
 export { default as Modal } from './Modal';
 export { default as Pagination } from './Pagination';
 export { default as SearchInput } from './SearchInput';
+export { default as PageHeader } from './PageHeader';

--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -7,7 +7,7 @@ import { useBookReviews, useConfirm } from '../hooks';
 import BookReviewCard from '../components/bookReviews/BookReviewCard';
 import BookReviewForm from '../components/bookReviews/BookReviewForm';
 import LoadingSpinner from '../components/common/LoadingSpinner';
-import { EmptyState, Modal, Pagination } from '../components/common';
+import { EmptyState, Modal, Pagination, PageHeader } from '../components/common';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 
 export default function BookReviewsPage() {
@@ -30,21 +30,12 @@ export default function BookReviewsPage() {
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-white">{t('bookReviews.title')}</h1>
-          <p className="text-gray-400 text-sm mt-1">{t('bookReviews.subtitle')}</p>
-        </div>
-        <button
-          onClick={() => setShowForm(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-          </svg>
-          {t('bookReviews.addReview')}
-        </button>
-      </div>
+      <PageHeader
+        title={t('bookReviews.title')}
+        subtitle={t('bookReviews.subtitle')}
+        actionLabel={t('bookReviews.addReview')}
+        onAction={() => setShowForm(true)}
+      />
 
       {/* Form Modal */}
       <Modal

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -8,7 +8,7 @@ import ProjectForm from '../components/projects/ProjectForm';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import EmptyState from '../components/common/EmptyState';
 import ConfirmDialog from '../components/common/ConfirmDialog';
-import { Modal } from '../components/common';
+import { Modal, PageHeader } from '../components/common';
 
 export default function ProjectsPage() {
   const { t } = useTranslation();
@@ -37,21 +37,12 @@ export default function ProjectsPage() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-white">{t('projects.title')}</h1>
-          <p className="text-gray-400 text-sm mt-1">{t('projects.subtitle')}</p>
-        </div>
-        <button
-          onClick={() => setShowForm(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-          </svg>
-          {t('projects.addProject')}
-        </button>
-      </div>
+      <PageHeader
+        title={t('projects.title')}
+        subtitle={t('projects.subtitle')}
+        actionLabel={t('projects.addProject')}
+        onAction={() => setShowForm(true)}
+      />
 
       {/* Form Modal */}
       <Modal

--- a/frontend/src/pages/QAPage.tsx
+++ b/frontend/src/pages/QAPage.tsx
@@ -7,7 +7,7 @@ import { useQuestions, useDebounce, useConfirm } from '../hooks';
 import QuestionCard from '../components/qa/QuestionCard';
 import QuestionForm from '../components/qa/QuestionForm';
 import { QuestionCardSkeleton } from '../components/common/Skeleton';
-import { EmptyState, Modal, Pagination, SearchInput } from '../components/common';
+import { EmptyState, Modal, Pagination, SearchInput, PageHeader } from '../components/common';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 
 export default function QAPage() {
@@ -44,21 +44,12 @@ export default function QAPage() {
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-white">{t('qa.pageTitle')}</h1>
-          <p className="text-gray-400 text-sm mt-1">{t('qa.pageSubtitle')}</p>
-        </div>
-        <button
-          onClick={() => setShowForm(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-          </svg>
-          {t('qa.askQuestion')}
-        </button>
-      </div>
+      <PageHeader
+        title={t('qa.pageTitle')}
+        subtitle={t('qa.pageSubtitle')}
+        actionLabel={t('qa.askQuestion')}
+        onAction={() => setShowForm(true)}
+      />
 
       {/* Search & Sort */}
       <div className="flex flex-wrap gap-4 mb-6">

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -8,7 +8,7 @@ import ResourceCard from '../components/resources/ResourceCard';
 import ResourceForm from '../components/resources/ResourceForm';
 import { ResourceCardSkeleton } from '../components/common/Skeleton';
 import EmptyState from '../components/common/EmptyState';
-import { Pagination, SearchInput } from '../components/common';
+import { Pagination, SearchInput, PageHeader } from '../components/common';
 
 const categories: (ResourceCategory | '')[] = ['', 'book', 'video', 'article', 'course', 'tutorial', 'podcast', 'tool', 'other'];
 const difficulties: (ResourceDifficulty | '')[] = ['', 'beginner', 'intermediate', 'advanced'];
@@ -43,21 +43,12 @@ export default function ResourcesPage() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-white">{t('resources.pageTitle')}</h1>
-          <p className="text-gray-400 text-sm mt-1">{t('resources.pageSubtitle')}</p>
-        </div>
-        <button
-          onClick={() => setShowForm(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-          </svg>
-          {t('resources.addResource')}
-        </button>
-      </div>
+      <PageHeader
+        title={t('resources.pageTitle')}
+        subtitle={t('resources.pageSubtitle')}
+        actionLabel={t('resources.addResource')}
+        onAction={() => setShowForm(true)}
+      />
 
       {/* Tabs */}
       <div className="flex gap-2 mb-6">

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -6,7 +6,7 @@ import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
 import { useRoadmaps, useRoadmapTemplates } from '../hooks';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import EmptyState from '../components/common/EmptyState';
-import { Modal } from '../components/common';
+import { Modal, PageHeader } from '../components/common';
 
 const CATEGORIES: { value: RoadmapCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'roadmaps.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -91,21 +91,12 @@ export default function RoadmapsPage() {
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
-      <div className="flex items-center justify-between mb-6">
-        <div>
-          <h1 className="text-2xl font-bold text-white">{t('roadmaps.title')}</h1>
-          <p className="text-gray-400 text-sm mt-1">{t('roadmaps.description')}</p>
-        </div>
-        <button
-          onClick={() => setShowForm(true)}
-          className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-        >
-          <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
-          </svg>
-          {t('roadmaps.addRoadmap')}
-        </button>
-      </div>
+      <PageHeader
+        title={t('roadmaps.title')}
+        subtitle={t('roadmaps.description')}
+        actionLabel={t('roadmaps.addRoadmap')}
+        onAction={() => setShowForm(true)}
+      />
 
       {/* Stats */}
       <div className="grid grid-cols-3 gap-4 mb-6">


### PR DESCRIPTION
## 概要
5ページで重複していたヘッダーパターン（タイトル+サブタイトル+追加ボタン）を`PageHeader`共通コンポーネントに統一しました。

## 変更内容
- `PageHeader`コンポーネント新規作成（`components/common/PageHeader.tsx`）
  - props: `title`, `subtitle?`, `actionLabel?`, `onAction?`
  - Plusアイコン付きアクションボタン
- 5ページで手書きヘッダーを`PageHeader`に置換
  - QAPage, ResourcesPage, BookReviewsPage, ProjectsPage, RoadmapsPage
- バレルエクスポート追加
- テスト8件追加

## テスト計画
- [x] TypeScriptビルドエラーなし
- [x] PageHeaderテスト8件パス
- [x] 各ページの表示確認

Closes #296