### PR TITLE
test: NotificationSettings・EmailPreferencesハンドラーのテスト追加

### DIFF
--- a/backend/internal/handler/email_preferences_test.go
+++ b/backend/internal/handler/email_preferences_test.go
@@ -1,0 +1,100 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestEmailPreferences_GetPreferences_Success(t *testing.T) {
+	h, svc := setupEmailPreferencesHandler()
+	svc.On("GetByID", uint(1)).Return(&model.User{
+		EmailWeeklyReport: true,
+		EmailLanguage:     "ja",
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/email-preferences", h.GetPreferences)
+
+	w := doRequest(r, http.MethodGet, "/email-preferences", nil)
+	assertStatus(t, w, http.StatusOK)
+
+	body := parseJSON(t, w)
+	assert.Equal(t, true, body["email_weekly_report"])
+	assert.Equal(t, "ja", body["email_language"])
+	svc.AssertExpectations(t)
+}
+
+func TestEmailPreferences_GetPreferences_ServiceError(t *testing.T) {
+	h, svc := setupEmailPreferencesHandler()
+	svc.On("GetByID", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/email-preferences", h.GetPreferences)
+
+	w := doRequest(r, http.MethodGet, "/email-preferences", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestEmailPreferences_UpdatePreferences_Success(t *testing.T) {
+	h, svc := setupEmailPreferencesHandler()
+	user := &model.User{EmailWeeklyReport: true, EmailLanguage: "ja"}
+	svc.On("GetByID", uint(1)).Return(user, nil)
+	svc.On("Update", mock.AnythingOfType("*model.User")).Return(nil)
+
+	r := newRouter(1)
+	r.PUT("/email-preferences", h.UpdatePreferences)
+
+	w := doRequest(r, http.MethodPut, "/email-preferences", map[string]interface{}{
+		"email_weekly_report": false,
+		"email_language":      "en",
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestEmailPreferences_UpdatePreferences_InvalidJSON(t *testing.T) {
+	h, _ := setupEmailPreferencesHandler()
+
+	r := newRouter(1)
+	r.PUT("/email-preferences", h.UpdatePreferences)
+
+	w := doRequestRaw(r, http.MethodPut, "/email-preferences", "bad json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestEmailPreferences_UpdatePreferences_InvalidLanguage(t *testing.T) {
+	h, svc := setupEmailPreferencesHandler()
+	user := &model.User{EmailWeeklyReport: true, EmailLanguage: "ja"}
+	svc.On("GetByID", uint(1)).Return(user, nil)
+
+	r := newRouter(1)
+	r.PUT("/email-preferences", h.UpdatePreferences)
+
+	w := doRequest(r, http.MethodPut, "/email-preferences", map[string]interface{}{
+		"email_language": "invalid",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+	svc.AssertExpectations(t)
+}
+
+func TestEmailPreferences_UpdatePreferences_ServiceError(t *testing.T) {
+	h, svc := setupEmailPreferencesHandler()
+	user := &model.User{EmailWeeklyReport: true, EmailLanguage: "ja"}
+	svc.On("GetByID", uint(1)).Return(user, nil)
+	svc.On("Update", mock.AnythingOfType("*model.User")).Return(errors.New("update failed"))
+
+	r := newRouter(1)
+	r.PUT("/email-preferences", h.UpdatePreferences)
+
+	w := doRequest(r, http.MethodPut, "/email-preferences", map[string]interface{}{
+		"email_weekly_report": false,
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/notification_settings_test.go
+++ b/backend/internal/handler/notification_settings_test.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNotificationSettings_GetSettings_Success(t *testing.T) {
+	h, svc := setupNotificationSettingsHandler()
+	svc.On("GetSettings", uint(1)).Return(&model.NotificationSettings{
+		EnableLikes:    true,
+		EnableComments: true,
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/notification-settings", h.GetSettings)
+
+	w := doRequest(r, http.MethodGet, "/notification-settings", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNotificationSettings_GetSettings_ServiceError(t *testing.T) {
+	h, svc := setupNotificationSettingsHandler()
+	svc.On("GetSettings", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/notification-settings", h.GetSettings)
+
+	w := doRequest(r, http.MethodGet, "/notification-settings", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestNotificationSettings_UpdateSettings_Success(t *testing.T) {
+	h, svc := setupNotificationSettingsHandler()
+	svc.On("UpdateSettings", uint(1), mock.AnythingOfType("*model.NotificationSettings")).Return(&model.NotificationSettings{
+		EnableLikes:    false,
+		EnableComments: true,
+	}, nil)
+
+	r := newRouter(1)
+	r.PUT("/notification-settings", h.UpdateSettings)
+
+	w := doRequest(r, http.MethodPut, "/notification-settings", map[string]interface{}{
+		"enable_likes":    false,
+		"enable_comments": true,
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNotificationSettings_UpdateSettings_InvalidJSON(t *testing.T) {
+	h, _ := setupNotificationSettingsHandler()
+
+	r := newRouter(1)
+	r.PUT("/notification-settings", h.UpdateSettings)
+
+	w := doRequestRaw(r, http.MethodPut, "/notification-settings", "bad json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNotificationSettings_UpdateSettings_ServiceError(t *testing.T) {
+	h, svc := setupNotificationSettingsHandler()
+	svc.On("UpdateSettings", uint(1), mock.AnythingOfType("*model.NotificationSettings")).Return(nil, errors.New("update failed"))
+
+	r := newRouter(1)
+	r.PUT("/notification-settings", h.UpdateSettings)
+
+	w := doRequest(r, http.MethodPut, "/notification-settings", map[string]interface{}{
+		"enable_likes": false,
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -447,12 +447,58 @@ func setupQuestionHandler() (*QuestionHandler, *MockQuestionRepository) {
 	return h, repo
 }
 
-// setupLearningResourceHandler はLearningResourceHandlerテスト用のセットアップを行う。
+// setupLearningResourceHandler はLearningResourceHandlerテスト用のセットアップを行う（リポジトリレベル）。
 func setupLearningResourceHandler() (*LearningResourceHandler, *MockLearningResourceRepository) {
 	repo := new(MockLearningResourceRepository)
 	svc := service.NewLearningResourceService(repo)
 	h := NewLearningResourceHandler(svc)
 	return h, repo
+}
+
+// MockNotificationSettingsService は NotificationSettingsServiceInterface のモック実装。
+type MockNotificationSettingsServiceMock struct{ mock.Mock }
+
+func (m *MockNotificationSettingsServiceMock) GetSettings(userID uint) (*model.NotificationSettings, error) {
+	args := m.Called(userID)
+	if s := args.Get(0); s != nil {
+		return s.(*model.NotificationSettings), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockNotificationSettingsServiceMock) UpdateSettings(userID uint, updates *model.NotificationSettings) (*model.NotificationSettings, error) {
+	args := m.Called(userID, updates)
+	if s := args.Get(0); s != nil {
+		return s.(*model.NotificationSettings), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// setupNotificationSettingsHandler はNotificationSettingsHandlerテスト用のセットアップを行う。
+func setupNotificationSettingsHandler() (*NotificationSettingsHandler, *MockNotificationSettingsServiceMock) {
+	svc := new(MockNotificationSettingsServiceMock)
+	h := NewNotificationSettingsHandler(svc)
+	return h, svc
+}
+
+// MockEmailPreferencesService は EmailPreferencesServiceInterface のモック実装。
+type MockEmailPreferencesService struct{ mock.Mock }
+
+func (m *MockEmailPreferencesService) GetByID(id uint) (*model.User, error) {
+	args := m.Called(id)
+	if u := args.Get(0); u != nil {
+		return u.(*model.User), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockEmailPreferencesService) Update(user *model.User) error {
+	return m.Called(user).Error(0)
+}
+
+// setupEmailPreferencesHandler はEmailPreferencesHandlerテスト用のセットアップを行う。
+func setupEmailPreferencesHandler() (*EmailPreferencesHandler, *MockEmailPreferencesService) {
+	svc := new(MockEmailPreferencesService)
+	h := NewEmailPreferencesHandler(svc)
+	return h, svc
 }
 
 // setupRoadmapHandler はRoadmapHandlerテスト用のセットアップを行う。


### PR DESCRIPTION
## 概要
サイクル10-2でインターフェース化したハンドラーに対するユニットテストを追加

## 変更内容
- `notification_settings_test.go` — 5テスト新規作成
- `email_preferences_test.go` — 6テスト新規作成
- `testutil_test.go` — MockNotificationSettingsServiceMock, MockEmailPreferencesService, セットアップ関数追加

## テスト計画
- [x] 新規11テスト全て通過
- [ ] CI通過確認

Closes #318