### PR TITLE
セクションコンテナスタイルを共通定数に統一

### DIFF
--- a/frontend/src/components/common/Skeleton.tsx
+++ b/frontend/src/components/common/Skeleton.tsx
@@ -1,3 +1,5 @@
+import { sectionContainerClass } from '../../constants/styles';
+
 interface SkeletonProps {
   className?: string;
 }
@@ -117,7 +119,7 @@ export function ListSkeleton({ count = 3 }: { count?: number }) {
 
 export function TableSkeleton({ rows = 5, cols = 4 }: { rows?: number; cols?: number }) {
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+    <div className={sectionContainerClass}>
       <div className="bg-gray-800 p-4 flex gap-4">
         {Array.from({ length: cols }).map((_, i) => (
           <Skeleton key={i} className="h-4 flex-1" />

--- a/frontend/src/components/profile/BadgeDisplay.tsx
+++ b/frontend/src/components/profile/BadgeDisplay.tsx
@@ -6,6 +6,7 @@ import {
   type LucideIcon,
 } from 'lucide-react';
 import type { BadgeResult } from '../../types/badge';
+import { sectionContainerClass } from '../../constants/styles';
 
 interface BadgeDisplayProps {
   badges: BadgeResult[];
@@ -42,7 +43,7 @@ export default function BadgeDisplay({ badges }: BadgeDisplayProps) {
   const lockedBadges = badges.filter((b) => !b.earned);
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+    <div className={sectionContainerClass}>
       <div className="px-6 py-4 border-b border-gray-800 flex items-center justify-between">
         <div className="flex items-center gap-2">
           <svg

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -12,3 +12,6 @@ export const cardPaddedClass =
 
 export const cardDarkClass =
   'bg-gray-900 border border-gray-800 rounded-md p-5 hover:border-gray-700 transition-colors';
+
+export const sectionContainerClass =
+  'bg-gray-900 border border-gray-800 rounded-md overflow-hidden';

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -8,6 +8,7 @@ import { getGitHubConnectURL } from '../api/github';
 import { connectZenn } from '../api/zenn';
 import { connectQiita } from '../api/qiita';
 import { connectAtCoder } from '../api/atcoder';
+import { sectionContainerClass } from '../constants/styles';
 import toast from 'react-hot-toast';
 import { LANGUAGES, FRAMEWORKS } from '../constants/skills';
 import { inputClass } from '../constants/styles';
@@ -213,7 +214,7 @@ export default function OnboardingPage() {
         </div>
 
         {/* Step Content */}
-        <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+        <div className={sectionContainerClass}>
           {/* Step 1: Profile */}
           {step === 1 && (
             <div>

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { usePostDetail, useConfirm } from '../hooks';
+import { sectionContainerClass } from '../constants/styles';
 import { deletePost } from '../api/posts';
 import { useAuthStore } from '../store/authStore';
 import PostCard from '../components/posts/PostCard';
@@ -78,7 +79,7 @@ export default function PostDetailPage() {
       )}
 
       {/* Comments Section */}
-      <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+      <div className={sectionContainerClass}>
         <div className="px-6 py-4 border-b border-gray-800 flex items-center gap-2">
           <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Sparkles, Rocket, FileText, Monitor, Target, FolderOpen } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { useProfile } from '../hooks';
+import { sectionContainerClass } from '../constants/styles';
 import Avatar from '../components/common/Avatar';
 import { PageLoader } from '../components/common';
 import FollowButton from '../components/profile/FollowButton';
@@ -168,12 +169,12 @@ export default function ProfilePage() {
       {/* GitHub Data */}
       {user.github_connected && (
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2 bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+          <div className={`lg:col-span-2 ${sectionContainerClass}`}>
             <div className="px-6 py-4 border-b border-gray-800"><h2 className="text-sm font-semibold">{t('profile.contributions')}</h2></div>
             <div className="p-6"><ContributionCalendar contributions={contributions} /></div>
           </div>
           {languages.length > 0 && (
-            <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+            <div className={sectionContainerClass}>
               <div className="px-6 py-4 border-b border-gray-800"><h2 className="text-sm font-semibold">{t('profile.languages')}</h2></div>
               <div className="p-6"><LanguageChart languages={languages} /></div>
             </div>

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useRankings } from '../hooks';
+import { sectionContainerClass } from '../constants/styles';
 import Avatar from '../components/common/Avatar';
 import { PageLoader } from '../components/common';
 
@@ -128,7 +129,7 @@ export default function RankingsPage() {
           {t('rankings.noData')}
         </div>
       ) : (
-        <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+        <div className={sectionContainerClass}>
           <div className="px-6 py-3 border-b border-gray-800 grid grid-cols-[3rem_1fr_auto] gap-4 text-xs font-medium text-gray-500 uppercase tracking-wider">
             <span className="text-center">{t('rankings.rank')}</span>
             <span>{t('rankings.developer')}</span>

--- a/frontend/src/pages/settings/AccountSection.tsx
+++ b/frontend/src/pages/settings/AccountSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, buttonSecondaryClass } from '../../constants/styles';
+import { inputClass, buttonSecondaryClass, sectionContainerClass } from '../../constants/styles';
 import { Modal } from '../../components/common';
 import type { User } from '../../types/user';
 
@@ -27,7 +27,7 @@ export default function AccountSection(props: Props) {
   return (
     <>
       {/* Email Notifications */}
-      <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+      <div className={sectionContainerClass}>
         <div className="px-6 py-4 border-b border-gray-800">
           <h2 className="text-base font-semibold">{t('settings.emailNotifications')}</h2>
         </div>

--- a/frontend/src/pages/settings/IntegrationSection.tsx
+++ b/frontend/src/pages/settings/IntegrationSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass } from '../../constants/styles';
+import { inputClass, sectionContainerClass } from '../../constants/styles';
 import type { User } from '../../types/user';
 
 interface Props {
@@ -49,7 +49,7 @@ export default function IntegrationSection(props: Props) {
   return (
     <>
       {/* GitHub Integration */}
-      <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+      <div className={sectionContainerClass}>
         <div className="px-6 py-4 border-b border-gray-800">
           <h2 className="text-base font-semibold">{t('settings.github')}</h2>
         </div>
@@ -96,7 +96,7 @@ export default function IntegrationSection(props: Props) {
       </div>
 
       {/* Zenn Integration */}
-      <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+      <div className={sectionContainerClass}>
         <div className="px-6 py-4 border-b border-gray-800">
           <h2 className="text-base font-semibold">{t('settings.zenn')}</h2>
         </div>
@@ -155,7 +155,7 @@ export default function IntegrationSection(props: Props) {
       </div>
 
       {/* Qiita Integration */}
-      <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+      <div className={sectionContainerClass}>
         <div className="px-6 py-4 border-b border-gray-800">
           <h2 className="text-base font-semibold">{t('settings.qiita')}</h2>
         </div>
@@ -214,7 +214,7 @@ export default function IntegrationSection(props: Props) {
       </div>
 
       {/* AtCoder Integration */}
-      <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+      <div className={sectionContainerClass}>
         <div className="px-6 py-4 border-b border-gray-800">
           <h2 className="text-base font-semibold">{t('settings.atcoder')}</h2>
         </div>
@@ -266,7 +266,7 @@ export default function IntegrationSection(props: Props) {
       </div>
 
       {/* paiza Rank */}
-      <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+      <div className={sectionContainerClass}>
         <div className="px-6 py-4 border-b border-gray-800">
           <h2 className="text-base font-semibold">{t('settings.paiza')}</h2>
         </div>

--- a/frontend/src/pages/settings/ProfileSection.tsx
+++ b/frontend/src/pages/settings/ProfileSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, buttonSecondaryClass } from '../../constants/styles';
+import { inputClass, buttonSecondaryClass, sectionContainerClass } from '../../constants/styles';
 
 interface Props {
   name: string;
@@ -16,7 +16,7 @@ export default function ProfileSection({ name, setName, bio, setBio, avatarUrl, 
   const { t } = useTranslation();
 
   return (
-    <form onSubmit={onSubmit} className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+    <form onSubmit={onSubmit} className={sectionContainerClass}>
       <div className="px-6 py-4 border-b border-gray-800">
         <h2 className="text-base font-semibold">{t('settings.profile')}</h2>
       </div>

--- a/frontend/src/pages/settings/SkillsSection.tsx
+++ b/frontend/src/pages/settings/SkillsSection.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Sparkles } from 'lucide-react';
-import { buttonSecondaryClass } from '../../constants/styles';
+import { buttonSecondaryClass, sectionContainerClass } from '../../constants/styles';
 import { LANGUAGES, FRAMEWORKS } from '../../constants/skills';
 
 interface Props {
@@ -19,7 +19,7 @@ export default function SkillsSection({
   const { t } = useTranslation();
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
+    <div className={sectionContainerClass}>
       <div className="px-6 py-4 border-b border-gray-800">
         <h2 className="text-base font-semibold flex items-center gap-2">
           <Sparkles className="w-5 h-5 text-yellow-400" /> {t('settings.skills')}


### PR DESCRIPTION
## 概要
- `bg-gray-900 border border-gray-800 rounded-md overflow-hidden` パターンを `sectionContainerClass` として `constants/styles.ts` に定義
- 10ファイル14箇所のインラインクラスを定数参照に置換

## 対象ファイル
- `constants/styles.ts` — 定数追加
- `RankingsPage`, `ProfilePage`, `PostDetailPage`, `OnboardingPage` — ページ
- `IntegrationSection`, `ProfileSection`, `SkillsSection`, `AccountSection` — 設定セクション
- `Skeleton`, `BadgeDisplay` — コンポーネント

## テスト
- TypeScript型チェック通過

Closes #338