### PR TITLE
FollowButtonのi18n対応・エラー通知・アクセシビリティ改善

### DIFF
--- a/frontend/src/components/profile/FollowButton.tsx
+++ b/frontend/src/components/profile/FollowButton.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
 import { followUser, unfollowUser, getFollowers } from '../../api/users';
 import { useAuthStore } from '../../store/authStore';
 
@@ -7,6 +9,7 @@ interface FollowButtonProps {
 }
 
 export default function FollowButton({ userId }: FollowButtonProps) {
+  const { t } = useTranslation();
   const currentUser = useAuthStore((s) => s.user);
   const [isFollowing, setIsFollowing] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -17,7 +20,9 @@ export default function FollowButton({ userId }: FollowButtonProps) {
       .then(({ data }) => {
         setIsFollowing((data || []).some((u) => u.id === currentUser.id));
       })
-      .catch(() => {})
+      .catch(() => {
+        setIsFollowing(false);
+      })
       .finally(() => setLoading(false));
   }, [userId, currentUser]);
 
@@ -32,7 +37,7 @@ export default function FollowButton({ userId }: FollowButtonProps) {
         setIsFollowing(true);
       }
     } catch {
-      // handle error
+      toast.error(isFollowing ? t('profile.unfollowFailed') : t('profile.followFailed'));
     } finally {
       setLoading(false);
     }
@@ -43,13 +48,15 @@ export default function FollowButton({ userId }: FollowButtonProps) {
   return (
     <button
       onClick={handleToggle}
+      aria-label={isFollowing ? t('profile.unfollow') : t('profile.follow')}
+      aria-pressed={isFollowing}
       className={`px-4 py-1.5 rounded-md text-sm font-medium transition-colors ${
         isFollowing
           ? 'bg-gray-700 text-gray-300 hover:bg-red-600 hover:text-white'
           : 'bg-blue-600 text-white hover:bg-blue-700'
       }`}
     >
-      {isFollowing ? 'Following' : 'Follow'}
+      {isFollowing ? t('profile.following') : t('profile.follow')}
     </button>
   );
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -153,7 +153,9 @@
     "qiitaArticles": "Qiita Artikel",
     "viewAllOnQiita": "Alle auf Qiita anzeigen",
     "competitiveProgramming": "Wettbewerbsprogrammierung",
-    "paizaRankLabel": "paiza Rang {{rank}}"
+    "paizaRankLabel": "paiza Rang {{rank}}",
+    "followFailed": "Fehler beim Folgen",
+    "unfollowFailed": "Fehler beim Entfolgen"
   },
   "settings": {
     "title": "Einstellungen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -153,7 +153,9 @@
     "qiitaArticles": "Qiita Articles",
     "viewAllOnQiita": "View all on Qiita",
     "competitiveProgramming": "Competitive Programming",
-    "paizaRankLabel": "paiza Rank {{rank}}"
+    "paizaRankLabel": "paiza Rank {{rank}}",
+    "followFailed": "Failed to follow user",
+    "unfollowFailed": "Failed to unfollow user"
   },
   "settings": {
     "title": "Settings",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -153,7 +153,9 @@
     "qiitaArticles": "Artículos de Qiita",
     "viewAllOnQiita": "Ver todo en Qiita",
     "competitiveProgramming": "Programación Competitiva",
-    "paizaRankLabel": "paiza Rango {{rank}}"
+    "paizaRankLabel": "paiza Rango {{rank}}",
+    "followFailed": "Error al seguir al usuario",
+    "unfollowFailed": "Error al dejar de seguir"
   },
   "settings": {
     "title": "Configuración",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -153,7 +153,9 @@
     "qiitaArticles": "Articles Qiita",
     "viewAllOnQiita": "Voir tout sur Qiita",
     "competitiveProgramming": "Programmation Compétitive",
-    "paizaRankLabel": "paiza Rang {{rank}}"
+    "paizaRankLabel": "paiza Rang {{rank}}",
+    "followFailed": "Échec du suivi",
+    "unfollowFailed": "Échec du désabonnement"
   },
   "settings": {
     "title": "Paramètres",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -170,7 +170,9 @@
     "qiitaArticles": "Qiita記事",
     "viewAllOnQiita": "Qiitaで全て見る",
     "competitiveProgramming": "競技プログラミング",
-    "paizaRankLabel": "paiza ランク{{rank}}"
+    "paizaRankLabel": "paiza ランク{{rank}}",
+    "followFailed": "フォローに失敗しました",
+    "unfollowFailed": "フォロー解除に失敗しました"
   },
   "settings": {
     "title": "設定",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -153,7 +153,9 @@
     "qiitaArticles": "Qiita 기사",
     "viewAllOnQiita": "Qiita에서 모두 보기",
     "competitiveProgramming": "경쟁 프로그래밍",
-    "paizaRankLabel": "paiza 랭크 {{rank}}"
+    "paizaRankLabel": "paiza 랭크 {{rank}}",
+    "followFailed": "팔로우에 실패했습니다",
+    "unfollowFailed": "언팔로우에 실패했습니다"
   },
   "settings": {
     "title": "설정",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -153,7 +153,9 @@
     "qiitaArticles": "Artigos do Qiita",
     "viewAllOnQiita": "Ver tudo no Qiita",
     "competitiveProgramming": "Programação Competitiva",
-    "paizaRankLabel": "paiza Rank {{rank}}"
+    "paizaRankLabel": "paiza Rank {{rank}}",
+    "followFailed": "Falha ao seguir o usuário",
+    "unfollowFailed": "Falha ao deixar de seguir"
   },
   "settings": {
     "title": "Configurações",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -153,7 +153,9 @@
     "qiitaArticles": "Статьи Qiita",
     "viewAllOnQiita": "Смотреть все на Qiita",
     "competitiveProgramming": "Спортивное программирование",
-    "paizaRankLabel": "paiza Ранг {{rank}}"
+    "paizaRankLabel": "paiza Ранг {{rank}}",
+    "followFailed": "Не удалось подписаться",
+    "unfollowFailed": "Не удалось отписаться"
   },
   "settings": {
     "title": "Настройки",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -153,7 +153,9 @@
     "qiitaArticles": "Qiita文章",
     "viewAllOnQiita": "在Qiita上查看全部",
     "competitiveProgramming": "竞技编程",
-    "paizaRankLabel": "paiza 等级 {{rank}}"
+    "paizaRankLabel": "paiza 等级 {{rank}}",
+    "followFailed": "关注失败",
+    "unfollowFailed": "取消关注失败"
   },
   "settings": {
     "title": "设置",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -153,7 +153,9 @@
     "qiitaArticles": "Qiita文章",
     "viewAllOnQiita": "在Qiita上查看全部",
     "competitiveProgramming": "競技程式設計",
-    "paizaRankLabel": "paiza 等級 {{rank}}"
+    "paizaRankLabel": "paiza 等級 {{rank}}",
+    "followFailed": "追蹤失敗",
+    "unfollowFailed": "取消追蹤失敗"
   },
   "settings": {
     "title": "設定",


### PR DESCRIPTION
## 概要
- FollowButtonコンポーネントのUX品質を改善
- ハードコード英語テキストのi18n対応
- 空catchブロックにtoastエラー通知を追加
- アクセシビリティ属性の追加

## 変更内容
- **FollowButton.tsx**:
  - "Follow"/"Following" → `t('profile.follow')`/`t('profile.following')` に置換
  - 空catch → `toast.error(t('profile.followFailed'))` / `toast.error(t('profile.unfollowFailed'))` に置換
  - getFollowers失敗時のcatch: `setIsFollowing(false)` でフォールバック処理追加
  - `aria-label` と `aria-pressed` 属性を追加
- **10言語ロケールファイル**: `profile.followFailed`・`profile.unfollowFailed` キー追加

## テスト結果
TypeScript型チェックパス

Closes #428