### PR TITLE
refactor: 外部APIサービスのfmt.Errorfをdomain.DomainErrorに統一

### DIFF
--- a/backend/internal/service/atcoder.go
+++ b/backend/internal/service/atcoder.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
 )
 
 // AtCoderRatingEntry はAtCoderのレーティング履歴エントリを表す。
@@ -44,20 +46,20 @@ func (s *AtCoderService) GetRating(username string) (*AtCoderRatingInfo, error) 
 	url := fmt.Sprintf("https://atcoder.jp/users/%s/history/json", username)
 	resp, err := s.client.Get(url)
 	if err != nil {
-		return nil, fmt.Errorf("AtCoder APIリクエストに失敗: %w", err)
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "AtCoder APIリクエストに失敗", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("AtCoderユーザーが見つかりません: %s", username)
+		return nil, domain.NewError(domain.ErrCodeNotFound, fmt.Sprintf("AtCoderユーザーが見つかりません: %s", username), nil)
 	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("AtCoder APIエラー: ステータスコード %d", resp.StatusCode)
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("AtCoder APIエラー: ステータスコード %d", resp.StatusCode), nil)
 	}
 
 	var history []AtCoderRatingEntry
 	if err := json.NewDecoder(resp.Body).Decode(&history); err != nil {
-		return nil, fmt.Errorf("AtCoder APIレスポンスのパースに失敗: %w", err)
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "AtCoder APIレスポンスのパースに失敗", err)
 	}
 
 	info := &AtCoderRatingInfo{

--- a/backend/internal/service/qiita.go
+++ b/backend/internal/service/qiita.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -57,21 +58,21 @@ func (s *QiitaService) FetchArticles(username string) ([]model.QiitaArticle, err
 
 		resp, err := s.httpClient.Get(url)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch Qiita articles: %w", err)
+			return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "Qiita記事の取得に失敗", err)
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode == http.StatusNotFound {
-			return nil, fmt.Errorf("Qiita user not found")
+			return nil, domain.NewError(domain.ErrCodeNotFound, "Qiitaユーザーが見つかりません", nil)
 		}
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("Qiita API returned status %d", resp.StatusCode)
+			return nil, domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("Qiita APIエラー: ステータスコード %d", resp.StatusCode), nil)
 		}
 
 		var apiArticles []QiitaAPIArticle
 		if err := json.NewDecoder(resp.Body).Decode(&apiArticles); err != nil {
-			return nil, fmt.Errorf("failed to decode Qiita response: %w", err)
+			return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "Qiitaレスポンスのデコードに失敗", err)
 		}
 
 		for _, article := range apiArticles {

--- a/backend/internal/service/zenn.go
+++ b/backend/internal/service/zenn.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -55,17 +56,17 @@ func (s *ZennService) FetchArticles(username string) ([]model.ZennArticle, error
 
 		resp, err := s.httpClient.Get(url)
 		if err != nil {
-			return nil, fmt.Errorf("failed to fetch Zenn articles: %w", err)
+			return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "Zenn記事の取得に失敗", err)
 		}
 		defer resp.Body.Close()
 
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("Zenn API returned status %d", resp.StatusCode)
+			return nil, domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("Zenn APIエラー: ステータスコード %d", resp.StatusCode), nil)
 		}
 
 		var apiResp ZennAPIResponse
 		if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
-			return nil, fmt.Errorf("failed to decode Zenn response: %w", err)
+			return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "Zennレスポンスのデコードに失敗", err)
 		}
 
 		for _, article := range apiResp.Articles {


### PR DESCRIPTION
## 概要
- atcoder/zenn/qiitaサービスの`fmt.Errorf`を`domain.NewError`に統一
- 外部APIエラー時に適切なHTTPステータスコード（404 NotFound / 503 ServiceUnavailable）が返されるように改善
- エラーメッセージの日本語統一

closes #388