### PR TITLE
feat: labelClass定数を追加しフォームコンポーネントのラベルスタイルを統一

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewForm.tsx
+++ b/frontend/src/components/bookReviews/BookReviewForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { BookReview, CreateBookReviewRequest } from '../../types/bookReview';
-import { buttonSecondaryClass, textareaClass } from '../../constants/styles';
+import { buttonSecondaryClass, labelClass, textareaClass } from '../../constants/styles';
 
 interface BookReviewFormProps {
   review?: BookReview;
@@ -60,7 +60,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
     <form onSubmit={handleSubmit} className="space-y-4">
       {/* Title */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('bookReviews.bookTitle')} *
         </label>
         <input
@@ -76,7 +76,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
 
       {/* Author */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('bookReviews.author')}
         </label>
         <input
@@ -91,7 +91,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
 
       {/* ISBN */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           ISBN
         </label>
         <input
@@ -114,7 +114,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
 
       {/* Review */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('bookReviews.review')}
         </label>
         <textarea
@@ -128,7 +128,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
 
       {/* Image URL */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('bookReviews.coverImage')}
         </label>
         <input

--- a/frontend/src/components/chat/CreateRoomModal.tsx
+++ b/frontend/src/components/chat/CreateRoomModal.tsx
@@ -5,7 +5,7 @@ import { createChatRoom } from '../../api/chatRooms';
 import type { User } from '../../types/user';
 import type { ChatRoom } from '../../types/chat';
 import Avatar from '../common/Avatar';
-import { textareaClass } from '../../constants/styles';
+import { labelClass, textareaClass } from '../../constants/styles';
 
 interface Props {
   followingUsers: User[];
@@ -57,7 +57,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
 
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">
+            <label className={labelClass}>
               {t('chat.groupName')}
             </label>
             <input
@@ -71,7 +71,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">
+            <label className={labelClass}>
               {t('chat.groupDescription')}
             </label>
             <textarea

--- a/frontend/src/components/chat/RoomSettingsModal.tsx
+++ b/frontend/src/components/chat/RoomSettingsModal.tsx
@@ -5,7 +5,7 @@ import {
   getChatRoomMembers, updateChatRoom, deleteChatRoom,
   addChatRoomMember, removeChatRoomMember,
 } from '../../api/chatRooms';
-import { textareaClass } from '../../constants/styles';
+import { labelClass, textareaClass } from '../../constants/styles';
 import { useConfirm } from '../../hooks';
 import type { User } from '../../types/user';
 import type { ChatRoom, ChatRoomMember } from '../../types/chat';
@@ -123,7 +123,7 @@ export default function RoomSettingsModal({
         {isOwner && (
           <div className="space-y-3 mb-6">
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1">
+              <label className={labelClass}>
                 {t('chat.groupName')}
               </label>
               <input
@@ -134,7 +134,7 @@ export default function RoomSettingsModal({
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1">
+              <label className={labelClass}>
                 {t('chat.groupDescription')}
               </label>
               <textarea

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Project, CreateProjectRequest } from '../../types/project';
 import type { GitHubRepository } from '../../types/github';
-import { buttonSecondaryClass, inputClass, textareaClass } from '../../constants/styles';
+import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
 
 interface ProjectFormProps {
   project?: Project;
@@ -82,7 +82,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
       {/* Link to GitHub Repo */}
       {repos.length > 0 && (
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">
+          <label className={labelClass}>
             {t('projects.linkGitHubRepo')}
           </label>
           <select
@@ -102,7 +102,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
 
       {/* Title */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('projects.title')} *
         </label>
         <input
@@ -118,7 +118,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
 
       {/* Description */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('projects.description')}
         </label>
         <textarea
@@ -132,7 +132,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
 
       {/* Tech Stack */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('projects.techStack')}
         </label>
         <div className="flex gap-2">
@@ -178,7 +178,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
       {/* URLs */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">
+          <label className={labelClass}>
             {t('projects.demoUrl')}
           </label>
           <input
@@ -190,7 +190,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">
+          <label className={labelClass}>
             {t('projects.githubUrl')}
           </label>
           <input
@@ -205,7 +205,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
 
       {/* Image URL */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('projects.imageUrl')}
         </label>
         <input
@@ -219,7 +219,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
 
       {/* Role */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('projects.role')}
         </label>
         <input
@@ -235,7 +235,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
       {/* Dates */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">
+          <label className={labelClass}>
             {t('projects.startDate')}
           </label>
           <input
@@ -246,7 +246,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
           />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">
+          <label className={labelClass}>
             {t('projects.endDate')}
           </label>
           <input

--- a/frontend/src/components/qa/QuestionForm.tsx
+++ b/frontend/src/components/qa/QuestionForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Question, CreateQuestionRequest } from '../../types/qa';
-import { buttonSecondaryClass, textareaClass } from '../../constants/styles';
+import { buttonSecondaryClass, labelClass, textareaClass } from '../../constants/styles';
 
 interface QuestionFormProps {
   question?: Question;
@@ -38,7 +38,7 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
     <form onSubmit={handleSubmit} className="space-y-4">
       {/* Title */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('qa.questionTitle')} *
         </label>
         <input
@@ -54,7 +54,7 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
 
       {/* Body */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('qa.questionBody')} *
         </label>
         <textarea
@@ -69,7 +69,7 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
 
       {/* Tags */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('qa.tags')}
         </label>
         <input

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LearningResource, CreateResourceRequest, ResourceCategory, ResourceDifficulty } from '../../types/resource';
-import { buttonSecondaryClass, inputClass, textareaClass } from '../../constants/styles';
+import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
 
 interface ResourceFormProps {
   resource?: LearningResource;
@@ -63,7 +63,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
     <form onSubmit={handleSubmit} className="space-y-4">
       {/* Title */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('resources.title')} *
         </label>
         <input
@@ -79,7 +79,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
 
       {/* URL */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('resources.url')}
         </label>
         <input
@@ -94,7 +94,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
       {/* Category & Difficulty */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">
+          <label className={labelClass}>
             {t('resources.category')} *
           </label>
           <select
@@ -110,7 +110,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           </select>
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1">
+          <label className={labelClass}>
             {t('resources.difficultyLabel')}
           </label>
           <select
@@ -130,7 +130,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
 
       {/* Description */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('resources.description')}
         </label>
         <textarea
@@ -144,7 +144,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
 
       {/* Tags */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('resources.tags')}
         </label>
         <div className="flex gap-2">
@@ -189,7 +189,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
 
       {/* Image URL */}
       <div>
-        <label className="block text-sm font-medium text-gray-300 mb-1">
+        <label className={labelClass}>
           {t('resources.imageUrl')}
         </label>
         <input

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -21,3 +21,6 @@ export const selectClass =
 
 export const textareaClass =
   'w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow resize-none';
+
+export const labelClass =
+  'block text-sm font-medium text-gray-300 mb-1';


### PR DESCRIPTION
## 概要
constants/styles.tsに`labelClass`定数を追加し、6フォームコンポーネント29箇所のインラインラベルスタイルを共通定数に統一。

## 変更内容
| ファイル | 置換数 |
|---------|--------|
| ResourceForm.tsx | 7 |
| ProjectForm.tsx | 10 |
| BookReviewForm.tsx | 5 |
| QuestionForm.tsx | 3 |
| CreateRoomModal.tsx | 2 |
| RoomSettingsModal.tsx | 2 |

## 定数定義
```ts
export const labelClass = 'block text-sm font-medium text-gray-300 mb-1';
```

Closes #356