### PR TITLE
UX: select要素にselectClassを統一適用

### DIFF
--- a/frontend/src/components/common/PomodoroTimer.tsx
+++ b/frontend/src/components/common/PomodoroTimer.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Timer, Play, Pause, SkipForward, RotateCcw, Volume2, VolumeX, ChevronDown, ChevronUp } from 'lucide-react';
+import { selectClass } from '../../constants/styles';
 import { usePomodoroTimer } from '../../hooks/usePomodoroTimer';
 import type { PomodoroPhase } from '../../hooks/usePomodoroTimer';
 import { createLog } from '../../api/learningLogs';
@@ -227,7 +228,7 @@ export default function PomodoroTimer() {
               <select
                 value={category}
                 onChange={(e) => setCategory(e.target.value as LogCategory)}
-                className="w-full bg-gray-700 border border-gray-600 rounded-lg px-3 py-1.5 text-sm text-white focus:outline-none focus:ring-1 focus:ring-blue-500"
+                className={`${selectClass} w-full`}
               >
                 {CATEGORIES.map((cat) => (
                   <option key={cat.value} value={cat.value}>

--- a/frontend/src/pages/settings/AccountSection.tsx
+++ b/frontend/src/pages/settings/AccountSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, buttonSecondaryClass, sectionContainerClass, labelClass } from '../../constants/styles';
+import { inputClass, buttonSecondaryClass, sectionContainerClass, labelClass, selectClass } from '../../constants/styles';
 import { Modal } from '../../components/common';
 import type { User } from '../../types/user';
 
@@ -63,7 +63,7 @@ export default function AccountSection(props: Props) {
             <select
               value={props.emailLanguage}
               onChange={(e) => props.setEmailLanguage(e.target.value)}
-              className={inputClass}
+              className={`${selectClass} w-full`}
             >
               <option value="ja">日本語</option>
               <option value="en">English</option>

--- a/frontend/src/pages/settings/IntegrationSection.tsx
+++ b/frontend/src/pages/settings/IntegrationSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, sectionContainerClass, labelClass } from '../../constants/styles';
+import { inputClass, sectionContainerClass, labelClass, selectClass } from '../../constants/styles';
 import type { User } from '../../types/user';
 
 interface Props {
@@ -280,7 +280,7 @@ export default function IntegrationSection(props: Props) {
             <select
               value={props.paizaRank}
               onChange={(e) => props.setPaizaRank(e.target.value)}
-              className={inputClass}
+              className={`${selectClass} w-full`}
             >
               <option value="">{t('settings.paizaSelectRank')}</option>
               <option value="S">S {t('settings.paizaRankS')}</option>


### PR DESCRIPTION
## 概要
select要素に`inputClass`やインラインスタイルが使われていた3ファイルを`selectClass`に統一。

## 変更内容
- **AccountSection.tsx** — メール言語選択: `inputClass` → `selectClass w-full`
- **IntegrationSection.tsx** — paizaランク選択: `inputClass` → `selectClass w-full`
- **PomodoroTimer.tsx** — カテゴリ選択: インラインスタイル → `selectClass w-full`

## 理由
select要素はinputとは異なるため、専用の`selectClass`を使用するのが適切。

Closes #374