### PR TITLE
learning_log/badge/email_preferencesのインラインstruct→DTO抽出

### DIFF
--- a/backend/internal/dto/badge_dto.go
+++ b/backend/internal/dto/badge_dto.go
@@ -1,0 +1,6 @@
+package dto
+
+// NotifyBadgeEarnedRequest はバッジ獲得通知リクエスト。
+type NotifyBadgeEarnedRequest struct {
+	BadgeID string `json:"badge_id" binding:"required" validate:"required"`
+}

--- a/backend/internal/dto/email_preferences_dto.go
+++ b/backend/internal/dto/email_preferences_dto.go
@@ -1,0 +1,7 @@
+package dto
+
+// UpdateEmailPreferencesRequest はメール配信設定更新リクエスト。
+type UpdateEmailPreferencesRequest struct {
+	EmailWeeklyReport *bool   `json:"email_weekly_report"`
+	EmailLanguage     *string `json:"email_language"`
+}

--- a/backend/internal/dto/learning_log_dto.go
+++ b/backend/internal/dto/learning_log_dto.go
@@ -1,0 +1,18 @@
+package dto
+
+// CreateLearningLogRequest は学習ログ作成リクエスト。
+type CreateLearningLogRequest struct {
+	Title    string `json:"title" binding:"required" validate:"required"`
+	Content  string `json:"content" binding:"required" validate:"required"`
+	Category string `json:"category"`
+	Duration int    `json:"duration"`
+	Source   string `json:"source"`
+}
+
+// UpdateLearningLogRequest は学習ログ更新リクエスト。
+type UpdateLearningLogRequest struct {
+	Title    *string `json:"title"`
+	Content  *string `json:"content"`
+	Category *string `json:"category"`
+	Duration *int    `json:"duration"`
+}

--- a/backend/internal/handler/badge.go
+++ b/backend/internal/handler/badge.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
 
@@ -43,9 +44,7 @@ func (h *BadgeHandler) GetUserBadges(c *gin.Context) {
 func (h *BadgeHandler) NotifyBadgeEarned(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req struct {
-		BadgeID string `json:"badge_id" binding:"required"`
-	}
+	var req dto.NotifyBadgeEarnedRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "badge_id is required")
 		return

--- a/backend/internal/handler/email_preferences.go
+++ b/backend/internal/handler/email_preferences.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -42,11 +43,7 @@ func (h *EmailPreferencesHandler) GetPreferences(c *gin.Context) {
 func (h *EmailPreferencesHandler) UpdatePreferences(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req struct {
-		EmailWeeklyReport *bool   `json:"email_weekly_report"`
-		EmailLanguage     *string `json:"email_language"`
-	}
-
+	var req dto.UpdateEmailPreferencesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "invalid request")
 		return

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -31,14 +32,7 @@ func NewLearningLogHandler(s LearningLogServiceInterface) *LearningLogHandler {
 func (h *LearningLogHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req struct {
-		Title    string `json:"title" binding:"required"`
-		Content  string `json:"content" binding:"required"`
-		Category string `json:"category"`
-		Duration int    `json:"duration"`
-		Source   string `json:"source"`
-	}
-
+	var req dto.CreateLearningLogRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "title and content are required")
 		return
@@ -74,13 +68,7 @@ func (h *LearningLogHandler) Update(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Title    *string `json:"title"`
-		Content  *string `json:"content"`
-		Category *string `json:"category"`
-		Duration *int    `json:"duration"`
-	}
-
+	var req dto.UpdateLearningLogRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "invalid request")
 		return


### PR DESCRIPTION
## 概要
- 3ハンドラに残っていたインラインstruct定義をDTO層に抽出
- クリーンアーキテクチャの一貫性向上

## 変更内容
- **dto/learning_log_dto.go**: CreateLearningLogRequest・UpdateLearningLogRequest を新規作成
- **dto/badge_dto.go**: NotifyBadgeEarnedRequest を新規作成
- **dto/email_preferences_dto.go**: UpdateEmailPreferencesRequest を新規作成
- **handler/learning_log.go**: インラインstruct 2箇所 → DTO参照に置換
- **handler/badge.go**: インラインstruct 1箇所 → DTO参照に置換
- **handler/email_preferences.go**: インラインstruct 1箇所 → DTO参照に置換

## テスト結果
全24テストパス（Badge 6件・EmailPreferences 6件・LearningLog 12件）

Closes #430