### PR TITLE
refactor: Message, ReminderSettings, Recommendationハンドラにインターフェース追加

### DIFF
--- a/backend/internal/handler/message.go
+++ b/backend/internal/handler/message.go
@@ -6,17 +6,24 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/repository"
 )
+
+// MessageServiceInterface はMessageHandlerが依存するサービスのインターフェース。
+type MessageServiceInterface interface {
+	GetConversations(userID uint) ([]repository.ConversationSummary, error)
+	GetConversation(userID, otherUserID uint, page, limit int) ([]model.Message, error)
+	SendMessage(msg *model.Message) error
+}
 
 // MessageHandler はDM（ダイレクトメッセージ）関連のHTTPハンドラ。
 // 会話一覧・メッセージ取得・メッセージ送信を処理する。
 type MessageHandler struct {
-	service *service.MessageService
+	service MessageServiceInterface
 }
 
 // NewMessageHandler は新しいMessageHandlerインスタンスを生成する。
-func NewMessageHandler(s *service.MessageService) *MessageHandler {
+func NewMessageHandler(s MessageServiceInterface) *MessageHandler {
 	return &MessageHandler{service: s}
 }
 

--- a/backend/internal/handler/recommendation.go
+++ b/backend/internal/handler/recommendation.go
@@ -2,16 +2,23 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
+
+// RecommendationServiceInterface はRecommendationHandlerが依存するサービスのインターフェース。
+type RecommendationServiceInterface interface {
+	GetRecommendedUsers(userID uint) ([]model.RecommendedUser, error)
+	GetTrendingPosts() ([]model.Post, error)
+	GetTrendingResources() ([]model.LearningResource, error)
+}
 
 // RecommendationHandler はレコメンド関連のHTTPリクエストを処理する。
 type RecommendationHandler struct {
-	service *service.RecommendationService
+	service RecommendationServiceInterface
 }
 
 // NewRecommendationHandler は新しいRecommendationHandlerインスタンスを生成する。
-func NewRecommendationHandler(service *service.RecommendationService) *RecommendationHandler {
+func NewRecommendationHandler(service RecommendationServiceInterface) *RecommendationHandler {
 	return &RecommendationHandler{service: service}
 }
 

--- a/backend/internal/handler/reminder_settings.go
+++ b/backend/internal/handler/reminder_settings.go
@@ -5,16 +5,21 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// ReminderSettingsServiceInterface はReminderSettingsHandlerが依存するサービスのインターフェース。
+type ReminderSettingsServiceInterface interface {
+	GetSettings(userID uint) (*model.ReminderSettings, error)
+	UpdateSettings(userID uint, updates *model.ReminderSettings) (*model.ReminderSettings, error)
+}
 
 // ReminderSettingsHandler は学習リマインダー設定関連のHTTPハンドラ。
 type ReminderSettingsHandler struct {
-	service *service.ReminderSettingsService
+	service ReminderSettingsServiceInterface
 }
 
 // NewReminderSettingsHandler は新しいReminderSettingsHandlerインスタンスを生成する。
-func NewReminderSettingsHandler(s *service.ReminderSettingsService) *ReminderSettingsHandler {
+func NewReminderSettingsHandler(s ReminderSettingsServiceInterface) *ReminderSettingsHandler {
 	return &ReminderSettingsHandler{service: s}
 }
 


### PR DESCRIPTION
## 概要
- テスト容易性向上のため、3ハンドラにサービスインターフェースを定義
- 具象型依存をインターフェース型に変更

## 対象
| ハンドラ | インターフェース | メソッド数 |
|---------|---------------|---------|
| MessageHandler | MessageServiceInterface | 3 |
| ReminderSettingsHandler | ReminderSettingsServiceInterface | 2 |
| RecommendationHandler | RecommendationServiceInterface | 3 |

## テスト計画
- [ ] `go build ./...` 成功確認
- [ ] 既存テストがパスすること

Closes #310