### PR TITLE
feat: セカンダリボタンスタイルを共通定数に統一

### DIFF
--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -1,2 +1,5 @@
 export const inputClass =
   'w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow';
+
+export const buttonSecondaryClass =
+  'px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors';

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -6,7 +6,7 @@ import { useGoals, useConfirm } from '../hooks';
 import { Modal, PageLoader } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 import ConfirmDialog from '../components/common/ConfirmDialog';
-import { inputClass } from '../constants/styles';
+import { inputClass, buttonSecondaryClass } from '../constants/styles';
 
 const CATEGORIES: { value: GoalCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'goals.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -112,7 +112,7 @@ export default function GoalsPage() {
         <h1 className="text-2xl font-bold">{t('goals.title')}</h1>
         <button
           onClick={() => setShowForm(true)}
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg font-medium text-sm transition-colors"
+          className={`${buttonSecondaryClass} font-medium text-sm`}
         >
           {t('goals.addGoal')}
         </button>
@@ -202,14 +202,14 @@ export default function GoalsPage() {
             <button
               type="button"
               onClick={resetForm}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
+              className={`${buttonSecondaryClass} text-sm font-medium`}
             >
               {t('common.cancel')}
             </button>
             <button
               type="submit"
               disabled={saving || !title.trim()}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+              className={`${buttonSecondaryClass} disabled:opacity-50 text-sm font-medium`}
             >
               {saving ? t('common.loading') : editingGoal ? t('common.save') : t('goals.create')}
             </button>

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -7,7 +7,7 @@ import type { LearningLog, LogCategory } from '../types/learningLog';
 import LogCalendar from '../components/learning-logs/LogCalendar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import { Modal } from '../components/common';
-import { inputClass } from '../constants/styles';
+import { inputClass, buttonSecondaryClass } from '../constants/styles';
 
 const CATEGORIES: { value: LogCategory; label: string; Icon: LucideIcon }[] = [
   { value: 'coding', label: 'learningLogs.categoryCoding', Icon: Code },
@@ -124,7 +124,7 @@ export default function LearningLogsPage() {
         </div>
         <button
           onClick={() => setShowForm(true)}
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg font-medium text-sm transition-colors"
+          className={`${buttonSecondaryClass} font-medium text-sm`}
         >
           {t('learningLogs.addLog')}
         </button>
@@ -272,7 +272,7 @@ export default function LearningLogsPage() {
             <button
               type="button"
               onClick={resetForm}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
+              className={`${buttonSecondaryClass} text-sm font-medium`}
             >
               {t('common.cancel')}
             </button>
@@ -298,7 +298,7 @@ export default function LearningLogsPage() {
               {!filterDate && (
                 <button
                   onClick={() => setShowForm(true)}
-                  className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg font-medium text-sm transition-colors"
+                  className={`${buttonSecondaryClass} font-medium text-sm`}
                 >
                   {t('learningLogs.addLog')}
                 </button>

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -7,6 +7,7 @@ import type { Notification, NotificationType } from '../types/notification';
 import Avatar from '../components/common/Avatar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import EmptyState from '../components/common/EmptyState';
+import { buttonSecondaryClass } from '../constants/styles';
 
 const FILTER_TYPES: { key: NotificationType | ''; labelKey: string }[] = [
   { key: '', labelKey: 'notifications.filterAll' },
@@ -100,7 +101,7 @@ export default function NotificationsPage() {
         {unreadCount > 0 && (
           <button
             onClick={markAllAsRead}
-            className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+            className={`flex items-center gap-2 ${buttonSecondaryClass}`}
           >
             <CheckCheck className="w-5 h-5" />
             {t('notifications.markAllRead')}

--- a/frontend/src/pages/RoadmapDetailPage.tsx
+++ b/frontend/src/pages/RoadmapDetailPage.tsx
@@ -7,7 +7,7 @@ import { useRoadmapDetail } from '../hooks';
 import { type RoadmapStep } from '../api/roadmaps';
 import { PageLoader, Modal } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
-import { inputClass } from '../constants/styles';
+import { inputClass, buttonSecondaryClass } from '../constants/styles';
 
 export default function RoadmapDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -122,7 +122,7 @@ export default function RoadmapDetailPage() {
         {isOwner && (
           <button
             onClick={() => setShowStepForm(true)}
-            className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+            className={`flex items-center gap-2 ${buttonSecondaryClass}`}
           >
             <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -192,14 +192,14 @@ export default function RoadmapDetailPage() {
             <button
               type="button"
               onClick={resetStepForm}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+              className={buttonSecondaryClass}
             >
               {t('common.cancel')}
             </button>
             <button
               type="submit"
               disabled={saving || !stepTitle.trim()}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+              className={`${buttonSecondaryClass} disabled:bg-gray-600 disabled:cursor-not-allowed`}
             >
               {saving ? t('common.saving') : editingStep ? t('common.save') : t('roadmaps.create')}
             </button>

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -6,7 +6,7 @@ import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
 import { useRoadmaps, useRoadmapTemplates } from '../hooks';
 import EmptyState from '../components/common/EmptyState';
 import { Modal, PageHeader, PageLoader } from '../components/common';
-import { inputClass } from '../constants/styles';
+import { inputClass, buttonSecondaryClass } from '../constants/styles';
 
 const CATEGORIES: { value: RoadmapCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'roadmaps.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -278,14 +278,14 @@ export default function RoadmapsPage() {
             <button
               type="button"
               onClick={resetForm}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+              className={buttonSecondaryClass}
             >
               {t('common.cancel')}
             </button>
             <button
               type="submit"
               disabled={saving || !title.trim()}
-              className="px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+              className={`${buttonSecondaryClass} disabled:bg-gray-600 disabled:cursor-not-allowed`}
             >
               {saving ? t('common.saving') : editingRoadmap ? t('common.save') : t('roadmaps.create')}
             </button>


### PR DESCRIPTION
## 概要
- `constants/styles.ts`に`buttonSecondaryClass`を追加
- 5ページの12箇所のインラインセカンダリボタンスタイルを共通定数に置き換え

## 変更内容
- `constants/styles.ts` — `buttonSecondaryClass`を新規追加
- `GoalsPage.tsx` — 3箇所置き換え
- `LearningLogsPage.tsx` — 3箇所置き換え
- `RoadmapsPage.tsx` — 2箇所置き換え
- `RoadmapDetailPage.tsx` — 3箇所置き換え
- `NotificationsPage.tsx` — 1箇所置き換え

## テスト計画
- [x] TypeScript型チェック通過
- [ ] 各ページのボタン表示確認

Closes #320