### PR TITLE
feat: 6ページのローディング表示をPageLoaderに統一

### DIFF
--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -6,8 +6,7 @@ import type { BookReview } from '../types/bookReview';
 import { useBookReviews, useConfirm } from '../hooks';
 import BookReviewCard from '../components/bookReviews/BookReviewCard';
 import BookReviewForm from '../components/bookReviews/BookReviewForm';
-import LoadingSpinner from '../components/common/LoadingSpinner';
-import { EmptyState, Modal, Pagination, PageHeader } from '../components/common';
+import { EmptyState, Modal, Pagination, PageHeader, PageLoader } from '../components/common';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 
 export default function BookReviewsPage() {
@@ -65,9 +64,7 @@ export default function BookReviewsPage() {
 
       {/* Content */}
       {loading ? (
-        <div className="flex justify-center items-center min-h-[400px]">
-          <LoadingSpinner />
-        </div>
+        <PageLoader />
       ) : reviews.length === 0 ? (
         <EmptyState
           icon={BookOpen}

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { gitHubCallback } from '../api/github';
 import { useAuthStore } from '../store/authStore';
-import LoadingSpinner from '../components/common/LoadingSpinner';
+import { PageLoader } from '../components/common';
 import toast from 'react-hot-toast';
 
 function parseStatePurpose(state: string): string {
@@ -88,13 +88,9 @@ export default function GitHubCallbackPage() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-      <div className="text-center">
-        <LoadingSpinner />
-        <p className="text-gray-400 mt-4">
-          {mode === 'login' ? 'Logging in with GitHub...' : 'Connecting GitHub...'}
-        </p>
-      </div>
-    </div>
+    <PageLoader
+      fullHeight
+      message={mode === 'login' ? 'Logging in with GitHub...' : 'Connecting GitHub...'}
+    />
   );
 }

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -5,10 +5,9 @@ import type { Project } from '../types/project';
 import { useProjects, useConfirm } from '../hooks';
 import ProjectCard from '../components/projects/ProjectCard';
 import ProjectForm from '../components/projects/ProjectForm';
-import LoadingSpinner from '../components/common/LoadingSpinner';
 import EmptyState from '../components/common/EmptyState';
 import ConfirmDialog from '../components/common/ConfirmDialog';
-import { Modal, PageHeader } from '../components/common';
+import { Modal, PageHeader, PageLoader } from '../components/common';
 
 export default function ProjectsPage() {
   const { t } = useTranslation();
@@ -28,11 +27,7 @@ export default function ProjectsPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex justify-center items-center min-h-[400px]">
-        <LoadingSpinner />
-      </div>
-    );
+    return <PageLoader />;
   }
 
   return (

--- a/frontend/src/pages/QADetailPage.tsx
+++ b/frontend/src/pages/QADetailPage.tsx
@@ -7,7 +7,7 @@ import type { Answer } from '../types/qa';
 import AnswerCard from '../components/qa/AnswerCard';
 import AnswerForm from '../components/qa/AnswerForm';
 import Avatar from '../components/common/Avatar';
-import LoadingSpinner from '../components/common/LoadingSpinner';
+import { PageLoader } from '../components/common';
 
 export default function QADetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -31,11 +31,7 @@ export default function QADetailPage() {
   const isQuestionOwner = user?.id === question?.user_id;
 
   if (loading) {
-    return (
-      <div className="flex justify-center items-center min-h-[400px]">
-        <LoadingSpinner />
-      </div>
-    );
+    return <PageLoader />;
   }
 
   if (!question) {

--- a/frontend/src/pages/RoadmapDetailPage.tsx
+++ b/frontend/src/pages/RoadmapDetailPage.tsx
@@ -5,7 +5,7 @@ import { List } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { useRoadmapDetail } from '../hooks';
 import { type RoadmapStep } from '../api/roadmaps';
-import LoadingSpinner from '../components/common/LoadingSpinner';
+import { PageLoader } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 
 export default function RoadmapDetailPage() {
@@ -70,11 +70,7 @@ export default function RoadmapDetailPage() {
   };
 
   if (loading) {
-    return (
-      <div className="flex justify-center items-center min-h-[400px]">
-        <LoadingSpinner />
-      </div>
-    );
+    return <PageLoader />;
   }
 
   if (!roadmap) {

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -4,9 +4,8 @@ import { useTranslation } from 'react-i18next';
 import { Monitor, Rocket, Target, FolderOpen, FileText, BookOpen, ChevronDown, ChevronUp, MapPin, type LucideIcon } from 'lucide-react';
 import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
 import { useRoadmaps, useRoadmapTemplates } from '../hooks';
-import LoadingSpinner from '../components/common/LoadingSpinner';
 import EmptyState from '../components/common/EmptyState';
-import { Modal, PageHeader } from '../components/common';
+import { Modal, PageHeader, PageLoader } from '../components/common';
 
 const CATEGORIES: { value: RoadmapCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'roadmaps.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -80,11 +79,7 @@ export default function RoadmapsPage() {
     CATEGORIES.find(c => c.value === cat) || CATEGORIES[4];
 
   if (loading) {
-    return (
-      <div className="flex justify-center items-center min-h-[400px]">
-        <LoadingSpinner />
-      </div>
-    );
+    return <PageLoader />;
   }
 
   const inputClass = 'w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent';


### PR DESCRIPTION
## 概要
6ページで手書きのLoadingSpinnerラッパーをPageLoaderコンポーネントに統一し、ローディング表示の一貫性とUXを向上。

## 変更内容
- ProjectsPage, RoadmapsPage, RoadmapDetailPage: 早期return型のLoadingSpinner → PageLoader
- BookReviewsPage, QADetailPage: 条件分岐型のLoadingSpinner → PageLoader
- GitHubCallbackPage: 全画面LoadingSpinner → PageLoader（fullHeight + カスタムメッセージ）
- 不要なLoadingSpinner直接importを削除し、バレルexport経由に統一

## テスト計画
- [x] TypeScriptビルドエラーなし

Closes #302