### PR TITLE
test: Message, ReminderSettings, Recommendationハンドラのテスト追加

### DIFF
--- a/backend/internal/handler/message_test.go
+++ b/backend/internal/handler/message_test.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestMessage_GetConversations_Success(t *testing.T) {
+	h, svc := setupMessageHandler()
+	svc.On("GetConversations", uint(1)).Return([]repository.ConversationSummary{
+		{UserID: 2, Name: "Alice", LastMessage: "Hello"},
+		{UserID: 3, Name: "Bob", LastMessage: "Hi"},
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/conversations", h.GetConversations)
+
+	w := doRequest(r, http.MethodGet, "/conversations", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestMessage_GetConversations_ServiceError(t *testing.T) {
+	h, svc := setupMessageHandler()
+	svc.On("GetConversations", uint(1)).Return([]repository.ConversationSummary(nil), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/conversations", h.GetConversations)
+
+	w := doRequest(r, http.MethodGet, "/conversations", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestMessage_GetMessages_Success(t *testing.T) {
+	h, svc := setupMessageHandler()
+	svc.On("GetConversation", uint(1), uint(5), 1, 50).Return([]model.Message{
+		{Content: "Hello"},
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/messages/:userId", h.GetMessages)
+
+	w := doRequest(r, http.MethodGet, "/messages/5", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestMessage_GetMessages_WithPagination(t *testing.T) {
+	h, svc := setupMessageHandler()
+	svc.On("GetConversation", uint(1), uint(5), 2, 30).Return([]model.Message{}, nil)
+
+	r := newRouter(1)
+	r.GET("/messages/:userId", h.GetMessages)
+
+	w := doRequest(r, http.MethodGet, "/messages/5?page=2&limit=30", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestMessage_SendMessage_Success(t *testing.T) {
+	h, svc := setupMessageHandler()
+	svc.On("SendMessage", mock.AnythingOfType("*model.Message")).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/messages/:userId", h.SendMessage)
+
+	w := doRequest(r, http.MethodPost, "/messages/5", map[string]string{
+		"content": "Hello!",
+	})
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestMessage_SendMessage_ValidationError(t *testing.T) {
+	h, _ := setupMessageHandler()
+
+	r := newRouter(1)
+	r.POST("/messages/:userId", h.SendMessage)
+
+	w := doRequest(r, http.MethodPost, "/messages/5", map[string]string{})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestMessage_SendMessage_ServiceError(t *testing.T) {
+	h, svc := setupMessageHandler()
+	svc.On("SendMessage", mock.AnythingOfType("*model.Message")).Return(errors.New("send failed"))
+
+	r := newRouter(1)
+	r.POST("/messages/:userId", h.SendMessage)
+
+	w := doRequest(r, http.MethodPost, "/messages/5", map[string]string{
+		"content": "Hello!",
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/recommendation_test.go
+++ b/backend/internal/handler/recommendation_test.go
@@ -12,7 +12,7 @@ import (
 // ---------- GetRecommendedUsers ----------
 
 func TestRecommendationGetUsers_Success(t *testing.T) {
-	h, recRepo, userRepo := setupRecommendationHandler()
+	h, recRepo, userRepo := setupRecommendationHandlerRepo()
 	r := newRouter(1)
 	r.GET("/recommendations/users", h.GetRecommendedUsers)
 
@@ -43,7 +43,7 @@ func TestRecommendationGetUsers_Success(t *testing.T) {
 }
 
 func TestRecommendationGetUsers_EmptySkills(t *testing.T) {
-	h, _, userRepo := setupRecommendationHandler()
+	h, _, userRepo := setupRecommendationHandlerRepo()
 	r := newRouter(1)
 	r.GET("/recommendations/users", h.GetRecommendedUsers)
 
@@ -62,7 +62,7 @@ func TestRecommendationGetUsers_EmptySkills(t *testing.T) {
 }
 
 func TestRecommendationGetUsers_UserNotFound(t *testing.T) {
-	h, _, userRepo := setupRecommendationHandler()
+	h, _, userRepo := setupRecommendationHandlerRepo()
 	r := newRouter(1)
 	r.GET("/recommendations/users", h.GetRecommendedUsers)
 
@@ -75,7 +75,7 @@ func TestRecommendationGetUsers_UserNotFound(t *testing.T) {
 // ---------- GetTrendingPosts ----------
 
 func TestRecommendationGetTrendingPosts_Success(t *testing.T) {
-	h, recRepo, _ := setupRecommendationHandler()
+	h, recRepo, _ := setupRecommendationHandlerRepo()
 	r := newRouter(1)
 	r.GET("/recommendations/posts", h.GetTrendingPosts)
 
@@ -93,7 +93,7 @@ func TestRecommendationGetTrendingPosts_Success(t *testing.T) {
 }
 
 func TestRecommendationGetTrendingPosts_Empty(t *testing.T) {
-	h, recRepo, _ := setupRecommendationHandler()
+	h, recRepo, _ := setupRecommendationHandlerRepo()
 	r := newRouter(1)
 	r.GET("/recommendations/posts", h.GetTrendingPosts)
 
@@ -110,7 +110,7 @@ func TestRecommendationGetTrendingPosts_Empty(t *testing.T) {
 // ---------- GetTrendingResources ----------
 
 func TestRecommendationGetTrendingResources_Success(t *testing.T) {
-	h, recRepo, _ := setupRecommendationHandler()
+	h, recRepo, _ := setupRecommendationHandlerRepo()
 	r := newRouter(1)
 	r.GET("/recommendations/resources", h.GetTrendingResources)
 
@@ -129,7 +129,7 @@ func TestRecommendationGetTrendingResources_Success(t *testing.T) {
 }
 
 func TestRecommendationGetTrendingResources_Empty(t *testing.T) {
-	h, recRepo, _ := setupRecommendationHandler()
+	h, recRepo, _ := setupRecommendationHandlerRepo()
 	r := newRouter(1)
 	r.GET("/recommendations/resources", h.GetTrendingResources)
 

--- a/backend/internal/handler/reminder_settings_test.go
+++ b/backend/internal/handler/reminder_settings_test.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestReminderSettings_GetSettings_Success(t *testing.T) {
+	h, svc := setupReminderSettingsHandler()
+	svc.On("GetSettings", uint(1)).Return(&model.ReminderSettings{
+		Enabled:   true,
+		Frequency: "daily",
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/reminder-settings", h.GetSettings)
+
+	w := doRequest(r, http.MethodGet, "/reminder-settings", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestReminderSettings_GetSettings_ServiceError(t *testing.T) {
+	h, svc := setupReminderSettingsHandler()
+	svc.On("GetSettings", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/reminder-settings", h.GetSettings)
+
+	w := doRequest(r, http.MethodGet, "/reminder-settings", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestReminderSettings_UpdateSettings_Success(t *testing.T) {
+	h, svc := setupReminderSettingsHandler()
+	svc.On("UpdateSettings", uint(1), mock.AnythingOfType("*model.ReminderSettings")).Return(&model.ReminderSettings{
+		Enabled:   true,
+		Frequency: "weekly",
+	}, nil)
+
+	r := newRouter(1)
+	r.PUT("/reminder-settings", h.UpdateSettings)
+
+	w := doRequest(r, http.MethodPut, "/reminder-settings", map[string]interface{}{
+		"enabled":   true,
+		"frequency": "weekly",
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestReminderSettings_UpdateSettings_InvalidJSON(t *testing.T) {
+	h, _ := setupReminderSettingsHandler()
+
+	r := newRouter(1)
+	r.PUT("/reminder-settings", h.UpdateSettings)
+
+	w := doRequestRaw(r, http.MethodPut, "/reminder-settings", "bad json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestReminderSettings_UpdateSettings_ServiceError(t *testing.T) {
+	h, svc := setupReminderSettingsHandler()
+	svc.On("UpdateSettings", uint(1), mock.AnythingOfType("*model.ReminderSettings")).Return(nil, errors.New("update failed"))
+
+	r := newRouter(1)
+	r.PUT("/reminder-settings", h.UpdateSettings)
+
+	w := doRequest(r, http.MethodPut, "/reminder-settings", map[string]interface{}{
+		"enabled": false,
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -473,8 +473,8 @@ func setupChatRoomHandlerRepo() (*ChatRoomHandler, *MockChatRoomRepository, *Moc
 	return h, roomRepo, msgRepo
 }
 
-// setupRecommendationHandler はRecommendationHandlerテスト用のセットアップを行う。
-func setupRecommendationHandler() (*RecommendationHandler, *MockRecommendationRepository, *MockUserRepository) {
+// setupRecommendationHandlerRepo はRecommendationHandlerテスト用のセットアップを行う（リポジトリモック版）。
+func setupRecommendationHandlerRepo() (*RecommendationHandler, *MockRecommendationRepository, *MockUserRepository) {
 	recRepo := new(MockRecommendationRepository)
 	userRepo := new(MockUserRepository)
 	svc := service.NewRecommendationService(recRepo, userRepo)
@@ -1167,5 +1167,75 @@ func (m *MockLearningLogService) GetCalendarData(userID uint) ([]model.CalendarE
 func setupLearningLogHandler() (*LearningLogHandler, *MockLearningLogService) {
 	svc := new(MockLearningLogService)
 	h := NewLearningLogHandler(svc)
+	return h, svc
+}
+
+// MockMessageService は MessageServiceInterface のモック実装。
+type MockMessageService struct{ mock.Mock }
+
+func (m *MockMessageService) GetConversations(userID uint) ([]repository.ConversationSummary, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]repository.ConversationSummary), args.Error(1)
+}
+func (m *MockMessageService) GetConversation(userID, otherUserID uint, page, limit int) ([]model.Message, error) {
+	args := m.Called(userID, otherUserID, page, limit)
+	return args.Get(0).([]model.Message), args.Error(1)
+}
+func (m *MockMessageService) SendMessage(msg *model.Message) error {
+	return m.Called(msg).Error(0)
+}
+
+// setupMessageHandler はMessageHandlerテスト用のセットアップを行う。
+func setupMessageHandler() (*MessageHandler, *MockMessageService) {
+	svc := new(MockMessageService)
+	h := NewMessageHandler(svc)
+	return h, svc
+}
+
+// MockReminderSettingsService は ReminderSettingsServiceInterface のモック実装。
+type MockReminderSettingsService struct{ mock.Mock }
+
+func (m *MockReminderSettingsService) GetSettings(userID uint) (*model.ReminderSettings, error) {
+	args := m.Called(userID)
+	if s := args.Get(0); s != nil {
+		return s.(*model.ReminderSettings), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockReminderSettingsService) UpdateSettings(userID uint, updates *model.ReminderSettings) (*model.ReminderSettings, error) {
+	args := m.Called(userID, updates)
+	if s := args.Get(0); s != nil {
+		return s.(*model.ReminderSettings), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// setupReminderSettingsHandler はReminderSettingsHandlerテスト用のセットアップを行う。
+func setupReminderSettingsHandler() (*ReminderSettingsHandler, *MockReminderSettingsService) {
+	svc := new(MockReminderSettingsService)
+	h := NewReminderSettingsHandler(svc)
+	return h, svc
+}
+
+// MockRecommendationService は RecommendationServiceInterface のモック実装。
+type MockRecommendationService struct{ mock.Mock }
+
+func (m *MockRecommendationService) GetRecommendedUsers(userID uint) ([]model.RecommendedUser, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.RecommendedUser), args.Error(1)
+}
+func (m *MockRecommendationService) GetTrendingPosts() ([]model.Post, error) {
+	args := m.Called()
+	return args.Get(0).([]model.Post), args.Error(1)
+}
+func (m *MockRecommendationService) GetTrendingResources() ([]model.LearningResource, error) {
+	args := m.Called()
+	return args.Get(0).([]model.LearningResource), args.Error(1)
+}
+
+// setupRecommendationHandler はRecommendationHandlerテスト用のセットアップを行う。
+func setupRecommendationHandler() (*RecommendationHandler, *MockRecommendationService) {
+	svc := new(MockRecommendationService)
+	h := NewRecommendationHandler(svc)
 	return h, svc
 }


### PR DESCRIPTION
## 概要
- サイクル9-2で追加したインターフェースに対応するモックとテストを作成
- 既存 `setupRecommendationHandler` を `setupRecommendationHandlerRepo` にリネーム（名前衝突回避）

## 追加テスト
| ファイル | テスト数 | カバー範囲 |
|---------|---------|----------|
| message_test.go | 7 | 会話一覧、メッセージ取得（ページネーション対応）、送信（成功/エラー/バリデーション） |
| reminder_settings_test.go | 5 | 設定取得（成功/エラー）、更新（成功/不正JSON/エラー） |

## テスト計画
- [ ] 全ハンドラテストがパスすること

Closes #312