### PR TITLE
refactor: handler/helpers.goのc.JSON直接使用をrespondBadRequestに統一

### DIFF
--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -14,7 +14,7 @@ func parseID(c *gin.Context, param string) (uint, bool) {
 	raw := c.Param(param)
 	id, err := strconv.ParseUint(raw, 10, 64)
 	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid " + param})
+		respondBadRequest(c, "invalid "+param)
 		return 0, false
 	}
 	return uint(id), true
@@ -45,7 +45,7 @@ func parsePagination(c *gin.Context) (page, limit int) {
 func bindJSON[T any](c *gin.Context) *T {
 	var req T
 	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		respondBadRequest(c, err.Error())
 		return nil
 	}
 	return &req


### PR DESCRIPTION
## 概要
- `parseID`の`c.JSON(http.StatusBadRequest, gin.H{...})` → `respondBadRequest`
- `bindJSON`の`c.JSON(http.StatusBadRequest, gin.H{...})` → `respondBadRequest`
- handler層のエラーレスポンス形式を`domain.NewErrorResponse`に完全統一

## テスト
- `go build ./...` 成功
- `go test ./internal/handler/...` 全テスト合格

Closes #412