### PR TITLE
fix: チャットモーダル・StudyCirclesPageのUX改善

### DIFF
--- a/frontend/src/components/chat/CreateRoomModal.tsx
+++ b/frontend/src/components/chat/CreateRoomModal.tsx
@@ -51,7 +51,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
       <div className="bg-gray-800 rounded-md p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-white">{t('chat.createGroup')}</h2>
-          <button onClick={onClose} className="p-1 text-gray-400 hover:text-white transition-colors">
+          <button onClick={onClose} className="p-1 text-gray-400 hover:text-white transition-colors" aria-label={t('common.close')}>
             <X className="w-5 h-5" />
           </button>
         </div>
@@ -125,7 +125,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
               disabled={!name.trim() || loading}
               className={`${buttonPrimaryClass} flex-1 text-sm disabled:opacity-50`}
             >
-              {loading ? '...' : t('chat.createButton')}
+              {loading ? t('common.saving') : t('chat.createButton')}
             </button>
           </div>
         </form>

--- a/frontend/src/components/chat/RoomSettingsModal.tsx
+++ b/frontend/src/components/chat/RoomSettingsModal.tsx
@@ -6,7 +6,7 @@ import {
   getChatRoomMembers, updateChatRoom, deleteChatRoom,
   addChatRoomMember, removeChatRoomMember,
 } from '../../api/chatRooms';
-import { labelClass, textareaClass, buttonPrimaryClass } from '../../constants/styles';
+import { inputClass, labelClass, textareaClass, buttonPrimaryClass } from '../../constants/styles';
 import { useConfirm } from '../../hooks';
 import type { User } from '../../types/user';
 import type { ChatRoom, ChatRoomMember } from '../../types/chat';
@@ -40,7 +40,7 @@ export default function RoomSettingsModal({
   useEffect(() => {
     getChatRoomMembers(room.id)
       .then(({ data }) => setMembers(data || []))
-      .catch(() => {});
+      .catch(() => { toast.error(t('chat.loadMembersFailed')); });
   }, [room.id]);
 
   const memberUserIds = members.map((m) => m.user_id);
@@ -115,7 +115,7 @@ export default function RoomSettingsModal({
       <div className="bg-gray-800 rounded-md p-6 w-full max-w-md max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between mb-4">
           <h2 className="text-lg font-semibold text-white">{t('chat.roomSettings')}</h2>
-          <button onClick={onClose} className="p-1 text-gray-400 hover:text-white transition-colors">
+          <button onClick={onClose} className="p-1 text-gray-400 hover:text-white transition-colors" aria-label={t('common.close')}>
             <X className="w-5 h-5" />
           </button>
         </div>
@@ -131,7 +131,7 @@ export default function RoomSettingsModal({
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
-                className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded-lg text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                className={inputClass}
               />
             </div>
             <div>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -294,7 +294,8 @@
     "addMemberFailed": "Mitglied konnte nicht hinzugefügt werden",
     "removeMemberFailed": "Mitglied konnte nicht entfernt werden",
     "leaveFailed": "Gruppe konnte nicht verlassen werden",
-    "chatDeleteFailed": "Gruppe konnte nicht gelöscht werden"
+    "chatDeleteFailed": "Gruppe konnte nicht gelöscht werden",
+    "loadMembersFailed": "Mitglieder konnten nicht geladen werden"
   },
   "rankings": {
     "title": "Ranglisten",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -294,7 +294,8 @@
     "addMemberFailed": "Failed to add member",
     "removeMemberFailed": "Failed to remove member",
     "leaveFailed": "Failed to leave group",
-    "chatDeleteFailed": "Failed to delete group"
+    "chatDeleteFailed": "Failed to delete group",
+    "loadMembersFailed": "Failed to load members"
   },
   "rankings": {
     "title": "Rankings",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -294,7 +294,8 @@
     "addMemberFailed": "Error al añadir miembro",
     "removeMemberFailed": "Error al eliminar miembro",
     "leaveFailed": "Error al salir del grupo",
-    "chatDeleteFailed": "Error al eliminar grupo"
+    "chatDeleteFailed": "Error al eliminar grupo",
+    "loadMembersFailed": "Error al cargar los miembros"
   },
   "rankings": {
     "title": "Rankings",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -294,7 +294,8 @@
     "addMemberFailed": "Échec de l'ajout du membre",
     "removeMemberFailed": "Échec de la suppression du membre",
     "leaveFailed": "Échec de la sortie du groupe",
-    "chatDeleteFailed": "Échec de la suppression du groupe"
+    "chatDeleteFailed": "Échec de la suppression du groupe",
+    "loadMembersFailed": "Échec du chargement des membres"
   },
   "rankings": {
     "title": "Classements",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -297,7 +297,8 @@
     "addMemberFailed": "メンバー追加に失敗しました",
     "removeMemberFailed": "メンバー削除に失敗しました",
     "leaveFailed": "グループ退出に失敗しました",
-    "chatDeleteFailed": "グループ削除に失敗しました"
+    "chatDeleteFailed": "グループ削除に失敗しました",
+    "loadMembersFailed": "メンバーの読み込みに失敗しました"
   },
   "rankings": {
     "title": "ランキング",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -294,7 +294,8 @@
     "addMemberFailed": "멤버 추가에 실패했습니다",
     "removeMemberFailed": "멤버 삭제에 실패했습니다",
     "leaveFailed": "그룹 탈퇴에 실패했습니다",
-    "chatDeleteFailed": "그룹 삭제에 실패했습니다"
+    "chatDeleteFailed": "그룹 삭제에 실패했습니다",
+    "loadMembersFailed": "멤버를 불러오지 못했습니다"
   },
   "rankings": {
     "title": "랭킹",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -294,7 +294,8 @@
     "addMemberFailed": "Falha ao adicionar membro",
     "removeMemberFailed": "Falha ao remover membro",
     "leaveFailed": "Falha ao sair do grupo",
-    "chatDeleteFailed": "Falha ao excluir grupo"
+    "chatDeleteFailed": "Falha ao excluir grupo",
+    "loadMembersFailed": "Falha ao carregar membros"
   },
   "rankings": {
     "title": "Rankings",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -294,7 +294,8 @@
     "addMemberFailed": "Не удалось добавить участника",
     "removeMemberFailed": "Не удалось удалить участника",
     "leaveFailed": "Не удалось покинуть группу",
-    "chatDeleteFailed": "Не удалось удалить группу"
+    "chatDeleteFailed": "Не удалось удалить группу",
+    "loadMembersFailed": "Не удалось загрузить участников"
   },
   "rankings": {
     "title": "Рейтинги",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -294,7 +294,8 @@
     "addMemberFailed": "添加成员失败",
     "removeMemberFailed": "移除成员失败",
     "leaveFailed": "退出群组失败",
-    "chatDeleteFailed": "删除群组失败"
+    "chatDeleteFailed": "删除群组失败",
+    "loadMembersFailed": "加载成员失败"
   },
   "rankings": {
     "title": "排行榜",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -294,7 +294,8 @@
     "addMemberFailed": "新增成員失敗",
     "removeMemberFailed": "移除成員失敗",
     "leaveFailed": "退出群組失敗",
-    "chatDeleteFailed": "刪除群組失敗"
+    "chatDeleteFailed": "刪除群組失敗",
+    "loadMembersFailed": "載入成員失敗"
   },
   "rankings": {
     "title": "排行榜",

--- a/frontend/src/pages/StudyCirclesPage.tsx
+++ b/frontend/src/pages/StudyCirclesPage.tsx
@@ -178,7 +178,7 @@ export default function StudyCirclesPage() {
             disabled={saving || !form.name || !form.topic}
             className="px-4 py-2 bg-purple-600 hover:bg-purple-500 disabled:opacity-50 text-white rounded-lg text-sm font-medium transition-colors"
           >
-            {saving ? '...' : t('studyCircle.create')}
+            {saving ? t('common.saving') : t('studyCircle.create')}
           </button>
         </div>
       </Modal>


### PR DESCRIPTION
## 概要
チャットモーダル2件とStudyCirclesPageのローディング状態表示・エラーハンドリング・アクセシビリティを改善。

## 変更内容
- **CreateRoomModal**: ローディング表示 `'...'` → `t('common.saving')`、closeボタンにaria-label追加
- **RoomSettingsModal**: `getChatRoomMembers`の空catch → toast.error通知、closeボタンにaria-label追加、インラインinputクラス → `inputClass`定数
- **StudyCirclesPage**: ローディング表示 `'...'` → `t('common.saving')`
- 10言語に`chat.loadMembersFailed`キー追加

## テスト
- TypeScript型チェックパス

Closes #440