### PR TITLE
test: RankingServiceのユニットテスト追加

### DIFF
--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1375,3 +1375,33 @@ func (m *MockNotificationService) CreateNotification(notification *model.Notific
 func (m *MockNotificationService) NotifyFollowers(actorID uint, postID uint, notificationType model.NotificationType) {
 	m.Called(actorID, postID, notificationType)
 }
+
+// ============================================================
+// MockRankingRepository は repository.RankingRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockRankingRepository struct {
+	mock.Mock
+}
+
+var _ repository.RankingRepositoryInterface = (*MockRankingRepository)(nil)
+
+func (m *MockRankingRepository) ContributionRanking(period string) ([]repository.RankingEntry, error) {
+	args := m.Called(period)
+	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+}
+
+func (m *MockRankingRepository) LanguageRanking(language, period string) ([]repository.RankingEntry, error) {
+	args := m.Called(language, period)
+	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+}
+
+func (m *MockRankingRepository) LevelRanking() ([]repository.RankingEntry, error) {
+	args := m.Called()
+	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+}
+
+func (m *MockRankingRepository) AvailableLanguages() ([]string, error) {
+	args := m.Called()
+	return args.Get(0).([]string), args.Error(1)
+}

--- a/backend/internal/service/ranking_test.go
+++ b/backend/internal/service/ranking_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/repository"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRankingService_ContributionRanking(t *testing.T) {
+	t.Run("正常にコントリビューションランキングを取得", func(t *testing.T) {
+		repo := new(MockRankingRepository)
+		svc := NewRankingService(repo)
+
+		expected := []repository.RankingEntry{
+			{UserID: 1, Name: "alice", Score: 100},
+			{UserID: 2, Name: "bob", Score: 80},
+		}
+		repo.On("ContributionRanking", "weekly").Return(expected, nil)
+
+		result, err := svc.ContributionRanking("weekly")
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("リポジトリエラー時にエラーを返す", func(t *testing.T) {
+		repo := new(MockRankingRepository)
+		svc := NewRankingService(repo)
+
+		repo.On("ContributionRanking", "monthly").Return([]repository.RankingEntry(nil), errors.New("db error"))
+
+		result, err := svc.ContributionRanking("monthly")
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		repo.AssertExpectations(t)
+	})
+}
+
+func TestRankingService_LanguageRanking(t *testing.T) {
+	t.Run("正常に言語別ランキングを取得", func(t *testing.T) {
+		repo := new(MockRankingRepository)
+		svc := NewRankingService(repo)
+
+		expected := []repository.RankingEntry{
+			{UserID: 1, Name: "alice", Score: 50},
+		}
+		repo.On("LanguageRanking", "Go", "weekly").Return(expected, nil)
+
+		result, err := svc.LanguageRanking("Go", "weekly")
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("リポジトリエラー時にエラーを返す", func(t *testing.T) {
+		repo := new(MockRankingRepository)
+		svc := NewRankingService(repo)
+
+		repo.On("LanguageRanking", "Python", "monthly").Return([]repository.RankingEntry(nil), errors.New("db error"))
+
+		result, err := svc.LanguageRanking("Python", "monthly")
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		repo.AssertExpectations(t)
+	})
+}
+
+func TestRankingService_LevelRanking(t *testing.T) {
+	t.Run("正常にレベルランキングを取得", func(t *testing.T) {
+		repo := new(MockRankingRepository)
+		svc := NewRankingService(repo)
+
+		expected := []repository.RankingEntry{
+			{UserID: 3, Name: "charlie", Score: 200},
+			{UserID: 1, Name: "alice", Score: 150},
+		}
+		repo.On("LevelRanking").Return(expected, nil)
+
+		result, err := svc.LevelRanking()
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("リポジトリエラー時にエラーを返す", func(t *testing.T) {
+		repo := new(MockRankingRepository)
+		svc := NewRankingService(repo)
+
+		repo.On("LevelRanking").Return([]repository.RankingEntry(nil), errors.New("db error"))
+
+		result, err := svc.LevelRanking()
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		repo.AssertExpectations(t)
+	})
+}
+
+func TestRankingService_AvailableLanguages(t *testing.T) {
+	t.Run("正常に利用可能言語一覧を取得", func(t *testing.T) {
+		repo := new(MockRankingRepository)
+		svc := NewRankingService(repo)
+
+		expected := []string{"Go", "Python", "TypeScript"}
+		repo.On("AvailableLanguages").Return(expected, nil)
+
+		result, err := svc.AvailableLanguages()
+		assert.NoError(t, err)
+		assert.Equal(t, expected, result)
+		repo.AssertExpectations(t)
+	})
+
+	t.Run("リポジトリエラー時にエラーを返す", func(t *testing.T) {
+		repo := new(MockRankingRepository)
+		svc := NewRankingService(repo)
+
+		repo.On("AvailableLanguages").Return([]string(nil), errors.New("db error"))
+
+		result, err := svc.AvailableLanguages()
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		repo.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
## 概要
`ranking.go`の4メソッドに対するユニットテストを追加し、テストカバレッジを向上。

## 変更内容
- `mock_test.go`にMockRankingRepository追加（4メソッド + インターフェース適合チェック）
- `ranking_test.go`新規作成（4テスト関数・8サブテスト）
  - `ContributionRanking` — 正常取得/DBエラー
  - `LanguageRanking` — 正常取得/DBエラー
  - `LevelRanking` — 正常取得/DBエラー
  - `AvailableLanguages` — 正常取得/DBエラー

## テスト
- `go test ./internal/service/ -run TestRankingService` 全8テストパス

Closes #438