### PR TITLE
テスト: message/ai_advice/common DTOバリデーションテスト追加

### DIFF
--- a/backend/internal/dto/ai_advice_dto_test.go
+++ b/backend/internal/dto/ai_advice_dto_test.go
@@ -1,0 +1,50 @@
+package dto_test
+
+import (
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/dto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAIChatRequest_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		request dto.AIChatRequest
+		wantErr bool
+	}{
+		{
+			name: "有効なリクエスト（新規会話）",
+			request: dto.AIChatRequest{
+				Message: "Go言語について教えてください",
+			},
+			wantErr: false,
+		},
+		{
+			name: "有効なリクエスト（既存会話）",
+			request: dto.AIChatRequest{
+				Message:        "続きを教えてください",
+				ConversationID: 42,
+			},
+			wantErr: false,
+		},
+		{
+			name: "メッセージが空",
+			request: dto.AIChatRequest{
+				Message: "",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validate.Struct(tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/backend/internal/dto/common_dto_test.go
+++ b/backend/internal/dto/common_dto_test.go
@@ -1,0 +1,38 @@
+package dto_test
+
+import (
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/dto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConnectUsernameRequest_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		request dto.ConnectUsernameRequest
+		wantErr bool
+	}{
+		{
+			name:    "有効なリクエスト",
+			request: dto.ConnectUsernameRequest{Username: "testuser"},
+			wantErr: false,
+		},
+		{
+			name:    "ユーザー名が空",
+			request: dto.ConnectUsernameRequest{Username: ""},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validate.Struct(tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/backend/internal/dto/message_dto_test.go
+++ b/backend/internal/dto/message_dto_test.go
@@ -1,0 +1,38 @@
+package dto_test
+
+import (
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/dto"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSendMessageRequest_Validation(t *testing.T) {
+	tests := []struct {
+		name    string
+		request dto.SendMessageRequest
+		wantErr bool
+	}{
+		{
+			name:    "有効なリクエスト",
+			request: dto.SendMessageRequest{Content: "こんにちは"},
+			wantErr: false,
+		},
+		{
+			name:    "コンテンツが空",
+			request: dto.SendMessageRequest{Content: ""},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validate.Struct(tt.request)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要
サイクル21-2で追加した3つのDTOのバリデーションテストを追加。

## 追加テスト
- **message_dto_test.go** — `TestSendMessageRequest_Validation`（2ケース）
- **ai_advice_dto_test.go** — `TestAIChatRequest_Validation`（3ケース）
- **common_dto_test.go** — `TestConnectUsernameRequest_Validation`（2ケース）

## 結果
全DTOテスト（auth 5 + chat_room 3 + code_snippet 3 + message 1 + ai_advice 1 + common 1 = 14テスト関数）パス。

Closes #384