### PR TITLE
fix: ハードコード英語aria-label/titleのi18n化

### DIFF
--- a/frontend/src/components/common/LanguageSelector.tsx
+++ b/frontend/src/components/common/LanguageSelector.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { languages } from '../../i18n';
 
 export default function LanguageSelector() {
-  const { i18n } = useTranslation();
+  const { t, i18n } = useTranslation();
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -30,7 +30,7 @@ export default function LanguageSelector() {
       <button
         onClick={() => setIsOpen(!isOpen)}
         className="flex items-center gap-1.5 px-2 py-1.5 text-sm text-gray-400 hover:text-white hover:bg-gray-800 rounded-md transition-colors"
-        aria-label="Select language"
+        aria-label={t('common.selectLanguage')}
       >
         <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
           <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" />

--- a/frontend/src/components/common/Toast.tsx
+++ b/frontend/src/components/common/Toast.tsx
@@ -54,6 +54,7 @@ interface ToastItemProps {
 }
 
 function ToastItem({ toast }: ToastItemProps) {
+  const { t } = useTranslation();
   const removeToast = useToastStore((state) => state.removeToast);
 
   useEffect(() => {
@@ -77,7 +78,7 @@ function ToastItem({ toast }: ToastItemProps) {
       <button
         onClick={() => removeToast(toast.id)}
         className="flex-shrink-0 ml-2 opacity-70 hover:opacity-100 transition-opacity"
-        aria-label="Close"
+        aria-label={t('common.close')}
       >
         <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
           <path

--- a/frontend/src/components/profile/PortfolioModal.tsx
+++ b/frontend/src/components/profile/PortfolioModal.tsx
@@ -121,7 +121,7 @@ export default function PortfolioModal({
               <iframe
                 srcDoc={html}
                 className="w-full h-96 border-0"
-                title="Portfolio Preview"
+                title={t('portfolio.preview')}
               />
             </div>
           )}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -19,7 +19,8 @@
     "or": "oder",
     "and": "und",
     "menu": "Menü",
-    "scrollToTop": "Nach oben"
+    "scrollToTop": "Nach oben",
+    "selectLanguage": "Sprache auswählen"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -19,7 +19,8 @@
     "and": "and",
     "add": "Add",
     "menu": "Menu",
-    "scrollToTop": "Back to top"
+    "scrollToTop": "Back to top",
+    "selectLanguage": "Select language"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -19,7 +19,8 @@
     "or": "o",
     "and": "y",
     "menu": "Menú",
-    "scrollToTop": "Volver arriba"
+    "scrollToTop": "Volver arriba",
+    "selectLanguage": "Seleccionar idioma"
   },
   "nav": {
     "dashboard": "Panel",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -19,7 +19,8 @@
     "or": "ou",
     "and": "et",
     "menu": "Menu",
-    "scrollToTop": "Retour en haut"
+    "scrollToTop": "Retour en haut",
+    "selectLanguage": "Choisir la langue"
   },
   "nav": {
     "dashboard": "Tableau de bord",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -20,7 +20,8 @@
     "add": "追加",
     "menu": "メニュー",
     "scrollToTop": "ページ上部に戻る",
-    "dismiss": "閉じる"
+    "dismiss": "閉じる",
+    "selectLanguage": "言語を選択"
   },
   "nav": {
     "dashboard": "ダッシュボード",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -19,7 +19,8 @@
     "or": "또는",
     "and": "그리고",
     "menu": "메뉴",
-    "scrollToTop": "맨 위로"
+    "scrollToTop": "맨 위로",
+    "selectLanguage": "언어 선택"
   },
   "nav": {
     "dashboard": "대시보드",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -19,7 +19,8 @@
     "or": "ou",
     "and": "e",
     "menu": "Menu",
-    "scrollToTop": "Voltar ao topo"
+    "scrollToTop": "Voltar ao topo",
+    "selectLanguage": "Selecionar idioma"
   },
   "nav": {
     "dashboard": "Painel",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -19,7 +19,8 @@
     "or": "или",
     "and": "и",
     "menu": "Меню",
-    "scrollToTop": "Наверх"
+    "scrollToTop": "Наверх",
+    "selectLanguage": "Выбрать язык"
   },
   "nav": {
     "dashboard": "Панель",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -19,7 +19,8 @@
     "or": "或",
     "and": "和",
     "menu": "菜单",
-    "scrollToTop": "返回顶部"
+    "scrollToTop": "返回顶部",
+    "selectLanguage": "选择语言"
   },
   "nav": {
     "dashboard": "仪表板",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -19,7 +19,8 @@
     "or": "或",
     "and": "和",
     "menu": "選單",
-    "scrollToTop": "返回頂部"
+    "scrollToTop": "返回頂部",
+    "selectLanguage": "選擇語言"
   },
   "nav": {
     "dashboard": "儀表板",


### PR DESCRIPTION
## 概要
残存するハードコード英語のaria-label/title属性をi18nキーに置換し、多言語対応を完了。

## 変更内容
- **Toast.tsx**: `aria-label="Close"` → `aria-label={t('common.close')}`、ToastItemにuseTranslation追加
- **LanguageSelector.tsx**: `aria-label="Select language"` → `aria-label={t('common.selectLanguage')}`、tの取得追加
- **PortfolioModal.tsx**: `title="Portfolio Preview"` → `title={t('portfolio.preview')}`（既存キー再利用）
- 10言語に`common.selectLanguage`キー追加

## テスト
- TypeScript型チェックパス

Closes #446