### PR TITLE
CodeSnippetHandlerのユニットテストを追加

### DIFF
--- a/backend/internal/handler/code_snippet_test.go
+++ b/backend/internal/handler/code_snippet_test.go
@@ -1,0 +1,237 @@
+package handler
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestCodeSnippetCreate_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	created := &model.CodeSnippet{Language: "Go", FileName: "main.go", Code: "package main"}
+	svc.On("Create", mock.AnythingOfType("*model.CodeSnippet")).Return(created, nil)
+
+	r := newRouter(1)
+	r.POST("/posts/:id/snippets", h.Create)
+	w := doRequest(r, "POST", "/posts/1/snippets", map[string]string{
+		"language": "Go", "file_name": "main.go", "code": "package main",
+	})
+
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetCreate_BadRequest(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.POST("/posts/:id/snippets", h.Create)
+	w := doRequest(r, "POST", "/posts/1/snippets", map[string]string{})
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetCreate_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("Create", mock.AnythingOfType("*model.CodeSnippet")).Return(nil, service.ErrBadRequest)
+
+	r := newRouter(1)
+	r.POST("/posts/:id/snippets", h.Create)
+	w := doRequest(r, "POST", "/posts/1/snippets", map[string]string{
+		"language": "Go", "code": "package main",
+	})
+
+	assertStatus(t, w, http.StatusBadRequest)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetCreate_InvalidID(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.POST("/posts/:id/snippets", h.Create)
+	w := doRequest(r, "POST", "/posts/abc/snippets", map[string]string{
+		"language": "Go", "code": "package main",
+	})
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetGetByPostID_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	snippets := []model.CodeSnippet{{Language: "Go", Code: "package main"}}
+	svc.On("GetByPostID", uint(1)).Return(snippets, nil)
+
+	r := newRouter(1)
+	r.GET("/posts/:id/snippets", h.GetByPostID)
+	w := doRequest(r, "GET", "/posts/1/snippets", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetGetByPostID_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("GetByPostID", uint(1)).Return([]model.CodeSnippet(nil), service.ErrNotFound)
+
+	r := newRouter(1)
+	r.GET("/posts/:id/snippets", h.GetByPostID)
+	w := doRequest(r, "GET", "/posts/1/snippets", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetGetByID_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	snippets := []model.CodeSnippet{{Language: "Go"}}
+	svc.On("GetByPostID", uint(5)).Return(snippets, nil)
+
+	r := newRouter(1)
+	r.GET("/snippets/:id", h.GetByID)
+	w := doRequest(r, "GET", "/snippets/5", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetUpdate_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	updated := &model.CodeSnippet{Language: "Python", FileName: "app.py", Code: "print('hi')"}
+	svc.On("Update", uint(1), uint(1), "Python", "app.py", "print('hi')").Return(updated, nil)
+
+	r := newRouter(1)
+	r.PUT("/snippets/:id", h.Update)
+	w := doRequest(r, "PUT", "/snippets/1", map[string]string{
+		"language": "Python", "file_name": "app.py", "code": "print('hi')",
+	})
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetUpdate_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("Update", uint(1), uint(1), "Python", "", "").Return(nil, service.ErrForbidden)
+
+	r := newRouter(1)
+	r.PUT("/snippets/:id", h.Update)
+	w := doRequest(r, "PUT", "/snippets/1", map[string]string{"language": "Python"})
+
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetDelete_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("Delete", uint(1), uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/snippets/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/snippets/1", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetDelete_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("Delete", uint(1), uint(1)).Return(service.ErrForbidden)
+
+	r := newRouter(1)
+	r.DELETE("/snippets/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/snippets/1", nil)
+
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetGetComments_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	comments := []model.SnippetComment{{Content: "nice code", LineNumber: 1}}
+	svc.On("GetComments", uint(1)).Return(comments, nil)
+
+	r := newRouter(1)
+	r.GET("/snippets/:id/comments", h.GetComments)
+	w := doRequest(r, "GET", "/snippets/1/comments", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetGetComments_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("GetComments", uint(1)).Return([]model.SnippetComment(nil), service.ErrNotFound)
+
+	r := newRouter(1)
+	r.GET("/snippets/:id/comments", h.GetComments)
+	w := doRequest(r, "GET", "/snippets/1/comments", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetCreateComment_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("CreateComment", mock.AnythingOfType("*model.SnippetComment")).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/snippets/:id/comments", h.CreateComment)
+	w := doRequest(r, "POST", "/snippets/1/comments", map[string]interface{}{
+		"line_number": 5, "content": "great code",
+	})
+
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetCreateComment_BadRequest(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.POST("/snippets/:id/comments", h.CreateComment)
+	w := doRequest(r, "POST", "/snippets/1/comments", map[string]string{})
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetCreateComment_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("CreateComment", mock.AnythingOfType("*model.SnippetComment")).Return(service.ErrBadRequest)
+
+	r := newRouter(1)
+	r.POST("/snippets/:id/comments", h.CreateComment)
+	w := doRequest(r, "POST", "/snippets/1/comments", map[string]interface{}{
+		"line_number": 5, "content": "great code",
+	})
+
+	assertStatus(t, w, http.StatusBadRequest)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetDeleteComment_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("DeleteComment", uint(1), uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/snippets/:id/comments/:commentId", h.DeleteComment)
+	w := doRequest(r, "DELETE", "/snippets/1/comments/1", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetDeleteComment_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("DeleteComment", uint(1), uint(1)).Return(service.ErrForbidden)
+
+	r := newRouter(1)
+	r.DELETE("/snippets/:id/comments/:commentId", h.DeleteComment)
+	w := doRequest(r, "DELETE", "/snippets/1/comments/1", nil)
+
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1514,6 +1514,50 @@ func setupGitHubHandlerMock() (*GitHubHandler, *MockGHService, *MockGHAuthServic
 	return h, ghSvc, authSvc
 }
 
+// ---------- CodeSnippetHandler モック ----------
+
+// MockCodeSnippetHandlerService は CodeSnippetHandlerServiceInterface のモック実装。
+type MockCodeSnippetHandlerService struct{ mock.Mock }
+
+func (m *MockCodeSnippetHandlerService) Create(snippet *model.CodeSnippet) (*model.CodeSnippet, error) {
+	args := m.Called(snippet)
+	if s := args.Get(0); s != nil {
+		return s.(*model.CodeSnippet), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockCodeSnippetHandlerService) GetByPostID(postID uint) ([]model.CodeSnippet, error) {
+	args := m.Called(postID)
+	return args.Get(0).([]model.CodeSnippet), args.Error(1)
+}
+func (m *MockCodeSnippetHandlerService) Update(id, userID uint, language, fileName, code string) (*model.CodeSnippet, error) {
+	args := m.Called(id, userID, language, fileName, code)
+	if s := args.Get(0); s != nil {
+		return s.(*model.CodeSnippet), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockCodeSnippetHandlerService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+func (m *MockCodeSnippetHandlerService) GetComments(snippetID uint) ([]model.SnippetComment, error) {
+	args := m.Called(snippetID)
+	return args.Get(0).([]model.SnippetComment), args.Error(1)
+}
+func (m *MockCodeSnippetHandlerService) CreateComment(comment *model.SnippetComment) error {
+	return m.Called(comment).Error(0)
+}
+func (m *MockCodeSnippetHandlerService) DeleteComment(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+
+// setupCodeSnippetHandler はCodeSnippetHandlerテスト用のセットアップを行う。
+func setupCodeSnippetHandler() (*CodeSnippetHandler, *MockCodeSnippetHandlerService) {
+	svc := new(MockCodeSnippetHandlerService)
+	h := NewCodeSnippetHandler(svc)
+	return h, svc
+}
+
 // ---------- NoteLinkHandler モック ----------
 
 // MockNoteLinkService は NoteLinkServiceInterface のモック実装。


### PR DESCRIPTION
## 概要
- `MockCodeSnippetHandlerService` と `setupCodeSnippetHandler` を `testutil_test.go` に追加
- `code_snippet_test.go` に18テストケースを実装

## テスト対象
- **Create**: 正常系、バリデーションエラー、サービスエラー、無効ID
- **GetByPostID**: 正常系、サービスエラー
- **GetByID**: 正常系
- **Update**: 正常系、サービスエラー
- **Delete**: 正常系、サービスエラー
- **GetComments**: 正常系、サービスエラー
- **CreateComment**: 正常系、バリデーションエラー、サービスエラー
- **DeleteComment**: 正常系、サービスエラー

## テスト結果
全18テスト通過

Closes #342