### PR TITLE
refactor: github.go/openai_client.goのfmt.ErrorfをDomainErrorに変換

### DIFF
--- a/backend/internal/service/github.go
+++ b/backend/internal/service/github.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/norman6464/devsync/backend/internal/config"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -68,7 +69,7 @@ func (s *GitHubService) ExchangeCode(code string) (string, error) {
 		return "", err
 	}
 	if result.Error != "" {
-		return "", fmt.Errorf("github oauth error: %s", result.Error)
+		return "", domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("GitHub OAuthエラー: %s", result.Error), nil)
 	}
 	return result.AccessToken, nil
 }
@@ -139,17 +140,17 @@ func (s *GitHubService) fetchPrimaryEmail(token string) string {
 // SyncData はGitHubのコントリビューション、リポジトリ、言語統計を同期する。
 func (s *GitHubService) SyncData(user *model.User) error {
 	if user.GitHubToken == "" {
-		return fmt.Errorf("github not connected")
+		return domain.NewError(domain.ErrCodeBadRequest, "GitHubが連携されていません", nil)
 	}
 
 	// コントリビューションを同期
 	if err := s.syncContributions(user); err != nil {
-		return fmt.Errorf("sync contributions: %w", err)
+		return domain.NewError(domain.ErrCodeServiceUnavailable, "GitHubコントリビューションの同期に失敗", err)
 	}
 
 	// リポジトリと言語統計を同期
 	if err := s.syncReposAndLanguages(user); err != nil {
-		return fmt.Errorf("sync repos: %w", err)
+		return domain.NewError(domain.ErrCodeServiceUnavailable, "GitHubリポジトリの同期に失敗", err)
 	}
 
 	return nil

--- a/backend/internal/service/openai_client.go
+++ b/backend/internal/service/openai_client.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"time"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
 )
 
 // LLMClientInterface はLLM APIクライアントの契約を定義する。
@@ -82,12 +84,12 @@ func (c *OpenAIClient) Complete(messages []ChatMessage) (*ChatResponse, error) {
 
 	jsonData, err := json.Marshal(reqBody)
 	if err != nil {
-		return nil, fmt.Errorf("failed to marshal request: %w", err)
+		return nil, domain.NewError(domain.ErrCodeInternal, "リクエストのシリアライズに失敗", err)
 	}
 
 	req, err := http.NewRequest("POST", c.baseURL, bytes.NewReader(jsonData))
 	if err != nil {
-		return nil, fmt.Errorf("failed to create request: %w", err)
+		return nil, domain.NewError(domain.ErrCodeInternal, "HTTPリクエストの作成に失敗", err)
 	}
 
 	req.Header.Set("Content-Type", "application/json")
@@ -95,30 +97,30 @@ func (c *OpenAIClient) Complete(messages []ChatMessage) (*ChatResponse, error) {
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("failed to call OpenAI API: %w", err)
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "OpenAI APIの呼び出しに失敗", err)
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read response: %w", err)
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "レスポンスの読み取りに失敗", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("OpenAI API error (status %d): %s", resp.StatusCode, string(body))
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("OpenAI APIエラー (ステータス %d): %s", resp.StatusCode, string(body)), nil)
 	}
 
 	var apiResp openAIResponse
 	if err := json.Unmarshal(body, &apiResp); err != nil {
-		return nil, fmt.Errorf("failed to parse response: %w", err)
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "レスポンスのパースに失敗", err)
 	}
 
 	if apiResp.Error != nil {
-		return nil, fmt.Errorf("OpenAI API error: %s", apiResp.Error.Message)
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("OpenAI APIエラー: %s", apiResp.Error.Message), nil)
 	}
 
 	if len(apiResp.Choices) == 0 {
-		return nil, fmt.Errorf("no response from OpenAI API")
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "OpenAI APIからの応答がありません", nil)
 	}
 
 	return &ChatResponse{


### PR DESCRIPTION
## 概要
- `github.go`の`fmt.Errorf`4箇所を`domain.NewError`に変換
  - OAuthエラー → `ErrCodeServiceUnavailable`
  - GitHub未連携 → `ErrCodeBadRequest`
  - コントリビューション/リポジトリ同期失敗 → `ErrCodeServiceUnavailable`
- `openai_client.go`の`fmt.Errorf`8箇所を`domain.NewError`に変換
  - シリアライズ/リクエスト作成失敗 → `ErrCodeInternal`
  - API呼び出し/レスポンス系エラー → `ErrCodeServiceUnavailable`

## テスト
- `go build ./...` 成功
- `go test ./internal/service/...` 全テスト合格

Closes #400