### PR TITLE
feat: buttonDangerOutlineClass定数を追加しIntegrationSectionに適用

### DIFF
--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -7,6 +7,9 @@ export const buttonPrimaryClass =
 export const buttonDangerClass =
   'px-4 py-2 bg-red-600 hover:bg-red-700 text-white rounded-lg font-medium transition-colors';
 
+export const buttonDangerOutlineClass =
+  'px-4 py-2 text-red-400 hover:text-red-300 border border-red-400/30 hover:border-red-400/50 rounded-lg text-sm font-medium transition-colors';
+
 export const buttonSecondaryClass =
   'px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition-colors';
 

--- a/frontend/src/pages/settings/IntegrationSection.tsx
+++ b/frontend/src/pages/settings/IntegrationSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, sectionContainerClass, labelClass, selectClass } from '../../constants/styles';
+import { inputClass, sectionContainerClass, labelClass, selectClass, buttonDangerOutlineClass } from '../../constants/styles';
 import type { User } from '../../types/user';
 
 interface Props {
@@ -73,7 +73,7 @@ export default function IntegrationSection(props: Props) {
                 </button>
                 <button
                   onClick={props.onDisconnectGitHub}
-                  className="px-4 py-2 text-red-400 hover:text-red-300 border border-red-400/30 hover:border-red-400/50 rounded-lg text-sm font-medium transition-colors"
+                  className={buttonDangerOutlineClass}
                 >
                   {t('settings.disconnect')}
                 </button>
@@ -120,7 +120,7 @@ export default function IntegrationSection(props: Props) {
                 </button>
                 <button
                   onClick={props.onDisconnectZenn}
-                  className="px-4 py-2 text-red-400 hover:text-red-300 border border-red-400/30 hover:border-red-400/50 rounded-lg text-sm font-medium transition-colors"
+                  className={buttonDangerOutlineClass}
                 >
                   {t('settings.disconnect')}
                 </button>
@@ -179,7 +179,7 @@ export default function IntegrationSection(props: Props) {
                 </button>
                 <button
                   onClick={props.onDisconnectQiita}
-                  className="px-4 py-2 text-red-400 hover:text-red-300 border border-red-400/30 hover:border-red-400/50 rounded-lg text-sm font-medium transition-colors"
+                  className={buttonDangerOutlineClass}
                 >
                   {t('settings.disconnect')}
                 </button>
@@ -231,7 +231,7 @@ export default function IntegrationSection(props: Props) {
               <div className="flex gap-2">
                 <button
                   onClick={props.onDisconnectAtCoder}
-                  className="px-4 py-2 text-red-400 hover:text-red-300 border border-red-400/30 hover:border-red-400/50 rounded-lg text-sm font-medium transition-colors"
+                  className={buttonDangerOutlineClass}
                 >
                   {t('settings.disconnect')}
                 </button>


### PR DESCRIPTION
## 概要
- `constants/styles.ts`に`buttonDangerOutlineClass`定数を追加
- `IntegrationSection.tsx`の4つの「接続解除」ボタン（GitHub/Zenn/Qiita/AtCoder）のインラインスタイルを共通定数に置換

## テスト
- `npx tsc --noEmit` 成功

Closes #404