### PR TITLE
handler層のc.JSON直接呼び出しをヘルパー関数に統一（第2弾）

### DIFF
--- a/backend/internal/handler/atcoder.go
+++ b/backend/internal/handler/atcoder.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
@@ -38,17 +36,17 @@ func NewAtCoderHandler(atcoderService AtCoderServiceInterface, userService AtCod
 func (h *AtCoderHandler) GetRating(c *gin.Context) {
 	username := c.Param("username")
 	if username == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "username is required"})
+		respondBadRequest(c, "username is required")
 		return
 	}
 
 	info, err := h.atcoderService.GetRating(username)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 
-	c.JSON(http.StatusOK, info)
+	respondOK(c, info)
 }
 
 // Connect はAtCoderユーザー名を検証し、ユーザープロフィールに保存する。
@@ -59,28 +57,28 @@ func (h *AtCoderHandler) Connect(c *gin.Context) {
 		Username string `json:"username" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "username is required"})
+		respondBadRequest(c, "username is required")
 		return
 	}
 
 	if !h.atcoderService.ValidateUsername(input.Username) {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid AtCoder username"})
+		respondBadRequest(c, "invalid AtCoder username")
 		return
 	}
 
 	user, err := h.userService.GetByID(userID)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		respondNotFound(c, "user not found")
 		return
 	}
 
 	user.AtCoderUsername = input.Username
 	if err := h.userService.Update(user); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, user)
+	respondOK(c, user)
 }
 
 // Disconnect はAtCoderユーザー名をクリアする。
@@ -89,15 +87,15 @@ func (h *AtCoderHandler) Disconnect(c *gin.Context) {
 
 	user, err := h.userService.GetByID(userID)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		respondNotFound(c, "user not found")
 		return
 	}
 
 	user.AtCoderUsername = ""
 	if err := h.userService.Update(user); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, user)
+	respondOK(c, user)
 }

--- a/backend/internal/handler/badge.go
+++ b/backend/internal/handler/badge.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
@@ -48,7 +46,7 @@ func (h *BadgeHandler) NotifyBadgeEarned(c *gin.Context) {
 		BadgeID string `json:"badge_id" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "badge_id is required"})
+		respondBadRequest(c, "badge_id is required")
 		return
 	}
 

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -94,6 +94,12 @@ func respondForbidden(c *gin.Context, message string) {
 	c.JSON(http.StatusForbidden, response)
 }
 
+// respondNotFound は404 Not Foundでエラーメッセージを返す。
+func respondNotFound(c *gin.Context, message string) {
+	response := domain.NewErrorResponse(message, string(domain.ErrCodeNotFound), nil)
+	c.JSON(http.StatusNotFound, response)
+}
+
 // respondPaginated はページネーション付きレスポンスを返す。
 func respondPaginated(c *gin.Context, data interface{}, total int64, page, limit int) {
 	response := domain.NewPaginatedResponse(data, total, page, limit)

--- a/backend/internal/handler/message.go
+++ b/backend/internal/handler/message.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -69,7 +68,7 @@ func (h *MessageHandler) SendMessage(c *gin.Context) {
 		Content string `json:"content" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 

--- a/backend/internal/handler/qiita.go
+++ b/backend/internal/handler/qiita.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -36,7 +34,7 @@ func (h *QiitaHandler) Connect(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "username is required"})
+		respondBadRequest(c, "username is required")
 		return
 	}
 

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -46,7 +44,7 @@ func (h *UserHandler) GetByID(c *gin.Context) {
 
 	user, err := h.service.GetByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		respondNotFound(c, "user not found")
 		return
 	}
 	respondOK(c, user)
@@ -56,13 +54,13 @@ func (h *UserHandler) GetByID(c *gin.Context) {
 func (h *UserHandler) GetByUsername(c *gin.Context) {
 	username := c.Param("username")
 	if username == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "username required"})
+		respondBadRequest(c, "username required")
 		return
 	}
 
 	user, err := h.service.GetByUsername(username)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		respondNotFound(c, "user not found")
 		return
 	}
 	respondOK(c, user)
@@ -78,13 +76,13 @@ func (h *UserHandler) Update(c *gin.Context) {
 
 	userID := c.GetUint("userID")
 	if userID != id {
-		c.JSON(http.StatusForbidden, gin.H{"error": "cannot update other user's profile"})
+		respondForbidden(c, "cannot update other user's profile")
 		return
 	}
 
 	existing, err := h.service.GetByID(id)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		respondNotFound(c, "user not found")
 		return
 	}
 
@@ -99,7 +97,7 @@ func (h *UserHandler) Update(c *gin.Context) {
 		OnboardingCompleted *bool   `json:"onboarding_completed"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 

--- a/backend/internal/handler/zenn.go
+++ b/backend/internal/handler/zenn.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -36,7 +34,7 @@ func (h *ZennHandler) Connect(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "username is required"})
+		respondBadRequest(c, "username is required")
 		return
 	}
 


### PR DESCRIPTION
## 概要
- `respondNotFound` ヘルパー関数を `helpers.go` に追加
- 6ファイル21箇所の `c.JSON()` 直接呼び出しをヘルパー関数に置換
- 不要な `net/http` インポートを削除

## 対象ファイル
- `helpers.go` — `respondNotFound` 追加
- `atcoder.go` — 11箇所（respondBadRequest, respondOK, respondNotFound, respondError）
- `user.go` — 6箇所（respondNotFound, respondBadRequest, respondForbidden）
- `badge.go` — 1箇所（respondBadRequest）
- `message.go` — 1箇所（respondBadRequest）
- `qiita.go` — 1箇所（respondBadRequest）
- `zenn.go` — 1箇所（respondBadRequest）

## テスト
- 全関連テスト通過（Badge, GitHub, Message, User）

Closes #340