### PR TITLE
RecommendationServiceのユニットテストを追加

### DIFF
--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -941,7 +941,31 @@ var _ repository.RoadmapRepositoryInterface = (*MockRoadmapRepository)(nil)
 var _ repository.ChatRoomRepositoryInterface = (*MockChatRoomRepository)(nil)
 var _ repository.GroupMessageRepositoryInterface = (*MockGroupMessageRepository)(nil)
 var _ repository.CodeSnippetRepositoryInterface = (*MockCodeSnippetRepository)(nil)
+var _ repository.RecommendationRepositoryInterface = (*MockRecommendationRepository)(nil)
 var _ repository.AIAdviceRepositoryInterface = (*MockAIAdviceRepository)(nil)
+
+// ============================================================
+// MockRecommendationRepository は repository.RecommendationRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockRecommendationRepository struct {
+	mock.Mock
+}
+
+func (m *MockRecommendationRepository) GetRecommendedUsers(userID uint, skills []string, limit int) ([]model.RecommendedUser, error) {
+	args := m.Called(userID, skills, limit)
+	return args.Get(0).([]model.RecommendedUser), args.Error(1)
+}
+
+func (m *MockRecommendationRepository) GetTrendingPosts(limit int, days int) ([]model.Post, error) {
+	args := m.Called(limit, days)
+	return args.Get(0).([]model.Post), args.Error(1)
+}
+
+func (m *MockRecommendationRepository) GetTrendingResources(limit int, days int) ([]model.LearningResource, error) {
+	args := m.Called(limit, days)
+	return args.Get(0).([]model.LearningResource), args.Error(1)
+}
 var _ repository.AIConversationRepositoryInterface = (*MockAIConversationRepository)(nil)
 var _ repository.GitHubRepositoryInterface = (*MockGitHubRepository)(nil)
 var _ LLMClientInterface = (*MockLLMClient)(nil)

--- a/backend/internal/service/recommendation_test.go
+++ b/backend/internal/service/recommendation_test.go
@@ -1,0 +1,198 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// ============================================================
+// 純粋関数テスト
+// ============================================================
+
+func TestTrimString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"通常の文字列", "Go", "Go"},
+		{"前後に空白", "  Go  ", "Go"},
+		{"前後にタブ", "\tGo\t", "Go"},
+		{"空白のみ", "   ", ""},
+		{"空文字列", "", ""},
+		{"内部の空白は保持", "Go Lang", "Go Lang"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := trimString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestSplitSkills(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"空文字列", "", nil},
+		{"単一スキル", "Go", []string{"Go"}},
+		{"複数スキル", "Go,Python,Rust", []string{"Go", "Python", "Rust"}},
+		{"空白付き", " Go , Python , Rust ", []string{"Go", "Python", "Rust"}},
+		{"末尾カンマ", "Go,Python,", []string{"Go", "Python"}},
+		{"連続カンマ", "Go,,Python", []string{"Go", "Python"}},
+		{"カンマのみ", ",,,", nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := splitSkills(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestParseSkills(t *testing.T) {
+	tests := []struct {
+		name       string
+		languages  string
+		frameworks string
+		expected   []string
+	}{
+		{"両方空", "", "", nil},
+		{"言語のみ", "Go,Python", "", []string{"Go", "Python"}},
+		{"フレームワークのみ", "", "React,Vue", []string{"React", "Vue"}},
+		{"両方あり", "Go,Python", "React,Vue", []string{"Go", "Python", "React", "Vue"}},
+		{"重複含む空白", " Go , ", " React , ", []string{"Go", "React"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := parseSkills(tt.languages, tt.frameworks)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// ============================================================
+// サービスメソッドテスト
+// ============================================================
+
+func TestGetRecommendedUsers_Success(t *testing.T) {
+	mockRepo := new(MockRecommendationRepository)
+	mockUserRepo := new(MockUserRepository)
+	svc := NewRecommendationService(mockRepo, mockUserRepo)
+
+	user := &model.User{SkillsLanguages: "Go,Python", SkillsFrameworks: "React"}
+	mockUserRepo.On("FindByID", uint(1)).Return(user, nil)
+
+	expected := []model.RecommendedUser{
+		{User: model.User{Username: "user2"}, CommonSkills: []string{"Go"}, MatchScore: 80},
+	}
+	mockRepo.On("GetRecommendedUsers", uint(1), []string{"Go", "Python", "React"}, 10).Return(expected, nil)
+
+	result, err := svc.GetRecommendedUsers(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	mockUserRepo.AssertExpectations(t)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestGetRecommendedUsers_UserNotFound(t *testing.T) {
+	mockRepo := new(MockRecommendationRepository)
+	mockUserRepo := new(MockUserRepository)
+	svc := NewRecommendationService(mockRepo, mockUserRepo)
+
+	mockUserRepo.On("FindByID", uint(1)).Return(nil, errors.New("user not found"))
+
+	result, err := svc.GetRecommendedUsers(1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	mockUserRepo.AssertExpectations(t)
+}
+
+func TestGetRecommendedUsers_NoSkills(t *testing.T) {
+	mockRepo := new(MockRecommendationRepository)
+	mockUserRepo := new(MockUserRepository)
+	svc := NewRecommendationService(mockRepo, mockUserRepo)
+
+	user := &model.User{SkillsLanguages: "", SkillsFrameworks: ""}
+	mockUserRepo.On("FindByID", uint(1)).Return(user, nil)
+
+	result, err := svc.GetRecommendedUsers(1)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	mockUserRepo.AssertExpectations(t)
+	mockRepo.AssertNotCalled(t, "GetRecommendedUsers")
+}
+
+func TestGetRecommendedUsers_RepoError(t *testing.T) {
+	mockRepo := new(MockRecommendationRepository)
+	mockUserRepo := new(MockUserRepository)
+	svc := NewRecommendationService(mockRepo, mockUserRepo)
+
+	user := &model.User{SkillsLanguages: "Go", SkillsFrameworks: ""}
+	mockUserRepo.On("FindByID", uint(1)).Return(user, nil)
+	mockRepo.On("GetRecommendedUsers", uint(1), []string{"Go"}, 10).Return([]model.RecommendedUser(nil), errors.New("db error"))
+
+	result, err := svc.GetRecommendedUsers(1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestGetTrendingPosts_Success(t *testing.T) {
+	mockRepo := new(MockRecommendationRepository)
+	mockUserRepo := new(MockUserRepository)
+	svc := NewRecommendationService(mockRepo, mockUserRepo)
+
+	expected := []model.Post{{Title: "Trending Post"}}
+	mockRepo.On("GetTrendingPosts", 10, 7).Return(expected, nil)
+
+	result, err := svc.GetTrendingPosts()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestGetTrendingPosts_Error(t *testing.T) {
+	mockRepo := new(MockRecommendationRepository)
+	mockUserRepo := new(MockUserRepository)
+	svc := NewRecommendationService(mockRepo, mockUserRepo)
+
+	mockRepo.On("GetTrendingPosts", 10, 7).Return([]model.Post(nil), errors.New("db error"))
+
+	result, err := svc.GetTrendingPosts()
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestGetTrendingResources_Success(t *testing.T) {
+	mockRepo := new(MockRecommendationRepository)
+	mockUserRepo := new(MockUserRepository)
+	svc := NewRecommendationService(mockRepo, mockUserRepo)
+
+	expected := []model.LearningResource{{Title: "Trending Resource"}}
+	mockRepo.On("GetTrendingResources", 10, 30).Return(expected, nil)
+
+	result, err := svc.GetTrendingResources()
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestGetTrendingResources_Error(t *testing.T) {
+	mockRepo := new(MockRecommendationRepository)
+	mockUserRepo := new(MockUserRepository)
+	svc := NewRecommendationService(mockRepo, mockUserRepo)
+
+	mockRepo.On("GetTrendingResources", 10, 30).Return([]model.LearningResource(nil), errors.New("db error"))
+
+	result, err := svc.GetTrendingResources()
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}


### PR DESCRIPTION
## 概要
- RecommendationServiceの全メソッド・純粋関数のユニットテストを新規作成
- MockRecommendationRepositoryをmock_test.goに追加

## 変更内容
- **recommendation_test.go**: 18テストケース（純粋関数テスト + サービスメソッドテスト）
  - `trimString`: 通常/空白/タブ/空文字列/内部空白保持の6ケース
  - `splitSkills`: 空/単一/複数/空白付き/末尾カンマ/連続カンマ/カンマのみの7ケース
  - `parseSkills`: 両方空/言語のみ/フレームワークのみ/両方あり/空白含むの5ケース
  - `GetRecommendedUsers`: 成功/ユーザー未存在/スキル無し/リポジトリエラーの4ケース
  - `GetTrendingPosts`: 成功/エラーの2ケース
  - `GetTrendingResources`: 成功/エラーの2ケース（計26テスト）
- **mock_test.go**: MockRecommendationRepository（3メソッド）とインターフェース適合チェック追加

## テスト結果
全テストパス確認済み

Closes #426