### PR TITLE
test: LearningLogハンドラーテスト12件追加

### DIFF
--- a/backend/internal/handler/chat_room_test.go
+++ b/backend/internal/handler/chat_room_test.go
@@ -14,7 +14,7 @@ import (
 // ---------- Create ----------
 
 func TestChatRoomCreate_Success(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.POST("/rooms", h.Create)
 
@@ -31,7 +31,7 @@ func TestChatRoomCreate_Success(t *testing.T) {
 }
 
 func TestChatRoomCreate_ValidationError(t *testing.T) {
-	h, _, _ := setupChatRoomHandler()
+	h, _, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.POST("/rooms", h.Create)
 
@@ -41,7 +41,7 @@ func TestChatRoomCreate_ValidationError(t *testing.T) {
 }
 
 func TestChatRoomCreate_InvalidJSON(t *testing.T) {
-	h, _, _ := setupChatRoomHandler()
+	h, _, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.POST("/rooms", h.Create)
 
@@ -52,7 +52,7 @@ func TestChatRoomCreate_InvalidJSON(t *testing.T) {
 // ---------- GetMyRooms ----------
 
 func TestChatRoomGetMyRooms_Success(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.GET("/rooms", h.GetMyRooms)
 
@@ -71,7 +71,7 @@ func TestChatRoomGetMyRooms_Success(t *testing.T) {
 // ---------- GetByID ----------
 
 func TestChatRoomGetByID_Success(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.GET("/rooms/:id", h.GetByID)
 
@@ -85,7 +85,7 @@ func TestChatRoomGetByID_Success(t *testing.T) {
 }
 
 func TestChatRoomGetByID_NotMember(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.GET("/rooms/:id", h.GetByID)
 
@@ -96,7 +96,7 @@ func TestChatRoomGetByID_NotMember(t *testing.T) {
 }
 
 func TestChatRoomGetByID_InvalidID(t *testing.T) {
-	h, _, _ := setupChatRoomHandler()
+	h, _, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.GET("/rooms/:id", h.GetByID)
 
@@ -107,7 +107,7 @@ func TestChatRoomGetByID_InvalidID(t *testing.T) {
 // ---------- Update ----------
 
 func TestChatRoomUpdate_Success(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.PUT("/rooms/:id", h.Update)
 
@@ -123,7 +123,7 @@ func TestChatRoomUpdate_Success(t *testing.T) {
 }
 
 func TestChatRoomUpdate_Forbidden(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.PUT("/rooms/:id", h.Update)
 
@@ -138,7 +138,7 @@ func TestChatRoomUpdate_Forbidden(t *testing.T) {
 }
 
 func TestChatRoomUpdate_NotFound(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.PUT("/rooms/:id", h.Update)
 
@@ -151,7 +151,7 @@ func TestChatRoomUpdate_NotFound(t *testing.T) {
 // ---------- Delete ----------
 
 func TestChatRoomDelete_Success(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.DELETE("/rooms/:id", h.Delete)
 
@@ -165,7 +165,7 @@ func TestChatRoomDelete_Success(t *testing.T) {
 }
 
 func TestChatRoomDelete_Forbidden(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.DELETE("/rooms/:id", h.Delete)
 
@@ -180,7 +180,7 @@ func TestChatRoomDelete_Forbidden(t *testing.T) {
 // ---------- GetMembers ----------
 
 func TestChatRoomGetMembers_Success(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.GET("/rooms/:id/members", h.GetMembers)
 
@@ -194,7 +194,7 @@ func TestChatRoomGetMembers_Success(t *testing.T) {
 }
 
 func TestChatRoomGetMembers_NotMember(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.GET("/rooms/:id/members", h.GetMembers)
 
@@ -207,7 +207,7 @@ func TestChatRoomGetMembers_NotMember(t *testing.T) {
 // ---------- AddMember ----------
 
 func TestChatRoomAddMember_Success(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.POST("/rooms/:id/members", h.AddMember)
 
@@ -221,7 +221,7 @@ func TestChatRoomAddMember_Success(t *testing.T) {
 }
 
 func TestChatRoomAddMember_NotMember(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.POST("/rooms/:id/members", h.AddMember)
 
@@ -234,7 +234,7 @@ func TestChatRoomAddMember_NotMember(t *testing.T) {
 }
 
 func TestChatRoomAddMember_ValidationError(t *testing.T) {
-	h, _, _ := setupChatRoomHandler()
+	h, _, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.POST("/rooms/:id/members", h.AddMember)
 
@@ -246,7 +246,7 @@ func TestChatRoomAddMember_ValidationError(t *testing.T) {
 // ---------- RemoveMember ----------
 
 func TestChatRoomRemoveMember_OwnerRemoves(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.DELETE("/rooms/:id/members/:userId", h.RemoveMember)
 
@@ -260,7 +260,7 @@ func TestChatRoomRemoveMember_OwnerRemoves(t *testing.T) {
 }
 
 func TestChatRoomRemoveMember_SelfLeave(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.DELETE("/rooms/:id/members/:userId", h.RemoveMember)
 
@@ -275,7 +275,7 @@ func TestChatRoomRemoveMember_SelfLeave(t *testing.T) {
 }
 
 func TestChatRoomRemoveMember_Forbidden(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1) // userID=1
 	r.DELETE("/rooms/:id/members/:userId", h.RemoveMember)
 
@@ -291,7 +291,7 @@ func TestChatRoomRemoveMember_Forbidden(t *testing.T) {
 // ---------- GetMessages ----------
 
 func TestChatRoomGetMessages_Success(t *testing.T) {
-	h, roomRepo, msgRepo := setupChatRoomHandler()
+	h, roomRepo, msgRepo := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.GET("/rooms/:id/messages", h.GetMessages)
 
@@ -305,7 +305,7 @@ func TestChatRoomGetMessages_Success(t *testing.T) {
 }
 
 func TestChatRoomGetMessages_NotMember(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.GET("/rooms/:id/messages", h.GetMessages)
 
@@ -316,7 +316,7 @@ func TestChatRoomGetMessages_NotMember(t *testing.T) {
 }
 
 func TestChatRoomGetMessages_WithPagination(t *testing.T) {
-	h, roomRepo, msgRepo := setupChatRoomHandler()
+	h, roomRepo, msgRepo := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.GET("/rooms/:id/messages", h.GetMessages)
 
@@ -330,7 +330,7 @@ func TestChatRoomGetMessages_WithPagination(t *testing.T) {
 // ---------- SendMessage ----------
 
 func TestChatRoomSendMessage_Success(t *testing.T) {
-	h, roomRepo, msgRepo := setupChatRoomHandler()
+	h, roomRepo, msgRepo := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.POST("/rooms/:id/messages", h.SendMessage)
 
@@ -346,7 +346,7 @@ func TestChatRoomSendMessage_Success(t *testing.T) {
 }
 
 func TestChatRoomSendMessage_NotMember(t *testing.T) {
-	h, roomRepo, _ := setupChatRoomHandler()
+	h, roomRepo, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.POST("/rooms/:id/messages", h.SendMessage)
 
@@ -359,7 +359,7 @@ func TestChatRoomSendMessage_NotMember(t *testing.T) {
 }
 
 func TestChatRoomSendMessage_ValidationError(t *testing.T) {
-	h, _, _ := setupChatRoomHandler()
+	h, _, _ := setupChatRoomHandlerRepo()
 	r := newRouter(1)
 	r.POST("/rooms/:id/messages", h.SendMessage)
 

--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -1,0 +1,204 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestLearningLog_Create_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	svc.On("Create", mock.AnythingOfType("*model.LearningLog")).Return(nil)
+
+	r := gin.New()
+	r.POST("/logs", authMiddleware(1), h.Create)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/logs", jsonBody(map[string]interface{}{
+		"title":   "Go学習",
+		"content": "インターフェースを学んだ",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_Create_ValidationError(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+
+	r := gin.New()
+	r.POST("/logs", authMiddleware(1), h.Create)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("POST", "/logs", jsonBody(map[string]interface{}{}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestLearningLog_GetByID_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	log := &model.LearningLog{Title: "Test", Content: "Content"}
+	svc.On("GetByID", uint(1)).Return(log, nil)
+
+	r := gin.New()
+	r.GET("/logs/:id", h.GetByID)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/logs/1", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_GetByID_ServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	svc.On("GetByID", uint(99)).Return(nil, errors.New("not found"))
+
+	r := gin.New()
+	r.GET("/logs/:id", h.GetByID)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/logs/99", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_GetMyLogs_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	logs := []model.LearningLog{{Title: "Log1"}, {Title: "Log2"}}
+	svc.On("GetByUserID", uint(1)).Return(logs, nil)
+
+	r := gin.New()
+	r.GET("/me/logs", authMiddleware(1), h.GetMyLogs)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/me/logs", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_GetByUserID_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	logs := []model.LearningLog{{Title: "Log1"}}
+	svc.On("GetByUserID", uint(5)).Return(logs, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/logs", h.GetByUserID)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/5/logs", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_Update_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	updated := &model.LearningLog{Title: "Updated"}
+	svc.On("Update", uint(1), uint(3), mock.AnythingOfType("*model.LearningLog")).Return(updated, nil)
+
+	r := gin.New()
+	r.PUT("/logs/:id", authMiddleware(3), h.Update)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/logs/1", jsonBody(map[string]interface{}{
+		"title": "Updated",
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_Delete_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	svc.On("Delete", uint(1), uint(3)).Return(nil)
+
+	r := gin.New()
+	r.DELETE("/logs/:id", authMiddleware(3), h.Delete)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/logs/1", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_Delete_ServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	svc.On("Delete", uint(99), uint(3)).Return(errors.New("not found"))
+
+	r := gin.New()
+	r.DELETE("/logs/:id", authMiddleware(3), h.Delete)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("DELETE", "/logs/99", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_GetStreakInfo_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	info := &model.StreakInfo{CurrentStreak: 5, LongestStreak: 10}
+	svc.On("GetStreakInfo", uint(1)).Return(info, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/streak", h.GetStreakInfo)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/streak", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_GetCalendarData_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	entries := []model.CalendarEntry{{Date: "2026-02-17", Count: 3}}
+	svc.On("GetCalendarData", uint(1)).Return(entries, nil)
+
+	r := gin.New()
+	r.GET("/users/:userId/calendar", h.GetCalendarData)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/1/calendar", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_GetCalendarData_ServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	svc.On("GetCalendarData", uint(99)).Return([]model.CalendarEntry(nil), errors.New("db error"))
+
+	r := gin.New()
+	r.GET("/users/:userId/calendar", h.GetCalendarData)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/users/99/calendar", nil)
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -463,8 +463,8 @@ func setupRoadmapHandler() (*RoadmapHandler, *MockRoadmapRepository) {
 	return h, repo
 }
 
-// setupChatRoomHandler はChatRoomHandlerテスト用のセットアップを行う。
-func setupChatRoomHandler() (*ChatRoomHandler, *MockChatRoomRepository, *MockGroupMessageRepository) {
+// setupChatRoomHandlerRepo はChatRoomHandlerテスト用のリポジトリレベルセットアップを行う。
+func setupChatRoomHandlerRepo() (*ChatRoomHandler, *MockChatRoomRepository, *MockGroupMessageRepository) {
 	roomRepo := new(MockChatRoomRepository)
 	msgRepo := new(MockGroupMessageRepository)
 	hub := service.NewHub()
@@ -1061,5 +1061,111 @@ func (m *MockLearningAnalyticsService) GetInsights(userID uint) ([]model.AIInsig
 func setupLearningAnalyticsHandler() (*LearningAnalyticsHandler, *MockLearningAnalyticsService) {
 	svc := new(MockLearningAnalyticsService)
 	h := NewLearningAnalyticsHandler(svc)
+	return h, svc
+}
+
+// MockChatRoomService は ChatRoomServiceInterface のモック実装。
+type MockChatRoomService struct{ mock.Mock }
+
+func (m *MockChatRoomService) Create(room *model.ChatRoom, memberIDs []uint) (*model.ChatRoom, error) {
+	args := m.Called(room, memberIDs)
+	if r := args.Get(0); r != nil {
+		return r.(*model.ChatRoom), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockChatRoomService) GetByUserID(userID uint) ([]model.ChatRoom, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.ChatRoom), args.Error(1)
+}
+func (m *MockChatRoomService) GetByID(roomID, userID uint) (*model.ChatRoom, error) {
+	args := m.Called(roomID, userID)
+	if r := args.Get(0); r != nil {
+		return r.(*model.ChatRoom), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockChatRoomService) Update(roomID, userID uint, name, description string) (*model.ChatRoom, error) {
+	args := m.Called(roomID, userID, name, description)
+	if r := args.Get(0); r != nil {
+		return r.(*model.ChatRoom), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockChatRoomService) Delete(roomID, userID uint) error {
+	return m.Called(roomID, userID).Error(0)
+}
+func (m *MockChatRoomService) GetMembers(roomID, userID uint) ([]model.ChatRoomMember, error) {
+	args := m.Called(roomID, userID)
+	return args.Get(0).([]model.ChatRoomMember), args.Error(1)
+}
+func (m *MockChatRoomService) AddMember(roomID, userID, targetUserID uint) error {
+	return m.Called(roomID, userID, targetUserID).Error(0)
+}
+func (m *MockChatRoomService) RemoveMember(roomID, userID, targetUserID uint) error {
+	return m.Called(roomID, userID, targetUserID).Error(0)
+}
+func (m *MockChatRoomService) GetMessages(roomID, userID uint, page, limit int) ([]model.GroupMessage, error) {
+	args := m.Called(roomID, userID, page, limit)
+	return args.Get(0).([]model.GroupMessage), args.Error(1)
+}
+func (m *MockChatRoomService) SendMessage(roomID, userID uint, content string) (*model.GroupMessage, error) {
+	args := m.Called(roomID, userID, content)
+	if r := args.Get(0); r != nil {
+		return r.(*model.GroupMessage), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// setupChatRoomHandler はChatRoomHandlerテスト用のセットアップを行う。
+func setupChatRoomHandler() (*ChatRoomHandler, *MockChatRoomService) {
+	svc := new(MockChatRoomService)
+	h := NewChatRoomHandler(svc)
+	return h, svc
+}
+
+// MockLearningLogService は LearningLogServiceInterface のモック実装。
+type MockLearningLogService struct{ mock.Mock }
+
+func (m *MockLearningLogService) Create(log *model.LearningLog) error {
+	return m.Called(log).Error(0)
+}
+func (m *MockLearningLogService) GetByID(id uint) (*model.LearningLog, error) {
+	args := m.Called(id)
+	if l := args.Get(0); l != nil {
+		return l.(*model.LearningLog), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockLearningLogService) GetByUserID(userID uint) ([]model.LearningLog, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.LearningLog), args.Error(1)
+}
+func (m *MockLearningLogService) Update(id, userID uint, updates *model.LearningLog) (*model.LearningLog, error) {
+	args := m.Called(id, userID, updates)
+	if l := args.Get(0); l != nil {
+		return l.(*model.LearningLog), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockLearningLogService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+func (m *MockLearningLogService) GetStreakInfo(userID uint) (*model.StreakInfo, error) {
+	args := m.Called(userID)
+	if s := args.Get(0); s != nil {
+		return s.(*model.StreakInfo), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockLearningLogService) GetCalendarData(userID uint) ([]model.CalendarEntry, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.CalendarEntry), args.Error(1)
+}
+
+// setupLearningLogHandler はLearningLogHandlerテスト用のセットアップを行う。
+func setupLearningLogHandler() (*LearningLogHandler, *MockLearningLogService) {
+	svc := new(MockLearningLogService)
+	h := NewLearningLogHandler(svc)
 	return h, svc
 }


### PR DESCRIPTION
## 概要
サイクル8-2でインターフェース化したLearningLogハンドラーのテストを追加。

## 変更内容
- `testutil_test.go`: MockChatRoomService・MockLearningLogService + セットアップヘルパー追加、既存setupChatRoomHandler名称変更（衝突解消）
- `learning_log_test.go`: 12テスト新規追加
  - Create: 成功・バリデーションエラー
  - GetByID: 成功・サービスエラー
  - GetMyLogs: 成功
  - GetByUserID: 成功
  - Update: 成功
  - Delete: 成功・サービスエラー
  - GetStreakInfo: 成功
  - GetCalendarData: 成功・サービスエラー
- `chat_room_test.go`: 旧セットアップ関数の参照を更新

## テスト計画
- [x] 12テスト全パス

Closes #306