### PR TITLE
feat: フォームコンポーネントのinputClass統一化

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewForm.tsx
+++ b/frontend/src/components/bookReviews/BookReviewForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { BookReview, CreateBookReviewRequest } from '../../types/bookReview';
-import { buttonSecondaryClass, labelClass, textareaClass } from '../../constants/styles';
+import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
 
 interface BookReviewFormProps {
   review?: BookReview;
@@ -69,7 +69,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
           onChange={(e) => setTitle(e.target.value)}
           required
           maxLength={300}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder={t('bookReviews.bookTitlePlaceholder')}
         />
       </div>
@@ -84,7 +84,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
           value={author}
           onChange={(e) => setAuthor(e.target.value)}
           maxLength={200}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder={t('bookReviews.authorPlaceholder')}
         />
       </div>
@@ -99,7 +99,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
           value={isbn}
           onChange={(e) => setIsbn(e.target.value)}
           maxLength={20}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder="978-4-..."
         />
       </div>
@@ -135,7 +135,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
           type="url"
           value={imageUrl}
           onChange={(e) => setImageUrl(e.target.value)}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder="https://..."
         />
       </div>

--- a/frontend/src/components/chat/CreateRoomModal.tsx
+++ b/frontend/src/components/chat/CreateRoomModal.tsx
@@ -5,7 +5,7 @@ import { createChatRoom } from '../../api/chatRooms';
 import type { User } from '../../types/user';
 import type { ChatRoom } from '../../types/chat';
 import Avatar from '../common/Avatar';
-import { labelClass, textareaClass } from '../../constants/styles';
+import { inputClass, labelClass, textareaClass } from '../../constants/styles';
 
 interface Props {
   followingUsers: User[];
@@ -65,7 +65,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={t('chat.groupNamePlaceholder')}
-              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className={inputClass}
               required
             />
           </div>

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -111,7 +111,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
           onChange={(e) => setTitle(e.target.value)}
           required
           maxLength={200}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder={t('projects.titlePlaceholder')}
         />
       </div>
@@ -141,7 +141,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
             value={techStackInput}
             onChange={(e) => setTechStackInput(e.target.value)}
             onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTech())}
-            className="flex-1 px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={`${inputClass} flex-1`}
             placeholder={t('projects.techStackPlaceholder')}
           />
           <button
@@ -185,7 +185,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
             type="url"
             value={demoUrl}
             onChange={(e) => setDemoUrl(e.target.value)}
-            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={inputClass}
             placeholder="https://..."
           />
         </div>
@@ -197,7 +197,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
             type="url"
             value={githubUrl}
             onChange={(e) => setGithubUrl(e.target.value)}
-            className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={inputClass}
             placeholder="https://github.com/..."
           />
         </div>
@@ -212,7 +212,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
           type="url"
           value={imageUrl}
           onChange={(e) => setImageUrl(e.target.value)}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder="https://..."
         />
       </div>
@@ -227,7 +227,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
           value={role}
           onChange={(e) => setRole(e.target.value)}
           maxLength={100}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder={t('projects.rolePlaceholder')}
         />
       </div>

--- a/frontend/src/components/qa/QuestionForm.tsx
+++ b/frontend/src/components/qa/QuestionForm.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Question, CreateQuestionRequest } from '../../types/qa';
-import { buttonSecondaryClass, labelClass, textareaClass } from '../../constants/styles';
+import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
 
 interface QuestionFormProps {
   question?: Question;
@@ -47,7 +47,7 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
           onChange={(e) => setTitle(e.target.value)}
           required
           maxLength={500}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder={t('qa.questionTitlePlaceholder')}
         />
       </div>
@@ -76,7 +76,7 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
           type="text"
           value={tagsInput}
           onChange={(e) => setTagsInput(e.target.value)}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder={t('qa.tagsPlaceholder')}
         />
         <p className="text-xs text-gray-500 mt-1">{t('qa.tagsHint')}</p>

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -72,7 +72,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           onChange={(e) => setTitle(e.target.value)}
           required
           maxLength={300}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder={t('resources.titlePlaceholder')}
         />
       </div>
@@ -86,7 +86,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           type="url"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder="https://..."
         />
       </div>
@@ -153,7 +153,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
             value={tagInput}
             onChange={(e) => setTagInput(e.target.value)}
             onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
-            className="flex-1 px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+            className={`${inputClass} flex-1`}
             placeholder={t('resources.tagsPlaceholder')}
           />
           <button
@@ -196,7 +196,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           type="url"
           value={imageUrl}
           onChange={(e) => setImageUrl(e.target.value)}
-          className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-gray-500 focus:border-transparent"
+          className={inputClass}
           placeholder="https://..."
         />
       </div>


### PR DESCRIPTION
## 概要
5つのフォームコンポーネントに残っていたインライン入力スタイル（17箇所）を`inputClass`に統一。

## 変更内容
- **QuestionForm**: 2箇所のインラインスタイル → `inputClass`
- **BookReviewForm**: 4箇所のインラインスタイル → `inputClass`
- **CreateRoomModal**: 1箇所のインラインスタイル（blue focus ring含む） → `inputClass`
- **ProjectForm**: 5箇所 → `inputClass`、1箇所 → `${inputClass} flex-1`
- **ResourceForm**: 3箇所 → `inputClass`、1箇所 → `${inputClass} flex-1`

`bg-gray-700 border-gray-600`スタイルが`bg-gray-800/50 border-gray-700`（inputClass）に統一され、フォーム入力フィールドの一貫性が向上。

Closes #368