### PR TITLE
refactor: study_circle・emailサービスのfmt.Errorfをdomain.DomainErrorに統一

### DIFF
--- a/backend/internal/service/email.go
+++ b/backend/internal/service/email.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/norman6464/devsync/backend/internal/config"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -91,10 +92,10 @@ func (s *WeeklyReportEmailService) SetAppURL(url string) {
 // SendWeeklyReport は指定ユーザーにウィークリーレポートメールを送信する。
 func (s *WeeklyReportEmailService) SendWeeklyReport(user *model.User, report *model.ActivityReport) error {
 	if user.Email == "" {
-		return fmt.Errorf("%w: email is empty", ErrBadRequest)
+		return domain.NewError(domain.ErrCodeBadRequest, "メールアドレスが空です", nil)
 	}
 	if report == nil {
-		return fmt.Errorf("%w: report is nil", ErrBadRequest)
+		return domain.NewError(domain.ErrCodeBadRequest, "レポートがありません", nil)
 	}
 
 	lang := user.EmailLanguage
@@ -104,7 +105,7 @@ func (s *WeeklyReportEmailService) SendWeeklyReport(user *model.User, report *mo
 
 	html, err := s.RenderHTML(user, report, lang)
 	if err != nil {
-		return fmt.Errorf("failed to render email template: %w", err)
+		return domain.NewError(domain.ErrCodeInternal, "メールテンプレートのレンダリングに失敗", err)
 	}
 
 	texts := getEmailTexts(lang)
@@ -118,7 +119,7 @@ func (s *WeeklyReportEmailService) SendWeeklyReport(user *model.User, report *mo
 func (s *WeeklyReportEmailService) SendAllWeeklyReports() error {
 	users, err := s.userRepo.FindAll()
 	if err != nil {
-		return fmt.Errorf("failed to fetch users: %w", err)
+		return domain.NewError(domain.ErrCodeDatabase, "ユーザー一覧の取得に失敗", err)
 	}
 
 	for _, user := range users {

--- a/backend/internal/service/email_test.go
+++ b/backend/internal/service/email_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -62,7 +63,10 @@ func TestSendWeeklyReport_EmptyEmail(t *testing.T) {
 	report := testReport()
 
 	err := svc.SendWeeklyReport(user, report)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Error(t, err)
+	var domainErr *domain.DomainError
+	assert.ErrorAs(t, err, &domainErr)
+	assert.Equal(t, domain.ErrCodeBadRequest, domainErr.Code)
 }
 
 func TestSendWeeklyReport_NilReport(t *testing.T) {
@@ -71,7 +75,10 @@ func TestSendWeeklyReport_NilReport(t *testing.T) {
 	user := &model.User{Name: "テストユーザー", Email: "test@example.com"}
 
 	err := svc.SendWeeklyReport(user, nil)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Error(t, err)
+	var domainErr *domain.DomainError
+	assert.ErrorAs(t, err, &domainErr)
+	assert.Equal(t, domain.ErrCodeBadRequest, domainErr.Code)
 }
 
 // ============================================================

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -1,9 +1,9 @@
 package service
 
 import (
-	"fmt"
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -135,7 +135,7 @@ func (s *StudyCircleService) AddMember(circleID, userID, targetUserID uint) erro
 		return err
 	}
 	if count >= circle.MaxMembers {
-		return fmt.Errorf("%w: member limit reached", ErrBadRequest)
+		return domain.NewError(domain.ErrCodeBadRequest, "メンバー上限に達しました", nil)
 	}
 
 	return s.repo.AddMember(circleID, targetUserID, model.StudyCircleRoleMember)
@@ -288,7 +288,7 @@ func (s *StudyCircleService) CreateCheckin(circleID, userID uint, content string
 		return nil, err
 	}
 	if done {
-		return nil, fmt.Errorf("%w: already checked in today", ErrConflict)
+		return nil, domain.NewError(domain.ErrCodeConflict, "本日は既にチェックイン済みです", nil)
 	}
 
 	checkin := &model.StudyCircleCheckin{


### PR DESCRIPTION
## 概要
- study_circle.go（2箇所）・email.go（4箇所）の`fmt.Errorf`を`domain.NewError`に統一
- email_test.goのエラー検証を`errors.Is`→`errors.As`+DomainErrorコード検証に更新
- service層のfmt.Errorf残りがgithub.go+openai_client.goのみに削減

closes #394