### PR TITLE
feat: textareaクラス統一化

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewForm.tsx
+++ b/frontend/src/components/bookReviews/BookReviewForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { BookReview, CreateBookReviewRequest } from '../../types/bookReview';
-import { buttonSecondaryClass } from '../../constants/styles';
+import { buttonSecondaryClass, textareaClass } from '../../constants/styles';
 
 interface BookReviewFormProps {
   review?: BookReview;
@@ -121,7 +121,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
           value={reviewText}
           onChange={(e) => setReviewText(e.target.value)}
           rows={4}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent resize-none"
+          className={textareaClass}
           placeholder={t('bookReviews.reviewPlaceholder')}
         />
       </div>

--- a/frontend/src/components/chat/CreateRoomModal.tsx
+++ b/frontend/src/components/chat/CreateRoomModal.tsx
@@ -5,6 +5,7 @@ import { createChatRoom } from '../../api/chatRooms';
 import type { User } from '../../types/user';
 import type { ChatRoom } from '../../types/chat';
 import Avatar from '../common/Avatar';
+import { textareaClass } from '../../constants/styles';
 
 interface Props {
   followingUsers: User[];
@@ -78,7 +79,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
               onChange={(e) => setDescription(e.target.value)}
               placeholder={t('chat.groupDescriptionPlaceholder')}
               rows={2}
-              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+              className={textareaClass}
             />
           </div>
 

--- a/frontend/src/components/chat/RoomSettingsModal.tsx
+++ b/frontend/src/components/chat/RoomSettingsModal.tsx
@@ -5,6 +5,7 @@ import {
   getChatRoomMembers, updateChatRoom, deleteChatRoom,
   addChatRoomMember, removeChatRoomMember,
 } from '../../api/chatRooms';
+import { textareaClass } from '../../constants/styles';
 import { useConfirm } from '../../hooks';
 import type { User } from '../../types/user';
 import type { ChatRoom, ChatRoomMember } from '../../types/chat';
@@ -140,7 +141,7 @@ export default function RoomSettingsModal({
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={2}
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+                className={textareaClass}
               />
             </div>
             <button

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Project, CreateProjectRequest } from '../../types/project';
 import type { GitHubRepository } from '../../types/github';
-import { buttonSecondaryClass, inputClass } from '../../constants/styles';
+import { buttonSecondaryClass, inputClass, textareaClass } from '../../constants/styles';
 
 interface ProjectFormProps {
   project?: Project;
@@ -125,7 +125,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           rows={3}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent resize-none"
+          className={textareaClass}
           placeholder={t('projects.descriptionPlaceholder')}
         />
       </div>

--- a/frontend/src/components/qa/AnswerForm.tsx
+++ b/frontend/src/components/qa/AnswerForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { textareaClass } from '../../constants/styles';
 
 interface AnswerFormProps {
   initialBody?: string;
@@ -28,7 +29,7 @@ export default function AnswerForm({ initialBody = '', onSubmit, onCancel, loadi
         onChange={(e) => setBody(e.target.value)}
         required
         rows={isEdit ? 4 : 6}
-        className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent resize-none"
+        className={textareaClass}
         placeholder={t('qa.answerPlaceholder')}
       />
       <div className="flex gap-3 justify-end">

--- a/frontend/src/components/qa/QuestionForm.tsx
+++ b/frontend/src/components/qa/QuestionForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Question, CreateQuestionRequest } from '../../types/qa';
-import { buttonSecondaryClass } from '../../constants/styles';
+import { buttonSecondaryClass, textareaClass } from '../../constants/styles';
 
 interface QuestionFormProps {
   question?: Question;
@@ -62,7 +62,7 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
           onChange={(e) => setBody(e.target.value)}
           required
           rows={8}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent resize-none"
+          className={textareaClass}
           placeholder={t('qa.questionBodyPlaceholder')}
         />
       </div>

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LearningResource, CreateResourceRequest, ResourceCategory, ResourceDifficulty } from '../../types/resource';
-import { buttonSecondaryClass, inputClass } from '../../constants/styles';
+import { buttonSecondaryClass, inputClass, textareaClass } from '../../constants/styles';
 
 interface ResourceFormProps {
   resource?: LearningResource;
@@ -137,7 +137,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           rows={3}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent resize-none"
+          className={textareaClass}
           placeholder={t('resources.descriptionPlaceholder')}
         />
       </div>

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -18,3 +18,6 @@ export const sectionContainerClass =
 
 export const selectClass =
   'px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow';
+
+export const textareaClass =
+  'w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow resize-none';


### PR DESCRIPTION
## 概要
フォームtextarea要素のスタイルを`constants/styles.ts`の共通定数`textareaClass`に統一。

## 変更内容
- `constants/styles.ts`に`textareaClass`を追加（inputClassベース + resize-none）
- 7コンポーネントのインラインtextareaスタイルを共通定数に置換

## 対象ファイル
| ファイル | 変更内容 |
|---------|---------|
| `constants/styles.ts` | textareaClass追加 |
| `components/qa/QuestionForm.tsx` | インライン → textareaClass |
| `components/qa/AnswerForm.tsx` | インライン → textareaClass |
| `components/bookReviews/BookReviewForm.tsx` | インライン → textareaClass |
| `components/resources/ResourceForm.tsx` | インライン → textareaClass |
| `components/projects/ProjectForm.tsx` | インライン → textareaClass |
| `components/chat/CreateRoomModal.tsx` | インライン → textareaClass |
| `components/chat/RoomSettingsModal.tsx` | インライン → textareaClass |

Closes #350