### PR TITLE
refactor: ハンドラ層のgin.H{"message":...}をdomain.NewMessageResponseに統一

### DIFF
--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -72,7 +73,7 @@ func (h *AIAdviceHandler) MarkAsRead(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "marked as read"})
+	respondOK(c, domain.NewMessageResponse("marked as read"))
 }
 
 // Chat はLLMとのチャットメッセージを送信する。
@@ -107,7 +108,7 @@ func (h *AIAdviceHandler) DeleteConversation(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "conversation deleted"})
+	respondOK(c, domain.NewMessageResponse("conversation deleted"))
 }
 
 // GetConversations は会話履歴一覧を取得する。

--- a/backend/internal/handler/answer.go
+++ b/backend/internal/handler/answer.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -137,7 +138,7 @@ func (h *AnswerHandler) SetBestAnswer(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Best answer set successfully"})
+	respondOK(c, domain.NewMessageResponse("Best answer set successfully"))
 }
 
 // Vote は回答に投票する。
@@ -158,7 +159,7 @@ func (h *AnswerHandler) Vote(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Voted successfully"})
+	respondOK(c, domain.NewMessageResponse("Voted successfully"))
 }
 
 // RemoveVote は回答への投票を取り消す。
@@ -174,5 +175,5 @@ func (h *AnswerHandler) RemoveVote(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Vote removed successfully"})
+	respondOK(c, domain.NewMessageResponse("Vote removed successfully"))
 }

--- a/backend/internal/handler/badge.go
+++ b/backend/internal/handler/badge.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
 
@@ -55,5 +56,5 @@ func (h *BadgeHandler) NotifyBadgeEarned(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "badge notification created"})
+	respondOK(c, domain.NewMessageResponse("badge notification created"))
 }

--- a/backend/internal/handler/chat_room.go
+++ b/backend/internal/handler/chat_room.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -153,7 +154,7 @@ func (h *ChatRoomHandler) AddMember(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "member added"})
+	respondOK(c, domain.NewMessageResponse("member added"))
 }
 
 // RemoveMember はチャットルームからメンバーを削除する。
@@ -172,7 +173,7 @@ func (h *ChatRoomHandler) RemoveMember(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "member removed"})
+	respondOK(c, domain.NewMessageResponse("member removed"))
 }
 
 // GetMessages は指定チャットルームのメッセージ一覧をページネーション付きで取得する。

--- a/backend/internal/handler/follow.go
+++ b/backend/internal/handler/follow.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -35,7 +36,7 @@ func (h *FollowHandler) Follow(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "followed"})
+	respondOK(c, domain.NewMessageResponse("followed"))
 }
 
 // Unfollow は指定ユーザーのフォローを解除する。
@@ -49,7 +50,7 @@ func (h *FollowHandler) Unfollow(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "unfollowed"})
+	respondOK(c, domain.NewMessageResponse("unfollowed"))
 }
 
 // GetFollowers は指定ユーザーのフォロワー一覧を返す。

--- a/backend/internal/handler/github.go
+++ b/backend/internal/handler/github.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -73,7 +74,7 @@ func (h *GitHubHandler) Callback(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "github connected"})
+	respondOK(c, domain.NewMessageResponse("github connected"))
 }
 
 // GetContributions は指定ユーザーのGitHubコントリビューション情報を取得する。
@@ -130,7 +131,7 @@ func (h *GitHubHandler) Sync(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "sync complete"})
+	respondOK(c, domain.NewMessageResponse("sync complete"))
 }
 
 // Disconnect は現在のユーザーのGitHub連携を解除する。
@@ -142,5 +143,5 @@ func (h *GitHubHandler) Disconnect(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "github disconnected"})
+	respondOK(c, domain.NewMessageResponse("github disconnected"))
 }

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -272,7 +273,7 @@ func (h *LearningResourceHandler) Like(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Resource liked"})
+	respondOK(c, domain.NewMessageResponse("Resource liked"))
 }
 
 // Unlike は学習リソースのいいねを取り消す。
@@ -288,7 +289,7 @@ func (h *LearningResourceHandler) Unlike(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Resource unliked"})
+	respondOK(c, domain.NewMessageResponse("Resource unliked"))
 }
 
 // SaveResource は学習リソースを保存する。
@@ -304,7 +305,7 @@ func (h *LearningResourceHandler) SaveResource(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Resource saved"})
+	respondOK(c, domain.NewMessageResponse("Resource saved"))
 }
 
 // UnsaveResource は学習リソースの保存を取り消す。
@@ -320,7 +321,7 @@ func (h *LearningResourceHandler) UnsaveResource(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Resource unsaved"})
+	respondOK(c, domain.NewMessageResponse("Resource unsaved"))
 }
 
 // GetSaved は認証ユーザーの保存済み学習リソース一覧を取得する。

--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -222,7 +223,7 @@ func (h *NoteHandler) ToggleFavorite(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "お気に入り状態を更新しました"})
+	respondOK(c, domain.NewMessageResponse("お気に入り状態を更新しました"))
 }
 
 // Archive はノートをアーカイブする。
@@ -237,7 +238,7 @@ func (h *NoteHandler) Archive(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "ノートをアーカイブしました"})
+	respondOK(c, domain.NewMessageResponse("ノートをアーカイブしました"))
 }
 
 // Unarchive はノートのアーカイブを解除する。
@@ -252,7 +253,7 @@ func (h *NoteHandler) Unarchive(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "ノートのアーカイブを解除しました"})
+	respondOK(c, domain.NewMessageResponse("ノートのアーカイブを解除しました"))
 }
 
 // GetArchived は現在のユーザーのアーカイブ済みノート一覧をページネーション付きで取得する。

--- a/backend/internal/handler/note_link.go
+++ b/backend/internal/handler/note_link.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -45,7 +46,7 @@ func (h *NoteLinkHandler) CreateLink(c *gin.Context) {
 		return
 	}
 
-	respondCreated(c, gin.H{"message": "リンクを作成しました"})
+	respondCreated(c, domain.NewMessageResponse("リンクを作成しました"))
 }
 
 // GetLinks は指定ノートからのリンク一覧を取得する。

--- a/backend/internal/handler/notification.go
+++ b/backend/internal/handler/notification.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -74,7 +75,7 @@ func (h *NotificationHandler) MarkAsRead(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "marked as read"})
+	respondOK(c, domain.NewMessageResponse("marked as read"))
 }
 
 // MarkAllAsRead は認証ユーザーの全通知を既読にする。
@@ -85,7 +86,7 @@ func (h *NotificationHandler) MarkAllAsRead(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "all marked as read"})
+	respondOK(c, domain.NewMessageResponse("all marked as read"))
 }
 
 // Delete は指定された通知を削除する。
@@ -100,5 +101,5 @@ func (h *NotificationHandler) Delete(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "deleted"})
+	respondOK(c, domain.NewMessageResponse("deleted"))
 }

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -217,7 +218,7 @@ func (h *PostHandler) Like(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "liked"})
+	respondOK(c, domain.NewMessageResponse("liked"))
 }
 
 // Unlike は投稿のいいねを取り消す。
@@ -232,7 +233,7 @@ func (h *PostHandler) Unlike(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "unliked"})
+	respondOK(c, domain.NewMessageResponse("unliked"))
 }
 
 // GetComments は投稿のコメント一覧を返す。

--- a/backend/internal/handler/qiita.go
+++ b/backend/internal/handler/qiita.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -59,7 +60,7 @@ func (h *QiitaHandler) Disconnect(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Qiita disconnected successfully"})
+	respondOK(c, domain.NewMessageResponse("Qiita disconnected successfully"))
 }
 
 // Sync は現在のユーザーのQiita記事を再同期する。

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -223,7 +224,7 @@ func (h *QuestionHandler) Vote(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Voted successfully"})
+	respondOK(c, domain.NewMessageResponse("Voted successfully"))
 }
 
 // RemoveVote は質問への投票を取り消す。
@@ -239,5 +240,5 @@ func (h *QuestionHandler) RemoveVote(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Vote removed successfully"})
+	respondOK(c, domain.NewMessageResponse("Vote removed successfully"))
 }

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
@@ -377,5 +378,5 @@ func (h *RoadmapHandler) ReorderSteps(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "steps reordered"})
+	respondOK(c, domain.NewMessageResponse("steps reordered"))
 }

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -164,7 +165,7 @@ func (h *StudyCircleHandler) AddMember(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "member added"})
+	respondOK(c, domain.NewMessageResponse("member added"))
 }
 
 // RemoveMember はメンバーを除外/退出する。
@@ -182,7 +183,7 @@ func (h *StudyCircleHandler) RemoveMember(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "member removed"})
+	respondOK(c, domain.NewMessageResponse("member removed"))
 }
 
 // CreateStep はステップを追加する。
@@ -279,7 +280,7 @@ func (h *StudyCircleHandler) ReorderSteps(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "reordered"})
+	respondOK(c, domain.NewMessageResponse("reordered"))
 }
 
 // UpdateProgress は自分のステップ進捗を更新する。
@@ -304,7 +305,7 @@ func (h *StudyCircleHandler) UpdateProgress(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "progress updated"})
+	respondOK(c, domain.NewMessageResponse("progress updated"))
 }
 
 // GetProgress は全メンバーの進捗を返す。

--- a/backend/internal/handler/zenn.go
+++ b/backend/internal/handler/zenn.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -59,7 +60,7 @@ func (h *ZennHandler) Disconnect(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "Zenn disconnected successfully"})
+	respondOK(c, domain.NewMessageResponse("Zenn disconnected successfully"))
 }
 
 // Sync は現在のユーザーのZenn記事を再同期する。


### PR DESCRIPTION
## 概要
ハンドラ層で直接使用されていた`gin.H{"message": "..."}`パターンを、ドメイン層の型付き構造体`domain.NewMessageResponse("...")`に統一。

## 変更内容
- 16個のハンドラファイルで35箇所の`gin.H{"message": "..."}`を`domain.NewMessageResponse("...")`に置換
- 各ファイルに`domain`パッケージのimportを追加

## 対象ファイル
note.go, post.go, answer.go, follow.go, chat_room.go, note_link.go, github.go, learning_resource.go, roadmap.go, zenn.go, question.go, badge.go, qiita.go, notification.go, ai_advice.go, study_circle.go

## 目的
- レスポンス形式の統一（helpers.goの`respondDeleted`で既に採用済みのパターンに合わせる）
- ハンドラ層からGin固有の型（gin.H）への依存を削減
- 型安全なレスポンス構造の推進

Closes #418