### PR TITLE
feat: buttonSecondaryClass適用を4コンポーネント6箇所に拡大

### DIFF
--- a/frontend/src/components/chat/CreateRoomModal.tsx
+++ b/frontend/src/components/chat/CreateRoomModal.tsx
@@ -5,7 +5,7 @@ import { createChatRoom } from '../../api/chatRooms';
 import type { User } from '../../types/user';
 import type { ChatRoom } from '../../types/chat';
 import Avatar from '../common/Avatar';
-import { inputClass, labelClass, textareaClass } from '../../constants/styles';
+import { inputClass, labelClass, textareaClass, buttonSecondaryClass } from '../../constants/styles';
 
 interface Props {
   followingUsers: User[];
@@ -115,7 +115,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
             <button
               type="button"
               onClick={onClose}
-              className="flex-1 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm transition-colors"
+              className={`${buttonSecondaryClass} flex-1 text-sm`}
             >
               {t('common.cancel')}
             </button>

--- a/frontend/src/components/common/PageHeader.tsx
+++ b/frontend/src/components/common/PageHeader.tsx
@@ -1,4 +1,5 @@
 import { Plus } from 'lucide-react';
+import { buttonSecondaryClass } from '../../constants/styles';
 
 interface PageHeaderProps {
   title: string;
@@ -17,7 +18,7 @@ export default function PageHeader({ title, subtitle, actionLabel, onAction }: P
       {actionLabel && onAction && (
         <button
           onClick={onAction}
-          className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+          className={`${buttonSecondaryClass} flex items-center gap-2`}
         >
           <Plus className="w-5 h-5" />
           {actionLabel}

--- a/frontend/src/components/profile/PortfolioModal.tsx
+++ b/frontend/src/components/profile/PortfolioModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import type { PortfolioTheme } from '../../utils/portfolioGenerator';
 import { generatePortfolioHTML, downloadPortfolio } from '../../utils/portfolioGenerator';
+import { buttonSecondaryClass } from '../../constants/styles';
 import type { User } from '../../types/user';
 import type { GitHubLanguageStat, GitHubRepository } from '../../types/github';
 import type { LearningGoal } from '../../api/goals';
@@ -130,7 +131,7 @@ export default function PortfolioModal({
         <div className="p-4 border-t border-gray-700 flex flex-wrap gap-3">
           <button
             onClick={handleOpenInNewTab}
-            className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+            className={`${buttonSecondaryClass} flex items-center gap-2`}
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
@@ -139,7 +140,7 @@ export default function PortfolioModal({
           </button>
           <button
             onClick={handleDownload}
-            className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+            className={`${buttonSecondaryClass} flex items-center gap-2`}
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
@@ -148,7 +149,7 @@ export default function PortfolioModal({
           </button>
           <button
             onClick={handleCopyHTML}
-            className="flex items-center gap-2 px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+            className={`${buttonSecondaryClass} flex items-center gap-2`}
           >
             <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 17.25v3.375c0 .621-.504 1.125-1.125 1.125h-9.75a1.125 1.125 0 0 1-1.125-1.125V7.875c0-.621.504-1.125 1.125-1.125H6.75a9.06 9.06 0 0 1 1.5.124m7.5 10.376h3.375c.621 0 1.125-.504 1.125-1.125V11.25c0-4.46-3.243-8.161-7.5-8.876a9.06 9.06 0 0 0-1.5-.124H9.375c-.621 0-1.125.504-1.125 1.125v3.5m7.5 10.375H9.375a1.125 1.125 0 0 1-1.125-1.125v-9.25m12 6.625v-1.875a3.375 3.375 0 0 0-3.375-3.375h-1.5a1.125 1.125 0 0 1-1.125-1.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H9.75" />

--- a/frontend/src/components/qa/AnswerForm.tsx
+++ b/frontend/src/components/qa/AnswerForm.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { textareaClass } from '../../constants/styles';
+import { textareaClass, buttonSecondaryClass } from '../../constants/styles';
 
 interface AnswerFormProps {
   initialBody?: string;
@@ -37,7 +37,7 @@ export default function AnswerForm({ initialBody = '', onSubmit, onCancel, loadi
           <button
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors"
+            className={buttonSecondaryClass}
           >
             {t('common.cancel')}
           </button>


### PR DESCRIPTION
## 概要
- AnswerForm・PageHeader・PortfolioModal・CreateRoomModalのインラインボタンスタイルを`buttonSecondaryClass`に統一
- 4コンポーネント6箇所のインラインスタイルを共通定数に置換

closes #392