### PR TITLE
test: Health・NoteLink・NoteTemplateハンドラーユニットテスト追加

### DIFF
--- a/backend/internal/handler/health_test.go
+++ b/backend/internal/handler/health_test.go
@@ -1,0 +1,18 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHealthCheck_Success(t *testing.T) {
+	r := newRouter(0)
+	r.GET("/health", HealthCheck)
+	w := doRequest(r, "GET", "/health", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	if status, ok := body["status"].(string); !ok || status != "ok" {
+		t.Errorf("expected status 'ok', got %v", body["status"])
+	}
+}

--- a/backend/internal/handler/note_link_test.go
+++ b/backend/internal/handler/note_link_test.go
@@ -1,0 +1,117 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+)
+
+func TestNoteLinkCreateLink_Success(t *testing.T) {
+	h, svc := setupNoteLinkHandler()
+	svc.On("CreateLink", uint(1), uint(2)).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/notes/:id/links", h.CreateLink)
+	w := doRequest(r, "POST", "/notes/1/links", map[string]interface{}{"target_note_id": 2})
+
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteLinkCreateLink_ServiceError(t *testing.T) {
+	h, svc := setupNoteLinkHandler()
+	svc.On("CreateLink", uint(1), uint(2)).Return(service.ErrConflict)
+
+	r := newRouter(1)
+	r.POST("/notes/:id/links", h.CreateLink)
+	w := doRequest(r, "POST", "/notes/1/links", map[string]interface{}{"target_note_id": 2})
+
+	assertStatus(t, w, http.StatusConflict)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteLinkCreateLink_InvalidID(t *testing.T) {
+	h, _ := setupNoteLinkHandler()
+
+	r := newRouter(1)
+	r.POST("/notes/:id/links", h.CreateLink)
+	w := doRequest(r, "POST", "/notes/abc/links", map[string]interface{}{"target_note_id": 2})
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteLinkGetLinks_Success(t *testing.T) {
+	h, svc := setupNoteLinkHandler()
+	links := []model.NoteLink{{ID: 1, SourceNoteID: 1, TargetNoteID: 2}}
+	svc.On("GetLinks", uint(1)).Return(links, nil)
+
+	r := newRouter(1)
+	r.GET("/notes/:id/links", h.GetLinks)
+	w := doRequest(r, "GET", "/notes/1/links", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteLinkGetLinks_ServiceError(t *testing.T) {
+	h, svc := setupNoteLinkHandler()
+	svc.On("GetLinks", uint(1)).Return([]model.NoteLink(nil), service.ErrNotFound)
+
+	r := newRouter(1)
+	r.GET("/notes/:id/links", h.GetLinks)
+	w := doRequest(r, "GET", "/notes/1/links", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteLinkGetBacklinks_Success(t *testing.T) {
+	h, svc := setupNoteLinkHandler()
+	backlinks := []model.NoteLink{{ID: 1, SourceNoteID: 2, TargetNoteID: 1}}
+	svc.On("GetBacklinks", uint(1)).Return(backlinks, nil)
+
+	r := newRouter(1)
+	r.GET("/notes/:id/backlinks", h.GetBacklinks)
+	w := doRequest(r, "GET", "/notes/1/backlinks", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteLinkGetBacklinks_ServiceError(t *testing.T) {
+	h, svc := setupNoteLinkHandler()
+	svc.On("GetBacklinks", uint(1)).Return([]model.NoteLink(nil), service.ErrNotFound)
+
+	r := newRouter(1)
+	r.GET("/notes/:id/backlinks", h.GetBacklinks)
+	w := doRequest(r, "GET", "/notes/1/backlinks", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteLinkDeleteLink_Success(t *testing.T) {
+	h, svc := setupNoteLinkHandler()
+	svc.On("DeleteLink", uint(1), uint(2)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/notes/:id/links/:targetId", h.DeleteLink)
+	w := doRequest(r, "DELETE", "/notes/1/links/2", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteLinkDeleteLink_ServiceError(t *testing.T) {
+	h, svc := setupNoteLinkHandler()
+	svc.On("DeleteLink", uint(1), uint(2)).Return(service.ErrNotFound)
+
+	r := newRouter(1)
+	r.DELETE("/notes/:id/links/:targetId", h.DeleteLink)
+	w := doRequest(r, "DELETE", "/notes/1/links/2", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/note_template_test.go
+++ b/backend/internal/handler/note_template_test.go
@@ -1,0 +1,195 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestNoteTemplateCreate_Success(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	svc.On("Create", mock.AnythingOfType("*model.NoteTemplate")).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/note-templates", h.Create)
+	w := doRequest(r, "POST", "/note-templates", map[string]interface{}{
+		"name":             "テスト",
+		"content_template": "テンプレート内容",
+	})
+
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateCreate_ServiceError(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	svc.On("Create", mock.AnythingOfType("*model.NoteTemplate")).Return(service.ErrBadRequest)
+
+	r := newRouter(1)
+	r.POST("/note-templates", h.Create)
+	w := doRequest(r, "POST", "/note-templates", map[string]interface{}{
+		"name":             "テスト",
+		"content_template": "テンプレート内容",
+	})
+
+	assertStatus(t, w, http.StatusBadRequest)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateGetByID_Success(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	tmpl := &model.NoteTemplate{ID: 1, UserID: 1, Name: "テスト"}
+	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+
+	r := newRouter(1)
+	r.GET("/note-templates/:id", h.GetByID)
+	w := doRequest(r, "GET", "/note-templates/1", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateGetByID_NotFound(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	svc.On("GetByID", uint(99)).Return(nil, service.ErrNotFound)
+
+	r := newRouter(1)
+	r.GET("/note-templates/:id", h.GetByID)
+	w := doRequest(r, "GET", "/note-templates/99", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateGetByUserID_Success(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	templates := []model.NoteTemplate{{ID: 1, UserID: 1, Name: "テスト"}}
+	svc.On("GetByUserID", uint(1)).Return(templates, nil)
+
+	r := newRouter(1)
+	r.GET("/note-templates", h.GetByUserID)
+	w := doRequest(r, "GET", "/note-templates", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateGetDefault_Success(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	tmpl := &model.NoteTemplate{ID: 1, UserID: 1, Name: "デフォルト", IsDefault: true}
+	svc.On("GetDefaultByUserID", uint(1)).Return(tmpl, nil)
+
+	r := newRouter(1)
+	r.GET("/note-templates/default", h.GetDefault)
+	w := doRequest(r, "GET", "/note-templates/default", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateUpdate_Success(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	tmpl := &model.NoteTemplate{ID: 1, UserID: 1, Name: "旧名"}
+	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+	svc.On("Update", mock.AnythingOfType("*model.NoteTemplate")).Return(nil)
+
+	r := newRouter(1)
+	r.PUT("/note-templates/:id", h.Update)
+	w := doRequest(r, "PUT", "/note-templates/1", map[string]interface{}{
+		"name": "新名",
+	})
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateUpdate_Forbidden(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	tmpl := &model.NoteTemplate{ID: 1, UserID: 99, Name: "他人の"}
+	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+
+	r := newRouter(1)
+	r.PUT("/note-templates/:id", h.Update)
+	w := doRequest(r, "PUT", "/note-templates/1", map[string]interface{}{
+		"name": "変更",
+	})
+
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateDelete_Success(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	tmpl := &model.NoteTemplate{ID: 1, UserID: 1}
+	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+	svc.On("Delete", uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/note-templates/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/note-templates/1", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateDelete_Forbidden(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	tmpl := &model.NoteTemplate{ID: 1, UserID: 99}
+	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+
+	r := newRouter(1)
+	r.DELETE("/note-templates/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/note-templates/1", nil)
+
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateUseTemplate_Success(t *testing.T) {
+	h, svc, noteSvc := setupNoteTemplateHandler()
+	tmpl := &model.NoteTemplate{
+		ID:              1,
+		UserID:          1,
+		DefaultTitle:    "テンプレタイトル",
+		ContentTemplate: "テンプレ内容",
+		DefaultTags:     "tag1",
+	}
+	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+	noteSvc.On("Create", mock.AnythingOfType("*model.Note")).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/note-templates/:id/use", h.UseTemplate)
+	w := doRequest(r, "POST", "/note-templates/1/use", nil)
+
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+	noteSvc.AssertExpectations(t)
+}
+
+func TestNoteTemplateUseTemplate_Forbidden(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	tmpl := &model.NoteTemplate{ID: 1, UserID: 99}
+	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+
+	r := newRouter(1)
+	r.POST("/note-templates/:id/use", h.UseTemplate)
+	w := doRequest(r, "POST", "/note-templates/1/use", nil)
+
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateUseTemplate_NotFound(t *testing.T) {
+	h, svc, _ := setupNoteTemplateHandler()
+	svc.On("GetByID", uint(99)).Return(nil, service.ErrNotFound)
+
+	r := newRouter(1)
+	r.POST("/note-templates/:id/use", h.UseTemplate)
+	w := doRequest(r, "POST", "/note-templates/99/use", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1513,3 +1513,129 @@ func setupGitHubHandlerMock() (*GitHubHandler, *MockGHService, *MockGHAuthServic
 	h := NewGitHubHandler(ghSvc, authSvc)
 	return h, ghSvc, authSvc
 }
+
+// ---------- NoteLinkHandler モック ----------
+
+// MockNoteLinkService は NoteLinkServiceInterface のモック実装。
+type MockNoteLinkService struct{ mock.Mock }
+
+func (m *MockNoteLinkService) CreateLink(sourceNoteID, targetNoteID uint) error {
+	return m.Called(sourceNoteID, targetNoteID).Error(0)
+}
+func (m *MockNoteLinkService) GetLinks(sourceNoteID uint) ([]model.NoteLink, error) {
+	args := m.Called(sourceNoteID)
+	return args.Get(0).([]model.NoteLink), args.Error(1)
+}
+func (m *MockNoteLinkService) GetBacklinks(targetNoteID uint) ([]model.NoteLink, error) {
+	args := m.Called(targetNoteID)
+	return args.Get(0).([]model.NoteLink), args.Error(1)
+}
+func (m *MockNoteLinkService) DeleteLink(sourceNoteID, targetNoteID uint) error {
+	return m.Called(sourceNoteID, targetNoteID).Error(0)
+}
+
+func setupNoteLinkHandler() (*NoteLinkHandler, *MockNoteLinkService) {
+	svc := new(MockNoteLinkService)
+	h := NewNoteLinkHandler(svc)
+	return h, svc
+}
+
+// ---------- NoteTemplateHandler モック ----------
+
+// MockNoteTemplateService は NoteTemplateServiceInterface のモック実装。
+type MockNoteTemplateService struct{ mock.Mock }
+
+func (m *MockNoteTemplateService) Create(template *model.NoteTemplate) error {
+	return m.Called(template).Error(0)
+}
+func (m *MockNoteTemplateService) GetByID(id uint) (*model.NoteTemplate, error) {
+	args := m.Called(id)
+	if t := args.Get(0); t != nil {
+		return t.(*model.NoteTemplate), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockNoteTemplateService) GetByUserID(userID uint) ([]model.NoteTemplate, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.NoteTemplate), args.Error(1)
+}
+func (m *MockNoteTemplateService) GetDefaultByUserID(userID uint) (*model.NoteTemplate, error) {
+	args := m.Called(userID)
+	if t := args.Get(0); t != nil {
+		return t.(*model.NoteTemplate), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockNoteTemplateService) Update(template *model.NoteTemplate) error {
+	return m.Called(template).Error(0)
+}
+func (m *MockNoteTemplateService) Delete(id uint) error {
+	return m.Called(id).Error(0)
+}
+
+// MockNoteServiceForTemplate は NoteTemplateHandler 用のノートサービスモック。
+type MockNoteServiceForTemplate struct{ mock.Mock }
+
+func (m *MockNoteServiceForTemplate) Create(note *model.Note) error {
+	return m.Called(note).Error(0)
+}
+func (m *MockNoteServiceForTemplate) GetByID(id uint) (*model.Note, error) {
+	args := m.Called(id)
+	if n := args.Get(0); n != nil {
+		return n.(*model.Note), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockNoteServiceForTemplate) GetByUserID(userID uint, page, limit int) ([]model.Note, error) {
+	args := m.Called(userID, page, limit)
+	return args.Get(0).([]model.Note), args.Error(1)
+}
+func (m *MockNoteServiceForTemplate) GetByFolderID(folderID uint) ([]model.Note, error) {
+	args := m.Called(folderID)
+	return args.Get(0).([]model.Note), args.Error(1)
+}
+func (m *MockNoteServiceForTemplate) Update(note *model.Note) error {
+	return m.Called(note).Error(0)
+}
+func (m *MockNoteServiceForTemplate) Delete(id uint) error {
+	return m.Called(id).Error(0)
+}
+func (m *MockNoteServiceForTemplate) Search(userID uint, query string, page, limit int) ([]model.Note, int64, error) {
+	args := m.Called(userID, query, page, limit)
+	return args.Get(0).([]model.Note), args.Get(1).(int64), args.Error(2)
+}
+func (m *MockNoteServiceForTemplate) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+func (m *MockNoteServiceForTemplate) ToggleFavorite(id uint) error {
+	return m.Called(id).Error(0)
+}
+func (m *MockNoteServiceForTemplate) Archive(id uint) error {
+	return m.Called(id).Error(0)
+}
+func (m *MockNoteServiceForTemplate) Unarchive(id uint) error {
+	return m.Called(id).Error(0)
+}
+func (m *MockNoteServiceForTemplate) GetArchived(userID uint, page, limit int) ([]model.Note, error) {
+	args := m.Called(userID, page, limit)
+	return args.Get(0).([]model.Note), args.Error(1)
+}
+func (m *MockNoteServiceForTemplate) CountArchivedByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+func (m *MockNoteServiceForTemplate) Duplicate(id uint, userID uint) (*model.Note, error) {
+	args := m.Called(id, userID)
+	if n := args.Get(0); n != nil {
+		return n.(*model.Note), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func setupNoteTemplateHandler() (*NoteTemplateHandler, *MockNoteTemplateService, *MockNoteServiceForTemplate) {
+	svc := new(MockNoteTemplateService)
+	noteSvc := new(MockNoteServiceForTemplate)
+	h := NewNoteTemplateHandler(svc, noteSvc)
+	return h, svc, noteSvc
+}


### PR DESCRIPTION
## 概要
テスト未作成だった3つのhandlerにユニットテストを追加。

## 追加テスト（22件）
- `health_test.go`: HealthCheck 1件
- `note_link_test.go`: CreateLink 3件・GetLinks 2件・GetBacklinks 2件・DeleteLink 2件（計9件）
- `note_template_test.go`: Create 2件・GetByID 2件・GetByUserID 1件・GetDefault 1件・Update 2件（所有者チェック含む）・Delete 2件（所有者チェック含む）・UseTemplate 3件（所有者チェック含む）（計12件）

## モック追加
- MockNoteLinkService（4メソッド）
- MockNoteTemplateService（6メソッド）
- MockNoteServiceForTemplate（14メソッド）

Closes #336