### PR TITLE
feat: selectクラス統一化

### DIFF
--- a/frontend/src/components/posts/LanguageSelector.tsx
+++ b/frontend/src/components/posts/LanguageSelector.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { selectClass } from '../../constants/styles';
 
 const LANGUAGES = [
   'go', 'typescript', 'javascript', 'python', 'java', 'rust', 'ruby', 'php',
@@ -19,7 +20,7 @@ export default function LanguageSelector({ value, onChange }: LanguageSelectorPr
     <select
       value={value}
       onChange={(e) => onChange(e.target.value)}
-      className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+      className={selectClass}
     >
       <option value="">{t('post.selectLanguage')}</option>
       {LANGUAGES.map((lang) => (

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Project, CreateProjectRequest } from '../../types/project';
 import type { GitHubRepository } from '../../types/github';
-import { buttonSecondaryClass } from '../../constants/styles';
+import { buttonSecondaryClass, inputClass } from '../../constants/styles';
 
 interface ProjectFormProps {
   project?: Project;
@@ -88,7 +88,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
           <select
             value={githubRepoId || ''}
             onChange={(e) => e.target.value && handleRepoSelect(parseInt(e.target.value))}
-            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={inputClass}
           >
             <option value="">{t('projects.selectRepo')}</option>
             {repos.map(repo => (
@@ -242,7 +242,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
             type="date"
             value={startDate}
             onChange={(e) => setStartDate(e.target.value)}
-            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={inputClass}
           />
         </div>
         <div>
@@ -253,7 +253,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
             type="date"
             value={endDate}
             onChange={(e) => setEndDate(e.target.value)}
-            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={inputClass}
           />
         </div>
       </div>

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LearningResource, CreateResourceRequest, ResourceCategory, ResourceDifficulty } from '../../types/resource';
-import { buttonSecondaryClass } from '../../constants/styles';
+import { buttonSecondaryClass, inputClass } from '../../constants/styles';
 
 interface ResourceFormProps {
   resource?: LearningResource;
@@ -100,7 +100,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           <select
             value={category}
             onChange={(e) => setCategory(e.target.value as ResourceCategory)}
-            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={inputClass}
           >
             {categories.map(cat => (
               <option key={cat} value={cat}>
@@ -116,7 +116,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           <select
             value={difficulty}
             onChange={(e) => setDifficulty(e.target.value as ResourceDifficulty | '')}
-            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={inputClass}
           >
             <option value="">{t('resources.selectDifficulty')}</option>
             {difficulties.map(diff => (

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -15,3 +15,6 @@ export const cardDarkClass =
 
 export const sectionContainerClass =
   'bg-gray-900 border border-gray-800 rounded-md overflow-hidden';
+
+export const selectClass =
+  'px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow';

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -8,6 +8,7 @@ import ResourceCard from '../components/resources/ResourceCard';
 import ResourceForm from '../components/resources/ResourceForm';
 import { ResourceCardSkeleton } from '../components/common/Skeleton';
 import EmptyState from '../components/common/EmptyState';
+import { selectClass } from '../constants/styles';
 import { Pagination, SearchInput, PageHeader, Modal } from '../components/common';
 
 const categories: (ResourceCategory | '')[] = ['', 'book', 'video', 'article', 'course', 'tutorial', 'podcast', 'tool', 'other'];
@@ -93,7 +94,7 @@ export default function ResourcesPage() {
           <select
             value={categoryFilter}
             onChange={(e) => setCategoryFilter(e.target.value as ResourceCategory | '')}
-            className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={selectClass}
           >
             <option value="">{t('resources.allCategories')}</option>
             {categories.slice(1).map(cat => (
@@ -105,7 +106,7 @@ export default function ResourcesPage() {
           <select
             value={difficultyFilter}
             onChange={(e) => setDifficultyFilter(e.target.value as ResourceDifficulty | '')}
-            className="px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={selectClass}
           >
             <option value="">{t('resources.allDifficulties')}</option>
             {difficulties.slice(1).map(diff => (


### PR DESCRIPTION
## 概要
フォームselect要素やフィルタードロップダウンのスタイルを`constants/styles.ts`の共通定数に統一。

## 変更内容
- `constants/styles.ts`に`selectClass`を追加（コンパクトなフィルター/ドロップダウン向け）
- フォームselect: インラインスタイル → `inputClass`（ResourceForm 2箇所、ProjectForm 3箇所）
- フィルターselect: インラインスタイル → `selectClass`（ResourcesPage 2箇所、LanguageSelector 1箇所）

## 対象ファイル
| ファイル | 変更箇所 | 定数 |
|---------|---------|------|
| `constants/styles.ts` | selectClass追加 | — |
| `pages/ResourcesPage.tsx` | 2箇所 | selectClass |
| `components/resources/ResourceForm.tsx` | 2箇所 | inputClass |
| `components/projects/ProjectForm.tsx` | 3箇所 | inputClass |
| `components/posts/LanguageSelector.tsx` | 1箇所 | selectClass |

Closes #344