### PR TITLE
refactor: NotificationSettings・EmailPreferences・LearningResourceハンドラーにインターフェース導入

### DIFF
--- a/backend/internal/handler/email_preferences.go
+++ b/backend/internal/handler/email_preferences.go
@@ -4,17 +4,23 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
+
+// EmailPreferencesServiceInterface はメール配信設定に必要なサービスの抽象インターフェース。
+type EmailPreferencesServiceInterface interface {
+	GetByID(id uint) (*model.User, error)
+	Update(user *model.User) error
+}
 
 // EmailPreferencesHandler はメール配信設定関連のHTTPハンドラ。
 // ユーザーのメール配信設定の取得・更新を処理する。
 type EmailPreferencesHandler struct {
-	userService *service.UserService
+	userService EmailPreferencesServiceInterface
 }
 
 // NewEmailPreferencesHandler は新しいEmailPreferencesHandlerインスタンスを生成する。
-func NewEmailPreferencesHandler(userService *service.UserService) *EmailPreferencesHandler {
+func NewEmailPreferencesHandler(userService EmailPreferencesServiceInterface) *EmailPreferencesHandler {
 	return &EmailPreferencesHandler{userService: userService}
 }
 

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -6,17 +6,35 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// LearningResourceServiceInterface は学習リソースサービスの抽象インターフェース。
+type LearningResourceServiceInterface interface {
+	Create(resource *model.LearningResource) error
+	GetByID(id, userID uint) (*model.LearningResource, error)
+	HasLiked(userID, resourceID uint) (bool, error)
+	HasSaved(userID, resourceID uint) (bool, error)
+	GetByUserID(targetUserID, currentUserID uint) ([]model.LearningResource, error)
+	GetPublic(limit, offset int, category, difficulty string) ([]model.LearningResource, int64, error)
+	Search(query string, limit, offset int) ([]model.LearningResource, int64, error)
+	Update(id, userID uint, updates *model.LearningResource) (*model.LearningResource, error)
+	UpdateVisibility(id, userID uint, isPublic bool) (*model.LearningResource, error)
+	Delete(id, userID uint) error
+	Like(userID, resourceID uint) error
+	Unlike(userID, resourceID uint) error
+	Save(userID, resourceID uint) error
+	Unsave(userID, resourceID uint) error
+	GetSavedByUserID(userID uint, limit, offset int) ([]model.LearningResource, int64, error)
+}
 
 // LearningResourceHandler は学習リソース関連のHTTPハンドラ。
 // 学習リソースのCRUD・検索・いいね・保存を処理する。
 type LearningResourceHandler struct {
-	service *service.LearningResourceService
+	service LearningResourceServiceInterface
 }
 
 // NewLearningResourceHandler は新しいLearningResourceHandlerインスタンスを生成する。
-func NewLearningResourceHandler(s *service.LearningResourceService) *LearningResourceHandler {
+func NewLearningResourceHandler(s LearningResourceServiceInterface) *LearningResourceHandler {
 	return &LearningResourceHandler{service: s}
 }
 

--- a/backend/internal/handler/notification_settings.go
+++ b/backend/internal/handler/notification_settings.go
@@ -3,16 +3,21 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// NotificationSettingsServiceInterface は通知設定サービスの抽象インターフェース。
+type NotificationSettingsServiceInterface interface {
+	GetSettings(userID uint) (*model.NotificationSettings, error)
+	UpdateSettings(userID uint, updates *model.NotificationSettings) (*model.NotificationSettings, error)
+}
 
 // NotificationSettingsHandler は通知設定関連のHTTPハンドラ。
 type NotificationSettingsHandler struct {
-	service *service.NotificationSettingsService
+	service NotificationSettingsServiceInterface
 }
 
 // NewNotificationSettingsHandler は新しいNotificationSettingsHandlerインスタンスを生成する。
-func NewNotificationSettingsHandler(s *service.NotificationSettingsService) *NotificationSettingsHandler {
+func NewNotificationSettingsHandler(s NotificationSettingsServiceInterface) *NotificationSettingsHandler {
 	return &NotificationSettingsHandler{service: s}
 }
 


### PR DESCRIPTION
## 概要
- 3つのハンドラーにサービスインターフェースを導入し、具体型への依存を解消

## 変更内容
- `NotificationSettingsHandler` — `NotificationSettingsServiceInterface`（2メソッド）
- `EmailPreferencesHandler` — `EmailPreferencesServiceInterface`（2メソッド）
- `LearningResourceHandler` — `LearningResourceServiceInterface`（15メソッド）

## テスト計画
- [x] `go build ./...` ビルド通過
- [ ] CI通過確認

Closes #316