### PR TITLE
refactor: auth/github/websocketハンドラーにサービスインターフェースを導入

### DIFF
--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -6,18 +6,40 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/dto"
+	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// AuthServiceInterface は認証サービスの抽象インターフェース。
+type AuthServiceInterface interface {
+	Register(input service.RegisterInput) (*service.AuthResponse, error)
+	Login(input service.LoginInput) (*service.AuthResponse, error)
+	GenerateLoginState() (string, error)
+	ValidateLoginState(state string) error
+	GitHubLogin(ghUser *service.GitHubUserInfo, accessToken string) (*service.AuthResponse, error)
+	GetMe(userID uint) (*model.User, error)
+	RequestPasswordReset(email string) (string, error)
+	ResetPassword(token string, newPassword string) error
+	DeleteAccount(userID uint, password string) error
+}
+
+// AuthGitHubServiceInterface はAuthHandler用のGitHubサービスの抽象インターフェース。
+type AuthGitHubServiceInterface interface {
+	GetLoginOAuthURL(state string) string
+	ExchangeCode(code string) (string, error)
+	GetGitHubUser(token string) (*service.GitHubUserInfo, error)
+	SyncUserData(userID uint) error
+}
 
 // AuthHandler は認証関連のHTTPハンドラ。
 // ユーザー登録・ログイン・GitHub OAuth・パスワードリセット・アカウント削除を処理する。
 type AuthHandler struct {
-	authService   *service.AuthService   // 認証ビジネスロジック
-	githubService *service.GitHubService // GitHub OAuth連携
+	authService   AuthServiceInterface       // 認証ビジネスロジック
+	githubService AuthGitHubServiceInterface // GitHub OAuth連携
 }
 
 // NewAuthHandler は新しいAuthHandlerインスタンスを生成する。
-func NewAuthHandler(authService *service.AuthService, githubService *service.GitHubService) *AuthHandler {
+func NewAuthHandler(authService AuthServiceInterface, githubService AuthGitHubServiceInterface) *AuthHandler {
 	return &AuthHandler{
 		authService:   authService,
 		githubService: githubService,

--- a/backend/internal/handler/github.go
+++ b/backend/internal/handler/github.go
@@ -4,20 +4,37 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
+
+// GitHubServiceInterface はGitHubサービスの抽象インターフェース。
+type GitHubServiceInterface interface {
+	GetOAuthURL(state string) string
+	ConnectGitHub(userID uint, code, state string) error
+	GetContributions(userID uint) ([]model.GitHubContribution, error)
+	GetLanguages(userID uint) ([]model.GitHubLanguageStat, error)
+	GetRepos(userID uint) ([]model.GitHubRepository, error)
+	SyncUserData(userID uint) error
+	DisconnectGitHub(userID uint) error
+}
+
+// GitHubAuthServiceInterface はGitHubHandler用の認証サービスの抽象インターフェース。
+type GitHubAuthServiceInterface interface {
+	GenerateOAuthState(userID uint) (string, error)
+	ValidateOAuthState(state string) (uint, error)
+}
 
 // GitHubHandler はGitHub連携関連のHTTPハンドラ。
 // GitHub OAuth認証・データ同期・コントリビューション取得を処理する。
 type GitHubHandler struct {
-	githubService *service.GitHubService
-	authService   *service.AuthService
+	githubService GitHubServiceInterface
+	authService   GitHubAuthServiceInterface
 }
 
 // NewGitHubHandler は新しいGitHubHandlerインスタンスを生成する。
 func NewGitHubHandler(
-	githubService *service.GitHubService,
-	authService *service.AuthService,
+	githubService GitHubServiceInterface,
+	authService GitHubAuthServiceInterface,
 ) *GitHubHandler {
 	return &GitHubHandler{
 		githubService: githubService,

--- a/backend/internal/handler/websocket.go
+++ b/backend/internal/handler/websocket.go
@@ -9,18 +9,23 @@ import (
 	"github.com/norman6464/devsync/backend/internal/service"
 )
 
+// WebSocketAuthServiceInterface はWebSocketHandler用の認証サービスの抽象インターフェース。
+type WebSocketAuthServiceInterface interface {
+	ValidateToken(tokenString string) (uint, error)
+}
+
 // WebSocketHandler はWebSocket関連のHTTPハンドラ。
 // リアルタイム通信のためのWebSocket接続確立を処理する。
 type WebSocketHandler struct {
 	hub            *service.Hub
-	authService    *service.AuthService
+	authService    WebSocketAuthServiceInterface
 	allowedOrigins map[string]bool // CORS設定と連動した許可オリジン
 	upgrader       websocket.Upgrader
 }
 
 // NewWebSocketHandler は新しいWebSocketHandlerインスタンスを生成する。
 // allowedOriginsにはCORS設定のオリジン一覧を渡す。
-func NewWebSocketHandler(hub *service.Hub, authService *service.AuthService, allowedOrigins []string) *WebSocketHandler {
+func NewWebSocketHandler(hub *service.Hub, authService WebSocketAuthServiceInterface, allowedOrigins []string) *WebSocketHandler {
 	originsMap := make(map[string]bool, len(allowedOrigins))
 	for _, o := range allowedOrigins {
 		originsMap[o] = true


### PR DESCRIPTION
## 概要
- `auth.go`: AuthServiceInterface（9メソッド）+ AuthGitHubServiceInterface（4メソッド）を定義
- `github.go`: GitHubServiceInterface（7メソッド）+ GitHubAuthServiceInterface（2メソッド）を定義
- `websocket.go`: WebSocketAuthServiceInterface（1メソッド）を定義

## 変更内容
- 各ハンドラーの構造体フィールドとコンストラクタ引数を具象型からインターフェースに変更
- github.goはimportを`service`から`model`に変更（具象サービス型への依存を完全に排除）
- websocket.goはhub（*service.Hub）の直接依存は残存（Client構造体との密結合のため）

## テスト
- `go build ./...` 通過

Closes #328