### PR TITLE
refactor: roadmapハンドラのインラインstructをDTO層に抽出

### DIFF
--- a/backend/internal/dto/roadmap_dto.go
+++ b/backend/internal/dto/roadmap_dto.go
@@ -1,0 +1,41 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/service"
+
+// CreateRoadmapRequest はロードマップ作成リクエストのDTO。
+type CreateRoadmapRequest struct {
+	Title       string `json:"title" binding:"required"`
+	Description string `json:"description"`
+	Category    string `json:"category"`
+	IsPublic    bool   `json:"is_public"`
+}
+
+// UpdateRoadmapRequest はロードマップ更新リクエストのDTO。
+type UpdateRoadmapRequest struct {
+	Title       *string `json:"title"`
+	Description *string `json:"description"`
+	Category    *string `json:"category"`
+	IsPublic    *bool   `json:"is_public"`
+	Status      *string `json:"status"`
+}
+
+// CreateRoadmapStepRequest はロードマップステップ作成リクエストのDTO。
+type CreateRoadmapStepRequest struct {
+	Title       string `json:"title" binding:"required"`
+	Description string `json:"description"`
+	ResourceURL string `json:"resource_url"`
+	OrderIndex  *int   `json:"order_index"`
+}
+
+// UpdateRoadmapStepRequest はロードマップステップ更新リクエストのDTO。
+type UpdateRoadmapStepRequest struct {
+	Title       *string `json:"title"`
+	Description *string `json:"description"`
+	ResourceURL *string `json:"resource_url"`
+	IsCompleted *bool   `json:"is_completed"`
+}
+
+// ReorderRoadmapStepsRequest はロードマップステップ並べ替えリクエストのDTO。
+type ReorderRoadmapStepsRequest struct {
+	Orders []service.StepOrder `json:"orders" binding:"required"`
+}

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
@@ -45,12 +46,7 @@ func NewRoadmapHandler(s RoadmapServiceInterface) *RoadmapHandler {
 func (h *RoadmapHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req struct {
-		Title       string `json:"title" binding:"required"`
-		Description string `json:"description"`
-		Category    string `json:"category"`
-		IsPublic    bool   `json:"is_public"`
-	}
+	var req dto.CreateRoadmapRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "title is required")
@@ -134,13 +130,7 @@ func (h *RoadmapHandler) Update(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Title       *string `json:"title"`
-		Description *string `json:"description"`
-		Category    *string `json:"category"`
-		IsPublic    *bool   `json:"is_public"`
-		Status      *string `json:"status"`
-	}
+	var req dto.UpdateRoadmapRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "invalid request")
@@ -249,12 +239,7 @@ func (h *RoadmapHandler) CreateStep(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Title       string `json:"title" binding:"required"`
-		Description string `json:"description"`
-		ResourceURL string `json:"resource_url"`
-		OrderIndex  *int   `json:"order_index"`
-	}
+	var req dto.CreateRoadmapStepRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "title is required")
@@ -290,12 +275,7 @@ func (h *RoadmapHandler) UpdateStep(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Title       *string `json:"title"`
-		Description *string `json:"description"`
-		ResourceURL *string `json:"resource_url"`
-		IsCompleted *bool   `json:"is_completed"`
-	}
+	var req dto.UpdateRoadmapStepRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "invalid request")
@@ -364,9 +344,7 @@ func (h *RoadmapHandler) ReorderSteps(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Orders []service.StepOrder `json:"orders" binding:"required"`
-	}
+	var req dto.ReorderRoadmapStepsRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "invalid request")


### PR DESCRIPTION
## 概要
`roadmap.go`内の5つのインラインstruct定義を`dto/roadmap_dto.go`に抽出し、ハンドラコードの可読性と保守性を向上。

## 変更内容
- `dto/roadmap_dto.go`を新規作成（5構造体）
  - `CreateRoadmapRequest` — ロードマップ作成用
  - `UpdateRoadmapRequest` — ロードマップ更新用（全フィールドポインタ型）
  - `CreateRoadmapStepRequest` — ステップ作成用
  - `UpdateRoadmapStepRequest` — ステップ更新用（全フィールドポインタ型）
  - `ReorderRoadmapStepsRequest` — ステップ並べ替え用
- `handler/roadmap.go`の5箇所のインラインstructをDTO参照に置換

## テスト
- `go build ./...` パス
- `go test ./internal/handler/` 全テストパス

Closes #436