### PR TITLE
refactor: Handler層レスポンスヘルパー統一第3弾

### DIFF
--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"log"
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -68,7 +67,7 @@ func (h *AIAdviceHandler) MarkAsRead(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	if err := h.service.MarkAsRead(id, userID); err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "advice not found"})
+		respondNotFound(c, "advice not found")
 		return
 	}
 
@@ -84,7 +83,7 @@ func (h *AIAdviceHandler) Chat(c *gin.Context) {
 		ConversationID uint   `json:"conversation_id"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 

--- a/backend/internal/handler/chat_room.go
+++ b/backend/internal/handler/chat_room.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -43,7 +42,7 @@ func (h *ChatRoomHandler) Create(c *gin.Context) {
 		MemberIDs   []uint `json:"member_ids"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 
@@ -102,7 +101,7 @@ func (h *ChatRoomHandler) Update(c *gin.Context) {
 		Description string `json:"description"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 
@@ -157,7 +156,7 @@ func (h *ChatRoomHandler) AddMember(c *gin.Context) {
 		UserID uint `json:"user_id" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 
@@ -218,7 +217,7 @@ func (h *ChatRoomHandler) SendMessage(c *gin.Context) {
 		Content string `json:"content" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -42,7 +40,7 @@ func (h *CodeSnippetHandler) Create(c *gin.Context) {
 		Code     string `json:"code" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 
@@ -105,7 +103,7 @@ func (h *CodeSnippetHandler) Update(c *gin.Context) {
 		Code     string `json:"code"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 
@@ -160,7 +158,7 @@ func (h *CodeSnippetHandler) CreateComment(c *gin.Context) {
 		Content    string `json:"content" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&input); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 

--- a/backend/internal/handler/email_preferences.go
+++ b/backend/internal/handler/email_preferences.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -50,7 +48,7 @@ func (h *EmailPreferencesHandler) UpdatePreferences(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		respondBadRequest(c, "invalid request")
 		return
 	}
 
@@ -70,7 +68,7 @@ func (h *EmailPreferencesHandler) UpdatePreferences(c *gin.Context) {
 			"es": true, "fr": true, "de": true, "pt": true, "ru": true,
 		}
 		if !validLangs[*req.EmailLanguage] {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid email language"})
+			respondBadRequest(c, "invalid email language")
 			return
 		}
 		user.EmailLanguage = *req.EmailLanguage

--- a/backend/internal/handler/reminder_settings.go
+++ b/backend/internal/handler/reminder_settings.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -43,7 +41,7 @@ func (h *ReminderSettingsHandler) GetSettings(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, settings)
+	respondOK(c, settings)
 }
 
 // UpdateSettings は認証ユーザーのリマインダー設定を更新する。
@@ -52,7 +50,7 @@ func (h *ReminderSettingsHandler) UpdateSettings(c *gin.Context) {
 
 	var req UpdateReminderSettingsInput
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 
@@ -71,5 +69,5 @@ func (h *ReminderSettingsHandler) UpdateSettings(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, settings)
+	respondOK(c, settings)
 }

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"net/http"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -53,7 +52,7 @@ func (h *RoadmapHandler) Create(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "title is required"})
+		respondBadRequest(c, "title is required")
 		return
 	}
 
@@ -143,7 +142,7 @@ func (h *RoadmapHandler) Update(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		respondBadRequest(c, "invalid request")
 		return
 	}
 
@@ -257,7 +256,7 @@ func (h *RoadmapHandler) CreateStep(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "title is required"})
+		respondBadRequest(c, "title is required")
 		return
 	}
 
@@ -298,7 +297,7 @@ func (h *RoadmapHandler) UpdateStep(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		respondBadRequest(c, "invalid request")
 		return
 	}
 
@@ -369,7 +368,7 @@ func (h *RoadmapHandler) ReorderSteps(c *gin.Context) {
 	}
 
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		respondBadRequest(c, "invalid request")
 		return
 	}
 


### PR DESCRIPTION
## 概要
Handler層のc.JSON直接使用をレスポンスヘルパー関数に統一する第3弾。

## 変更内容
6ファイル19箇所のc.JSON → ヘルパー関数に置換。全ファイルからnet/httpインポートを除去。

| ファイル | 置換数 | ヘルパー |
|---------|-------|---------|
| `email_preferences.go` | 2 | respondBadRequest |
| `ai_advice.go` | 2 | respondNotFound, respondBadRequest |
| `code_snippet.go` | 3 | respondBadRequest |
| `chat_room.go` | 4 | respondBadRequest |
| `roadmap.go` | 5 | respondBadRequest |
| `reminder_settings.go` | 3 | respondOK, respondBadRequest |

## テスト
既存のHandler層テスト全件通過確認済み

Closes #346