### PR TITLE
fix: 既存の失敗テスト3件を修正

### DIFF
--- a/backend/internal/handler/auth_test.go
+++ b/backend/internal/handler/auth_test.go
@@ -240,7 +240,7 @@ func TestRegister_SetsCookie(t *testing.T) {
 	mockUserRepo.On("Create", mock.AnythingOfType("*model.User")).Return(nil)
 
 	body, _ := json.Marshal(map[string]string{
-		"name":             "New User",
+		"name":             "NewUser",
 		"email":            "new@example.com",
 		"password":         "password123",
 		"confirm_password": "password123",
@@ -411,8 +411,8 @@ func TestDeleteAccount_WrongPassword(t *testing.T) {
 
 	r.ServeHTTP(w, req)
 
-	// パスワード不一致の場合、service層でErrForbiddenが返されるが、respondErrorで401に変換される
-	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	// パスワード不一致の場合、service層でErrForbiddenが返され、respondErrorで403に変換される
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }
 
 // TestRequestPasswordReset_Success は正常なパスワードリセット要求をテストする。

--- a/backend/internal/handler/learning_resource_test.go
+++ b/backend/internal/handler/learning_resource_test.go
@@ -20,7 +20,7 @@ func TestResourceCreate_Success(t *testing.T) {
 	repo.On("Create", mock.AnythingOfType("*model.LearningResource")).Return(nil)
 
 	w := doRequest(r, http.MethodPost, "/resources", map[string]string{
-		"title": "Go Tutorial", "category": "programming",
+		"title": "Go Tutorial", "category": "article", "url": "https://example.com/go-tutorial",
 	})
 	assertStatus(t, w, http.StatusCreated)
 }


### PR DESCRIPTION
## 概要
既存の失敗テスト3件を修正。テストデータがドメインバリデーションルールと不整合だった問題を解消。

## 修正内容
- **TestResourceCreate_Success**: 無効カテゴリ `programming` → `article`、必須URLフィールド追加
- **TestRegister_SetsCookie**: スペース入りユーザー名 `New User` → `NewUser`（ValidateUsernameは `^[a-zA-Z0-9_\-]+$` のみ許可）
- **TestDeleteAccount_WrongPassword**: 期待ステータス 401 → 403（ErrForbiddenはrespondErrorで403にマッピング）

Closes #366