### PR TITLE
test: auth/githubハンドラーのモックベーステスト追加

### DIFF
--- a/backend/internal/handler/auth_test.go
+++ b/backend/internal/handler/auth_test.go
@@ -469,3 +469,113 @@ func TestResetPassword_ValidationError(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
+
+// ---------- モックベースのAuth Handlerテスト ----------
+
+// TestAuthGitHubLogin_ReturnsURL はGitHub OAuthログインURLの生成をテストする。
+func TestAuthGitHubLogin_ReturnsURL(t *testing.T) {
+	h, authSvc, ghSvc := setupAuthHandlerMock()
+	authSvc.On("GenerateLoginState").Return("test-state", nil)
+	ghSvc.On("GetLoginOAuthURL", "test-state").Return("https://github.com/login/oauth/authorize?state=test-state")
+
+	r := gin.New()
+	r.GET("/auth/github", h.GitHubLogin)
+	w := doRequest(r, "GET", "/auth/github", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	assert.NotEmpty(t, body["url"])
+	authSvc.AssertExpectations(t)
+	ghSvc.AssertExpectations(t)
+}
+
+// TestAuthGitHubLogin_StateError はstate生成エラーをテストする。
+func TestAuthGitHubLogin_StateError(t *testing.T) {
+	h, authSvc, _ := setupAuthHandlerMock()
+	authSvc.On("GenerateLoginState").Return("", service.ErrBadRequest)
+
+	r := gin.New()
+	r.GET("/auth/github", h.GitHubLogin)
+	w := doRequest(r, "GET", "/auth/github", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+	authSvc.AssertExpectations(t)
+}
+
+// TestAuthMeMock_Success はモック版のMe成功テスト。
+func TestAuthMeMock_Success(t *testing.T) {
+	h, authSvc, _ := setupAuthHandlerMock()
+	user := &model.User{Name: "Test User", Email: "test@example.com"}
+	authSvc.On("GetMe", uint(1)).Return(user, nil)
+
+	r := newRouter(1)
+	r.GET("/me", h.Me)
+	w := doRequest(r, "GET", "/me", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	authSvc.AssertExpectations(t)
+}
+
+// TestAuthMeMock_NotFound はモック版のMeユーザー未発見テスト。
+func TestAuthMeMock_NotFound(t *testing.T) {
+	h, authSvc, _ := setupAuthHandlerMock()
+	authSvc.On("GetMe", uint(1)).Return(nil, service.ErrNotFound)
+
+	r := newRouter(1)
+	r.GET("/me", h.Me)
+	w := doRequest(r, "GET", "/me", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	authSvc.AssertExpectations(t)
+}
+
+// TestAuthLoginMock_Success はモック版のLogin成功テスト。
+func TestAuthLoginMock_Success(t *testing.T) {
+	h, authSvc, _ := setupAuthHandlerMock()
+	resp := &service.AuthResponse{
+		Token: "test-token",
+		User:  model.User{Name: "Test User", Email: "test@example.com"},
+	}
+	authSvc.On("Login", mock.Anything).Return(resp, nil)
+
+	r := gin.New()
+	r.POST("/login", h.Login)
+	w := doRequest(r, "POST", "/login", map[string]string{
+		"email":    "test@example.com",
+		"password": "password123",
+	})
+
+	assertStatus(t, w, http.StatusOK)
+	authSvc.AssertExpectations(t)
+}
+
+// TestAuthLoginMock_Unauthorized はモック版のログイン失敗テスト。
+func TestAuthLoginMock_Unauthorized(t *testing.T) {
+	h, authSvc, _ := setupAuthHandlerMock()
+	authSvc.On("Login", mock.Anything).Return(nil, service.ErrUnauthorized)
+
+	r := gin.New()
+	r.POST("/login", h.Login)
+	w := doRequest(r, "POST", "/login", map[string]string{
+		"email":    "test@example.com",
+		"password": "wrong",
+	})
+
+	assertStatus(t, w, http.StatusUnauthorized)
+	authSvc.AssertExpectations(t)
+}
+
+// TestAuthDeleteAccountMock_Success はモック版のアカウント削除成功テスト。
+func TestAuthDeleteAccountMock_Success(t *testing.T) {
+	h, authSvc, _ := setupAuthHandlerMock()
+	authSvc.On("DeleteAccount", uint(1), "password123").Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/account", h.DeleteAccount)
+	w := doRequest(r, "DELETE", "/account", map[string]string{
+		"password": "password123",
+	})
+
+	assertStatus(t, w, http.StatusOK)
+	authSvc.AssertExpectations(t)
+}

--- a/backend/internal/handler/github_test.go
+++ b/backend/internal/handler/github_test.go
@@ -1,0 +1,193 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+)
+
+func TestGitHubConnect_Success(t *testing.T) {
+	h, ghSvc, authSvc := setupGitHubHandlerMock()
+	authSvc.On("GenerateOAuthState", uint(1)).Return("test-state", nil)
+	ghSvc.On("GetOAuthURL", "test-state").Return("https://github.com/login/oauth/authorize?state=test-state")
+
+	r := newRouter(1)
+	r.GET("/github/connect", h.Connect)
+	w := doRequest(r, "GET", "/github/connect", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	if url, ok := body["url"].(string); !ok || url == "" {
+		t.Error("expected non-empty URL in response")
+	}
+	authSvc.AssertExpectations(t)
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubConnect_StateError(t *testing.T) {
+	h, _, authSvc := setupGitHubHandlerMock()
+	authSvc.On("GenerateOAuthState", uint(1)).Return("", service.ErrBadRequest)
+
+	r := newRouter(1)
+	r.GET("/github/connect", h.Connect)
+	w := doRequest(r, "GET", "/github/connect", nil)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	authSvc.AssertExpectations(t)
+}
+
+func TestGitHubCallback_Success(t *testing.T) {
+	h, ghSvc, authSvc := setupGitHubHandlerMock()
+	authSvc.On("ValidateOAuthState", "valid-state").Return(1, nil)
+	ghSvc.On("ConnectGitHub", uint(1), "test-code", "valid-state").Return(nil)
+
+	r := newRouter(1)
+	r.GET("/github/callback", h.Callback)
+	w := doRequest(r, "GET", "/github/callback?code=test-code&state=valid-state", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	if msg, ok := body["message"].(string); !ok || msg == "" {
+		t.Error("expected message in response")
+	}
+	authSvc.AssertExpectations(t)
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubCallback_MissingParams(t *testing.T) {
+	h, _, _ := setupGitHubHandlerMock()
+
+	r := newRouter(1)
+	r.GET("/github/callback", h.Callback)
+	w := doRequest(r, "GET", "/github/callback", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestGitHubCallback_InvalidState(t *testing.T) {
+	h, _, authSvc := setupGitHubHandlerMock()
+	authSvc.On("ValidateOAuthState", "bad-state").Return(0, service.ErrBadRequest)
+
+	r := newRouter(1)
+	r.GET("/github/callback", h.Callback)
+	w := doRequest(r, "GET", "/github/callback?code=test-code&state=bad-state", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+	authSvc.AssertExpectations(t)
+}
+
+func TestGitHubGetContributions_Success(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	contributions := []model.GitHubContribution{
+		{Date: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), Count: 5},
+	}
+	ghSvc.On("GetContributions", uint(1)).Return(contributions, nil)
+
+	r := newRouter(1)
+	r.GET("/github/:userId/contributions", h.GetContributions)
+	w := doRequest(r, "GET", "/github/1/contributions", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubGetContributions_ServiceError(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	ghSvc.On("GetContributions", uint(1)).Return([]model.GitHubContribution(nil), service.ErrNotFound)
+
+	r := newRouter(1)
+	r.GET("/github/:userId/contributions", h.GetContributions)
+	w := doRequest(r, "GET", "/github/1/contributions", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubGetLanguages_Success(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	languages := []model.GitHubLanguageStat{
+		{Language: "Go", Bytes: 50000},
+	}
+	ghSvc.On("GetLanguages", uint(1)).Return(languages, nil)
+
+	r := newRouter(1)
+	r.GET("/github/:userId/languages", h.GetLanguages)
+	w := doRequest(r, "GET", "/github/1/languages", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubGetRepos_Success(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	repos := []model.GitHubRepository{
+		{Name: "test-repo"},
+	}
+	ghSvc.On("GetRepos", uint(1)).Return(repos, nil)
+
+	r := newRouter(1)
+	r.GET("/github/:userId/repos", h.GetRepos)
+	w := doRequest(r, "GET", "/github/1/repos", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubSync_Success(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	ghSvc.On("SyncUserData", uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/github/sync", h.Sync)
+	w := doRequest(r, "POST", "/github/sync", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	if msg, ok := body["message"].(string); !ok || msg == "" {
+		t.Error("expected message in response")
+	}
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubSync_ServiceError(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	ghSvc.On("SyncUserData", uint(1)).Return(service.ErrNotFound)
+
+	r := newRouter(1)
+	r.POST("/github/sync", h.Sync)
+	w := doRequest(r, "POST", "/github/sync", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubDisconnect_Success(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	ghSvc.On("DisconnectGitHub", uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/github/disconnect", h.Disconnect)
+	w := doRequest(r, "POST", "/github/disconnect", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	if msg, ok := body["message"].(string); !ok || msg == "" {
+		t.Error("expected message in response")
+	}
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubDisconnect_ServiceError(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	ghSvc.On("DisconnectGitHub", uint(1)).Return(service.ErrNotFound)
+
+	r := newRouter(1)
+	r.POST("/github/disconnect", h.Disconnect)
+	w := doRequest(r, "POST", "/github/disconnect", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	ghSvc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1387,3 +1387,129 @@ func setupAtCoderHandler() (*AtCoderHandler, *MockAtCoderService, *MockAtCoderUs
 	h := NewAtCoderHandler(atcoderSvc, userSvc)
 	return h, atcoderSvc, userSvc
 }
+
+// MockAuthService は AuthServiceInterface のモック実装。
+type MockAuthService struct{ mock.Mock }
+
+func (m *MockAuthService) Register(input service.RegisterInput) (*service.AuthResponse, error) {
+	args := m.Called(input)
+	if r := args.Get(0); r != nil {
+		return r.(*service.AuthResponse), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockAuthService) Login(input service.LoginInput) (*service.AuthResponse, error) {
+	args := m.Called(input)
+	if r := args.Get(0); r != nil {
+		return r.(*service.AuthResponse), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockAuthService) GenerateLoginState() (string, error) {
+	args := m.Called()
+	return args.String(0), args.Error(1)
+}
+func (m *MockAuthService) ValidateLoginState(state string) error {
+	return m.Called(state).Error(0)
+}
+func (m *MockAuthService) GitHubLogin(ghUser *service.GitHubUserInfo, accessToken string) (*service.AuthResponse, error) {
+	args := m.Called(ghUser, accessToken)
+	if r := args.Get(0); r != nil {
+		return r.(*service.AuthResponse), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockAuthService) GetMe(userID uint) (*model.User, error) {
+	args := m.Called(userID)
+	if u := args.Get(0); u != nil {
+		return u.(*model.User), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockAuthService) RequestPasswordReset(email string) (string, error) {
+	args := m.Called(email)
+	return args.String(0), args.Error(1)
+}
+func (m *MockAuthService) ResetPassword(token string, newPassword string) error {
+	return m.Called(token, newPassword).Error(0)
+}
+func (m *MockAuthService) DeleteAccount(userID uint, password string) error {
+	return m.Called(userID, password).Error(0)
+}
+
+// MockAuthGitHubService は AuthGitHubServiceInterface のモック実装。
+type MockAuthGitHubService struct{ mock.Mock }
+
+func (m *MockAuthGitHubService) GetLoginOAuthURL(state string) string {
+	return m.Called(state).String(0)
+}
+func (m *MockAuthGitHubService) ExchangeCode(code string) (string, error) {
+	args := m.Called(code)
+	return args.String(0), args.Error(1)
+}
+func (m *MockAuthGitHubService) GetGitHubUser(token string) (*service.GitHubUserInfo, error) {
+	args := m.Called(token)
+	if u := args.Get(0); u != nil {
+		return u.(*service.GitHubUserInfo), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockAuthGitHubService) SyncUserData(userID uint) error {
+	return m.Called(userID).Error(0)
+}
+
+// setupAuthHandler はAuthHandlerテスト用のセットアップを行う。
+func setupAuthHandlerMock() (*AuthHandler, *MockAuthService, *MockAuthGitHubService) {
+	authSvc := new(MockAuthService)
+	ghSvc := new(MockAuthGitHubService)
+	h := NewAuthHandler(authSvc, ghSvc)
+	return h, authSvc, ghSvc
+}
+
+// MockGHService は GitHubServiceInterface のモック実装。
+type MockGHService struct{ mock.Mock }
+
+func (m *MockGHService) GetOAuthURL(state string) string {
+	return m.Called(state).String(0)
+}
+func (m *MockGHService) ConnectGitHub(userID uint, code, state string) error {
+	return m.Called(userID, code, state).Error(0)
+}
+func (m *MockGHService) GetContributions(userID uint) ([]model.GitHubContribution, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.GitHubContribution), args.Error(1)
+}
+func (m *MockGHService) GetLanguages(userID uint) ([]model.GitHubLanguageStat, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.GitHubLanguageStat), args.Error(1)
+}
+func (m *MockGHService) GetRepos(userID uint) ([]model.GitHubRepository, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.GitHubRepository), args.Error(1)
+}
+func (m *MockGHService) SyncUserData(userID uint) error {
+	return m.Called(userID).Error(0)
+}
+func (m *MockGHService) DisconnectGitHub(userID uint) error {
+	return m.Called(userID).Error(0)
+}
+
+// MockGHAuthService は GitHubAuthServiceInterface のモック実装。
+type MockGHAuthService struct{ mock.Mock }
+
+func (m *MockGHAuthService) GenerateOAuthState(userID uint) (string, error) {
+	args := m.Called(userID)
+	return args.String(0), args.Error(1)
+}
+func (m *MockGHAuthService) ValidateOAuthState(state string) (uint, error) {
+	args := m.Called(state)
+	return uint(args.Int(0)), args.Error(1)
+}
+
+// setupGitHubHandlerMock はGitHubHandlerテスト用のセットアップを行う。
+func setupGitHubHandlerMock() (*GitHubHandler, *MockGHService, *MockGHAuthService) {
+	ghSvc := new(MockGHService)
+	authSvc := new(MockGHAuthService)
+	h := NewGitHubHandler(ghSvc, authSvc)
+	return h, ghSvc, authSvc
+}


### PR DESCRIPTION
## 概要
- サイクル12-2で導入したインターフェースを活用したモックベースのハンドラーテストを追加
- auth_test.go: 7テスト追加（GitHubLogin URL生成、Me、Login、DeleteAccountの正常/異常系）
- github_test.go: 13テスト新規作成（Connect、Callback、GetContributions、GetLanguages、GetRepos、Sync、Disconnectの正常/異常系）

## テスト一覧（全20テスト通過）
### auth_test.go（追加分）
- TestAuthGitHubLogin_ReturnsURL / TestAuthGitHubLogin_StateError
- TestAuthMeMock_Success / TestAuthMeMock_NotFound
- TestAuthLoginMock_Success / TestAuthLoginMock_Unauthorized
- TestAuthDeleteAccountMock_Success

### github_test.go（新規）
- TestGitHubConnect_Success / TestGitHubConnect_StateError
- TestGitHubCallback_Success / TestGitHubCallback_MissingParams / TestGitHubCallback_InvalidState
- TestGitHubGetContributions_Success / TestGitHubGetContributions_ServiceError
- TestGitHubGetLanguages_Success / TestGitHubGetRepos_Success
- TestGitHubSync_Success / TestGitHubSync_ServiceError
- TestGitHubDisconnect_Success / TestGitHubDisconnect_ServiceError

Closes #330