### PR TITLE
UX: ProfileSection textareaClass + SearchInput buttonSecondaryClass統一

### DIFF
--- a/frontend/src/components/common/SearchInput.tsx
+++ b/frontend/src/components/common/SearchInput.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Search } from 'lucide-react';
+import { buttonSecondaryClass } from '../../constants/styles';
 
 interface SearchInputProps {
   value: string;
@@ -35,7 +36,7 @@ export default function SearchInput({ value, onChange, onSearch, placeholder, sh
         <button
           type="button"
           onClick={onSearch}
-          className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+          className={buttonSecondaryClass}
         >
           {t('common.search')}
         </button>

--- a/frontend/src/pages/settings/ProfileSection.tsx
+++ b/frontend/src/pages/settings/ProfileSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, buttonSecondaryClass, sectionContainerClass, labelClass } from '../../constants/styles';
+import { inputClass, buttonSecondaryClass, sectionContainerClass, labelClass, textareaClass } from '../../constants/styles';
 
 interface Props {
   name: string;
@@ -27,7 +27,7 @@ export default function ProfileSection({ name, setName, bio, setBio, avatarUrl, 
         </div>
         <div>
           <label className={labelClass}>{t('settings.bio')}</label>
-          <textarea value={bio} onChange={(e) => setBio(e.target.value)} rows={3} placeholder="Tell us about yourself" className={`${inputClass} resize-none`} />
+          <textarea value={bio} onChange={(e) => setBio(e.target.value)} rows={3} placeholder="Tell us about yourself" className={textareaClass} />
         </div>
         <div>
           <label className={labelClass}>{t('settings.avatar')}</label>


### PR DESCRIPTION
## 概要
スタイル定数の適用漏れ2箇所を修正。

## 変更内容
- **ProfileSection.tsx** — textarea: `${inputClass} resize-none` → `textareaClass`（textareaClassにresize-none含む）
- **SearchInput.tsx** — 検索ボタン: インラインスタイル → `buttonSecondaryClass`（完全一致）

Closes #380