### PR TITLE
refactor: qiita/zenn/study_circleハンドラのインラインstruct→DTO抽出

### DIFF
--- a/backend/internal/dto/study_circle_dto.go
+++ b/backend/internal/dto/study_circle_dto.go
@@ -1,0 +1,53 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/repository"
+
+// CreateStudyCircleRequest はスタディサークル作成リクエストのDTO。
+type CreateStudyCircleRequest struct {
+	Name        string `json:"name" binding:"required"`
+	Topic       string `json:"topic" binding:"required"`
+	Description string `json:"description"`
+	MaxMembers  int    `json:"max_members"`
+	MemberIDs   []uint `json:"member_ids"`
+}
+
+// UpdateStudyCircleRequest はスタディサークル更新リクエストのDTO。
+type UpdateStudyCircleRequest struct {
+	Name        *string `json:"name"`
+	Topic       *string `json:"topic"`
+	Description *string `json:"description"`
+}
+
+// AddStudyCircleMemberRequest はスタディサークルメンバー追加リクエストのDTO。
+type AddStudyCircleMemberRequest struct {
+	UserID uint `json:"user_id" binding:"required"`
+}
+
+// CreateStudyCircleStepRequest はスタディサークルステップ作成リクエストのDTO。
+type CreateStudyCircleStepRequest struct {
+	Title       string `json:"title" binding:"required"`
+	Description string `json:"description"`
+	ResourceURL string `json:"resource_url"`
+	OrderIndex  int    `json:"order_index"`
+}
+
+// UpdateStudyCircleStepRequest はスタディサークルステップ更新リクエストのDTO。
+type UpdateStudyCircleStepRequest struct {
+	Title       *string `json:"title"`
+	Description *string `json:"description"`
+}
+
+// ReorderStudyCircleStepsRequest はスタディサークルステップ並べ替えリクエストのDTO。
+type ReorderStudyCircleStepsRequest struct {
+	Orders []repository.StepOrder `json:"orders" binding:"required"`
+}
+
+// UpdateStudyCircleProgressRequest はスタディサークル進捗更新リクエストのDTO。
+type UpdateStudyCircleProgressRequest struct {
+	IsCompleted bool `json:"is_completed"`
+}
+
+// CreateStudyCircleCheckinRequest はスタディサークルチェックイン作成リクエストのDTO。
+type CreateStudyCircleCheckinRequest struct {
+	Content string `json:"content" binding:"required"`
+}

--- a/backend/internal/handler/qiita.go
+++ b/backend/internal/handler/qiita.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -30,9 +31,7 @@ func NewQiitaHandler(s QiitaServiceInterface) *QiitaHandler {
 func (h *QiitaHandler) Connect(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req struct {
-		Username string `json:"username" binding:"required"`
-	}
+	var req dto.ConnectUsernameRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "username is required")

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -40,13 +41,7 @@ func NewStudyCircleHandler(svc StudyCircleServiceInterface) *StudyCircleHandler 
 
 // Create はサークルを作成する。
 func (h *StudyCircleHandler) Create(c *gin.Context) {
-	var req struct {
-		Name        string `json:"name" binding:"required"`
-		Topic       string `json:"topic" binding:"required"`
-		Description string `json:"description"`
-		MaxMembers  int    `json:"max_members"`
-		MemberIDs   []uint `json:"member_ids"`
-	}
+	var req dto.CreateStudyCircleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, err.Error())
 		return
@@ -100,11 +95,7 @@ func (h *StudyCircleHandler) Update(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req struct {
-		Name        *string `json:"name"`
-		Topic       *string `json:"topic"`
-		Description *string `json:"description"`
-	}
+	var req dto.UpdateStudyCircleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, err.Error())
 		return
@@ -153,9 +144,7 @@ func (h *StudyCircleHandler) AddMember(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req struct {
-		UserID uint `json:"user_id" binding:"required"`
-	}
+	var req dto.AddStudyCircleMemberRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, err.Error())
 		return
@@ -192,12 +181,7 @@ func (h *StudyCircleHandler) CreateStep(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req struct {
-		Title       string `json:"title" binding:"required"`
-		Description string `json:"description"`
-		ResourceURL string `json:"resource_url"`
-		OrderIndex  int    `json:"order_index"`
-	}
+	var req dto.CreateStudyCircleStepRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, err.Error())
 		return
@@ -227,10 +211,7 @@ func (h *StudyCircleHandler) UpdateStep(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req struct {
-		Title       *string `json:"title"`
-		Description *string `json:"description"`
-	}
+	var req dto.UpdateStudyCircleStepRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, err.Error())
 		return
@@ -268,9 +249,7 @@ func (h *StudyCircleHandler) ReorderSteps(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req struct {
-		Orders []repository.StepOrder `json:"orders" binding:"required"`
-	}
+	var req dto.ReorderStudyCircleStepsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, err.Error())
 		return
@@ -293,9 +272,7 @@ func (h *StudyCircleHandler) UpdateProgress(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req struct {
-		IsCompleted bool `json:"is_completed"`
-	}
+	var req dto.UpdateStudyCircleProgressRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, err.Error())
 		return
@@ -329,9 +306,7 @@ func (h *StudyCircleHandler) CreateCheckin(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req struct {
-		Content string `json:"content" binding:"required"`
-	}
+	var req dto.CreateStudyCircleCheckinRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, err.Error())
 		return

--- a/backend/internal/handler/zenn.go
+++ b/backend/internal/handler/zenn.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -30,9 +31,7 @@ func NewZennHandler(s ZennServiceInterface) *ZennHandler {
 func (h *ZennHandler) Connect(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req struct {
-		Username string `json:"username" binding:"required"`
-	}
+	var req dto.ConnectUsernameRequest
 
 	if err := c.ShouldBindJSON(&req); err != nil {
 		respondBadRequest(c, "username is required")


### PR DESCRIPTION
## 概要
残りのハンドラファイルからインラインstruct定義をDTO層に抽出し、ハンドラ層のインラインstruct完全排除に向けて前進。

## 変更内容
- **qiita.go / zenn.go**: 各1箇所のUsername struct → 既存`dto.ConnectUsernameRequest`に置換
- **study_circle.go**: 8箇所のインラインstruct → 新規`dto/study_circle_dto.go`に抽出
  - `CreateStudyCircleRequest` / `UpdateStudyCircleRequest`
  - `AddStudyCircleMemberRequest`
  - `CreateStudyCircleStepRequest` / `UpdateStudyCircleStepRequest`
  - `ReorderStudyCircleStepsRequest`
  - `UpdateStudyCircleProgressRequest`
  - `CreateStudyCircleCheckinRequest`

## テスト
- `go build ./...` パス
- `go test ./internal/handler/` 全テストパス

Closes #442