### PR TITLE
feat: NotesPageのフォームボタンをbuttonPrimaryClass/buttonSecondaryClassに統一

### DIFF
--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -4,7 +4,7 @@ import { BookOpen, Star, Plus, Edit, Trash2 } from 'lucide-react';
 import { useNotes } from '../hooks';
 import { PageLoader, SearchInput } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
-import { buttonPrimaryClass } from '../constants/styles';
+import { buttonPrimaryClass, buttonSecondaryClass } from '../constants/styles';
 import type { Note } from '../api/notes';
 
 export default function NotesPage() {
@@ -132,14 +132,14 @@ export default function NotesPage() {
               <button
                 type="submit"
                 disabled={saving}
-                className="px-6 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors disabled:opacity-50"
+                className={`${buttonPrimaryClass} disabled:opacity-50`}
               >
                 {saving ? t('common.saving') : t('common.save')}
               </button>
               <button
                 type="button"
                 onClick={resetForm}
-                className="px-6 py-2 bg-gray-700 text-white rounded-md hover:bg-gray-600 transition-colors"
+                className={buttonSecondaryClass}
               >
                 {t('common.cancel')}
               </button>


### PR DESCRIPTION
## 概要
- NotesPageのノート編集フォーム内ボタンを共通定数に統一
  - 保存ボタン: `rounded-md hover:bg-blue-700` → `buttonPrimaryClass`（`rounded-lg hover:bg-blue-500`に正規化）
  - キャンセルボタン: インラインスタイル → `buttonSecondaryClass`

## テスト
- `npx tsc --noEmit` 成功

Closes #410