### PR TITLE
refactor: qiita/zenn/upload/ai_adviceハンドラのgin.H→型付きDTO変換

### DIFF
--- a/backend/internal/dto/ai_advice_dto.go
+++ b/backend/internal/dto/ai_advice_dto.go
@@ -1,5 +1,14 @@
 package dto
 
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// AIAdviceResponse はAIアドバイス取得レスポンス。
+type AIAdviceResponse struct {
+	Advices            []model.AIAdvice `json:"advices"`
+	LLMAvailable       bool             `json:"llm_available"`
+	DailyChatRemaining int              `json:"daily_chat_remaining"`
+}
+
 // AIChatRequest はLLMチャットリクエスト。
 type AIChatRequest struct {
 	Message        string `json:"message" binding:"required" validate:"required"`

--- a/backend/internal/dto/common_dto.go
+++ b/backend/internal/dto/common_dto.go
@@ -5,3 +5,10 @@ package dto
 type ConnectUsernameRequest struct {
 	Username string `json:"username" binding:"required" validate:"required"`
 }
+
+// ConnectSyncResponse は外部サービス接続・同期のレスポンス。
+// Qiita・Zennで共通使用する。
+type ConnectSyncResponse struct {
+	Message       string `json:"message"`
+	ArticlesCount int    `json:"articles_count"`
+}

--- a/backend/internal/dto/upload_dto.go
+++ b/backend/internal/dto/upload_dto.go
@@ -1,0 +1,12 @@
+package dto
+
+// UploadResponse は単一ファイルアップロードレスポンス。
+type UploadResponse struct {
+	URL      string `json:"url"`
+	Filename string `json:"filename"`
+}
+
+// UploadMultipleResponse は複数ファイルアップロードレスポンス。
+type UploadMultipleResponse struct {
+	URLs []string `json:"urls"`
+}

--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -53,10 +53,10 @@ func (h *AIAdviceHandler) GetAdvice(c *gin.Context) {
 		}
 	}
 
-	respondOK(c, gin.H{
-		"advices":              advices,
-		"llm_available":        llmAvailable,
-		"daily_chat_remaining": remaining,
+	respondOK(c, dto.AIAdviceResponse{
+		Advices:            advices,
+		LLMAvailable:       llmAvailable,
+		DailyChatRemaining: remaining,
 	})
 }
 

--- a/backend/internal/handler/qiita.go
+++ b/backend/internal/handler/qiita.go
@@ -44,9 +44,9 @@ func (h *QiitaHandler) Connect(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"message":        "Qiita connected successfully",
-		"articles_count": count,
+	respondOK(c, dto.ConnectSyncResponse{
+		Message:       "Qiita connected successfully",
+		ArticlesCount: count,
 	})
 }
 
@@ -72,9 +72,9 @@ func (h *QiitaHandler) Sync(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"message":        "Qiita synced successfully",
-		"articles_count": count,
+	respondOK(c, dto.ConnectSyncResponse{
+		Message:       "Qiita synced successfully",
+		ArticlesCount: count,
 	})
 }
 

--- a/backend/internal/handler/upload.go
+++ b/backend/internal/handler/upload.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/norman6464/devsync/backend/internal/dto"
 )
 
 // allowedMIMETypes はアップロードを許可するMIMEタイプの一覧。
@@ -125,9 +126,9 @@ func (h *UploadHandler) UploadImage(c *gin.Context) {
 
 	// URLパスを返す
 	urlPath := fmt.Sprintf("/uploads/%s/%s", dateDir, filename)
-	respondOK(c, gin.H{
-		"url":      urlPath,
-		"filename": filename,
+	respondOK(c, dto.UploadResponse{
+		URL:      urlPath,
+		Filename: filename,
 	})
 }
 
@@ -210,5 +211,5 @@ func (h *UploadHandler) UploadMultipleImages(c *gin.Context) {
 		urls = append(urls, fmt.Sprintf("/uploads/%s/%s", dateDir, filename))
 	}
 
-	respondOK(c, gin.H{"urls": urls})
+	respondOK(c, dto.UploadMultipleResponse{URLs: urls})
 }

--- a/backend/internal/handler/zenn.go
+++ b/backend/internal/handler/zenn.go
@@ -44,9 +44,9 @@ func (h *ZennHandler) Connect(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"message":        "Zenn connected successfully",
-		"articles_count": count,
+	respondOK(c, dto.ConnectSyncResponse{
+		Message:       "Zenn connected successfully",
+		ArticlesCount: count,
 	})
 }
 
@@ -72,9 +72,9 @@ func (h *ZennHandler) Sync(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"message":        "Zenn synced successfully",
-		"articles_count": count,
+	respondOK(c, dto.ConnectSyncResponse{
+		Message:       "Zenn synced successfully",
+		ArticlesCount: count,
 	})
 }
 


### PR DESCRIPTION
## 概要
- 4ハンドラファイル7箇所の`gin.H`を型付きDTOレスポンスに変換（第2弾）
- qiita.go×2, zenn.go×2: `gin.H{"message":..., "articles_count":...}` → `dto.ConnectSyncResponse`
- upload.go×2: `gin.H{"url":..., "filename":...}` → `dto.UploadResponse` / `dto.UploadMultipleResponse`
- ai_advice.go×1: `gin.H{"advices":..., ...}` → `dto.AIAdviceResponse`

## テスト
- `go build ./...` パス
- `go test ./internal/handler/...` パス

Closes #454