### PR TITLE
リファクタリング: chat_room/code_snippetのインラインstructをDTOに抽出

### DIFF
--- a/backend/internal/dto/chat_room_dto.go
+++ b/backend/internal/dto/chat_room_dto.go
@@ -1,0 +1,24 @@
+package dto
+
+// CreateChatRoomRequest はチャットルーム作成リクエスト。
+type CreateChatRoomRequest struct {
+	Name        string `json:"name" binding:"required"`
+	Description string `json:"description"`
+	MemberIDs   []uint `json:"member_ids"`
+}
+
+// UpdateChatRoomRequest はチャットルーム更新リクエスト。
+type UpdateChatRoomRequest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// AddChatRoomMemberRequest はメンバー追加リクエスト。
+type AddChatRoomMemberRequest struct {
+	UserID uint `json:"user_id" binding:"required"`
+}
+
+// SendChatRoomMessageRequest はチャットルームメッセージ送信リクエスト。
+type SendChatRoomMessageRequest struct {
+	Content string `json:"content" binding:"required"`
+}

--- a/backend/internal/dto/code_snippet_dto.go
+++ b/backend/internal/dto/code_snippet_dto.go
@@ -1,0 +1,21 @@
+package dto
+
+// CreateCodeSnippetRequest はコードスニペット作成リクエスト。
+type CreateCodeSnippetRequest struct {
+	Language string `json:"language" binding:"required"`
+	FileName string `json:"file_name"`
+	Code     string `json:"code" binding:"required"`
+}
+
+// UpdateCodeSnippetRequest はコードスニペット更新リクエスト。
+type UpdateCodeSnippetRequest struct {
+	Language string `json:"language"`
+	FileName string `json:"file_name"`
+	Code     string `json:"code"`
+}
+
+// CreateSnippetCommentRequest はスニペットコメント作成リクエスト。
+type CreateSnippetCommentRequest struct {
+	LineNumber int    `json:"line_number" binding:"required"`
+	Content    string `json:"content" binding:"required"`
+}

--- a/backend/internal/handler/chat_room.go
+++ b/backend/internal/handler/chat_room.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -36,13 +37,8 @@ func NewChatRoomHandler(s ChatRoomServiceInterface) *ChatRoomHandler {
 func (h *ChatRoomHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var input struct {
-		Name        string `json:"name" binding:"required"`
-		Description string `json:"description"`
-		MemberIDs   []uint `json:"member_ids"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.CreateChatRoomRequest](c)
+	if input == nil {
 		return
 	}
 
@@ -96,12 +92,8 @@ func (h *ChatRoomHandler) Update(c *gin.Context) {
 		return
 	}
 
-	var input struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.UpdateChatRoomRequest](c)
+	if input == nil {
 		return
 	}
 
@@ -152,11 +144,8 @@ func (h *ChatRoomHandler) AddMember(c *gin.Context) {
 		return
 	}
 
-	var input struct {
-		UserID uint `json:"user_id" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.AddChatRoomMemberRequest](c)
+	if input == nil {
 		return
 	}
 
@@ -213,11 +202,8 @@ func (h *ChatRoomHandler) SendMessage(c *gin.Context) {
 		return
 	}
 
-	var input struct {
-		Content string `json:"content" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.SendChatRoomMessageRequest](c)
+	if input == nil {
 		return
 	}
 

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -34,13 +35,8 @@ func (h *CodeSnippetHandler) Create(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	var input struct {
-		Language string `json:"language" binding:"required"`
-		FileName string `json:"file_name"`
-		Code     string `json:"code" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.CreateCodeSnippetRequest](c)
+	if input == nil {
 		return
 	}
 
@@ -97,13 +93,8 @@ func (h *CodeSnippetHandler) Update(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	var input struct {
-		Language string `json:"language"`
-		FileName string `json:"file_name"`
-		Code     string `json:"code"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.UpdateCodeSnippetRequest](c)
+	if input == nil {
 		return
 	}
 
@@ -153,12 +144,8 @@ func (h *CodeSnippetHandler) CreateComment(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	var input struct {
-		LineNumber int    `json:"line_number" binding:"required"`
-		Content    string `json:"content" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.CreateSnippetCommentRequest](c)
+	if input == nil {
 		return
 	}
 


### PR DESCRIPTION
## 概要
chat_room.goとcode_snippet.goの7つのインラインstructを専用DTOファイルに抽出。

## 変更内容
- **dto/chat_room_dto.go** — 4つのリクエストDTO新規作成
- **dto/code_snippet_dto.go** — 3つのリクエストDTO新規作成
- **handler/chat_room.go** — インラインstruct → `bindJSON[dto.T]` に変換（4箇所）
- **handler/code_snippet.go** — インラインstruct → `bindJSON[dto.T]` に変換（3箇所）

## 効果
- リクエスト型の再利用性向上・DTOパッケージへの型集約
- handlerのコード量削減（bindJSONジェネリックヘルパー活用）

Closes #376