### PR TITLE
refactor: ハンドラ層gin.H→型付きDTOレスポンス変換を完了

### DIFF
--- a/backend/internal/dto/book_review_dto.go
+++ b/backend/internal/dto/book_review_dto.go
@@ -1,0 +1,11 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// BookReviewListResponse は書籍レビュー一覧レスポンス。
+type BookReviewListResponse struct {
+	Reviews []model.BookReview `json:"reviews"`
+	Total   int64              `json:"total"`
+	Limit   int                `json:"limit"`
+	Offset  int                `json:"offset"`
+}

--- a/backend/internal/dto/email_preferences_dto.go
+++ b/backend/internal/dto/email_preferences_dto.go
@@ -5,3 +5,9 @@ type UpdateEmailPreferencesRequest struct {
 	EmailWeeklyReport *bool   `json:"email_weekly_report"`
 	EmailLanguage     *string `json:"email_language"`
 }
+
+// EmailPreferencesResponse はメール配信設定レスポンス。
+type EmailPreferencesResponse struct {
+	EmailWeeklyReport bool   `json:"email_weekly_report"`
+	EmailLanguage     string `json:"email_language"`
+}

--- a/backend/internal/dto/learning_resource_dto.go
+++ b/backend/internal/dto/learning_resource_dto.go
@@ -1,0 +1,18 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// ResourceDetailResponse は学習リソース詳細レスポンス（いいね・保存状態付き）。
+type ResourceDetailResponse struct {
+	Resource model.LearningResource `json:"resource"`
+	HasLiked bool                   `json:"has_liked"`
+	HasSaved bool                   `json:"has_saved"`
+}
+
+// ResourceListResponse は学習リソース一覧レスポンス。
+type ResourceListResponse struct {
+	Resources []model.LearningResource `json:"resources"`
+	Total     int64                    `json:"total"`
+	Limit     int                      `json:"limit"`
+	Offset    int                      `json:"offset"`
+}

--- a/backend/internal/dto/project_dto.go
+++ b/backend/internal/dto/project_dto.go
@@ -1,0 +1,11 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// ProjectListResponse はプロジェクト一覧レスポンス。
+type ProjectListResponse struct {
+	Projects []model.Project `json:"projects"`
+	Total    int64           `json:"total"`
+	Limit    int             `json:"limit"`
+	Offset   int             `json:"offset"`
+}

--- a/backend/internal/dto/question_dto.go
+++ b/backend/internal/dto/question_dto.go
@@ -1,0 +1,17 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// QuestionListResponse は質問一覧レスポンス。
+type QuestionListResponse struct {
+	Questions []model.Question `json:"questions"`
+	Total     int64            `json:"total"`
+	Limit     int              `json:"limit"`
+	Offset    int              `json:"offset"`
+}
+
+// QuestionDetailResponse は質問詳細レスポンス（ユーザー投票情報付き）。
+type QuestionDetailResponse struct {
+	Question model.Question `json:"question"`
+	UserVote int            `json:"user_vote"`
+}

--- a/backend/internal/dto/roadmap_dto.go
+++ b/backend/internal/dto/roadmap_dto.go
@@ -1,6 +1,9 @@
 package dto
 
-import "github.com/norman6464/devsync/backend/internal/service"
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+)
 
 // CreateRoadmapRequest はロードマップ作成リクエストのDTO。
 type CreateRoadmapRequest struct {
@@ -38,4 +41,10 @@ type UpdateRoadmapStepRequest struct {
 // ReorderRoadmapStepsRequest はロードマップステップ並べ替えリクエストのDTO。
 type ReorderRoadmapStepsRequest struct {
 	Orders []service.StepOrder `json:"orders" binding:"required"`
+}
+
+// RoadmapListResponse はロードマップ一覧レスポンス。
+type RoadmapListResponse struct {
+	Roadmaps []model.Roadmap `json:"roadmaps"`
+	Total    int64           `json:"total"`
 }

--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -4,6 +4,7 @@ import (
 	"strconv"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -122,11 +123,11 @@ func (h *BookReviewHandler) GetAll(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"reviews": reviews,
-		"total":   total,
-		"limit":   limit,
-		"offset":  offset,
+	respondOK(c, dto.BookReviewListResponse{
+		Reviews: reviews,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
 	})
 }
 

--- a/backend/internal/handler/email_preferences.go
+++ b/backend/internal/handler/email_preferences.go
@@ -33,9 +33,9 @@ func (h *EmailPreferencesHandler) GetPreferences(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"email_weekly_report": user.EmailWeeklyReport,
-		"email_language":      user.EmailLanguage,
+	respondOK(c, dto.EmailPreferencesResponse{
+		EmailWeeklyReport: user.EmailWeeklyReport,
+		EmailLanguage:     user.EmailLanguage,
 	})
 }
 
@@ -76,8 +76,8 @@ func (h *EmailPreferencesHandler) UpdatePreferences(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"email_weekly_report": user.EmailWeeklyReport,
-		"email_language":      user.EmailLanguage,
+	respondOK(c, dto.EmailPreferencesResponse{
+		EmailWeeklyReport: user.EmailWeeklyReport,
+		EmailLanguage:     user.EmailLanguage,
 	})
 }

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -116,10 +117,10 @@ func (h *LearningResourceHandler) GetByID(c *gin.Context) {
 	hasLiked, _ := h.service.HasLiked(userID, id)
 	hasSaved, _ := h.service.HasSaved(userID, id)
 
-	respondOK(c, gin.H{
-		"resource":  resource,
-		"has_liked": hasLiked,
-		"has_saved": hasSaved,
+	respondOK(c, dto.ResourceDetailResponse{
+		Resource: *resource,
+		HasLiked: hasLiked,
+		HasSaved: hasSaved,
 	})
 }
 
@@ -158,11 +159,11 @@ func (h *LearningResourceHandler) GetPublic(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"resources": resources,
-		"total":     total,
-		"limit":     limit,
-		"offset":    offset,
+	respondOK(c, dto.ResourceListResponse{
+		Resources: resources,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
 	})
 }
 
@@ -182,11 +183,11 @@ func (h *LearningResourceHandler) Search(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"resources": resources,
-		"total":     total,
-		"limit":     limit,
-		"offset":    offset,
+	respondOK(c, dto.ResourceListResponse{
+		Resources: resources,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
 	})
 }
 
@@ -340,10 +341,10 @@ func (h *LearningResourceHandler) GetSaved(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"resources": resources,
-		"total":     total,
-		"limit":     limit,
-		"offset":    offset,
+	respondOK(c, dto.ResourceListResponse{
+		Resources: resources,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
 	})
 }

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -257,10 +258,10 @@ func (h *ProjectHandler) GetAll(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"projects": projects,
-		"total":    total,
-		"limit":    limit,
-		"offset":   offset,
+	respondOK(c, dto.ProjectListResponse{
+		Projects: projects,
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
 	})
 }

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -93,11 +94,11 @@ func (h *QuestionHandler) GetAll(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"questions": questions,
-		"total":     total,
-		"limit":     limit,
-		"offset":    offset,
+	respondOK(c, dto.QuestionListResponse{
+		Questions: questions,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
 	})
 }
 
@@ -122,11 +123,11 @@ func (h *QuestionHandler) Search(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"questions": questions,
-		"total":     total,
-		"limit":     limit,
-		"offset":    offset,
+	respondOK(c, dto.QuestionListResponse{
+		Questions: questions,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
 	})
 }
 
@@ -146,9 +147,9 @@ func (h *QuestionHandler) GetByID(c *gin.Context) {
 
 	userVote, _ := h.service.GetUserVote(userID, id)
 
-	respondOK(c, gin.H{
-		"question":  question,
-		"user_vote": userVote,
+	respondOK(c, dto.QuestionDetailResponse{
+		Question: *question,
+		UserVote: userVote,
 	})
 }
 

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -98,9 +98,9 @@ func (h *RoadmapHandler) GetPublicRoadmaps(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"roadmaps": roadmaps,
-		"total":    total,
+	respondOK(c, dto.RoadmapListResponse{
+		Roadmaps: roadmaps,
+		Total:    total,
 	})
 }
 


### PR DESCRIPTION
## 概要
- 残り12箇所のgin.Hレスポンスを型付きDTOに変換
- **ハンドラ層のgin.H使用を完全排除**（テストファイル除く）

## 新規DTO（8構造体）
- `EmailPreferencesResponse` — メール配信設定レスポンス
- `RoadmapListResponse` — ロードマップ一覧
- `BookReviewListResponse` — 書籍レビュー一覧
- `QuestionListResponse` / `QuestionDetailResponse` — 質問一覧/詳細
- `ProjectListResponse` — プロジェクト一覧
- `ResourceDetailResponse` / `ResourceListResponse` — 学習リソース詳細/一覧

## 変更ファイル
- email_preferences.go (2箇所), roadmap.go (1箇所), book_review.go (1箇所)
- question.go (3箇所), project.go (1箇所), learning_resource.go (4箇所)

closes #460