### PR TITLE
refactor: ChatRoom・CodeSnippet・LearningLogハンドラーのインターフェース化

### DIFF
--- a/backend/internal/handler/chat_room.go
+++ b/backend/internal/handler/chat_room.go
@@ -6,17 +6,30 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// ChatRoomServiceInterface はChatRoomHandlerが依存するサービスのインターフェース。
+type ChatRoomServiceInterface interface {
+	Create(room *model.ChatRoom, memberIDs []uint) (*model.ChatRoom, error)
+	GetByUserID(userID uint) ([]model.ChatRoom, error)
+	GetByID(roomID, userID uint) (*model.ChatRoom, error)
+	Update(roomID, userID uint, name, description string) (*model.ChatRoom, error)
+	Delete(roomID, userID uint) error
+	GetMembers(roomID, userID uint) ([]model.ChatRoomMember, error)
+	AddMember(roomID, userID, targetUserID uint) error
+	RemoveMember(roomID, userID, targetUserID uint) error
+	GetMessages(roomID, userID uint, page, limit int) ([]model.GroupMessage, error)
+	SendMessage(roomID, userID uint, content string) (*model.GroupMessage, error)
+}
 
 // ChatRoomHandler はチャットルーム関連のHTTPハンドラ。
 // チャットルームのCRUD・メンバー管理・メッセージ送受信を処理する。
 type ChatRoomHandler struct {
-	service *service.ChatRoomService
+	service ChatRoomServiceInterface
 }
 
 // NewChatRoomHandler は新しいChatRoomHandlerインスタンスを生成する。
-func NewChatRoomHandler(s *service.ChatRoomService) *ChatRoomHandler {
+func NewChatRoomHandler(s ChatRoomServiceInterface) *ChatRoomHandler {
 	return &ChatRoomHandler{service: s}
 }
 

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -5,16 +5,26 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// CodeSnippetHandlerServiceInterface はCodeSnippetHandlerが依存するサービスのインターフェース。
+type CodeSnippetHandlerServiceInterface interface {
+	Create(snippet *model.CodeSnippet) (*model.CodeSnippet, error)
+	GetByPostID(postID uint) ([]model.CodeSnippet, error)
+	Update(id, userID uint, language, fileName, code string) (*model.CodeSnippet, error)
+	Delete(id, userID uint) error
+	GetComments(snippetID uint) ([]model.SnippetComment, error)
+	CreateComment(comment *model.SnippetComment) error
+	DeleteComment(id, userID uint) error
+}
 
 // CodeSnippetHandler はコードスニペット関連のHTTPハンドラ。
 type CodeSnippetHandler struct {
-	service *service.CodeSnippetService
+	service CodeSnippetHandlerServiceInterface
 }
 
 // NewCodeSnippetHandler は新しいCodeSnippetHandlerインスタンスを生成する。
-func NewCodeSnippetHandler(s *service.CodeSnippetService) *CodeSnippetHandler {
+func NewCodeSnippetHandler(s CodeSnippetHandlerServiceInterface) *CodeSnippetHandler {
 	return &CodeSnippetHandler{service: s}
 }
 

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -5,17 +5,27 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// LearningLogServiceInterface はLearningLogHandlerが依存するサービスのインターフェース。
+type LearningLogServiceInterface interface {
+	Create(log *model.LearningLog) error
+	GetByID(id uint) (*model.LearningLog, error)
+	GetByUserID(userID uint) ([]model.LearningLog, error)
+	Update(id, userID uint, updates *model.LearningLog) (*model.LearningLog, error)
+	Delete(id, userID uint) error
+	GetStreakInfo(userID uint) (*model.StreakInfo, error)
+	GetCalendarData(userID uint) ([]model.CalendarEntry, error)
+}
 
 // LearningLogHandler は学習ログ関連のHTTPハンドラ。
 // 学習ログのCRUD・ストリーク・カレンダーデータの取得を処理する。
 type LearningLogHandler struct {
-	service *service.LearningLogService
+	service LearningLogServiceInterface
 }
 
 // NewLearningLogHandler は新しいLearningLogHandlerインスタンスを生成する。
-func NewLearningLogHandler(s *service.LearningLogService) *LearningLogHandler {
+func NewLearningLogHandler(s LearningLogServiceInterface) *LearningLogHandler {
 	return &LearningLogHandler{service: s}
 }
 


### PR DESCRIPTION
## 概要
3つのハンドラーのサービス依存を具体型からインターフェースに変更し、テスト容易性を向上。

## 変更内容
- `ChatRoomServiceInterface`（10メソッド: Create, GetByUserID, GetByID, Update, Delete, GetMembers, AddMember, RemoveMember, GetMessages, SendMessage）
- `CodeSnippetHandlerServiceInterface`（7メソッド: Create, GetByPostID, Update, Delete, GetComments, CreateComment, DeleteComment）
- `LearningLogServiceInterface`（7メソッド: Create, GetByID, GetByUserID, Update, Delete, GetStreakInfo, GetCalendarData）

## テスト計画
- [x] `go build ./...` 成功

Closes #304