### PR TITLE
refactor: Qiita・Zenn・AtCoderハンドラーにインターフェース導入

### DIFF
--- a/backend/internal/handler/atcoder.go
+++ b/backend/internal/handler/atcoder.go
@@ -4,17 +4,30 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
 
+// AtCoderServiceInterface はAtCoderサービスの抽象インターフェース。
+type AtCoderServiceInterface interface {
+	GetRating(username string) (*service.AtCoderRatingInfo, error)
+	ValidateUsername(username string) bool
+}
+
+// AtCoderUserServiceInterface はAtCoderハンドラーが必要とするユーザーサービスの抽象インターフェース。
+type AtCoderUserServiceInterface interface {
+	GetByID(id uint) (*model.User, error)
+	Update(user *model.User) error
+}
+
 // AtCoderHandler はAtCoder関連のHTTPハンドラ。
 type AtCoderHandler struct {
-	atcoderService *service.AtCoderService
-	userService    *service.UserService
+	atcoderService AtCoderServiceInterface
+	userService    AtCoderUserServiceInterface
 }
 
 // NewAtCoderHandler は新しいAtCoderHandlerインスタンスを生成する。
-func NewAtCoderHandler(atcoderService *service.AtCoderService, userService *service.UserService) *AtCoderHandler {
+func NewAtCoderHandler(atcoderService AtCoderServiceInterface, userService AtCoderUserServiceInterface) *AtCoderHandler {
 	return &AtCoderHandler{
 		atcoderService: atcoderService,
 		userService:    userService,

--- a/backend/internal/handler/qiita.go
+++ b/backend/internal/handler/qiita.go
@@ -4,17 +4,26 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
+
+// QiitaServiceInterface はQiitaサービスの抽象インターフェース。
+type QiitaServiceInterface interface {
+	Connect(userID uint, username string) (int, error)
+	Disconnect(userID uint) error
+	Sync(userID uint) (int, error)
+	GetArticles(userID uint) ([]model.QiitaArticle, error)
+	GetStats(userID uint) (*model.QiitaStats, error)
+}
 
 // QiitaHandler はQiita連携関連のHTTPハンドラ。
 // Qiitaアカウントの接続・切断・記事同期・統計情報の取得を処理する。
 type QiitaHandler struct {
-	service *service.QiitaService
+	service QiitaServiceInterface
 }
 
 // NewQiitaHandler は新しいQiitaHandlerインスタンスを生成する。
-func NewQiitaHandler(s *service.QiitaService) *QiitaHandler {
+func NewQiitaHandler(s QiitaServiceInterface) *QiitaHandler {
 	return &QiitaHandler{service: s}
 }
 

--- a/backend/internal/handler/zenn.go
+++ b/backend/internal/handler/zenn.go
@@ -4,17 +4,26 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
+
+// ZennServiceInterface はZennサービスの抽象インターフェース。
+type ZennServiceInterface interface {
+	Connect(userID uint, username string) (int, error)
+	Disconnect(userID uint) error
+	Sync(userID uint) (int, error)
+	GetArticles(userID uint) ([]model.ZennArticle, error)
+	GetStats(userID uint) (*model.ZennStats, error)
+}
 
 // ZennHandler はZenn連携関連のHTTPハンドラ。
 // Zennアカウントの接続・切断・記事同期・統計情報の取得を処理する。
 type ZennHandler struct {
-	service *service.ZennService
+	service ZennServiceInterface
 }
 
 // NewZennHandler は新しいZennHandlerインスタンスを生成する。
-func NewZennHandler(s *service.ZennService) *ZennHandler {
+func NewZennHandler(s ZennServiceInterface) *ZennHandler {
 	return &ZennHandler{service: s}
 }
 


### PR DESCRIPTION
## 概要
- 3つのハンドラーにサービスインターフェースを導入し、具体型への依存を解消

## 変更内容
- `QiitaHandler` — `QiitaServiceInterface`（5メソッド）
- `ZennHandler` — `ZennServiceInterface`（5メソッド）
- `AtCoderHandler` — `AtCoderServiceInterface`（2メソッド）+ `AtCoderUserServiceInterface`（2メソッド）

## テスト計画
- [x] `go build ./...` ビルド通過
- [ ] CI通過確認

Closes #322