### PR TITLE
labelClassをページレベルに展開・mb値統一

### DIFF
--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -23,4 +23,4 @@ export const textareaClass =
   'w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow resize-none';
 
 export const labelClass =
-  'block text-sm font-medium text-gray-300 mb-1';
+  'block text-sm font-medium text-gray-300 mb-1.5';

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { requestPasswordReset } from '../api/auth';
+import { labelClass } from '../constants/styles';
 
 export default function ForgotPasswordPage() {
   const { t } = useTranslation();
@@ -69,7 +70,7 @@ export default function ForgotPasswordPage() {
               )}
 
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                <label className={labelClass}>
                   {t('auth.email')}
                 </label>
                 <input

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -6,7 +6,7 @@ import { useGoals, useConfirm } from '../hooks';
 import { Modal, PageLoader } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 import ConfirmDialog from '../components/common/ConfirmDialog';
-import { inputClass, buttonSecondaryClass } from '../constants/styles';
+import { inputClass, buttonSecondaryClass, labelClass } from '../constants/styles';
 
 const CATEGORIES: { value: GoalCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'goals.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -147,7 +147,7 @@ export default function GoalsPage() {
       >
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+            <label className={labelClass}>
               {t('goals.goalTitle')}
             </label>
             <input
@@ -160,7 +160,7 @@ export default function GoalsPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+            <label className={labelClass}>
               {t('goals.description')}
             </label>
             <textarea
@@ -172,7 +172,7 @@ export default function GoalsPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+            <label className={labelClass}>
               {t('goals.category')}
             </label>
             <select
@@ -188,7 +188,7 @@ export default function GoalsPage() {
             </select>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+            <label className={labelClass}>
               {t('goals.targetDate')}
             </label>
             <input

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -7,7 +7,7 @@ import type { LearningLog, LogCategory } from '../types/learningLog';
 import LogCalendar from '../components/learning-logs/LogCalendar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import { Modal } from '../components/common';
-import { inputClass, buttonSecondaryClass } from '../constants/styles';
+import { inputClass, buttonSecondaryClass, labelClass } from '../constants/styles';
 
 const CATEGORIES: { value: LogCategory; label: string; Icon: LucideIcon }[] = [
   { value: 'coding', label: 'learningLogs.categoryCoding', Icon: Code },
@@ -212,7 +212,7 @@ export default function LearningLogsPage() {
       >
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+            <label className={labelClass}>
               {t('learningLogs.logTitle')}
             </label>
             <input
@@ -225,7 +225,7 @@ export default function LearningLogsPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+            <label className={labelClass}>
               {t('learningLogs.content')}
             </label>
             <textarea
@@ -239,7 +239,7 @@ export default function LearningLogsPage() {
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              <label className={labelClass}>
                 {t('learningLogs.category')}
               </label>
               <select
@@ -255,7 +255,7 @@ export default function LearningLogsPage() {
               </select>
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              <label className={labelClass}>
                 {t('learningLogs.duration')}
               </label>
               <input

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../store/authStore';
 import { useToast } from '../hooks';
+import { labelClass } from '../constants/styles';
 
 export default function LoginPage() {
   const { t } = useTranslation();
@@ -71,7 +72,7 @@ export default function LoginPage() {
 
           <form onSubmit={handleSubmit} className="space-y-3">
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              <label className={labelClass}>
                 {t('auth.email')}
               </label>
               <input
@@ -83,7 +84,7 @@ export default function LoginPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              <label className={labelClass}>
                 {t('auth.password')}
               </label>
               <input

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -8,10 +8,9 @@ import { getGitHubConnectURL } from '../api/github';
 import { connectZenn } from '../api/zenn';
 import { connectQiita } from '../api/qiita';
 import { connectAtCoder } from '../api/atcoder';
-import { sectionContainerClass } from '../constants/styles';
+import { sectionContainerClass, inputClass, labelClass } from '../constants/styles';
 import toast from 'react-hot-toast';
 import { LANGUAGES, FRAMEWORKS } from '../constants/skills';
-import { inputClass } from '../constants/styles';
 
 const STEPS = [
   { id: 1, icon: User },
@@ -224,7 +223,7 @@ export default function OnboardingPage() {
               </div>
               <div className="p-6 space-y-4">
                 <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  <label className={labelClass}>
                     {t('settings.name')}
                   </label>
                   <input
@@ -236,7 +235,7 @@ export default function OnboardingPage() {
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                  <label className={labelClass}>
                     {t('settings.bio')}
                   </label>
                   <textarea

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../store/authStore';
 import toast from 'react-hot-toast';
+import { labelClass } from '../constants/styles';
 
 export default function RegisterPage() {
   const { t } = useTranslation();
@@ -75,7 +76,7 @@ export default function RegisterPage() {
 
           <form onSubmit={handleSubmit} className="space-y-3">
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              <label className={labelClass}>
                 {t('auth.name')}
               </label>
               <input
@@ -87,7 +88,7 @@ export default function RegisterPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              <label className={labelClass}>
                 {t('auth.email')}
               </label>
               <input
@@ -99,7 +100,7 @@ export default function RegisterPage() {
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-300 mb-1.5">
+              <label className={labelClass}>
                 {t('auth.password')}
               </label>
               <input

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Link, useSearchParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { resetPassword } from '../api/auth';
+import { labelClass } from '../constants/styles';
 
 export default function ResetPasswordPage() {
   const { t } = useTranslation();
@@ -100,7 +101,7 @@ export default function ResetPasswordPage() {
               )}
 
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                <label className={labelClass}>
                   {t('accountManagement.newPassword')}
                 </label>
                 <input
@@ -115,7 +116,7 @@ export default function ResetPasswordPage() {
               </div>
 
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">
+                <label className={labelClass}>
                   {t('auth.confirmPassword')}
                 </label>
                 <input

--- a/frontend/src/pages/RoadmapDetailPage.tsx
+++ b/frontend/src/pages/RoadmapDetailPage.tsx
@@ -7,7 +7,7 @@ import { useRoadmapDetail } from '../hooks';
 import { type RoadmapStep } from '../api/roadmaps';
 import { PageLoader, Modal } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
-import { inputClass, buttonSecondaryClass } from '../constants/styles';
+import { inputClass, buttonSecondaryClass, labelClass } from '../constants/styles';
 
 export default function RoadmapDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -158,7 +158,7 @@ export default function RoadmapDetailPage() {
       >
         <form onSubmit={handleStepSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.stepTitle')}</label>
+            <label className={labelClass}>{t('roadmaps.stepTitle')}</label>
             <input
               type="text"
               value={stepTitle}
@@ -169,7 +169,7 @@ export default function RoadmapDetailPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.stepDescription')}</label>
+            <label className={labelClass}>{t('roadmaps.stepDescription')}</label>
             <textarea
               value={stepDescription}
               onChange={e => setStepDescription(e.target.value)}
@@ -179,7 +179,7 @@ export default function RoadmapDetailPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.resourceURL')}</label>
+            <label className={labelClass}>{t('roadmaps.resourceURL')}</label>
             <input
               type="url"
               value={stepResourceURL}

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -6,7 +6,7 @@ import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
 import { useRoadmaps, useRoadmapTemplates } from '../hooks';
 import EmptyState from '../components/common/EmptyState';
 import { Modal, PageHeader, PageLoader } from '../components/common';
-import { inputClass, buttonSecondaryClass } from '../constants/styles';
+import { inputClass, buttonSecondaryClass, labelClass } from '../constants/styles';
 
 const CATEGORIES: { value: RoadmapCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'roadmaps.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -230,7 +230,7 @@ export default function RoadmapsPage() {
       >
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.roadmapTitle')}</label>
+            <label className={labelClass}>{t('roadmaps.roadmapTitle')}</label>
             <input
               type="text"
               value={title}
@@ -241,7 +241,7 @@ export default function RoadmapsPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.descriptionLabel')}</label>
+            <label className={labelClass}>{t('roadmaps.descriptionLabel')}</label>
             <textarea
               value={description}
               onChange={e => setDescription(e.target.value)}
@@ -251,7 +251,7 @@ export default function RoadmapsPage() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1">{t('roadmaps.category')}</label>
+            <label className={labelClass}>{t('roadmaps.category')}</label>
             <select
               value={category}
               onChange={e => setCategory(e.target.value as RoadmapCategory)}

--- a/frontend/src/pages/settings/AccountSection.tsx
+++ b/frontend/src/pages/settings/AccountSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, buttonSecondaryClass, sectionContainerClass } from '../../constants/styles';
+import { inputClass, buttonSecondaryClass, sectionContainerClass, labelClass } from '../../constants/styles';
 import { Modal } from '../../components/common';
 import type { User } from '../../types/user';
 
@@ -58,7 +58,7 @@ export default function AccountSection(props: Props) {
           </div>
 
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">{t('settings.emailLanguage')}</label>
+            <label className={labelClass}>{t('settings.emailLanguage')}</label>
             <p className="text-xs text-gray-500 mb-2">{t('settings.emailLanguageDesc')}</p>
             <select
               value={props.emailLanguage}
@@ -121,7 +121,7 @@ export default function AccountSection(props: Props) {
 
         {!props.user.github_connected && (
           <div className="mb-4">
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">
+            <label className={labelClass}>
               {t('auth.password')}
             </label>
             <input

--- a/frontend/src/pages/settings/IntegrationSection.tsx
+++ b/frontend/src/pages/settings/IntegrationSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, sectionContainerClass } from '../../constants/styles';
+import { inputClass, sectionContainerClass, labelClass } from '../../constants/styles';
 import type { User } from '../../types/user';
 
 interface Props {
@@ -133,7 +133,7 @@ export default function IntegrationSection(props: Props) {
                 <p className="text-gray-400 text-sm mb-4">{t('settings.zennDescription')}</p>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">{t('settings.zennUsername')}</label>
+                <label className={labelClass}>{t('settings.zennUsername')}</label>
                 <input
                   type="text"
                   value={props.zennUsername}
@@ -192,7 +192,7 @@ export default function IntegrationSection(props: Props) {
                 <p className="text-gray-400 text-sm mb-4">{t('settings.qiitaDescription')}</p>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">{t('settings.qiitaUsername')}</label>
+                <label className={labelClass}>{t('settings.qiitaUsername')}</label>
                 <input
                   type="text"
                   value={props.qiitaUsername}
@@ -244,7 +244,7 @@ export default function IntegrationSection(props: Props) {
                 <p className="text-gray-400 text-sm mb-4">{t('settings.atcoderDescription')}</p>
               </div>
               <div>
-                <label className="block text-sm font-medium text-gray-300 mb-1.5">{t('settings.atcoderUsername')}</label>
+                <label className={labelClass}>{t('settings.atcoderUsername')}</label>
                 <input
                   type="text"
                   value={props.atcoderUsername}
@@ -276,7 +276,7 @@ export default function IntegrationSection(props: Props) {
             <p className="text-gray-400 text-sm mb-4">{t('settings.paizaDescription')}</p>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-300 mb-1.5">{t('settings.paizaRankLabel')}</label>
+            <label className={labelClass}>{t('settings.paizaRankLabel')}</label>
             <select
               value={props.paizaRank}
               onChange={(e) => props.setPaizaRank(e.target.value)}

--- a/frontend/src/pages/settings/ProfileSection.tsx
+++ b/frontend/src/pages/settings/ProfileSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, buttonSecondaryClass, sectionContainerClass } from '../../constants/styles';
+import { inputClass, buttonSecondaryClass, sectionContainerClass, labelClass } from '../../constants/styles';
 
 interface Props {
   name: string;
@@ -22,15 +22,15 @@ export default function ProfileSection({ name, setName, bio, setBio, avatarUrl, 
       </div>
       <div className="p-6 space-y-4">
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1.5">{t('settings.name')}</label>
+          <label className={labelClass}>{t('settings.name')}</label>
           <input type="text" value={name} onChange={(e) => setName(e.target.value)} className={inputClass} />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1.5">{t('settings.bio')}</label>
+          <label className={labelClass}>{t('settings.bio')}</label>
           <textarea value={bio} onChange={(e) => setBio(e.target.value)} rows={3} placeholder="Tell us about yourself" className={`${inputClass} resize-none`} />
         </div>
         <div>
-          <label className="block text-sm font-medium text-gray-300 mb-1.5">{t('settings.avatar')}</label>
+          <label className={labelClass}>{t('settings.avatar')}</label>
           <input type="text" value={avatarUrl} onChange={(e) => setAvatarUrl(e.target.value)} placeholder="https://..." className={inputClass} />
         </div>
       </div>


### PR DESCRIPTION
## 概要
constants/styles.tsのlabelClassをmb-1.5に更新し、12ページ33箇所のインラインラベルスタイルを共通定数に統一。

## 変更内容
- labelClassのmb値をmb-1→mb-1.5に更新（ページの多数派に合わせる）
- 認証系4ページ（Login・Register・ForgotPassword・ResetPassword）にlabelClassインポート追加
- フォームページ4ページ（Goals・LearningLogs・Roadmaps・RoadmapDetail）でlabelClass適用
- Settings3セクション（Integration・Profile・Account）でlabelClass適用
- OnboardingPageのstyles.tsインポート2行を1行にマージ

## TypeScript型チェック
npx tsc --noEmit パス確認済み

closes #362