### PR TITLE
refactor: Handler層レスポンスヘルパー統一第7弾（upload・websocket）

### DIFF
--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -100,6 +100,18 @@ func respondNotFound(c *gin.Context, message string) {
 	c.JSON(http.StatusNotFound, response)
 }
 
+// respondUnauthorized は401 Unauthorizedでエラーメッセージを返す。
+func respondUnauthorized(c *gin.Context, message string) {
+	response := domain.NewErrorResponse(message, string(domain.ErrCodeUnauthorized), nil)
+	c.JSON(http.StatusUnauthorized, response)
+}
+
+// respondInternalError は500 Internal Server Errorでエラーメッセージを返す。
+func respondInternalError(c *gin.Context, message string) {
+	response := domain.NewErrorResponse(message, string(domain.ErrCodeInternal), nil)
+	c.JSON(http.StatusInternalServerError, response)
+}
+
 // respondPaginated はページネーション付きレスポンスを返す。
 func respondPaginated(c *gin.Context, data interface{}, total int64, page, limit int) {
 	response := domain.NewPaginatedResponse(data, total, page, limit)

--- a/backend/internal/handler/upload.go
+++ b/backend/internal/handler/upload.go
@@ -63,13 +63,13 @@ func NewUploadHandler() *UploadHandler {
 func (h *UploadHandler) UploadImage(c *gin.Context) {
 	file, err := c.FormFile("image")
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "No image file provided"})
+		respondBadRequest(c, "No image file provided")
 		return
 	}
 
 	// ファイルサイズのバリデーション（最大5MB）
 	if file.Size > 5*1024*1024 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "File size exceeds 5MB limit"})
+		respondBadRequest(c, "File size exceeds 5MB limit")
 		return
 	}
 
@@ -83,25 +83,25 @@ func (h *UploadHandler) UploadImage(c *gin.Context) {
 		".webp": true,
 	}
 	if !allowedExts[ext] {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid file type. Allowed: jpg, jpeg, png, gif, webp"})
+		respondBadRequest(c, "Invalid file type. Allowed: jpg, jpeg, png, gif, webp")
 		return
 	}
 
 	// マジックバイトによるMIMEタイプ検証（拡張子偽装防止）
 	src, err := file.Open()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read file"})
+		respondInternalError(c, "Failed to read file")
 		return
 	}
 	defer src.Close()
 
 	mimeType, err := detectMIMEType(src)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to detect file type"})
+		respondInternalError(c, "Failed to detect file type")
 		return
 	}
 	if !allowedMIMETypes[mimeType] {
-		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid file content type: %s. Only image files are allowed", mimeType)})
+		respondBadRequest(c, fmt.Sprintf("Invalid file content type: %s. Only image files are allowed", mimeType))
 		return
 	}
 
@@ -112,20 +112,20 @@ func (h *UploadHandler) UploadImage(c *gin.Context) {
 	dateDir := time.Now().Format("2006/01")
 	fullDir := filepath.Join(h.uploadDir, dateDir)
 	if err := os.MkdirAll(fullDir, 0755); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create directory"})
+		respondInternalError(c, "Failed to create directory")
 		return
 	}
 
 	// ファイルを保存する
 	filePath := filepath.Join(fullDir, filename)
 	if err := c.SaveUploadedFile(file, filePath); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save file"})
+		respondInternalError(c, "Failed to save file")
 		return
 	}
 
 	// URLパスを返す
 	urlPath := fmt.Sprintf("/uploads/%s/%s", dateDir, filename)
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"url":      urlPath,
 		"filename": filename,
 	})
@@ -136,18 +136,18 @@ func (h *UploadHandler) UploadImage(c *gin.Context) {
 func (h *UploadHandler) UploadMultipleImages(c *gin.Context) {
 	form, err := c.MultipartForm()
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Failed to parse form"})
+		respondBadRequest(c, "Failed to parse form")
 		return
 	}
 
 	files := form.File["images"]
 	if len(files) == 0 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "No image files provided"})
+		respondBadRequest(c, "No image files provided")
 		return
 	}
 
 	if len(files) > 10 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Maximum 10 images allowed"})
+		respondBadRequest(c, "Maximum 10 images allowed")
 		return
 	}
 
@@ -163,38 +163,38 @@ func (h *UploadHandler) UploadMultipleImages(c *gin.Context) {
 	dateDir := time.Now().Format("2006/01")
 	fullDir := filepath.Join(h.uploadDir, dateDir)
 	if err := os.MkdirAll(fullDir, 0755); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to create directory"})
+		respondInternalError(c, "Failed to create directory")
 		return
 	}
 
 	for _, file := range files {
 		// ファイルサイズのバリデーション
 		if file.Size > 5*1024*1024 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("File %s exceeds 5MB limit", file.Filename)})
+			respondBadRequest(c, fmt.Sprintf("File %s exceeds 5MB limit", file.Filename))
 			return
 		}
 
 		// ファイル拡張子のバリデーション
 		ext := strings.ToLower(filepath.Ext(file.Filename))
 		if !allowedExts[ext] {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid file type for %s", file.Filename)})
+			respondBadRequest(c, fmt.Sprintf("Invalid file type for %s", file.Filename))
 			return
 		}
 
 		// マジックバイトによるMIMEタイプ検証（拡張子偽装防止）
 		src, err := file.Open()
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read file"})
+			respondInternalError(c, "Failed to read file")
 			return
 		}
 		mimeType, err := detectMIMEType(src)
 		src.Close()
 		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to detect file type"})
+			respondInternalError(c, "Failed to detect file type")
 			return
 		}
 		if !allowedMIMETypes[mimeType] {
-			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("Invalid content type for %s: %s", file.Filename, mimeType)})
+			respondBadRequest(c, fmt.Sprintf("Invalid content type for %s: %s", file.Filename, mimeType))
 			return
 		}
 
@@ -203,12 +203,12 @@ func (h *UploadHandler) UploadMultipleImages(c *gin.Context) {
 		filePath := filepath.Join(fullDir, filename)
 
 		if err := c.SaveUploadedFile(file, filePath); err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save file"})
+			respondInternalError(c, "Failed to save file")
 			return
 		}
 
 		urls = append(urls, fmt.Sprintf("/uploads/%s/%s", dateDir, filename))
 	}
 
-	c.JSON(http.StatusOK, gin.H{"urls": urls})
+	respondOK(c, gin.H{"urls": urls})
 }

--- a/backend/internal/handler/websocket.go
+++ b/backend/internal/handler/websocket.go
@@ -63,14 +63,14 @@ func (h *WebSocketHandler) HandleWebSocket(c *gin.Context) {
 	// httpOnly Cookieからトークンを取得（URLクエリパラメータには含めない）
 	token, err := c.Cookie("token")
 	if err != nil || token == "" {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		respondUnauthorized(c, "authentication required")
 		return
 	}
 
 	// トークンを検証してユーザーIDを取得
 	userID, err := h.authService.ValidateToken(token)
 	if err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid token"})
+		respondUnauthorized(c, "invalid token")
 		return
 	}
 


### PR DESCRIPTION
## 概要
Handler層で残っていたc.JSON直接使用をレスポンスヘルパーに統一。upload.go（20箇所）とwebsocket.go（2箇所）を変換。

## 変更内容
- **helpers.go**: `respondUnauthorized`・`respondInternalError` ヘルパーを追加
- **upload.go**: 20箇所のc.JSON → `respondBadRequest`（10箇所）・`respondInternalError`（8箇所）・`respondOK`（2箇所）
- **websocket.go**: 2箇所のc.JSON → `respondUnauthorized`

upload.goは`http.DetectContentType`のため`net/http`インポートを維持。

Closes #370