### PR TITLE
リファクタリング: 残り全handlerのインラインstructをDTOに抽出

### DIFF
--- a/backend/internal/dto/ai_advice_dto.go
+++ b/backend/internal/dto/ai_advice_dto.go
@@ -1,0 +1,7 @@
+package dto
+
+// AIChatRequest はLLMチャットリクエスト。
+type AIChatRequest struct {
+	Message        string `json:"message" binding:"required" validate:"required"`
+	ConversationID uint   `json:"conversation_id"`
+}

--- a/backend/internal/dto/common_dto.go
+++ b/backend/internal/dto/common_dto.go
@@ -1,0 +1,7 @@
+package dto
+
+// ConnectUsernameRequest は外部サービスのユーザー名接続リクエスト。
+// AtCoder・Zenn・Qiitaなど共通で使用する。
+type ConnectUsernameRequest struct {
+	Username string `json:"username" binding:"required" validate:"required"`
+}

--- a/backend/internal/dto/message_dto.go
+++ b/backend/internal/dto/message_dto.go
@@ -1,0 +1,6 @@
+package dto
+
+// SendMessageRequest はDMメッセージ送信リクエスト。
+type SendMessageRequest struct {
+	Content string `json:"content" binding:"required" validate:"required"`
+}

--- a/backend/internal/dto/user_dto.go
+++ b/backend/internal/dto/user_dto.go
@@ -1,0 +1,13 @@
+package dto
+
+// UpdateUserRequest はユーザープロフィール更新リクエスト。
+type UpdateUserRequest struct {
+	Name                string  `json:"name"`
+	Bio                 string  `json:"bio"`
+	AvatarURL           string  `json:"avatar_url"`
+	SkillsLanguages     *string `json:"skills_languages"`
+	SkillsFrameworks    *string `json:"skills_frameworks"`
+	AtCoderUsername     *string `json:"atcoder_username"`
+	PaizaRank           *string `json:"paiza_rank"`
+	OnboardingCompleted *bool   `json:"onboarding_completed"`
+}

--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -78,12 +79,8 @@ func (h *AIAdviceHandler) MarkAsRead(c *gin.Context) {
 func (h *AIAdviceHandler) Chat(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var input struct {
-		Message        string `json:"message" binding:"required"`
-		ConversationID uint   `json:"conversation_id"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.AIChatRequest](c)
+	if input == nil {
 		return
 	}
 

--- a/backend/internal/handler/atcoder.go
+++ b/backend/internal/handler/atcoder.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
@@ -53,11 +54,8 @@ func (h *AtCoderHandler) GetRating(c *gin.Context) {
 func (h *AtCoderHandler) Connect(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var input struct {
-		Username string `json:"username" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, "username is required")
+	input := bindJSON[dto.ConnectUsernameRequest](c)
+	if input == nil {
 		return
 	}
 

--- a/backend/internal/handler/message.go
+++ b/backend/internal/handler/message.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -64,11 +65,8 @@ func (h *MessageHandler) SendMessage(c *gin.Context) {
 		return
 	}
 
-	var input struct {
-		Content string `json:"content" binding:"required"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.SendMessageRequest](c)
+	if input == nil {
 		return
 	}
 

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -86,18 +87,8 @@ func (h *UserHandler) Update(c *gin.Context) {
 		return
 	}
 
-	var input struct {
-		Name                string  `json:"name"`
-		Bio                 string  `json:"bio"`
-		AvatarURL           string  `json:"avatar_url"`
-		SkillsLanguages     *string `json:"skills_languages"`
-		SkillsFrameworks    *string `json:"skills_frameworks"`
-		AtCoderUsername     *string `json:"atcoder_username"`
-		PaizaRank           *string `json:"paiza_rank"`
-		OnboardingCompleted *bool   `json:"onboarding_completed"`
-	}
-	if err := c.ShouldBindJSON(&input); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.UpdateUserRequest](c)
+	if input == nil {
 		return
 	}
 


### PR DESCRIPTION
## 概要
handler層の残りインラインstruct4つをDTO化し、全handlerのインラインstructをゼロに。

## 新規DTOファイル
- **dto/message_dto.go** — `SendMessageRequest`
- **dto/ai_advice_dto.go** — `AIChatRequest`
- **dto/common_dto.go** — `ConnectUsernameRequest`（AtCoder/Zenn/Qiita共通）
- **dto/user_dto.go** — `UpdateUserRequest`

## 更新ハンドラー
- **message.go** — `bindJSON[dto.SendMessageRequest]`
- **ai_advice.go** — `bindJSON[dto.AIChatRequest]`
- **atcoder.go** — `bindJSON[dto.ConnectUsernameRequest]`
- **user.go** — `bindJSON[dto.UpdateUserRequest]`

## 結果
handler層のインラインstruct: 11個 → 0個（全てDTO化完了）

Closes #382