### PR TITLE
test: Qiita・Zenn・AtCoderハンドラーのテスト追加

### DIFF
--- a/backend/internal/handler/atcoder_test.go
+++ b/backend/internal/handler/atcoder_test.go
@@ -1,0 +1,103 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestAtCoder_GetRating_Success(t *testing.T) {
+	h, atcoderSvc, _ := setupAtCoderHandler()
+	atcoderSvc.On("GetRating", "tourist").Return(&service.AtCoderRatingInfo{
+		Rating: 3000,
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/atcoder/:username/rating", h.GetRating)
+
+	w := doRequest(r, http.MethodGet, "/atcoder/tourist/rating", nil)
+	assertStatus(t, w, http.StatusOK)
+	atcoderSvc.AssertExpectations(t)
+}
+
+func TestAtCoder_GetRating_Error(t *testing.T) {
+	h, atcoderSvc, _ := setupAtCoderHandler()
+	atcoderSvc.On("GetRating", "invalid").Return(nil, errors.New("not found"))
+
+	r := newRouter(1)
+	r.GET("/atcoder/:username/rating", h.GetRating)
+
+	w := doRequest(r, http.MethodGet, "/atcoder/invalid/rating", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+	atcoderSvc.AssertExpectations(t)
+}
+
+func TestAtCoder_Connect_Success(t *testing.T) {
+	h, atcoderSvc, userSvc := setupAtCoderHandler()
+	atcoderSvc.On("ValidateUsername", "myuser").Return(true)
+	userSvc.On("GetByID", uint(1)).Return(&model.User{}, nil)
+	userSvc.On("Update", mock.AnythingOfType("*model.User")).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/atcoder/connect", h.Connect)
+
+	w := doRequest(r, http.MethodPost, "/atcoder/connect", map[string]string{
+		"username": "myuser",
+	})
+	assertStatus(t, w, http.StatusOK)
+	atcoderSvc.AssertExpectations(t)
+	userSvc.AssertExpectations(t)
+}
+
+func TestAtCoder_Connect_MissingUsername(t *testing.T) {
+	h, _, _ := setupAtCoderHandler()
+
+	r := newRouter(1)
+	r.POST("/atcoder/connect", h.Connect)
+
+	w := doRequest(r, http.MethodPost, "/atcoder/connect", map[string]string{})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestAtCoder_Connect_InvalidUsername(t *testing.T) {
+	h, atcoderSvc, _ := setupAtCoderHandler()
+	atcoderSvc.On("ValidateUsername", "bad!user").Return(false)
+
+	r := newRouter(1)
+	r.POST("/atcoder/connect", h.Connect)
+
+	w := doRequest(r, http.MethodPost, "/atcoder/connect", map[string]string{
+		"username": "bad!user",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+	atcoderSvc.AssertExpectations(t)
+}
+
+func TestAtCoder_Disconnect_Success(t *testing.T) {
+	h, _, userSvc := setupAtCoderHandler()
+	userSvc.On("GetByID", uint(1)).Return(&model.User{AtCoderUsername: "myuser"}, nil)
+	userSvc.On("Update", mock.AnythingOfType("*model.User")).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/atcoder/disconnect", h.Disconnect)
+
+	w := doRequest(r, http.MethodDelete, "/atcoder/disconnect", nil)
+	assertStatus(t, w, http.StatusOK)
+	userSvc.AssertExpectations(t)
+}
+
+func TestAtCoder_Disconnect_UserNotFound(t *testing.T) {
+	h, _, userSvc := setupAtCoderHandler()
+	userSvc.On("GetByID", uint(1)).Return(nil, errors.New("not found"))
+
+	r := newRouter(1)
+	r.DELETE("/atcoder/disconnect", h.Disconnect)
+
+	w := doRequest(r, http.MethodDelete, "/atcoder/disconnect", nil)
+	assertStatus(t, w, http.StatusNotFound)
+	userSvc.AssertExpectations(t)
+}

--- a/backend/internal/handler/qiita_test.go
+++ b/backend/internal/handler/qiita_test.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+func TestQiita_Connect_Success(t *testing.T) {
+	h, svc := setupQiitaHandler()
+	svc.On("Connect", uint(1), "testuser").Return(5, nil)
+
+	r := newRouter(1)
+	r.POST("/qiita/connect", h.Connect)
+
+	w := doRequest(r, http.MethodPost, "/qiita/connect", map[string]string{
+		"username": "testuser",
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestQiita_Connect_MissingUsername(t *testing.T) {
+	h, _ := setupQiitaHandler()
+
+	r := newRouter(1)
+	r.POST("/qiita/connect", h.Connect)
+
+	w := doRequest(r, http.MethodPost, "/qiita/connect", map[string]string{})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestQiita_Connect_ServiceError(t *testing.T) {
+	h, svc := setupQiitaHandler()
+	svc.On("Connect", uint(1), "testuser").Return(0, errors.New("api error"))
+
+	r := newRouter(1)
+	r.POST("/qiita/connect", h.Connect)
+
+	w := doRequest(r, http.MethodPost, "/qiita/connect", map[string]string{
+		"username": "testuser",
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestQiita_Disconnect_Success(t *testing.T) {
+	h, svc := setupQiitaHandler()
+	svc.On("Disconnect", uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/qiita/disconnect", h.Disconnect)
+
+	w := doRequest(r, http.MethodDelete, "/qiita/disconnect", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestQiita_Sync_Success(t *testing.T) {
+	h, svc := setupQiitaHandler()
+	svc.On("Sync", uint(1)).Return(10, nil)
+
+	r := newRouter(1)
+	r.POST("/qiita/sync", h.Sync)
+
+	w := doRequest(r, http.MethodPost, "/qiita/sync", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestQiita_GetArticles_Success(t *testing.T) {
+	h, svc := setupQiitaHandler()
+	svc.On("GetArticles", uint(5)).Return([]model.QiitaArticle{
+		{Title: "Article 1"},
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/qiita/:userId/articles", h.GetArticles)
+
+	w := doRequest(r, http.MethodGet, "/qiita/5/articles", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestQiita_GetStats_Success(t *testing.T) {
+	h, svc := setupQiitaHandler()
+	svc.On("GetStats", uint(5)).Return(&model.QiitaStats{
+		TotalArticles: 10,
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/qiita/:userId/stats", h.GetStats)
+
+	w := doRequest(r, http.MethodGet, "/qiita/5/stats", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1285,3 +1285,105 @@ func setupRecommendationHandler() (*RecommendationHandler, *MockRecommendationSe
 	h := NewRecommendationHandler(svc)
 	return h, svc
 }
+
+// MockQiitaService は QiitaServiceInterface のモック実装。
+type MockQiitaService struct{ mock.Mock }
+
+func (m *MockQiitaService) Connect(userID uint, username string) (int, error) {
+	args := m.Called(userID, username)
+	return args.Int(0), args.Error(1)
+}
+func (m *MockQiitaService) Disconnect(userID uint) error {
+	return m.Called(userID).Error(0)
+}
+func (m *MockQiitaService) Sync(userID uint) (int, error) {
+	args := m.Called(userID)
+	return args.Int(0), args.Error(1)
+}
+func (m *MockQiitaService) GetArticles(userID uint) ([]model.QiitaArticle, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.QiitaArticle), args.Error(1)
+}
+func (m *MockQiitaService) GetStats(userID uint) (*model.QiitaStats, error) {
+	args := m.Called(userID)
+	if s := args.Get(0); s != nil {
+		return s.(*model.QiitaStats), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// setupQiitaHandler はQiitaHandlerテスト用のセットアップを行う。
+func setupQiitaHandler() (*QiitaHandler, *MockQiitaService) {
+	svc := new(MockQiitaService)
+	h := NewQiitaHandler(svc)
+	return h, svc
+}
+
+// MockZennService は ZennServiceInterface のモック実装。
+type MockZennService struct{ mock.Mock }
+
+func (m *MockZennService) Connect(userID uint, username string) (int, error) {
+	args := m.Called(userID, username)
+	return args.Int(0), args.Error(1)
+}
+func (m *MockZennService) Disconnect(userID uint) error {
+	return m.Called(userID).Error(0)
+}
+func (m *MockZennService) Sync(userID uint) (int, error) {
+	args := m.Called(userID)
+	return args.Int(0), args.Error(1)
+}
+func (m *MockZennService) GetArticles(userID uint) ([]model.ZennArticle, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.ZennArticle), args.Error(1)
+}
+func (m *MockZennService) GetStats(userID uint) (*model.ZennStats, error) {
+	args := m.Called(userID)
+	if s := args.Get(0); s != nil {
+		return s.(*model.ZennStats), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+// setupZennHandler はZennHandlerテスト用のセットアップを行う。
+func setupZennHandler() (*ZennHandler, *MockZennService) {
+	svc := new(MockZennService)
+	h := NewZennHandler(svc)
+	return h, svc
+}
+
+// MockAtCoderService は AtCoderServiceInterface のモック実装。
+type MockAtCoderService struct{ mock.Mock }
+
+func (m *MockAtCoderService) GetRating(username string) (*service.AtCoderRatingInfo, error) {
+	args := m.Called(username)
+	if r := args.Get(0); r != nil {
+		return r.(*service.AtCoderRatingInfo), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockAtCoderService) ValidateUsername(username string) bool {
+	return m.Called(username).Bool(0)
+}
+
+// MockAtCoderUserService は AtCoderUserServiceInterface のモック実装。
+type MockAtCoderUserService struct{ mock.Mock }
+
+func (m *MockAtCoderUserService) GetByID(id uint) (*model.User, error) {
+	args := m.Called(id)
+	if u := args.Get(0); u != nil {
+		return u.(*model.User), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockAtCoderUserService) Update(user *model.User) error {
+	return m.Called(user).Error(0)
+}
+
+// setupAtCoderHandler はAtCoderHandlerテスト用のセットアップを行う。
+func setupAtCoderHandler() (*AtCoderHandler, *MockAtCoderService, *MockAtCoderUserService) {
+	atcoderSvc := new(MockAtCoderService)
+	userSvc := new(MockAtCoderUserService)
+	h := NewAtCoderHandler(atcoderSvc, userSvc)
+	return h, atcoderSvc, userSvc
+}

--- a/backend/internal/handler/zenn_test.go
+++ b/backend/internal/handler/zenn_test.go
@@ -1,0 +1,99 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+func TestZenn_Connect_Success(t *testing.T) {
+	h, svc := setupZennHandler()
+	svc.On("Connect", uint(1), "testuser").Return(3, nil)
+
+	r := newRouter(1)
+	r.POST("/zenn/connect", h.Connect)
+
+	w := doRequest(r, http.MethodPost, "/zenn/connect", map[string]string{
+		"username": "testuser",
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestZenn_Connect_MissingUsername(t *testing.T) {
+	h, _ := setupZennHandler()
+
+	r := newRouter(1)
+	r.POST("/zenn/connect", h.Connect)
+
+	w := doRequest(r, http.MethodPost, "/zenn/connect", map[string]string{})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestZenn_Connect_ServiceError(t *testing.T) {
+	h, svc := setupZennHandler()
+	svc.On("Connect", uint(1), "testuser").Return(0, errors.New("api error"))
+
+	r := newRouter(1)
+	r.POST("/zenn/connect", h.Connect)
+
+	w := doRequest(r, http.MethodPost, "/zenn/connect", map[string]string{
+		"username": "testuser",
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestZenn_Disconnect_Success(t *testing.T) {
+	h, svc := setupZennHandler()
+	svc.On("Disconnect", uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/zenn/disconnect", h.Disconnect)
+
+	w := doRequest(r, http.MethodDelete, "/zenn/disconnect", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestZenn_Sync_Success(t *testing.T) {
+	h, svc := setupZennHandler()
+	svc.On("Sync", uint(1)).Return(8, nil)
+
+	r := newRouter(1)
+	r.POST("/zenn/sync", h.Sync)
+
+	w := doRequest(r, http.MethodPost, "/zenn/sync", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestZenn_GetArticles_Success(t *testing.T) {
+	h, svc := setupZennHandler()
+	svc.On("GetArticles", uint(5)).Return([]model.ZennArticle{
+		{Title: "Article 1"},
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/zenn/:userId/articles", h.GetArticles)
+
+	w := doRequest(r, http.MethodGet, "/zenn/5/articles", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestZenn_GetStats_Success(t *testing.T) {
+	h, svc := setupZennHandler()
+	svc.On("GetStats", uint(5)).Return(&model.ZennStats{
+		TotalArticles: 8,
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/zenn/:userId/stats", h.GetStats)
+
+	w := doRequest(r, http.MethodGet, "/zenn/5/stats", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
サイクル11-2でインターフェース化したハンドラーに対するユニットテストを追加

## 変更内容
- `qiita_test.go` — 7テスト新規作成
- `zenn_test.go` — 7テスト新規作成
- `atcoder_test.go` — 7テスト新規作成
- `testutil_test.go` — MockQiitaService, MockZennService, MockAtCoderService, MockAtCoderUserService, セットアップ関数追加

## テスト計画
- [x] 新規21テスト全て通過
- [ ] CI通過確認

Closes #324