### PR TITLE
fix: ThemeToggle i18n化 & useChat空catch修正

### DIFF
--- a/frontend/src/components/common/ThemeToggle.tsx
+++ b/frontend/src/components/common/ThemeToggle.tsx
@@ -1,6 +1,8 @@
+import { useTranslation } from 'react-i18next';
 import { useThemeStore } from '../../store/themeStore';
 
 export default function ThemeToggle() {
+  const { t } = useTranslation();
   const { theme, setTheme } = useThemeStore();
 
   const themes = [
@@ -15,7 +17,7 @@ export default function ThemeToggle() {
           />
         </svg>
       ),
-      label: 'Light',
+      label: t('settings.light'),
     },
     {
       value: 'dark' as const,
@@ -28,7 +30,7 @@ export default function ThemeToggle() {
           />
         </svg>
       ),
-      label: 'Dark',
+      label: t('settings.dark'),
     },
     {
       value: 'system' as const,
@@ -41,7 +43,7 @@ export default function ThemeToggle() {
           />
         </svg>
       ),
-      label: 'System',
+      label: t('settings.system'),
     },
   ];
 
@@ -57,7 +59,7 @@ export default function ThemeToggle() {
               : 'text-gray-400 hover:text-white'
           }`}
           title={t.label}
-          aria-label={`Set ${t.label} theme`}
+          aria-label={t('settings.setTheme', { theme: t.label })}
         >
           {t.icon}
         </button>

--- a/frontend/src/hooks/useChat.ts
+++ b/frontend/src/hooks/useChat.ts
@@ -40,11 +40,11 @@ export function useChat() {
 
     getConversations()
       .then(({ data }) => setConversations(data || []))
-      .catch(() => {});
+      .catch((e) => console.warn('Failed to load conversations:', e));
 
     getFollowing(currentUser.id)
       .then(({ data }) => setFollowingUsers(data || []))
-      .catch(() => {});
+      .catch((e) => console.warn('Failed to load following users:', e));
 
     loadChatRooms();
   }, [currentUser]);
@@ -52,7 +52,7 @@ export function useChat() {
   const loadChatRooms = () => {
     getChatRooms()
       .then(({ data }) => setChatRooms(data || []))
-      .catch(() => {});
+      .catch((e) => console.warn('Failed to load chat rooms:', e));
   };
 
   useEffect(() => {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -223,7 +223,8 @@
     "emailLanguageDesc": "Sprache für E-Mail-Zustellung wählen",
     "emailEnabled": "Aktiviert",
     "emailDisabled": "Deaktiviert",
-    "emailPreferencesSaved": "E-Mail-Einstellungen gespeichert"
+    "emailPreferencesSaved": "E-Mail-Einstellungen gespeichert",
+    "setTheme": "{{theme}}-Design einstellen"
   },
   "explore": {
     "title": "Entwickler entdecken",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -223,7 +223,8 @@
     "emailLanguageDesc": "Select the language for email delivery",
     "emailEnabled": "Enabled",
     "emailDisabled": "Disabled",
-    "emailPreferencesSaved": "Email preferences saved"
+    "emailPreferencesSaved": "Email preferences saved",
+    "setTheme": "Set {{theme}} theme"
   },
   "explore": {
     "title": "Discover Developers",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -223,7 +223,8 @@
     "emailLanguageDesc": "Seleccionar el idioma de entrega del correo",
     "emailEnabled": "Habilitado",
     "emailDisabled": "Deshabilitado",
-    "emailPreferencesSaved": "Preferencias de correo guardadas"
+    "emailPreferencesSaved": "Preferencias de correo guardadas",
+    "setTheme": "Establecer tema {{theme}}"
   },
   "explore": {
     "title": "Descubrir Desarrolladores",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -223,7 +223,8 @@
     "emailLanguageDesc": "Sélectionner la langue de livraison",
     "emailEnabled": "Activé",
     "emailDisabled": "Désactivé",
-    "emailPreferencesSaved": "Préférences e-mail enregistrées"
+    "emailPreferencesSaved": "Préférences e-mail enregistrées",
+    "setTheme": "Définir le thème {{theme}}"
   },
   "explore": {
     "title": "Découvrir des Développeurs",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -236,7 +236,8 @@
     "emailLanguageDesc": "メールの配信言語を選択",
     "emailEnabled": "有効",
     "emailDisabled": "無効",
-    "emailPreferencesSaved": "メール設定を保存しました"
+    "emailPreferencesSaved": "メール設定を保存しました",
+    "setTheme": "{{theme}}テーマに設定"
   },
   "explore": {
     "title": "開発者を見つける",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -223,7 +223,8 @@
     "emailLanguageDesc": "이메일 전송 언어 선택",
     "emailEnabled": "활성화",
     "emailDisabled": "비활성화",
-    "emailPreferencesSaved": "이메일 설정이 저장되었습니다"
+    "emailPreferencesSaved": "이메일 설정이 저장되었습니다",
+    "setTheme": "{{theme}} 테마로 설정"
   },
   "explore": {
     "title": "개발자 찾기",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -223,7 +223,8 @@
     "emailLanguageDesc": "Selecionar o idioma de entrega do e-mail",
     "emailEnabled": "Ativado",
     "emailDisabled": "Desativado",
-    "emailPreferencesSaved": "Preferências de e-mail salvas"
+    "emailPreferencesSaved": "Preferências de e-mail salvas",
+    "setTheme": "Definir tema {{theme}}"
   },
   "explore": {
     "title": "Descobrir Desenvolvedores",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -223,7 +223,8 @@
     "emailLanguageDesc": "Выбрать язык доставки",
     "emailEnabled": "Включено",
     "emailDisabled": "Отключено",
-    "emailPreferencesSaved": "Настройки email сохранены"
+    "emailPreferencesSaved": "Настройки email сохранены",
+    "setTheme": "Установить тему {{theme}}"
   },
   "explore": {
     "title": "Найти разработчиков",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -223,7 +223,8 @@
     "emailLanguageDesc": "选择邮件投递语言",
     "emailEnabled": "已启用",
     "emailDisabled": "已禁用",
-    "emailPreferencesSaved": "邮件设置已保存"
+    "emailPreferencesSaved": "邮件设置已保存",
+    "setTheme": "设置{{theme}}主题"
   },
   "explore": {
     "title": "发现开发者",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -223,7 +223,8 @@
     "emailLanguageDesc": "選擇郵件投遞語言",
     "emailEnabled": "已啟用",
     "emailDisabled": "已停用",
-    "emailPreferencesSaved": "郵件設定已儲存"
+    "emailPreferencesSaved": "郵件設定已儲存",
+    "setTheme": "設置{{theme}}主題"
   },
   "explore": {
     "title": "探索開發者",


### PR DESCRIPTION
## 概要
- ThemeToggleのLight/Dark/Systemラベルとaria-labelをi18nキーに置換
- useChatの3箇所の空catchブロックにconsole.warnを追加

## 変更内容
### ThemeToggle (4箇所)
- `label: 'Light'` → `label: t('settings.light')` 等3箇所
- `aria-label="Set ${t.label} theme"` → `aria-label={t('settings.setTheme', { theme: t.label })}`
- `settings.setTheme`キーを全10言語に追加

### useChat (3箇所)
- `getConversations().catch(() => {})` → `catch((e) => console.warn(...))`
- `getFollowing().catch(() => {})` → 同上
- `getChatRooms().catch(() => {})` → 同上

closes #464