### PR TITLE
テスト: レスポンスヘルパー関数の網羅テスト追加

### DIFF
--- a/backend/internal/handler/helpers_test.go
+++ b/backend/internal/handler/helpers_test.go
@@ -352,3 +352,127 @@ func TestRespondDeleted(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.Equal(t, "deleted", resp["message"])
 }
+
+// --- respondBadRequest / respondForbidden / respondNotFound / respondUnauthorized / respondInternalError ---
+
+func TestRespondBadRequest(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.GET("/test", func(c *gin.Context) {
+		respondBadRequest(c, "invalid input")
+	})
+	req := httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "invalid input", resp["error"])
+	assert.Equal(t, string(domain.ErrCodeValidation), resp["code"])
+}
+
+func TestRespondForbidden(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.GET("/test", func(c *gin.Context) {
+		respondForbidden(c, "access denied")
+	})
+	req := httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "access denied", resp["error"])
+	assert.Equal(t, string(domain.ErrCodeForbidden), resp["code"])
+}
+
+func TestRespondNotFound(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.GET("/test", func(c *gin.Context) {
+		respondNotFound(c, "resource not found")
+	})
+	req := httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "resource not found", resp["error"])
+	assert.Equal(t, string(domain.ErrCodeNotFound), resp["code"])
+}
+
+func TestRespondUnauthorized(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.GET("/test", func(c *gin.Context) {
+		respondUnauthorized(c, "authentication required")
+	})
+	req := httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "authentication required", resp["error"])
+	assert.Equal(t, string(domain.ErrCodeUnauthorized), resp["code"])
+}
+
+func TestRespondInternalError(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.GET("/test", func(c *gin.Context) {
+		respondInternalError(c, "internal server error")
+	})
+	req := httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "internal server error", resp["error"])
+	assert.Equal(t, string(domain.ErrCodeInternal), resp["code"])
+}
+
+// --- respondPaginated ---
+
+func TestRespondPaginated(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.GET("/test", func(c *gin.Context) {
+		items := []string{"a", "b", "c"}
+		respondPaginated(c, items, 25, 2, 10)
+	})
+	req := httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(25), resp["total"])
+	assert.Equal(t, float64(2), resp["page"])
+	assert.Equal(t, float64(10), resp["limit"])
+	assert.Equal(t, float64(3), resp["total_pages"])
+	data := resp["data"].([]interface{})
+	assert.Len(t, data, 3)
+}
+
+func TestRespondPaginated_Empty(t *testing.T) {
+	w := httptest.NewRecorder()
+	_, r := gin.CreateTestContext(w)
+	r.GET("/test", func(c *gin.Context) {
+		respondPaginated(c, []string{}, 0, 1, 20)
+	})
+	req := httptest.NewRequest("GET", "/test", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(0), resp["total"])
+	// total_pagesはomitemptyのため0の場合はJSONに含まれない
+	assert.Nil(t, resp["total_pages"])
+	data := resp["data"].([]interface{})
+	assert.Len(t, data, 0)
+}


### PR DESCRIPTION
## 概要
helpers.goのレスポンスヘルパー関数のうち、テストが未作成だった6関数のユニットテストを追加。

## 追加テスト（8テスト関数）
- `TestRespondBadRequest` — 400 + ErrCodeValidation
- `TestRespondForbidden` — 403 + ErrCodeForbidden
- `TestRespondNotFound` — 404 + ErrCodeNotFound
- `TestRespondUnauthorized` — 401 + ErrCodeUnauthorized
- `TestRespondInternalError` — 500 + ErrCodeInternal
- `TestRespondPaginated` — ページネーション構造体の全フィールド検証
- `TestRespondPaginated_Empty` — 空データ時のomitempty挙動検証

## 結果
helpers.goの全レスポンスヘルパー（11関数）のテストカバレッジが完全になった。

Closes #372