### PR TITLE
feat: buttonPrimaryClass適用をCreateRoomModal・RoomSettingsModalに拡大

### DIFF
--- a/frontend/src/components/chat/CreateRoomModal.tsx
+++ b/frontend/src/components/chat/CreateRoomModal.tsx
@@ -5,7 +5,7 @@ import { createChatRoom } from '../../api/chatRooms';
 import type { User } from '../../types/user';
 import type { ChatRoom } from '../../types/chat';
 import Avatar from '../common/Avatar';
-import { inputClass, labelClass, textareaClass, buttonSecondaryClass } from '../../constants/styles';
+import { inputClass, labelClass, textareaClass, buttonSecondaryClass, buttonPrimaryClass } from '../../constants/styles';
 
 interface Props {
   followingUsers: User[];
@@ -122,7 +122,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
             <button
               type="submit"
               disabled={!name.trim() || loading}
-              className="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+              className={`${buttonPrimaryClass} flex-1 text-sm disabled:opacity-50`}
             >
               {loading ? '...' : t('chat.createButton')}
             </button>

--- a/frontend/src/components/chat/RoomSettingsModal.tsx
+++ b/frontend/src/components/chat/RoomSettingsModal.tsx
@@ -5,7 +5,7 @@ import {
   getChatRoomMembers, updateChatRoom, deleteChatRoom,
   addChatRoomMember, removeChatRoomMember,
 } from '../../api/chatRooms';
-import { labelClass, textareaClass } from '../../constants/styles';
+import { labelClass, textareaClass, buttonPrimaryClass } from '../../constants/styles';
 import { useConfirm } from '../../hooks';
 import type { User } from '../../types/user';
 import type { ChatRoom, ChatRoomMember } from '../../types/chat';
@@ -147,7 +147,7 @@ export default function RoomSettingsModal({
             <button
               onClick={handleUpdate}
               disabled={!name.trim() || loading}
-              className="w-full px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
+              className={`${buttonPrimaryClass} w-full text-sm disabled:opacity-50`}
             >
               {t('chat.editRoom')}
             </button>


### PR DESCRIPTION
## 概要
- CreateRoomModal・RoomSettingsModalの青ボタンインラインスタイルを`buttonPrimaryClass`に統一
- 2コンポーネント2箇所のインラインスタイルを共通定数に置換

closes #398