### PR TITLE
refactor: ActivityReport・AIAdvice・LearningAnalyticsハンドラーのインターフェース化

### DIFF
--- a/backend/internal/handler/activity_report.go
+++ b/backend/internal/handler/activity_report.go
@@ -3,17 +3,23 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// ActivityReportServiceInterface はActivityReportHandlerが依存するサービスのインターフェース。
+type ActivityReportServiceInterface interface {
+	GetWeeklyReport(userID uint) (*model.ActivityReport, error)
+	GetMonthlyReport(userID uint) (*model.ActivityReport, error)
+	GetComparison(userID uint, period model.ReportPeriod) (*model.ReportComparison, error)
+}
 
 // ActivityReportHandler はアクティビティレポート関連のHTTPハンドラ。
 // 週次・月次レポートの取得および期間比較を処理する。
 type ActivityReportHandler struct {
-	service *service.ActivityReportService
+	service ActivityReportServiceInterface
 }
 
 // NewActivityReportHandler は新しいActivityReportHandlerインスタンスを生成する。
-func NewActivityReportHandler(s *service.ActivityReportService) *ActivityReportHandler {
+func NewActivityReportHandler(s ActivityReportServiceInterface) *ActivityReportHandler {
 	return &ActivityReportHandler{service: s}
 }
 

--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -6,16 +6,28 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
+
+// AIAdviceServiceInterface はAIAdviceHandlerが依存するサービスのインターフェース。
+type AIAdviceServiceInterface interface {
+	GenerateAdvice(userID uint) []model.AIAdvice
+	IsLLMAvailable() bool
+	GetDailyChatRemaining(userID uint) (int, error)
+	MarkAsRead(id, userID uint) error
+	Chat(userID uint, message string, conversationID uint) (*model.AIConversation, error)
+	DeleteConversation(id, userID uint) error
+	GetConversations(userID uint, limit, offset int) ([]model.AIConversation, error)
+	GetConversation(id, userID uint) (*model.AIConversation, error)
+}
 
 // AIAdviceHandler はAIアドバイス関連のHTTPハンドラ。
 type AIAdviceHandler struct {
-	service *service.AIAdviceService
+	service AIAdviceServiceInterface
 }
 
 // NewAIAdviceHandler は新しいAIAdviceHandlerインスタンスを生成する。
-func NewAIAdviceHandler(s *service.AIAdviceService) *AIAdviceHandler {
+func NewAIAdviceHandler(s AIAdviceServiceInterface) *AIAdviceHandler {
 	return &AIAdviceHandler{service: s}
 }
 

--- a/backend/internal/handler/learning_analytics.go
+++ b/backend/internal/handler/learning_analytics.go
@@ -4,17 +4,26 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
+
+// LearningAnalyticsServiceInterface はLearningAnalyticsHandlerが依存するサービスのインターフェース。
+type LearningAnalyticsServiceInterface interface {
+	GetHeatmap(userID uint) ([]model.HeatmapEntry, error)
+	GetCategoryBreakdown(userID uint) ([]model.CategoryBreakdown, error)
+	GetWeeklyTrends(userID uint, weeks int) ([]model.WeeklyTrend, error)
+	GetProductivityScore(userID uint) (*model.ProductivityScore, error)
+	GetInsights(userID uint) ([]model.AIInsight, error)
+}
 
 // LearningAnalyticsHandler は学習分析関連のHTTPハンドラ。
 // ヒートマップ、カテゴリ別、トレンド、生産性スコア、AIインサイトの取得を処理する。
 type LearningAnalyticsHandler struct {
-	service *service.LearningAnalyticsService
+	service LearningAnalyticsServiceInterface
 }
 
 // NewLearningAnalyticsHandler は新しいLearningAnalyticsHandlerインスタンスを生成する。
-func NewLearningAnalyticsHandler(s *service.LearningAnalyticsService) *LearningAnalyticsHandler {
+func NewLearningAnalyticsHandler(s LearningAnalyticsServiceInterface) *LearningAnalyticsHandler {
 	return &LearningAnalyticsHandler{service: s}
 }
 


### PR DESCRIPTION
## 概要
3つのハンドラーのサービス依存を具体型からインターフェースに変更し、テスト容易性を向上。

## 変更内容
- `ActivityReportServiceInterface`（3メソッド: GetWeeklyReport, GetMonthlyReport, GetComparison）
- `AIAdviceServiceInterface`（8メソッド: GenerateAdvice, IsLLMAvailable, GetDailyChatRemaining, MarkAsRead, Chat, DeleteConversation, GetConversations, GetConversation）
- `LearningAnalyticsServiceInterface`（5メソッド: GetHeatmap, GetCategoryBreakdown, GetWeeklyTrends, GetProductivityScore, GetInsights）

## テスト計画
- [x] `go build ./...` 成功

Closes #298