### PR TITLE
refactor: middleware/auth.goのレスポンス形式をdomain.NewErrorResponseに統一

### DIFF
--- a/backend/internal/middleware/auth.go
+++ b/backend/internal/middleware/auth.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
 
@@ -32,7 +33,7 @@ func AuthRequired(authService *service.AuthService) gin.HandlerFunc {
 				if len(parts) == 2 && parts[0] == "Bearer" {
 					tokenString = parts[1]
 				} else {
-					c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid authorization header format"})
+					c.JSON(http.StatusUnauthorized, domain.NewErrorResponse("invalid authorization header format", string(domain.ErrCodeUnauthorized), nil))
 					c.Abort()
 					return
 				}
@@ -41,14 +42,14 @@ func AuthRequired(authService *service.AuthService) gin.HandlerFunc {
 
 		// CookieもAuthorizationヘッダーもない場合
 		if tokenString == "" {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+			c.JSON(http.StatusUnauthorized, domain.NewErrorResponse("authentication required", string(domain.ErrCodeUnauthorized), nil))
 			c.Abort()
 			return
 		}
 
 		userID, err := authService.ValidateToken(tokenString)
 		if err != nil {
-			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
+			c.JSON(http.StatusUnauthorized, domain.NewErrorResponse("invalid or expired token", string(domain.ErrCodeUnauthorized), nil))
 			c.Abort()
 			return
 		}


### PR DESCRIPTION
## 概要
- middleware/auth.goの3箇所の`gin.H{"error": "..."}`を`domain.NewErrorResponse`に変換
  - 認可ヘッダー形式エラー → `ErrCodeUnauthorized`
  - 認証必須エラー → `ErrCodeUnauthorized`
  - トークン無効エラー → `ErrCodeUnauthorized`
- handler層と同一の構造化エラーレスポンス形式に統一

## テスト
- `go build ./...` 成功
- `go test ./...` 全テスト合格

Closes #406