### PR TITLE
refactor: Handler層レスポンスヘルパー統一第4弾

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"net/http"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -160,11 +159,11 @@ func (h *LearningGoalHandler) GetByID(c *gin.Context) {
 
 	goal, err := h.service.GetByID(goalID)
 	if err != nil {
-		c.JSON(http.StatusNotFound, gin.H{"error": "goal not found"})
+		respondNotFound(c, "goal not found")
 		return
 	}
 
-	c.JSON(http.StatusOK, goal)
+	respondOK(c, goal)
 }
 
 // GetByUserID は指定されたユーザーの学習目標一覧を取得する。
@@ -176,11 +175,11 @@ func (h *LearningGoalHandler) GetByUserID(c *gin.Context) {
 
 	goals, err := h.service.GetByUserID(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get goals"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, goals)
+	respondOK(c, goals)
 }
 
 // GetMyGoals は認証ユーザー自身の学習目標一覧を取得する。
@@ -189,11 +188,11 @@ func (h *LearningGoalHandler) GetMyGoals(c *gin.Context) {
 
 	goals, err := h.service.GetByUserID(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get goals"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, goals)
+	respondOK(c, goals)
 }
 
 // GetStats は指定されたユーザーの学習目標統計情報を取得する。
@@ -205,9 +204,9 @@ func (h *LearningGoalHandler) GetStats(c *gin.Context) {
 
 	stats, err := h.service.GetStats(userID)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get stats"})
+		respondError(c, err)
 		return
 	}
 
-	c.JSON(http.StatusOK, stats)
+	respondOK(c, stats)
 }

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -49,7 +47,7 @@ func (h *StudyCircleHandler) Create(c *gin.Context) {
 		MemberIDs   []uint `json:"member_ids"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 
@@ -107,7 +105,7 @@ func (h *StudyCircleHandler) Update(c *gin.Context) {
 		Description *string `json:"description"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 	userID := c.GetUint("userID")
@@ -158,7 +156,7 @@ func (h *StudyCircleHandler) AddMember(c *gin.Context) {
 		UserID uint `json:"user_id" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 	userID := c.GetUint("userID")
@@ -200,7 +198,7 @@ func (h *StudyCircleHandler) CreateStep(c *gin.Context) {
 		OrderIndex  int    `json:"order_index"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 	userID := c.GetUint("userID")
@@ -233,7 +231,7 @@ func (h *StudyCircleHandler) UpdateStep(c *gin.Context) {
 		Description *string `json:"description"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 	userID := c.GetUint("userID")
@@ -273,7 +271,7 @@ func (h *StudyCircleHandler) ReorderSteps(c *gin.Context) {
 		Orders []repository.StepOrder `json:"orders" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 	userID := c.GetUint("userID")
@@ -298,7 +296,7 @@ func (h *StudyCircleHandler) UpdateProgress(c *gin.Context) {
 		IsCompleted bool `json:"is_completed"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 	userID := c.GetUint("userID")
@@ -334,7 +332,7 @@ func (h *StudyCircleHandler) CreateCheckin(c *gin.Context) {
 		Content string `json:"content" binding:"required"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return
 	}
 	userID := c.GetUint("userID")


### PR DESCRIPTION
## 概要
Handler層のc.JSON直接使用をレスポンスヘルパー関数に統一する第4弾。

## 変更内容
| ファイル | 置換数 | ヘルパー |
|---------|-------|---------|
| `study_circle.go` | 8 | respondBadRequest |
| `learning_goal.go` | 8 | respondNotFound, respondOK, respondError |

## テスト
既存のStudyCircle・LearningGoalテスト全件通過確認済み

Closes #352