### PR TITLE
feat: 手書きモーダルをModal共通コンポーネントに統一

### DIFF
--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -6,6 +6,7 @@ import { useAuthStore } from '../store/authStore';
 import type { LearningLog, LogCategory } from '../types/learningLog';
 import LogCalendar from '../components/learning-logs/LogCalendar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
+import { Modal } from '../components/common';
 
 const CATEGORIES: { value: LogCategory; label: string; Icon: LucideIcon }[] = [
   { value: 'coding', label: 'learningLogs.categoryCoding', Icon: Code },
@@ -203,90 +204,88 @@ export default function LearningLogsPage() {
       )}
 
       {/* Create/Edit Form Modal */}
-      {showForm && (
-        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 px-4">
-          <div className="bg-gray-900 border border-gray-700 rounded-md max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold mb-4">
-              {editingLog ? t('learningLogs.editLog') : t('learningLogs.addLog')}
-            </h3>
-            <form onSubmit={handleSubmit} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                  {t('learningLogs.logTitle')}
-                </label>
-                <input
-                  type="text"
-                  value={title}
-                  onChange={(e) => setTitle(e.target.value)}
-                  placeholder={t('learningLogs.titlePlaceholder')}
-                  className={inputClass}
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                  {t('learningLogs.content')}
-                </label>
-                <textarea
-                  value={content}
-                  onChange={(e) => setContent(e.target.value)}
-                  placeholder={t('learningLogs.contentPlaceholder')}
-                  rows={4}
-                  className={`${inputClass} resize-none`}
-                  required
-                />
-              </div>
-              <div className="grid grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                    {t('learningLogs.category')}
-                  </label>
-                  <select
-                    value={category}
-                    onChange={(e) => setCategory(e.target.value as LogCategory)}
-                    className={inputClass}
-                  >
-                    {CATEGORIES.map((cat) => (
-                      <option key={cat.value} value={cat.value}>
-                        {t(cat.label)}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                    {t('learningLogs.duration')}
-                  </label>
-                  <input
-                    type="number"
-                    value={duration}
-                    onChange={(e) => setDuration(e.target.value)}
-                    placeholder={t('learningLogs.durationPlaceholder')}
-                    min="0"
-                    className={inputClass}
-                  />
-                </div>
-              </div>
-              <div className="flex gap-3 justify-end pt-2">
-                <button
-                  type="button"
-                  onClick={resetForm}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  type="submit"
-                  disabled={saving || !title.trim() || !content.trim()}
-                  className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
-                >
-                  {saving ? t('common.loading') : editingLog ? t('common.save') : t('learningLogs.addLog')}
-                </button>
-              </div>
-            </form>
+      <Modal
+        isOpen={showForm}
+        onClose={resetForm}
+        title={editingLog ? t('learningLogs.editLog') : t('learningLogs.addLog')}
+        maxWidth="max-w-md"
+      >
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              {t('learningLogs.logTitle')}
+            </label>
+            <input
+              type="text"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder={t('learningLogs.titlePlaceholder')}
+              className={inputClass}
+              required
+            />
           </div>
-        </div>
-      )}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              {t('learningLogs.content')}
+            </label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder={t('learningLogs.contentPlaceholder')}
+              rows={4}
+              className={`${inputClass} resize-none`}
+              required
+            />
+          </div>
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                {t('learningLogs.category')}
+              </label>
+              <select
+                value={category}
+                onChange={(e) => setCategory(e.target.value as LogCategory)}
+                className={inputClass}
+              >
+                {CATEGORIES.map((cat) => (
+                  <option key={cat.value} value={cat.value}>
+                    {t(cat.label)}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                {t('learningLogs.duration')}
+              </label>
+              <input
+                type="number"
+                value={duration}
+                onChange={(e) => setDuration(e.target.value)}
+                placeholder={t('learningLogs.durationPlaceholder')}
+                min="0"
+                className={inputClass}
+              />
+            </div>
+          </div>
+          <div className="flex gap-3 justify-end pt-2">
+            <button
+              type="button"
+              onClick={resetForm}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={saving || !title.trim() || !content.trim()}
+              className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+            >
+              {saving ? t('common.loading') : editingLog ? t('common.save') : t('learningLogs.addLog')}
+            </button>
+          </div>
+        </form>
+      </Modal>
 
       {/* Logs List */}
       {view === 'list' && (

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -8,7 +8,7 @@ import PostCard from '../components/posts/PostCard';
 import PostForm from '../components/posts/PostForm';
 import CodeSnippetViewer from '../components/posts/CodeSnippetViewer';
 import Avatar from '../components/common/Avatar';
-import { PageLoader } from '../components/common';
+import { PageLoader, Modal } from '../components/common';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 import { format } from 'date-fns';
 import toast from 'react-hot-toast';
@@ -141,21 +141,16 @@ export default function PostDetailPage() {
       <ConfirmDialog {...dialogProps} />
 
       {/* Edit Modal */}
-      {editingPost && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-md p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <h2 className="text-xl font-semibold text-white mb-4">投稿を編集</h2>
-            <PostForm
-              post={post}
-              onSubmit={async (title, content, imageUrls) => {
-                const result = await updatePost(title, content, imageUrls);
-                if (result) setEditingPost(false);
-              }}
-              onCancel={() => setEditingPost(false)}
-            />
-          </div>
-        </div>
-      )}
+      <Modal isOpen={editingPost} onClose={() => setEditingPost(false)} title="投稿を編集">
+        <PostForm
+          post={post}
+          onSubmit={async (title, content, imageUrls) => {
+            const result = await updatePost(title, content, imageUrls);
+            if (result) setEditingPost(false);
+          }}
+          onCancel={() => setEditingPost(false)}
+        />
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -8,7 +8,7 @@ import ResourceCard from '../components/resources/ResourceCard';
 import ResourceForm from '../components/resources/ResourceForm';
 import { ResourceCardSkeleton } from '../components/common/Skeleton';
 import EmptyState from '../components/common/EmptyState';
-import { Pagination, SearchInput, PageHeader } from '../components/common';
+import { Pagination, SearchInput, PageHeader, Modal } from '../components/common';
 
 const categories: (ResourceCategory | '')[] = ['', 'book', 'video', 'article', 'course', 'tutorial', 'podcast', 'tool', 'other'];
 const difficulties: (ResourceDifficulty | '')[] = ['', 'beginner', 'intermediate', 'advanced'];
@@ -118,32 +118,29 @@ export default function ResourcesPage() {
       )}
 
       {/* Form Modal */}
-      {(showForm || editingResource) && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-md p-6 w-full max-w-2xl max-h-[90vh] overflow-y-auto">
-            <h2 className="text-xl font-semibold text-white mb-4">
-              {editingResource ? t('resources.editResource') : t('resources.newResource')}
-            </h2>
-            <ResourceForm
-              resource={editingResource || undefined}
-              onSubmit={async (data) => {
-                if (editingResource) {
-                  const result = await updateResource(editingResource.id, data);
-                  if (result) setEditingResource(null);
-                } else {
-                  const result = await createResource(data);
-                  if (result) setShowForm(false);
-                }
-              }}
-              onCancel={() => {
-                setShowForm(false);
-                setEditingResource(null);
-              }}
-              loading={saving}
-            />
-          </div>
-        </div>
-      )}
+      <Modal
+        isOpen={showForm || !!editingResource}
+        onClose={() => { setShowForm(false); setEditingResource(null); }}
+        title={editingResource ? t('resources.editResource') : t('resources.newResource')}
+      >
+        <ResourceForm
+          resource={editingResource || undefined}
+          onSubmit={async (data) => {
+            if (editingResource) {
+              const result = await updateResource(editingResource.id, data);
+              if (result) setEditingResource(null);
+            } else {
+              const result = await createResource(data);
+              if (result) setShowForm(false);
+            }
+          }}
+          onCancel={() => {
+            setShowForm(false);
+            setEditingResource(null);
+          }}
+          loading={saving}
+        />
+      </Modal>
 
       {/* Content */}
       {loading ? (

--- a/frontend/src/pages/RoadmapDetailPage.tsx
+++ b/frontend/src/pages/RoadmapDetailPage.tsx
@@ -5,7 +5,7 @@ import { List } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { useRoadmapDetail } from '../hooks';
 import { type RoadmapStep } from '../api/roadmaps';
-import { PageLoader } from '../components/common';
+import { PageLoader, Modal } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 
 export default function RoadmapDetailPage() {
@@ -150,64 +150,62 @@ export default function RoadmapDetailPage() {
       </div>
 
       {/* Step Form Modal */}
-      {showStepForm && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-gray-800 rounded-md p-6 w-full max-w-md">
-            <h2 className="text-xl font-semibold text-white mb-4">
-              {editingStep ? t('roadmaps.editStep') : t('roadmaps.addStep')}
-            </h2>
-            <form onSubmit={handleStepSubmit} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.stepTitle')}</label>
-                <input
-                  type="text"
-                  value={stepTitle}
-                  onChange={e => setStepTitle(e.target.value)}
-                  placeholder={t('roadmaps.stepTitlePlaceholder')}
-                  className={inputClass}
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.stepDescription')}</label>
-                <textarea
-                  value={stepDescription}
-                  onChange={e => setStepDescription(e.target.value)}
-                  placeholder={t('roadmaps.stepDescriptionPlaceholder')}
-                  rows={3}
-                  className={`${inputClass} resize-none`}
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.resourceURL')}</label>
-                <input
-                  type="url"
-                  value={stepResourceURL}
-                  onChange={e => setStepResourceURL(e.target.value)}
-                  placeholder="https://..."
-                  className={inputClass}
-                />
-              </div>
-              <div className="flex gap-3 justify-end pt-2">
-                <button
-                  type="button"
-                  onClick={resetStepForm}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
-                >
-                  {t('common.cancel')}
-                </button>
-                <button
-                  type="submit"
-                  disabled={saving || !stepTitle.trim()}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
-                >
-                  {saving ? t('common.saving') : editingStep ? t('common.save') : t('roadmaps.create')}
-                </button>
-              </div>
-            </form>
+      <Modal
+        isOpen={showStepForm}
+        onClose={resetStepForm}
+        title={editingStep ? t('roadmaps.editStep') : t('roadmaps.addStep')}
+        maxWidth="max-w-md"
+      >
+        <form onSubmit={handleStepSubmit} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.stepTitle')}</label>
+            <input
+              type="text"
+              value={stepTitle}
+              onChange={e => setStepTitle(e.target.value)}
+              placeholder={t('roadmaps.stepTitlePlaceholder')}
+              className={inputClass}
+              required
+            />
           </div>
-        </div>
-      )}
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.stepDescription')}</label>
+            <textarea
+              value={stepDescription}
+              onChange={e => setStepDescription(e.target.value)}
+              placeholder={t('roadmaps.stepDescriptionPlaceholder')}
+              rows={3}
+              className={`${inputClass} resize-none`}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.resourceURL')}</label>
+            <input
+              type="url"
+              value={stepResourceURL}
+              onChange={e => setStepResourceURL(e.target.value)}
+              placeholder="https://..."
+              className={inputClass}
+            />
+          </div>
+          <div className="flex gap-3 justify-end pt-2">
+            <button
+              type="button"
+              onClick={resetStepForm}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+            >
+              {t('common.cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={saving || !stepTitle.trim()}
+              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+            >
+              {saving ? t('common.saving') : editingStep ? t('common.save') : t('roadmaps.create')}
+            </button>
+          </div>
+        </form>
+      </Modal>
 
       {/* Steps List */}
       {roadmap.steps && roadmap.steps.length === 0 ? (

--- a/frontend/src/pages/settings/AccountSection.tsx
+++ b/frontend/src/pages/settings/AccountSection.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { inputClass } from '../../constants/styles';
+import { Modal } from '../../components/common';
 import type { User } from '../../types/user';
 
 interface Props {
@@ -108,52 +109,50 @@ export default function AccountSection(props: Props) {
       </div>
 
       {/* Delete Confirmation Modal */}
-      {props.showDeleteModal && (
-        <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 px-4">
-          <div className="bg-gray-900 border border-gray-700 rounded-md max-w-md w-full p-6">
-            <h3 className="text-lg font-semibold text-white mb-2">
-              {t('accountManagement.confirmDelete')}
-            </h3>
-            <p className="text-gray-400 text-sm mb-4">
-              {t('accountManagement.deleteConfirmText')}
-            </p>
+      <Modal
+        isOpen={props.showDeleteModal}
+        onClose={() => { props.setShowDeleteModal(false); props.setDeletePassword(''); }}
+        title={t('accountManagement.confirmDelete')}
+        maxWidth="max-w-md"
+      >
+        <p className="text-gray-400 text-sm mb-4">
+          {t('accountManagement.deleteConfirmText')}
+        </p>
 
-            {!props.user.github_connected && (
-              <div className="mb-4">
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
-                  {t('auth.password')}
-                </label>
-                <input
-                  type="password"
-                  value={props.deletePassword}
-                  onChange={(e) => props.setDeletePassword(e.target.value)}
-                  className={inputClass}
-                  placeholder="••••••••"
-                />
-              </div>
-            )}
-
-            <div className="flex gap-3 justify-end">
-              <button
-                onClick={() => {
-                  props.setShowDeleteModal(false);
-                  props.setDeletePassword('');
-                }}
-                className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
-              >
-                {t('common.cancel')}
-              </button>
-              <button
-                onClick={props.onDeleteAccount}
-                disabled={props.deleting}
-                className="px-4 py-2 bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
-              >
-                {props.deleting ? t('common.loading') : t('accountManagement.deleteAccount')}
-              </button>
-            </div>
+        {!props.user.github_connected && (
+          <div className="mb-4">
+            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              {t('auth.password')}
+            </label>
+            <input
+              type="password"
+              value={props.deletePassword}
+              onChange={(e) => props.setDeletePassword(e.target.value)}
+              className={inputClass}
+              placeholder="••••••••"
+            />
           </div>
+        )}
+
+        <div className="flex gap-3 justify-end">
+          <button
+            onClick={() => {
+              props.setShowDeleteModal(false);
+              props.setDeletePassword('');
+            }}
+            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={props.onDeleteAccount}
+            disabled={props.deleting}
+            className="px-4 py-2 bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+          >
+            {props.deleting ? t('common.loading') : t('accountManagement.deleteAccount')}
+          </button>
         </div>
-      )}
+      </Modal>
     </>
   );
 }


### PR DESCRIPTION
## 概要
- 5ページの手書きモーダル（`fixed inset-0`パターン）を共通`Modal`コンポーネントに移行
- ESCキー・オーバーレイクリックによるクローズ動作を一元管理
- モーダルのスタイル（z-index、背景色、角丸、パディング）を統一

## 対象ページ
- **PostDetailPage**: 投稿編集モーダル
- **ResourcesPage**: リソース作成/編集モーダル
- **RoadmapDetailPage**: ステップ追加/編集モーダル（`max-w-md`）
- **LearningLogsPage**: 学習ログ追加/編集モーダル（`max-w-md`）
- **AccountSection**: アカウント削除確認モーダル（`max-w-md`）

## テスト計画
- [ ] 各ページでモーダルの開閉が正常に動作すること
- [ ] ESCキーでモーダルが閉じること
- [ ] オーバーレイクリックでモーダルが閉じること
- [ ] フォーム送信が正常に動作すること

Closes #308