### PR TITLE
GitHubCallbackPageの全ハードコード英語文字列をi18n対応

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1172,5 +1172,16 @@
     "favoriteToggled": "Favoritenstatus aktualisiert",
     "lastUpdated": "Zuletzt aktualisiert",
     "createdAt": "Erstellt am"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "Fehlende OAuth-Parameter",
+    "loginSuccess": "Mit GitHub angemeldet!",
+    "loginFailed": "GitHub-Anmeldung fehlgeschlagen",
+    "connectSuccess": "GitHub erfolgreich verbunden!",
+    "connectFailed": "GitHub-Verbindung fehlgeschlagen",
+    "backToLogin": "Zurück zum Login",
+    "backToSettings": "Zurück zu Einstellungen",
+    "loggingIn": "Anmeldung mit GitHub...",
+    "connecting": "GitHub wird verbunden..."
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1172,5 +1172,16 @@
     "favoriteToggled": "Favorite status updated",
     "lastUpdated": "Last updated",
     "createdAt": "Created at"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "Missing OAuth parameters",
+    "loginSuccess": "Logged in with GitHub!",
+    "loginFailed": "GitHub login failed",
+    "connectSuccess": "GitHub connected successfully!",
+    "connectFailed": "Failed to connect GitHub",
+    "backToLogin": "Back to Login",
+    "backToSettings": "Back to Settings",
+    "loggingIn": "Logging in with GitHub...",
+    "connecting": "Connecting GitHub..."
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1172,5 +1172,16 @@
     "favoriteToggled": "Estado de favorito actualizado",
     "lastUpdated": "Última actualización",
     "createdAt": "Creado el"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "Faltan parámetros OAuth",
+    "loginSuccess": "¡Sesión iniciada con GitHub!",
+    "loginFailed": "Error al iniciar sesión con GitHub",
+    "connectSuccess": "¡GitHub conectado exitosamente!",
+    "connectFailed": "Error al conectar GitHub",
+    "backToLogin": "Volver al inicio de sesión",
+    "backToSettings": "Volver a configuración",
+    "loggingIn": "Iniciando sesión con GitHub...",
+    "connecting": "Conectando GitHub..."
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1172,5 +1172,16 @@
     "favoriteToggled": "Statut favori mis à jour",
     "lastUpdated": "Dernière mise à jour",
     "createdAt": "Créé le"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "Paramètres OAuth manquants",
+    "loginSuccess": "Connecté avec GitHub !",
+    "loginFailed": "Échec de la connexion GitHub",
+    "connectSuccess": "GitHub connecté avec succès !",
+    "connectFailed": "Échec de la connexion GitHub",
+    "backToLogin": "Retour à la connexion",
+    "backToSettings": "Retour aux paramètres",
+    "loggingIn": "Connexion avec GitHub...",
+    "connecting": "Connexion de GitHub..."
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1073,5 +1073,16 @@
     "favoriteToggled": "お気に入りを更新しました",
     "lastUpdated": "最終更新",
     "createdAt": "作成日時"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "OAuthパラメータが不足しています",
+    "loginSuccess": "GitHubでログインしました",
+    "loginFailed": "GitHubログインに失敗しました",
+    "connectSuccess": "GitHubの連携に成功しました",
+    "connectFailed": "GitHubの連携に失敗しました",
+    "backToLogin": "ログインに戻る",
+    "backToSettings": "設定に戻る",
+    "loggingIn": "GitHubでログイン中...",
+    "connecting": "GitHub連携中..."
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1172,5 +1172,16 @@
     "favoriteToggled": "즐겨찾기 상태가 업데이트되었습니다",
     "lastUpdated": "마지막 업데이트",
     "createdAt": "생성일"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "OAuth 매개변수가 없습니다",
+    "loginSuccess": "GitHub으로 로그인했습니다!",
+    "loginFailed": "GitHub 로그인에 실패했습니다",
+    "connectSuccess": "GitHub 연결에 성공했습니다!",
+    "connectFailed": "GitHub 연결에 실패했습니다",
+    "backToLogin": "로그인으로 돌아가기",
+    "backToSettings": "설정으로 돌아가기",
+    "loggingIn": "GitHub으로 로그인 중...",
+    "connecting": "GitHub 연결 중..."
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1172,5 +1172,16 @@
     "favoriteToggled": "Status de favorito atualizado",
     "lastUpdated": "Última atualização",
     "createdAt": "Criado em"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "Parâmetros OAuth ausentes",
+    "loginSuccess": "Conectado com GitHub!",
+    "loginFailed": "Falha ao entrar com GitHub",
+    "connectSuccess": "GitHub conectado com sucesso!",
+    "connectFailed": "Falha ao conectar GitHub",
+    "backToLogin": "Voltar ao login",
+    "backToSettings": "Voltar às configurações",
+    "loggingIn": "Entrando com GitHub...",
+    "connecting": "Conectando GitHub..."
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1172,5 +1172,16 @@
     "favoriteToggled": "Статус избранного обновлен",
     "lastUpdated": "Последнее обновление",
     "createdAt": "Создано"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "Отсутствуют параметры OAuth",
+    "loginSuccess": "Вход через GitHub выполнен!",
+    "loginFailed": "Не удалось войти через GitHub",
+    "connectSuccess": "GitHub успешно подключён!",
+    "connectFailed": "Не удалось подключить GitHub",
+    "backToLogin": "Вернуться к входу",
+    "backToSettings": "Вернуться к настройкам",
+    "loggingIn": "Вход через GitHub...",
+    "connecting": "Подключение GitHub..."
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1172,5 +1172,16 @@
     "favoriteToggled": "收藏状态已更新",
     "lastUpdated": "最后更新",
     "createdAt": "创建时间"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "缺少OAuth参数",
+    "loginSuccess": "已通过GitHub登录！",
+    "loginFailed": "GitHub登录失败",
+    "connectSuccess": "GitHub连接成功！",
+    "connectFailed": "GitHub连接失败",
+    "backToLogin": "返回登录",
+    "backToSettings": "返回设置",
+    "loggingIn": "正在通过GitHub登录...",
+    "connecting": "正在连接GitHub..."
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1172,5 +1172,16 @@
     "favoriteToggled": "收藏狀態已更新",
     "lastUpdated": "最後更新",
     "createdAt": "創建時間"
+  },
+  "githubCallback": {
+    "missingOAuthParams": "缺少OAuth參數",
+    "loginSuccess": "已透過GitHub登入！",
+    "loginFailed": "GitHub登入失敗",
+    "connectSuccess": "GitHub連接成功！",
+    "connectFailed": "GitHub連接失敗",
+    "backToLogin": "返回登入",
+    "backToSettings": "返回設定",
+    "loggingIn": "正在透過GitHub登入...",
+    "connecting": "正在連接GitHub..."
   }
 }

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { gitHubCallback } from '../api/github';
 import { useAuthStore } from '../store/authStore';
@@ -16,6 +17,7 @@ function parseStatePurpose(state: string): string {
 }
 
 export default function GitHubCallbackPage() {
+  const { t } = useTranslation();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const loadUser = useAuthStore((s) => s.loadUser);
@@ -33,7 +35,7 @@ export default function GitHubCallbackPage() {
     const state = searchParams.get('state');
 
     if (!code || !state) {
-      setError('Missing OAuth parameters');
+      setError(t('githubCallback.missingOAuthParams'));
       return;
     }
 
@@ -43,18 +45,18 @@ export default function GitHubCallbackPage() {
       setMode('login');
       handleGitHubCallback(code, state)
         .then(() => {
-          toast.success('Logged in with GitHub!');
+          toast.success(t('githubCallback.loginSuccess'));
           navigate('/');
         })
         .catch(() => {
-          setError('GitHub login failed');
+          setError(t('githubCallback.loginFailed'));
         });
     } else {
       setMode('connect');
       gitHubCallback(code, state)
         .then(async () => {
           await loadUser();
-          toast.success('GitHub connected successfully!');
+          toast.success(t('githubCallback.connectSuccess'));
           const onboardingRedirect = localStorage.getItem('onboarding_redirect');
           if (onboardingRedirect) {
             localStorage.removeItem('onboarding_redirect');
@@ -64,18 +66,18 @@ export default function GitHubCallbackPage() {
           }
         })
         .catch(() => {
-          setError('Failed to connect GitHub');
+          setError(t('githubCallback.connectFailed'));
         });
     }
-  }, [searchParams, navigate, loadUser, handleGitHubCallback]);
+  }, [searchParams, navigate, loadUser, handleGitHubCallback, t]);
 
   if (error) {
     const backPath = mode === 'login' ? '/login' : '/settings';
-    const backLabel = mode === 'login' ? 'Back to Login' : 'Back to Settings';
+    const backLabel = mode === 'login' ? t('githubCallback.backToLogin') : t('githubCallback.backToSettings');
     return (
       <div className="min-h-screen bg-gray-950 flex items-center justify-center">
         <div className="text-center">
-          <p className="text-red-400 mb-4">{error}</p>
+          <p className="text-red-400 mb-4" role="alert">{error}</p>
           <button
             onClick={() => navigate(backPath)}
             className="px-4 py-2 bg-blue-600 text-white rounded-md"
@@ -90,7 +92,7 @@ export default function GitHubCallbackPage() {
   return (
     <PageLoader
       fullHeight
-      message={mode === 'login' ? 'Logging in with GitHub...' : 'Connecting GitHub...'}
+      message={mode === 'login' ? t('githubCallback.loggingIn') : t('githubCallback.connecting')}
     />
   );
 }


### PR DESCRIPTION
## 概要
- GitHubCallbackPageの8箇所のハードコード英語文字列をi18nキーに置換
- エラー表示にrole="alert"を追加しアクセシビリティ向上

## 変更内容
- **GitHubCallbackPage.tsx**: 8箇所の文字列をt()に置換
  - OAuthパラメータ不足・ログイン成功/失敗・連携成功/失敗
  - 戻るボタンラベル（ログイン/設定）・ローディングメッセージ
- **10言語ロケールファイル**: githubCallbackセクション（9キー）を追加

## テスト結果
TypeScript型チェックパス

Closes #434