### PR TITLE
fix: MarkdownEditorコンポーネントのi18n対応

### DIFF
--- a/frontend/src/components/posts/MarkdownEditor.tsx
+++ b/frontend/src/components/posts/MarkdownEditor.tsx
@@ -1,4 +1,5 @@
 import { useState, useRef, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
@@ -18,10 +19,11 @@ interface MarkdownEditorProps {
 export default function MarkdownEditor({
   value,
   onChange,
-  placeholder = 'Write your content here... (Markdown supported)',
+  placeholder,
   minHeight = '200px',
   onImagesChange,
 }: MarkdownEditorProps) {
+  const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState<'write' | 'preview'>('write');
   const [uploading, setUploading] = useState(false);
   const [uploadedImages, setUploadedImages] = useState<string[]>([]);
@@ -151,21 +153,21 @@ export default function MarkdownEditor({
   };
 
   const toolbarButtons = [
-    { action: 'heading', icon: 'H', title: 'Heading' },
-    { action: 'bold', icon: 'B', title: 'Bold', className: 'font-bold' },
-    { action: 'italic', icon: 'I', title: 'Italic', className: 'italic' },
-    { action: 'strikethrough', icon: 'S', title: 'Strikethrough', className: 'line-through' },
+    { action: 'heading', icon: 'H', title: t('editor.heading') },
+    { action: 'bold', icon: 'B', title: t('editor.bold'), className: 'font-bold' },
+    { action: 'italic', icon: 'I', title: t('editor.italic'), className: 'italic' },
+    { action: 'strikethrough', icon: 'S', title: t('editor.strikethrough'), className: 'line-through' },
     { action: 'divider' },
-    { action: 'link', icon: <Link2 className="w-3.5 h-3.5" />, title: 'Link' },
-    { action: 'image', icon: <Image className="w-3.5 h-3.5" />, title: 'Image' },
+    { action: 'link', icon: <Link2 className="w-3.5 h-3.5" />, title: t('editor.link') },
+    { action: 'image', icon: <Image className="w-3.5 h-3.5" />, title: t('editor.image') },
     { action: 'divider' },
-    { action: 'code', icon: '<>', title: 'Inline Code' },
-    { action: 'codeblock', icon: '{}', title: 'Code Block' },
+    { action: 'code', icon: '<>', title: t('editor.inlineCode') },
+    { action: 'codeblock', icon: '{}', title: t('editor.codeBlock') },
     { action: 'divider' },
-    { action: 'quote', icon: '"', title: 'Quote' },
-    { action: 'list', icon: '•', title: 'Bullet List' },
-    { action: 'orderedlist', icon: '1.', title: 'Numbered List' },
-    { action: 'task', icon: '☐', title: 'Task List' },
+    { action: 'quote', icon: '"', title: t('editor.quote') },
+    { action: 'list', icon: '•', title: t('editor.bulletList') },
+    { action: 'orderedlist', icon: '1.', title: t('editor.numberedList') },
+    { action: 'task', icon: '☐', title: t('editor.taskList') },
   ];
 
   return (
@@ -181,7 +183,7 @@ export default function MarkdownEditor({
               : 'text-gray-400 hover:text-white hover:bg-gray-750'
           }`}
         >
-          Write
+          {t('editor.write')}
         </button>
         <button
           type="button"
@@ -192,7 +194,7 @@ export default function MarkdownEditor({
               : 'text-gray-400 hover:text-white hover:bg-gray-750'
           }`}
         >
-          Preview
+          {t('editor.preview')}
         </button>
 
         {/* Toolbar */}
@@ -228,7 +230,7 @@ export default function MarkdownEditor({
               onPaste={handlePaste}
               onDrop={handleDrop}
               onDragOver={handleDragOver}
-              placeholder={placeholder}
+              placeholder={placeholder || t('editor.placeholder')}
               className="w-full p-4 bg-transparent text-white resize-none focus:outline-none font-mono text-sm"
               style={{ minHeight }}
             />
@@ -243,7 +245,7 @@ export default function MarkdownEditor({
                       d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
                     />
                   </svg>
-                  <span className="text-sm">Uploading...</span>
+                  <span className="text-sm">{t('editor.uploading')}</span>
                 </div>
               </div>
             )}
@@ -279,7 +281,7 @@ export default function MarkdownEditor({
                 }}
               >{value}</ReactMarkdown>
             ) : (
-              <p className="text-gray-500 italic">Nothing to preview</p>
+              <p className="text-gray-500 italic">{t('editor.nothingToPreview')}</p>
             )}
           </div>
         )}
@@ -298,13 +300,13 @@ export default function MarkdownEditor({
       {/* Uploaded images preview */}
       {uploadedImages.length > 0 && (
         <div className="border-t border-gray-700 p-3">
-          <div className="text-xs text-gray-500 mb-2">Attached images:</div>
+          <div className="text-xs text-gray-500 mb-2">{t('editor.attachedImages')}</div>
           <div className="flex flex-wrap gap-2">
             {uploadedImages.map((url, i) => (
               <div key={i} className="relative group">
                 <img
                   src={url}
-                  alt={`Uploaded ${i + 1}`}
+                  alt={t('editor.uploadedImage', { number: i + 1 })}
                   className="w-16 h-16 object-cover rounded border border-gray-600"
                 />
                 <button
@@ -326,8 +328,8 @@ export default function MarkdownEditor({
 
       {/* Hint */}
       <div className="border-t border-gray-700 px-4 py-2 text-xs text-gray-500 flex items-center gap-4">
-        <span>Markdown supported</span>
-        <span>Paste or drag images to upload</span>
+        <span>{t('editor.markdownSupported')}</span>
+        <span>{t('editor.pasteOrDragImages')}</span>
       </div>
     </div>
   );

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1187,5 +1187,28 @@
     "backToSettings": "Zurück zu Einstellungen",
     "loggingIn": "Anmeldung mit GitHub...",
     "connecting": "GitHub wird verbunden..."
+  },
+  "editor": {
+    "write": "Schreiben",
+    "preview": "Vorschau",
+    "placeholder": "Schreiben Sie hier Ihren Inhalt... (Markdown unterstützt)",
+    "heading": "Überschrift",
+    "bold": "Fett",
+    "italic": "Kursiv",
+    "strikethrough": "Durchgestrichen",
+    "link": "Link",
+    "image": "Bild",
+    "inlineCode": "Inline-Code",
+    "codeBlock": "Codeblock",
+    "quote": "Zitat",
+    "bulletList": "Aufzählung",
+    "numberedList": "Nummerierte Liste",
+    "taskList": "Aufgabenliste",
+    "uploading": "Wird hochgeladen...",
+    "nothingToPreview": "Keine Vorschau verfügbar",
+    "attachedImages": "Angehängte Bilder:",
+    "uploadedImage": "Hochgeladenes Bild {{number}}",
+    "markdownSupported": "Markdown unterstützt",
+    "pasteOrDragImages": "Bilder einfügen oder ziehen zum Hochladen"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1187,5 +1187,28 @@
     "backToSettings": "Back to Settings",
     "loggingIn": "Logging in with GitHub...",
     "connecting": "Connecting GitHub..."
+  },
+  "editor": {
+    "write": "Write",
+    "preview": "Preview",
+    "placeholder": "Write your content here... (Markdown supported)",
+    "heading": "Heading",
+    "bold": "Bold",
+    "italic": "Italic",
+    "strikethrough": "Strikethrough",
+    "link": "Link",
+    "image": "Image",
+    "inlineCode": "Inline Code",
+    "codeBlock": "Code Block",
+    "quote": "Quote",
+    "bulletList": "Bullet List",
+    "numberedList": "Numbered List",
+    "taskList": "Task List",
+    "uploading": "Uploading...",
+    "nothingToPreview": "Nothing to preview",
+    "attachedImages": "Attached images:",
+    "uploadedImage": "Uploaded {{number}}",
+    "markdownSupported": "Markdown supported",
+    "pasteOrDragImages": "Paste or drag images to upload"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1187,5 +1187,28 @@
     "backToSettings": "Volver a configuración",
     "loggingIn": "Iniciando sesión con GitHub...",
     "connecting": "Conectando GitHub..."
+  },
+  "editor": {
+    "write": "Escribir",
+    "preview": "Vista previa",
+    "placeholder": "Escribe tu contenido aquí... (Markdown compatible)",
+    "heading": "Encabezado",
+    "bold": "Negrita",
+    "italic": "Cursiva",
+    "strikethrough": "Tachado",
+    "link": "Enlace",
+    "image": "Imagen",
+    "inlineCode": "Código en línea",
+    "codeBlock": "Bloque de código",
+    "quote": "Cita",
+    "bulletList": "Lista con viñetas",
+    "numberedList": "Lista numerada",
+    "taskList": "Lista de tareas",
+    "uploading": "Subiendo...",
+    "nothingToPreview": "Nada que previsualizar",
+    "attachedImages": "Imágenes adjuntas:",
+    "uploadedImage": "Imagen subida {{number}}",
+    "markdownSupported": "Markdown compatible",
+    "pasteOrDragImages": "Pega o arrastra imágenes para subir"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1187,5 +1187,28 @@
     "backToSettings": "Retour aux paramètres",
     "loggingIn": "Connexion avec GitHub...",
     "connecting": "Connexion de GitHub..."
+  },
+  "editor": {
+    "write": "Écrire",
+    "preview": "Aperçu",
+    "placeholder": "Écrivez votre contenu ici... (Markdown pris en charge)",
+    "heading": "Titre",
+    "bold": "Gras",
+    "italic": "Italique",
+    "strikethrough": "Barré",
+    "link": "Lien",
+    "image": "Image",
+    "inlineCode": "Code en ligne",
+    "codeBlock": "Bloc de code",
+    "quote": "Citation",
+    "bulletList": "Liste à puces",
+    "numberedList": "Liste numérotée",
+    "taskList": "Liste de tâches",
+    "uploading": "Téléchargement...",
+    "nothingToPreview": "Rien à prévisualiser",
+    "attachedImages": "Images jointes :",
+    "uploadedImage": "Image téléchargée {{number}}",
+    "markdownSupported": "Markdown pris en charge",
+    "pasteOrDragImages": "Collez ou glissez des images pour télécharger"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1088,5 +1088,28 @@
     "backToSettings": "設定に戻る",
     "loggingIn": "GitHubでログイン中...",
     "connecting": "GitHub連携中..."
+  },
+  "editor": {
+    "write": "書く",
+    "preview": "プレビュー",
+    "placeholder": "ここに内容を入力... (Markdown対応)",
+    "heading": "見出し",
+    "bold": "太字",
+    "italic": "斜体",
+    "strikethrough": "取り消し線",
+    "link": "リンク",
+    "image": "画像",
+    "inlineCode": "インラインコード",
+    "codeBlock": "コードブロック",
+    "quote": "引用",
+    "bulletList": "箇条書き",
+    "numberedList": "番号付きリスト",
+    "taskList": "タスクリスト",
+    "uploading": "アップロード中...",
+    "nothingToPreview": "プレビューする内容がありません",
+    "attachedImages": "添付画像:",
+    "uploadedImage": "アップロード画像 {{number}}",
+    "markdownSupported": "Markdown対応",
+    "pasteOrDragImages": "画像を貼り付けまたはドラッグしてアップロード"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1187,5 +1187,28 @@
     "backToSettings": "설정으로 돌아가기",
     "loggingIn": "GitHub으로 로그인 중...",
     "connecting": "GitHub 연결 중..."
+  },
+  "editor": {
+    "write": "작성",
+    "preview": "미리보기",
+    "placeholder": "여기에 내용을 입력하세요... (마크다운 지원)",
+    "heading": "제목",
+    "bold": "굵게",
+    "italic": "기울임",
+    "strikethrough": "취소선",
+    "link": "링크",
+    "image": "이미지",
+    "inlineCode": "인라인 코드",
+    "codeBlock": "코드 블록",
+    "quote": "인용",
+    "bulletList": "글머리 기호 목록",
+    "numberedList": "번호 매기기 목록",
+    "taskList": "작업 목록",
+    "uploading": "업로드 중...",
+    "nothingToPreview": "미리볼 내용이 없습니다",
+    "attachedImages": "첨부 이미지:",
+    "uploadedImage": "업로드된 이미지 {{number}}",
+    "markdownSupported": "마크다운 지원",
+    "pasteOrDragImages": "이미지를 붙여넣거나 드래그하여 업로드"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1187,5 +1187,28 @@
     "backToSettings": "Voltar às configurações",
     "loggingIn": "Entrando com GitHub...",
     "connecting": "Conectando GitHub..."
+  },
+  "editor": {
+    "write": "Escrever",
+    "preview": "Pré-visualização",
+    "placeholder": "Escreva seu conteúdo aqui... (Markdown suportado)",
+    "heading": "Título",
+    "bold": "Negrito",
+    "italic": "Itálico",
+    "strikethrough": "Tachado",
+    "link": "Link",
+    "image": "Imagem",
+    "inlineCode": "Código inline",
+    "codeBlock": "Bloco de código",
+    "quote": "Citação",
+    "bulletList": "Lista com marcadores",
+    "numberedList": "Lista numerada",
+    "taskList": "Lista de tarefas",
+    "uploading": "Enviando...",
+    "nothingToPreview": "Nada para pré-visualizar",
+    "attachedImages": "Imagens anexadas:",
+    "uploadedImage": "Imagem enviada {{number}}",
+    "markdownSupported": "Markdown suportado",
+    "pasteOrDragImages": "Cole ou arraste imagens para enviar"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1187,5 +1187,28 @@
     "backToSettings": "Вернуться к настройкам",
     "loggingIn": "Вход через GitHub...",
     "connecting": "Подключение GitHub..."
+  },
+  "editor": {
+    "write": "Написать",
+    "preview": "Предпросмотр",
+    "placeholder": "Напишите содержание здесь... (поддерживается Markdown)",
+    "heading": "Заголовок",
+    "bold": "Жирный",
+    "italic": "Курсив",
+    "strikethrough": "Зачёркнутый",
+    "link": "Ссылка",
+    "image": "Изображение",
+    "inlineCode": "Встроенный код",
+    "codeBlock": "Блок кода",
+    "quote": "Цитата",
+    "bulletList": "Маркированный список",
+    "numberedList": "Нумерованный список",
+    "taskList": "Список задач",
+    "uploading": "Загрузка...",
+    "nothingToPreview": "Нет содержимого для предпросмотра",
+    "attachedImages": "Прикреплённые изображения:",
+    "uploadedImage": "Загруженное изображение {{number}}",
+    "markdownSupported": "Поддерживается Markdown",
+    "pasteOrDragImages": "Вставьте или перетащите изображения для загрузки"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1187,5 +1187,28 @@
     "backToSettings": "返回设置",
     "loggingIn": "正在通过GitHub登录...",
     "connecting": "正在连接GitHub..."
+  },
+  "editor": {
+    "write": "编辑",
+    "preview": "预览",
+    "placeholder": "在此输入内容...（支持Markdown）",
+    "heading": "标题",
+    "bold": "粗体",
+    "italic": "斜体",
+    "strikethrough": "删除线",
+    "link": "链接",
+    "image": "图片",
+    "inlineCode": "行内代码",
+    "codeBlock": "代码块",
+    "quote": "引用",
+    "bulletList": "无序列表",
+    "numberedList": "有序列表",
+    "taskList": "任务列表",
+    "uploading": "上传中...",
+    "nothingToPreview": "没有可预览的内容",
+    "attachedImages": "附加图片：",
+    "uploadedImage": "已上传图片 {{number}}",
+    "markdownSupported": "支持Markdown",
+    "pasteOrDragImages": "粘贴或拖拽图片上传"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1187,5 +1187,28 @@
     "backToSettings": "返回設定",
     "loggingIn": "正在透過GitHub登入...",
     "connecting": "正在連接GitHub..."
+  },
+  "editor": {
+    "write": "編輯",
+    "preview": "預覽",
+    "placeholder": "在此輸入內容...（支援Markdown）",
+    "heading": "標題",
+    "bold": "粗體",
+    "italic": "斜體",
+    "strikethrough": "刪除線",
+    "link": "連結",
+    "image": "圖片",
+    "inlineCode": "行內程式碼",
+    "codeBlock": "程式碼區塊",
+    "quote": "引用",
+    "bulletList": "無序清單",
+    "numberedList": "有序清單",
+    "taskList": "任務清單",
+    "uploading": "上傳中...",
+    "nothingToPreview": "沒有可預覽的內容",
+    "attachedImages": "附加圖片：",
+    "uploadedImage": "已上傳圖片 {{number}}",
+    "markdownSupported": "支援Markdown",
+    "pasteOrDragImages": "貼上或拖曳圖片上傳"
   }
 }


### PR DESCRIPTION
## 概要
- MarkdownEditorの20箇所のハードコード英語テキストをi18n化
- `editor`セクションを新規作成し全10言語に21キーを追加

## 対象箇所
- placeholder: `Write your content here...` → `t('editor.placeholder')`
- タブ: Write / Preview → `t('editor.write')` / `t('editor.preview')`
- ツールバーtitle 12個: Heading, Bold, Italic, Strikethrough, Link, Image, Inline Code, Code Block, Quote, Bullet List, Numbered List, Task List
- Uploading... / Nothing to preview / Attached images / alt text / ヒント2行

closes #458