### PR TITLE
feat: inputClass定義を共通定数に統一

### DIFF
--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -6,6 +6,7 @@ import { useGoals, useConfirm } from '../hooks';
 import { Modal, PageLoader } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 import ConfirmDialog from '../components/common/ConfirmDialog';
+import { inputClass } from '../constants/styles';
 
 const CATEGORIES: { value: GoalCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'goals.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -104,7 +105,6 @@ export default function GoalsPage() {
 
   if (loading) return <PageLoader />;
 
-  const inputClass = "w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow";
 
   return (
     <div className="max-w-4xl mx-auto space-y-6">

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -7,6 +7,7 @@ import type { LearningLog, LogCategory } from '../types/learningLog';
 import LogCalendar from '../components/learning-logs/LogCalendar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import { Modal } from '../components/common';
+import { inputClass } from '../constants/styles';
 
 const CATEGORIES: { value: LogCategory; label: string; Icon: LucideIcon }[] = [
   { value: 'coding', label: 'learningLogs.categoryCoding', Icon: Code },
@@ -113,7 +114,6 @@ export default function LearningLogsPage() {
 
   if (loading) return <div className="py-12"><LoadingSpinner /></div>;
 
-  const inputClass = "w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent transition-shadow";
 
   return (
     <div className="max-w-4xl mx-auto space-y-6">

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -10,6 +10,7 @@ import { connectQiita } from '../api/qiita';
 import { connectAtCoder } from '../api/atcoder';
 import toast from 'react-hot-toast';
 import { LANGUAGES, FRAMEWORKS } from '../constants/skills';
+import { inputClass } from '../constants/styles';
 
 const STEPS = [
   { id: 1, icon: User },
@@ -169,7 +170,6 @@ export default function OnboardingPage() {
     }
   };
 
-  const inputClass = "w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow";
 
   return (
     <div className="min-h-screen bg-gray-950 flex flex-col items-center justify-center px-4 py-12">

--- a/frontend/src/pages/RoadmapDetailPage.tsx
+++ b/frontend/src/pages/RoadmapDetailPage.tsx
@@ -7,6 +7,7 @@ import { useRoadmapDetail } from '../hooks';
 import { type RoadmapStep } from '../api/roadmaps';
 import { PageLoader, Modal } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
+import { inputClass } from '../constants/styles';
 
 export default function RoadmapDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -81,7 +82,6 @@ export default function RoadmapDetailPage() {
     );
   }
 
-  const inputClass = 'w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent';
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -6,6 +6,7 @@ import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
 import { useRoadmaps, useRoadmapTemplates } from '../hooks';
 import EmptyState from '../components/common/EmptyState';
 import { Modal, PageHeader, PageLoader } from '../components/common';
+import { inputClass } from '../constants/styles';
 
 const CATEGORIES: { value: RoadmapCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'roadmaps.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -82,7 +83,6 @@ export default function RoadmapsPage() {
     return <PageLoader />;
   }
 
-  const inputClass = 'w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent';
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">


### PR DESCRIPTION
## 概要
- 5ページに散在していたローカル`inputClass`定義を`constants/styles.ts`の共通定数に統一
- フォーム入力フィールドのスタイルが全ページで一貫するように改善

## 変更内容
- `OnboardingPage.tsx` — ローカル定義削除、共通定数をインポート
- `GoalsPage.tsx` — 同上
- `LearningLogsPage.tsx` — 同上（紫リングを青リングに統一）
- `RoadmapsPage.tsx` — 同上（異なるスタイルを標準スタイルに統一）
- `RoadmapDetailPage.tsx` — 同上

## テスト計画
- [x] TypeScript型チェック通過
- [ ] 各ページのフォーム入力フィールドの表示確認