### PR TITLE
feat: 設定ページ・フォームのボタンスタイルをbuttonSecondaryClassに統一

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewForm.tsx
+++ b/frontend/src/components/bookReviews/BookReviewForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { BookReview, CreateBookReviewRequest } from '../../types/bookReview';
+import { buttonSecondaryClass } from '../../constants/styles';
 
 interface BookReviewFormProps {
   review?: BookReview;
@@ -144,14 +145,14 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
         <button
           type="button"
           onClick={onCancel}
-          className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+          className={`flex-1 ${buttonSecondaryClass}`}
         >
           {t('common.cancel')}
         </button>
         <button
           type="submit"
           disabled={loading || !title.trim()}
-          className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+          className={`flex-1 ${buttonSecondaryClass} disabled:bg-gray-600 disabled:cursor-not-allowed`}
         >
           {loading ? t('common.saving') : t('common.save')}
         </button>

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Project, CreateProjectRequest } from '../../types/project';
 import type { GitHubRepository } from '../../types/github';
+import { buttonSecondaryClass } from '../../constants/styles';
 
 interface ProjectFormProps {
   project?: Project;
@@ -276,14 +277,14 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
         <button
           type="button"
           onClick={onCancel}
-          className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+          className={`flex-1 ${buttonSecondaryClass}`}
         >
           {t('common.cancel')}
         </button>
         <button
           type="submit"
           disabled={loading || !title.trim()}
-          className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+          className={`flex-1 ${buttonSecondaryClass} disabled:bg-gray-600 disabled:cursor-not-allowed`}
         >
           {loading ? t('common.saving') : t('common.save')}
         </button>

--- a/frontend/src/components/qa/QuestionForm.tsx
+++ b/frontend/src/components/qa/QuestionForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Question, CreateQuestionRequest } from '../../types/qa';
+import { buttonSecondaryClass } from '../../constants/styles';
 
 interface QuestionFormProps {
   question?: Question;
@@ -86,14 +87,14 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
         <button
           type="button"
           onClick={onCancel}
-          className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+          className={`flex-1 ${buttonSecondaryClass}`}
         >
           {t('common.cancel')}
         </button>
         <button
           type="submit"
           disabled={loading || !title.trim() || !body.trim()}
-          className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+          className={`flex-1 ${buttonSecondaryClass} disabled:bg-gray-600 disabled:cursor-not-allowed`}
         >
           {loading ? t('common.saving') : t('common.save')}
         </button>

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LearningResource, CreateResourceRequest, ResourceCategory, ResourceDifficulty } from '../../types/resource';
+import { buttonSecondaryClass } from '../../constants/styles';
 
 interface ResourceFormProps {
   resource?: LearningResource;
@@ -219,14 +220,14 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
         <button
           type="button"
           onClick={onCancel}
-          className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+          className={`flex-1 ${buttonSecondaryClass}`}
         >
           {t('common.cancel')}
         </button>
         <button
           type="submit"
           disabled={loading || !title.trim()}
-          className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 disabled:bg-gray-600 disabled:cursor-not-allowed text-white rounded-lg transition-colors"
+          className={`flex-1 ${buttonSecondaryClass} disabled:bg-gray-600 disabled:cursor-not-allowed`}
         >
           {loading ? t('common.saving') : t('common.save')}
         </button>

--- a/frontend/src/pages/settings/AccountSection.tsx
+++ b/frontend/src/pages/settings/AccountSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass } from '../../constants/styles';
+import { inputClass, buttonSecondaryClass } from '../../constants/styles';
 import { Modal } from '../../components/common';
 import type { User } from '../../types/user';
 
@@ -83,7 +83,7 @@ export default function AccountSection(props: Props) {
             type="button"
             onClick={props.onSaveEmailPreferences}
             disabled={props.savingEmail}
-            className="px-5 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white rounded-lg font-medium text-sm transition-colors"
+            className={`${buttonSecondaryClass} px-5 font-medium text-sm disabled:opacity-50`}
           >
             {props.savingEmail ? t('common.loading') : t('common.save')}
           </button>
@@ -140,7 +140,7 @@ export default function AccountSection(props: Props) {
               props.setShowDeleteModal(false);
               props.setDeletePassword('');
             }}
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm font-medium transition-colors"
+            className={`${buttonSecondaryClass} text-sm font-medium`}
           >
             {t('common.cancel')}
           </button>

--- a/frontend/src/pages/settings/ProfileSection.tsx
+++ b/frontend/src/pages/settings/ProfileSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass } from '../../constants/styles';
+import { inputClass, buttonSecondaryClass } from '../../constants/styles';
 
 interface Props {
   name: string;
@@ -38,7 +38,7 @@ export default function ProfileSection({ name, setName, bio, setBio, avatarUrl, 
         <button
           type="submit"
           disabled={saving}
-          className="px-5 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white rounded-lg font-medium text-sm transition-colors"
+          className={`${buttonSecondaryClass} px-5 font-medium text-sm disabled:opacity-50`}
         >
           {saving ? t('common.loading') : t('common.save')}
         </button>

--- a/frontend/src/pages/settings/SkillsSection.tsx
+++ b/frontend/src/pages/settings/SkillsSection.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Sparkles } from 'lucide-react';
+import { buttonSecondaryClass } from '../../constants/styles';
 import { LANGUAGES, FRAMEWORKS } from '../../constants/skills';
 
 interface Props {
@@ -103,7 +104,7 @@ export default function SkillsSection({
           type="button"
           onClick={onSave}
           disabled={savingSkills}
-          className="px-5 py-2 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white rounded-lg font-medium text-sm transition-colors"
+          className={`${buttonSecondaryClass} px-5 font-medium text-sm disabled:opacity-50`}
         >
           {savingSkills ? t('common.loading') : t('common.save')}
         </button>


### PR DESCRIPTION
## 概要
- 設定ページ3ファイル（AccountSection, ProfileSection, SkillsSection）のインラインボタンスタイルを`buttonSecondaryClass`に置換
- フォームコンポーネント4ファイル（BookReviewForm, ProjectForm, QuestionForm, ResourceForm）のキャンセル/送信ボタンを`buttonSecondaryClass`に統一
- 合計7ファイル・12箇所のスタイル統一

## 変更内容
- `constants/styles.ts`の`buttonSecondaryClass`をインポートに追加
- `px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors`パターンを定数参照に置換
- 各ボタン固有のクラス（`disabled:opacity-50`, `flex-1`など）はテンプレートリテラルで追加

## テスト
- TypeScript型チェック通過（`npx tsc --noEmit`）
- 見た目の変更なし（同一CSSクラスの定数化のみ）

Closes #326