### PR TITLE
test: ActivityReport・AIAdvice・LearningAnalyticsハンドラーテスト27件追加

### DIFF
--- a/backend/internal/handler/activity_report_test.go
+++ b/backend/internal/handler/activity_report_test.go
@@ -1,0 +1,135 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+func TestActivityReport_GetWeeklyReport_Success(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	report := &model.ActivityReport{Period: model.ReportPeriodWeekly, TotalContributions: 10}
+	svc.On("GetWeeklyReport", uint(1)).Return(report, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/reports/weekly", h.GetWeeklyReport)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/reports/weekly", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestActivityReport_GetWeeklyReport_InvalidID(t *testing.T) {
+	h, _ := setupActivityReportHandler()
+
+	r := gin.New()
+	r.GET("/users/:userId/reports/weekly", h.GetWeeklyReport)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/abc/reports/weekly", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestActivityReport_GetWeeklyReport_ServiceError(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	svc.On("GetWeeklyReport", uint(1)).Return(nil, errors.New("db error"))
+
+	r := gin.New()
+	r.GET("/users/:userId/reports/weekly", h.GetWeeklyReport)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/reports/weekly", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestActivityReport_GetMonthlyReport_Success(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	report := &model.ActivityReport{Period: model.ReportPeriodMonthly, TotalContributions: 42}
+	svc.On("GetMonthlyReport", uint(1)).Return(report, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/reports/monthly", h.GetMonthlyReport)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/reports/monthly", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestActivityReport_GetMyWeeklyReport_Success(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	report := &model.ActivityReport{Period: model.ReportPeriodWeekly}
+	svc.On("GetWeeklyReport", uint(5)).Return(report, nil)
+
+	r := gin.New()
+	r.GET("/me/reports/weekly", authMiddleware(5), h.GetMyWeeklyReport)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/me/reports/weekly", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestActivityReport_GetMyMonthlyReport_Success(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	report := &model.ActivityReport{Period: model.ReportPeriodMonthly}
+	svc.On("GetMonthlyReport", uint(5)).Return(report, nil)
+
+	r := gin.New()
+	r.GET("/me/reports/monthly", authMiddleware(5), h.GetMyMonthlyReport)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/me/reports/monthly", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestActivityReport_GetComparison_Success(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	comp := &model.ReportComparison{ContributionsDiff: 5}
+	svc.On("GetComparison", uint(3), model.ReportPeriodWeekly).Return(comp, nil)
+
+	r := gin.New()
+	r.GET("/me/reports/comparison", authMiddleware(3), h.GetComparison)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/me/reports/comparison", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestActivityReport_GetComparison_Monthly(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	comp := &model.ReportComparison{ContributionsDiff: -2}
+	svc.On("GetComparison", uint(3), model.ReportPeriodMonthly).Return(comp, nil)
+
+	r := gin.New()
+	r.GET("/me/reports/comparison", authMiddleware(3), h.GetComparison)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/me/reports/comparison?period=monthly", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/ai_advice_test.go
+++ b/backend/internal/handler/ai_advice_test.go
@@ -1,0 +1,170 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+func TestAIAdvice_GetAdvice_Success(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	advices := []model.AIAdvice{{ID: 1, TitleKey: "test"}}
+	svc.On("GenerateAdvice", uint(1)).Return(advices)
+	svc.On("IsLLMAvailable").Return(true)
+	svc.On("GetDailyChatRemaining", uint(1)).Return(5, nil)
+
+	r := gin.New()
+	r.GET("/advice", authMiddleware(1), h.GetAdvice)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/advice", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdvice_GetAdvice_LLMUnavailable(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	svc.On("GenerateAdvice", uint(1)).Return([]model.AIAdvice{})
+	svc.On("IsLLMAvailable").Return(false)
+
+	r := gin.New()
+	r.GET("/advice", authMiddleware(1), h.GetAdvice)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/advice", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdvice_MarkAsRead_Success(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	svc.On("MarkAsRead", uint(10), uint(1)).Return(nil)
+
+	r := gin.New()
+	r.PUT("/advice/:id/read", authMiddleware(1), h.MarkAsRead)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/advice/10/read", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdvice_MarkAsRead_NotFound(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	svc.On("MarkAsRead", uint(99), uint(1)).Return(errors.New("not found"))
+
+	r := gin.New()
+	r.PUT("/advice/:id/read", authMiddleware(1), h.MarkAsRead)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/advice/99/read", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdvice_Chat_Success(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	conv := &model.AIConversation{ID: 1, Title: "Test"}
+	svc.On("Chat", uint(1), "hello", uint(0)).Return(conv, nil)
+
+	r := gin.New()
+	r.POST("/advice/chat", authMiddleware(1), h.Chat)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/advice/chat", jsonBody(map[string]interface{}{
+		"message": "hello",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdvice_Chat_ValidationError(t *testing.T) {
+	h, _ := setupAIAdviceHandler()
+
+	r := gin.New()
+	r.POST("/advice/chat", authMiddleware(1), h.Chat)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/advice/chat", jsonBody(map[string]interface{}{}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestAIAdvice_DeleteConversation_Success(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	svc.On("DeleteConversation", uint(5), uint(1)).Return(nil)
+
+	r := gin.New()
+	r.DELETE("/conversations/:id", authMiddleware(1), h.DeleteConversation)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/conversations/5", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdvice_GetConversations_Success(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	convs := []model.AIConversation{{ID: 1}, {ID: 2}}
+	svc.On("GetConversations", uint(1), 20, 0).Return(convs, nil)
+
+	r := gin.New()
+	r.GET("/conversations", authMiddleware(1), h.GetConversations)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/conversations", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdvice_GetConversation_Success(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	conv := &model.AIConversation{ID: 3, Title: "Test Conv"}
+	svc.On("GetConversation", uint(3), uint(1)).Return(conv, nil)
+
+	r := gin.New()
+	r.GET("/conversations/:id", authMiddleware(1), h.GetConversation)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/conversations/3", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdvice_GetConversation_ServiceError(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	svc.On("GetConversation", uint(99), uint(1)).Return(nil, errors.New("not found"))
+
+	r := gin.New()
+	r.GET("/conversations/:id", authMiddleware(1), h.GetConversation)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/conversations/99", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/learning_analytics_test.go
+++ b/backend/internal/handler/learning_analytics_test.go
@@ -1,0 +1,150 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+func TestLearningAnalytics_GetHeatmap_Success(t *testing.T) {
+	h, svc := setupLearningAnalyticsHandler()
+	data := []model.HeatmapEntry{{DayOfWeek: 1, Hour: 10, TotalMinutes: 60}}
+	svc.On("GetHeatmap", uint(1)).Return(data, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/analytics/heatmap", h.GetHeatmap)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/analytics/heatmap", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningAnalytics_GetHeatmap_InvalidID(t *testing.T) {
+	h, _ := setupLearningAnalyticsHandler()
+
+	r := gin.New()
+	r.GET("/users/:userId/analytics/heatmap", h.GetHeatmap)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/abc/analytics/heatmap", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestLearningAnalytics_GetHeatmap_ServiceError(t *testing.T) {
+	h, svc := setupLearningAnalyticsHandler()
+	svc.On("GetHeatmap", uint(1)).Return([]model.HeatmapEntry(nil), errors.New("db error"))
+
+	r := gin.New()
+	r.GET("/users/:userId/analytics/heatmap", h.GetHeatmap)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/analytics/heatmap", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningAnalytics_GetCategoryBreakdown_Success(t *testing.T) {
+	h, svc := setupLearningAnalyticsHandler()
+	data := []model.CategoryBreakdown{{Category: "coding", TotalMinutes: 120}}
+	svc.On("GetCategoryBreakdown", uint(2)).Return(data, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/analytics/categories", h.GetCategoryBreakdown)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/2/analytics/categories", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningAnalytics_GetProductivityScore_Success(t *testing.T) {
+	h, svc := setupLearningAnalyticsHandler()
+	score := &model.ProductivityScore{OverallScore: 85.5}
+	svc.On("GetProductivityScore", uint(1)).Return(score, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/analytics/productivity", h.GetProductivityScore)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/analytics/productivity", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningAnalytics_GetWeeklyTrends_Success(t *testing.T) {
+	h, svc := setupLearningAnalyticsHandler()
+	data := []model.WeeklyTrend{{WeekStart: "2026-02-10", TotalMinutes: 300}}
+	svc.On("GetWeeklyTrends", uint(1), 12).Return(data, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/analytics/trends", h.GetWeeklyTrends)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/analytics/trends", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningAnalytics_GetWeeklyTrends_CustomWeeks(t *testing.T) {
+	h, svc := setupLearningAnalyticsHandler()
+	data := []model.WeeklyTrend{{WeekStart: "2026-02-10", TotalMinutes: 200}}
+	svc.On("GetWeeklyTrends", uint(1), 4).Return(data, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/analytics/trends", h.GetWeeklyTrends)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/analytics/trends?weeks=4", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningAnalytics_GetInsights_Success(t *testing.T) {
+	h, svc := setupLearningAnalyticsHandler()
+	insights := []model.AIInsight{{Type: "peak_time", Params: map[string]interface{}{"hour": float64(14)}}}
+	svc.On("GetInsights", uint(3)).Return(insights, nil)
+
+	r := gin.New()
+	r.GET("/me/analytics/insights", authMiddleware(3), h.GetInsights)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/me/analytics/insights", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningAnalytics_GetInsights_ServiceError(t *testing.T) {
+	h, svc := setupLearningAnalyticsHandler()
+	svc.On("GetInsights", uint(3)).Return([]model.AIInsight(nil), errors.New("db error"))
+
+	r := gin.New()
+	r.GET("/me/analytics/insights", authMiddleware(3), h.GetInsights)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/me/analytics/insights", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -951,3 +951,115 @@ func setupLevelHandler() (*LevelHandler, *MockLevelService) {
 	h := NewLevelHandler(svc)
 	return h, svc
 }
+
+// MockActivityReportService は ActivityReportServiceInterface のモック実装。
+type MockActivityReportService struct{ mock.Mock }
+
+func (m *MockActivityReportService) GetWeeklyReport(userID uint) (*model.ActivityReport, error) {
+	args := m.Called(userID)
+	if r := args.Get(0); r != nil {
+		return r.(*model.ActivityReport), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockActivityReportService) GetMonthlyReport(userID uint) (*model.ActivityReport, error) {
+	args := m.Called(userID)
+	if r := args.Get(0); r != nil {
+		return r.(*model.ActivityReport), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockActivityReportService) GetComparison(userID uint, period model.ReportPeriod) (*model.ReportComparison, error) {
+	args := m.Called(userID, period)
+	if r := args.Get(0); r != nil {
+		return r.(*model.ReportComparison), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// setupActivityReportHandler はActivityReportHandlerテスト用のセットアップを行う。
+func setupActivityReportHandler() (*ActivityReportHandler, *MockActivityReportService) {
+	svc := new(MockActivityReportService)
+	h := NewActivityReportHandler(svc)
+	return h, svc
+}
+
+// MockAIAdviceService は AIAdviceServiceInterface のモック実装。
+type MockAIAdviceService struct{ mock.Mock }
+
+func (m *MockAIAdviceService) GenerateAdvice(userID uint) []model.AIAdvice {
+	args := m.Called(userID)
+	return args.Get(0).([]model.AIAdvice)
+}
+func (m *MockAIAdviceService) IsLLMAvailable() bool {
+	return m.Called().Bool(0)
+}
+func (m *MockAIAdviceService) GetDailyChatRemaining(userID uint) (int, error) {
+	args := m.Called(userID)
+	return args.Int(0), args.Error(1)
+}
+func (m *MockAIAdviceService) MarkAsRead(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+func (m *MockAIAdviceService) Chat(userID uint, message string, conversationID uint) (*model.AIConversation, error) {
+	args := m.Called(userID, message, conversationID)
+	if c := args.Get(0); c != nil {
+		return c.(*model.AIConversation), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockAIAdviceService) DeleteConversation(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+func (m *MockAIAdviceService) GetConversations(userID uint, limit, offset int) ([]model.AIConversation, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.AIConversation), args.Error(1)
+}
+func (m *MockAIAdviceService) GetConversation(id, userID uint) (*model.AIConversation, error) {
+	args := m.Called(id, userID)
+	if c := args.Get(0); c != nil {
+		return c.(*model.AIConversation), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// setupAIAdviceHandler はAIAdviceHandlerテスト用のセットアップを行う。
+func setupAIAdviceHandler() (*AIAdviceHandler, *MockAIAdviceService) {
+	svc := new(MockAIAdviceService)
+	h := NewAIAdviceHandler(svc)
+	return h, svc
+}
+
+// MockLearningAnalyticsService は LearningAnalyticsServiceInterface のモック実装。
+type MockLearningAnalyticsService struct{ mock.Mock }
+
+func (m *MockLearningAnalyticsService) GetHeatmap(userID uint) ([]model.HeatmapEntry, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.HeatmapEntry), args.Error(1)
+}
+func (m *MockLearningAnalyticsService) GetCategoryBreakdown(userID uint) ([]model.CategoryBreakdown, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.CategoryBreakdown), args.Error(1)
+}
+func (m *MockLearningAnalyticsService) GetWeeklyTrends(userID uint, weeks int) ([]model.WeeklyTrend, error) {
+	args := m.Called(userID, weeks)
+	return args.Get(0).([]model.WeeklyTrend), args.Error(1)
+}
+func (m *MockLearningAnalyticsService) GetProductivityScore(userID uint) (*model.ProductivityScore, error) {
+	args := m.Called(userID)
+	if s := args.Get(0); s != nil {
+		return s.(*model.ProductivityScore), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockLearningAnalyticsService) GetInsights(userID uint) ([]model.AIInsight, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.AIInsight), args.Error(1)
+}
+
+// setupLearningAnalyticsHandler はLearningAnalyticsHandlerテスト用のセットアップを行う。
+func setupLearningAnalyticsHandler() (*LearningAnalyticsHandler, *MockLearningAnalyticsService) {
+	svc := new(MockLearningAnalyticsService)
+	h := NewLearningAnalyticsHandler(svc)
+	return h, svc
+}


### PR DESCRIPTION
## 概要
サイクル7-2でインターフェース化した3ハンドラーのテストを追加。

## 変更内容
- `testutil_test.go`: MockActivityReportService, MockAIAdviceService, MockLearningAnalyticsService + セットアップヘルパー追加
- `activity_report_test.go`: 8テスト（GetWeeklyReport成功/InvalidID/エラー、GetMonthlyReport成功、GetMyWeekly/Monthly、GetComparison成功/Monthly）
- `ai_advice_test.go`: 10テスト（GetAdvice成功/LLM無効、MarkAsRead成功/NotFound、Chat成功/ValidationError、DeleteConversation、GetConversations、GetConversation成功/エラー）
- `learning_analytics_test.go`: 9テスト（GetHeatmap成功/InvalidID/エラー、CategoryBreakdown、ProductivityScore、WeeklyTrends成功/CustomWeeks、GetInsights成功/エラー）

## テスト計画
- [x] 27テスト全パス

Closes #300