### PR TITLE
refactor: ハンドラレスポンスのgin.H→型付きDTO変換

### DIFF
--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -1,6 +1,13 @@
 // Package dto provides Data Transfer Objects for API requests and responses.
 package dto
 
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// UserResponse はユーザー情報レスポンス（認証後のレスポンスで使用）
+type UserResponse struct {
+	User model.User `json:"user"`
+}
+
 // RegisterRequest は新規ユーザー登録リクエスト
 type RegisterRequest struct {
 	Name            string `json:"name" binding:"required" validate:"required"`

--- a/backend/internal/dto/badge_dto.go
+++ b/backend/internal/dto/badge_dto.go
@@ -1,5 +1,12 @@
 package dto
 
+import "github.com/norman6464/devsync/backend/internal/service"
+
+// BadgesResponse はバッジ一覧レスポンス
+type BadgesResponse struct {
+	Badges []service.BadgeResult `json:"badges"`
+}
+
 // NotifyBadgeEarnedRequest はバッジ獲得通知リクエスト。
 type NotifyBadgeEarnedRequest struct {
 	BadgeID string `json:"badge_id" binding:"required" validate:"required"`

--- a/backend/internal/dto/notification_dto.go
+++ b/backend/internal/dto/notification_dto.go
@@ -1,0 +1,9 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// NotificationListResponse は通知一覧レスポンス
+type NotificationListResponse struct {
+	Notifications []model.Notification `json:"notifications"`
+	Total         int64                `json:"total"`
+}

--- a/backend/internal/dto/response.go
+++ b/backend/internal/dto/response.go
@@ -16,6 +16,16 @@ type URLResponse struct {
 	URL string `json:"url"`
 }
 
+// StatusResponse はステータスレスポンス
+type StatusResponse struct {
+	Status string `json:"status"`
+}
+
+// CountResponse はカウントレスポンス
+type CountResponse struct {
+	Count int64 `json:"count"`
+}
+
 // DataResponse は汎用データレスポンス
 type DataResponse[T any] struct {
 	Data T `json:"data"`

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -84,7 +84,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	}
 
 	setAuthCookie(c, resp.Token)
-	respondCreated(c, gin.H{"user": resp.User})
+	respondCreated(c, dto.UserResponse{User: resp.User})
 }
 
 // Login はメール・パスワードによるログインを処理する。
@@ -107,7 +107,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	}
 
 	setAuthCookie(c, resp.Token)
-	respondOK(c, gin.H{"user": resp.User})
+	respondOK(c, dto.UserResponse{User: resp.User})
 }
 
 // GitHubLogin はGitHub OAuthログインのURLを生成して返す。
@@ -160,7 +160,7 @@ func (h *AuthHandler) GitHubLoginCallback(c *gin.Context) {
 	go h.githubService.SyncUserData(resp.User.ID)
 
 	setAuthCookie(c, resp.Token)
-	respondOK(c, gin.H{"user": resp.User})
+	respondOK(c, dto.UserResponse{User: resp.User})
 }
 
 // Me は認証済みユーザーの情報を返す。

--- a/backend/internal/handler/badge.go
+++ b/backend/internal/handler/badge.go
@@ -37,7 +37,7 @@ func (h *BadgeHandler) GetUserBadges(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"badges": badges})
+	respondOK(c, dto.BadgesResponse{Badges: badges})
 }
 
 // NotifyBadgeEarned は新しく獲得したバッジの通知を作成する。

--- a/backend/internal/handler/github.go
+++ b/backend/internal/handler/github.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -50,7 +51,7 @@ func (h *GitHubHandler) Connect(c *gin.Context) {
 		return
 	}
 	url := h.githubService.GetOAuthURL(state)
-	respondOK(c, gin.H{"url": url})
+	respondOK(c, dto.URLResponse{URL: url})
 }
 
 // Callback はGitHub OAuthコールバックを処理してアカウントを連携する。

--- a/backend/internal/handler/health.go
+++ b/backend/internal/handler/health.go
@@ -2,10 +2,13 @@
 // Ginフレームワークを使用し、リクエストの受付・バリデーション・レスポンス返却を担当する。
 package handler
 
-import "github.com/gin-gonic/gin"
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
+)
 
 // HealthCheck はヘルスチェックエンドポイントのハンドラ。
 // サーバーの稼働状態を確認するために使用する。
 func HealthCheck(c *gin.Context) {
-	respondOK(c, gin.H{"status": "ok"})
+	respondOK(c, dto.StatusResponse{Status: "ok"})
 }

--- a/backend/internal/handler/notification.go
+++ b/backend/internal/handler/notification.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -45,9 +46,9 @@ func (h *NotificationHandler) GetAll(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"notifications": notifications,
-		"total":         total,
+	respondOK(c, dto.NotificationListResponse{
+		Notifications: notifications,
+		Total:         total,
 	})
 }
 
@@ -60,7 +61,7 @@ func (h *NotificationHandler) GetUnreadCount(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"count": count})
+	respondOK(c, dto.CountResponse{Count: count})
 }
 
 // MarkAsRead は指定された通知を既読にする。


### PR DESCRIPTION
## 概要
- ハンドラ層の`gin.H`（型安全性なし）を型付きDTOレスポンス構造体に変換
- 5ハンドラファイル8箇所を置換（auth.go×3, github.go×1, health.go×1, notification.go×2, badge.go×1）
- 新規DTO: `UserResponse`, `StatusResponse`, `CountResponse`, `BadgesResponse`, `NotificationListResponse`

## テスト
- `go build ./...` パス
- `go test ./internal/handler/...` パス

Closes #448