### PR TITLE
refactor: Handler層レスポンスヘルパー統一（respondForbidden追加）

### DIFF
--- a/backend/internal/handler/github.go
+++ b/backend/internal/handler/github.go
@@ -60,13 +60,13 @@ func (h *GitHubHandler) Callback(c *gin.Context) {
 	state := c.Query("state")
 
 	if code == "" || state == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "missing code or state"})
+		respondBadRequest(c, "missing code or state")
 		return
 	}
 
 	userID, err := h.authService.ValidateOAuthState(state)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid state"})
+		respondBadRequest(c, "invalid state")
 		return
 	}
 

--- a/backend/internal/handler/health.go
+++ b/backend/internal/handler/health.go
@@ -2,14 +2,10 @@
 // Ginフレームワークを使用し、リクエストの受付・バリデーション・レスポンス返却を担当する。
 package handler
 
-import (
-	"net/http"
-
-	"github.com/gin-gonic/gin"
-)
+import "github.com/gin-gonic/gin"
 
 // HealthCheck はヘルスチェックエンドポイントのハンドラ。
 // サーバーの稼働状態を確認するために使用する。
 func HealthCheck(c *gin.Context) {
-	c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	respondOK(c, gin.H{"status": "ok"})
 }

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -88,6 +88,12 @@ func respondBadRequest(c *gin.Context, message string) {
 	c.JSON(http.StatusBadRequest, response)
 }
 
+// respondForbidden は403 Forbiddenでエラーメッセージを返す。
+func respondForbidden(c *gin.Context, message string) {
+	response := domain.NewErrorResponse(message, string(domain.ErrCodeForbidden), nil)
+	c.JSON(http.StatusForbidden, response)
+}
+
 // respondPaginated はページネーション付きレスポンスを返す。
 func respondPaginated(c *gin.Context, data interface{}, total int64, page, limit int) {
 	response := domain.NewPaginatedResponse(data, total, page, limit)

--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -151,7 +149,7 @@ func (h *NoteHandler) Update(c *gin.Context) {
 
 	// 所有者チェック
 	if note.UserID != userID {
-		c.JSON(http.StatusForbidden, gin.H{"error": "この操作を行う権限がありません"})
+		respondForbidden(c, "この操作を行う権限がありません")
 		return
 	}
 
@@ -197,7 +195,7 @@ func (h *NoteHandler) Search(c *gin.Context) {
 	userID := c.GetUint("userID")
 	query := c.Query("q")
 	if query == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "検索キーワードが必要です"})
+		respondBadRequest(c, "検索キーワードが必要です")
 		return
 	}
 

--- a/backend/internal/handler/note_folder.go
+++ b/backend/internal/handler/note_folder.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -144,7 +142,7 @@ func (h *NoteFolderHandler) Update(c *gin.Context) {
 
 	// 所有者チェック
 	if folder.UserID != userID {
-		c.JSON(http.StatusForbidden, gin.H{"error": "この操作を行う権限がありません"})
+		respondForbidden(c, "この操作を行う権限がありません")
 		return
 	}
 

--- a/backend/internal/handler/note_template.go
+++ b/backend/internal/handler/note_template.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -141,7 +139,7 @@ func (h *NoteTemplateHandler) Update(c *gin.Context) {
 
 	// 所有者チェック
 	if template.UserID != userID {
-		c.JSON(http.StatusForbidden, gin.H{"error": "この操作を行う権限がありません"})
+		respondForbidden(c, "この操作を行う権限がありません")
 		return
 	}
 
@@ -189,7 +187,7 @@ func (h *NoteTemplateHandler) Delete(c *gin.Context) {
 	}
 
 	if template.UserID != userID {
-		c.JSON(http.StatusForbidden, gin.H{"error": "この操作を行う権限がありません"})
+		respondForbidden(c, "この操作を行う権限がありません")
 		return
 	}
 
@@ -220,7 +218,7 @@ func (h *NoteTemplateHandler) UseTemplate(c *gin.Context) {
 
 	// 所有者チェック
 	if template.UserID != userID {
-		c.JSON(http.StatusForbidden, gin.H{"error": "この操作を行う権限がありません"})
+		respondForbidden(c, "この操作を行う権限がありません")
 		return
 	}
 

--- a/backend/internal/handler/search.go
+++ b/backend/internal/handler/search.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -35,7 +34,7 @@ func NewSearchHandler(postRepo PostSearchRepository, circleRepo StudyCircleSearc
 func (h *SearchHandler) SearchPosts(c *gin.Context) {
 	query := c.Query("q")
 	if query == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "query parameter 'q' is required"})
+		respondBadRequest(c, "query parameter 'q' is required")
 		return
 	}
 
@@ -55,7 +54,7 @@ func (h *SearchHandler) SearchPosts(c *gin.Context) {
 func (h *SearchHandler) SearchCircles(c *gin.Context) {
 	query := c.Query("q")
 	if query == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "query parameter 'q' is required"})
+		respondBadRequest(c, "query parameter 'q' is required")
 		return
 	}
 


### PR DESCRIPTION
## 概要
- `helpers.go`に`respondForbidden`ヘルパー関数を追加（domain.ErrCodeForbidden使用）
- 7ファイルの`c.JSON`直接使用をヘルパー関数に統一:
  - `note.go`: respondForbidden + respondBadRequest（2箇所）
  - `note_template.go`: respondForbidden（3箇所）
  - `note_folder.go`: respondForbidden（1箇所）
  - `search.go`: respondBadRequest（2箇所）
  - `health.go`: respondOK（1箇所）
  - `github.go`: respondBadRequest（2箇所）
- 不要になった`net/http`インポートを4ファイルから削除

Closes #334