### PR TITLE
feat: buttonPrimaryClass・buttonDangerClassを追加しボタンスタイルを統一

### DIFF
--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -1,6 +1,12 @@
 export const inputClass =
   'w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow';
 
+export const buttonPrimaryClass =
+  'px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg font-medium transition-colors';
+
+export const buttonDangerClass =
+  'px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg font-medium transition-colors';
+
 export const buttonSecondaryClass =
   'px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors';
 

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -13,6 +13,7 @@ import PostForm from '../components/posts/PostForm';
 import { Modal } from '../components/common';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 import QuickPostForm from '../components/posts/QuickPostForm';
+import { buttonPrimaryClass } from '../constants/styles';
 import { PostCardSkeleton } from '../components/common/Skeleton';
 import Avatar from '../components/common/Avatar';
 import { formatDistanceToNow } from '../utils/timeFormat';
@@ -136,7 +137,7 @@ export default function DashboardPage() {
             {tab === 'timeline' && (
               <Link
                 to="/search"
-                className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg text-sm font-medium transition-colors"
+                className={`${buttonPrimaryClass} inline-flex items-center gap-2 text-sm`}
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z" />

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -4,6 +4,7 @@ import { BookOpen, Star, Plus, Edit, Trash2 } from 'lucide-react';
 import { useNotes } from '../hooks';
 import { PageLoader, SearchInput } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
+import { buttonPrimaryClass } from '../constants/styles';
 import type { Note } from '../api/notes';
 
 export default function NotesPage() {
@@ -74,7 +75,7 @@ export default function NotesPage() {
         </div>
         <button
           onClick={() => setShowForm(!showForm)}
-          className="flex items-center gap-2 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
+          className={`${buttonPrimaryClass} flex items-center gap-2`}
         >
           <Plus className="w-5 h-5" />
           {t('notes.createNote')}

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -8,7 +8,7 @@ import { getGitHubConnectURL } from '../api/github';
 import { connectZenn } from '../api/zenn';
 import { connectQiita } from '../api/qiita';
 import { connectAtCoder } from '../api/atcoder';
-import { sectionContainerClass, inputClass, labelClass } from '../constants/styles';
+import { sectionContainerClass, inputClass, labelClass, buttonPrimaryClass } from '../constants/styles';
 import toast from 'react-hot-toast';
 import { LANGUAGES, FRAMEWORKS } from '../constants/skills';
 
@@ -423,7 +423,7 @@ export default function OnboardingPage() {
                       <button
                         onClick={handleConnectZenn}
                         disabled={connectingZenn || !zennUsername.trim()}
-                        className="px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg font-medium text-sm transition-colors whitespace-nowrap"
+                        className={`${buttonPrimaryClass} text-sm disabled:opacity-50 whitespace-nowrap`}
                       >
                         {connectingZenn ? t('common.loading') : t('settings.connect')}
                       </button>

--- a/frontend/src/pages/settings/AccountSection.tsx
+++ b/frontend/src/pages/settings/AccountSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, buttonSecondaryClass, sectionContainerClass, labelClass, selectClass } from '../../constants/styles';
+import { inputClass, buttonSecondaryClass, buttonDangerClass, sectionContainerClass, labelClass, selectClass } from '../../constants/styles';
 import { Modal } from '../../components/common';
 import type { User } from '../../types/user';
 
@@ -101,7 +101,7 @@ export default function AccountSection(props: Props) {
           </p>
           <button
             onClick={() => props.setShowDeleteModal(true)}
-            className="px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg text-sm font-medium transition-colors"
+            className={`${buttonDangerClass} text-sm`}
           >
             {t('accountManagement.deleteAccount')}
           </button>
@@ -147,7 +147,7 @@ export default function AccountSection(props: Props) {
           <button
             onClick={props.onDeleteAccount}
             disabled={props.deleting}
-            className="px-4 py-2 bg-red-600 hover:bg-red-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+            className={`${buttonDangerClass} text-sm disabled:opacity-50`}
           >
             {props.deleting ? t('common.loading') : t('accountManagement.deleteAccount')}
           </button>


### PR DESCRIPTION
## 概要
- `constants/styles.ts`に`buttonPrimaryClass`（青ボタン）・`buttonDangerClass`（赤ボタン）を追加
- DashboardPage、NotesPage、OnboardingPageの青ボタンを`buttonPrimaryClass`に統一
- AccountSectionの赤ボタンを`buttonDangerClass`に統一
- NotesPageのボタンスタイル正規化（rounded-md→rounded-lg、hover色統一）

closes #386