### PR TITLE
feat: ConfirmDialogのダークテーマ統一とlucide-reactアイコン化

### DIFF
--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { AlertTriangle, AlertCircle, Info } from 'lucide-react';
 
 export interface ConfirmDialogProps {
   isOpen: boolean;
@@ -19,9 +20,15 @@ const CONFIRM_STYLES = {
 };
 
 const ICON_STYLES = {
-  danger: 'text-red-600 dark:text-red-400',
-  warning: 'text-yellow-600 dark:text-yellow-400',
-  info: 'text-blue-600 dark:text-blue-400',
+  danger: 'text-red-400',
+  warning: 'text-yellow-400',
+  info: 'text-blue-400',
+};
+
+const ICON_COMPONENTS = {
+  danger: AlertTriangle,
+  warning: AlertCircle,
+  info: Info,
 };
 
 export default function ConfirmDialog({
@@ -66,30 +73,23 @@ export default function ConfirmDialog({
         aria-modal="true"
         aria-labelledby="confirm-dialog-title"
         aria-describedby="confirm-dialog-message"
-        className="relative z-10 w-full max-w-md mx-4 bg-white dark:bg-gray-800 rounded-xl shadow-2xl p-6"
+        className="relative z-10 w-full max-w-md mx-4 bg-gray-800 rounded-xl shadow-2xl p-6"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-start gap-4">
-          <div className={`flex-shrink-0 mt-0.5 ${ICON_STYLES[variant]}`}>
-            {variant === 'danger' ? (
-              <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
-              </svg>
-            ) : variant === 'warning' ? (
-              <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v3.75m9-.75a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 3.75h.008v.008H12v-.008Z" />
-              </svg>
-            ) : (
-              <svg className="w-6 h-6" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" d="m11.25 11.25.041-.02a.75.75 0 0 1 1.063.852l-.708 2.836a.75.75 0 0 0 1.063.853l.041-.021M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9-3.75h.008v.008H12V8.25Z" />
-              </svg>
-            )}
-          </div>
+          {(() => {
+            const IconComponent = ICON_COMPONENTS[variant];
+            return (
+              <div className={`flex-shrink-0 mt-0.5 ${ICON_STYLES[variant]}`}>
+                <IconComponent className="w-6 h-6" />
+              </div>
+            );
+          })()}
           <div className="flex-1">
-            <h3 id="confirm-dialog-title" className="text-lg font-semibold text-gray-900 dark:text-white">
+            <h3 id="confirm-dialog-title" className="text-lg font-semibold text-white">
               {title}
             </h3>
-            <p id="confirm-dialog-message" className="mt-2 text-sm text-gray-600 dark:text-gray-300">
+            <p id="confirm-dialog-message" className="mt-2 text-sm text-gray-300">
               {message}
             </p>
           </div>
@@ -98,7 +98,7 @@ export default function ConfirmDialog({
           <button
             type="button"
             onClick={onCancel}
-            className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-gray-100 dark:bg-gray-700 hover:bg-gray-200 dark:hover:bg-gray-600 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
+            className="px-4 py-2 text-sm font-medium text-gray-300 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2"
           >
             {cancelText || t('common.cancel')}
           </button>


### PR DESCRIPTION
## 概要
- ConfirmDialogの`dark:`プレフィックス7箇所を削除（アプリ全体がダーク直接指定のため不整合）
- raw SVGアイコン3つ（danger/warning/info）をlucide-react（AlertTriangle/AlertCircle/Info）に置換
- `ICON_COMPONENTS`マッピングでバリアント別アイコンを簡潔に管理

## 変更ファイル
- `frontend/src/components/common/ConfirmDialog.tsx`

Closes #416