### PR TITLE
feat: カードコンポーネントスタイル統一（cardClass定数化）

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/frontend/public/Gemini_Generated_Image_f84ijbf84ijbf84i.png" />
+    <link rel="icon" type="image/png" href="/Gemini_Generated_Image_f84ijbf84ijbf84i.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>frontend</title>
   </head>

--- a/frontend/src/components/bookReviews/BookReviewCard.tsx
+++ b/frontend/src/components/bookReviews/BookReviewCard.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { BookReview } from '../../types/bookReview';
 import Avatar from '../common/Avatar';
+import { cardClass } from '../../constants/styles';
 
 interface BookReviewCardProps {
   review: BookReview;
@@ -38,7 +39,7 @@ export default function BookReviewCard({
   };
 
   return (
-    <div className="bg-gray-800 rounded-md overflow-hidden border border-gray-700 hover:border-gray-600 transition-colors">
+    <div className={cardClass}>
       <div className="flex">
         {/* Book Cover */}
         {review.image_url && (

--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -11,6 +11,7 @@ import Avatar from '../common/Avatar';
 import { format } from 'date-fns';
 import { useState } from 'react';
 import { Code2 } from 'lucide-react';
+import { cardDarkClass } from '../../constants/styles';
 
 interface PostCardProps {
   post: Post;
@@ -53,7 +54,7 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
   }
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-5 hover:border-gray-700 transition-colors">
+    <div className={cardDarkClass}>
       <div className="flex items-center gap-3 mb-3">
         <Link to={`/profile/${post.user_id}`}>
           <Avatar name={post.user?.name || 'U'} avatarUrl={post.user?.avatar_url} size="sm" />

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { Project } from '../../types/project';
+import { cardClass } from '../../constants/styles';
 
 interface ProjectCardProps {
   project: Project;
@@ -19,7 +20,7 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
   };
 
   return (
-    <div className="bg-gray-800 rounded-md overflow-hidden border border-gray-700 hover:border-gray-600 transition-colors">
+    <div className={cardClass}>
       {project.image_url && (
         <div className="aspect-video bg-gray-700 overflow-hidden">
           <img

--- a/frontend/src/components/qa/QuestionCard.tsx
+++ b/frontend/src/components/qa/QuestionCard.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { Question } from '../../types/qa';
 import Avatar from '../common/Avatar';
+import { cardPaddedClass } from '../../constants/styles';
 
 interface QuestionCardProps {
   question: Question;
@@ -18,7 +19,7 @@ export default function QuestionCard({ question, isOwner = false, onEdit, onDele
   })() : [];
 
   return (
-    <div className="bg-gray-800 rounded-md p-5 border border-gray-700 hover:border-gray-600 transition-colors">
+    <div className={cardPaddedClass}>
       <div className="flex gap-4">
         {/* Vote & Answer counts */}
         <div className="flex flex-col items-center gap-2 text-center min-w-[60px]">

--- a/frontend/src/components/resources/ResourceCard.tsx
+++ b/frontend/src/components/resources/ResourceCard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin, type LucideIcon } from 'lucide-react';
 import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import Avatar from '../common/Avatar';
+import { cardClass } from '../../constants/styles';
 
 interface ResourceCardProps {
   resource: LearningResource;
@@ -82,7 +83,7 @@ export default function ResourceCard({
   };
 
   return (
-    <div className="bg-gray-800 rounded-md overflow-hidden border border-gray-700 hover:border-gray-600 transition-colors">
+    <div className={cardClass}>
       <div className="p-4">
         {/* Header */}
         <div className="flex items-start justify-between gap-2">

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -3,3 +3,12 @@ export const inputClass =
 
 export const buttonSecondaryClass =
   'px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors';
+
+export const cardClass =
+  'bg-gray-800 rounded-md overflow-hidden border border-gray-700 hover:border-gray-600 transition-colors';
+
+export const cardPaddedClass =
+  'bg-gray-800 rounded-md p-5 border border-gray-700 hover:border-gray-600 transition-colors';
+
+export const cardDarkClass =
+  'bg-gray-900 border border-gray-800 rounded-md p-5 hover:border-gray-700 transition-colors';


### PR DESCRIPTION
## 概要
- `constants/styles.ts`に3つのカードスタイル定数を追加
  - `cardClass`: overflow-hidden付きカード（ProjectCard, ResourceCard, BookReviewCard）
  - `cardPaddedClass`: p-5パディング付きカード（QuestionCard）
  - `cardDarkClass`: bg-gray-900ダークカード（PostCard）
- 5つのカードコンポーネントのインラインスタイルを共通定数に置換
- faviconのパスとtypeを修正

## 対象ファイル（6ファイル）
- `frontend/src/constants/styles.ts`
- `frontend/src/components/projects/ProjectCard.tsx`
- `frontend/src/components/resources/ResourceCard.tsx`
- `frontend/src/components/bookReviews/BookReviewCard.tsx`
- `frontend/src/components/qa/QuestionCard.tsx`
- `frontend/src/components/posts/PostCard.tsx`
- `frontend/index.html`

Closes #332