### PR TITLE
fix: DashboardPage/SearchPage/PostCardのi18n・エラーハンドリング改善

### DIFF
--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -38,8 +38,8 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
         setLikeCount((c) => c + 1);
       }
       onUpdate?.();
-    } catch {
-      // handle error
+    } catch (e) {
+      console.warn('Failed to toggle like:', e);
     }
   };
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -84,7 +84,8 @@
     "noNotifications": "Keine Benachrichtigungen",
     "quickStats": "Schnellstatistik",
     "goalsCompleted": "Abgeschlossene Ziele",
-    "goalsInProgress": "Ziele in Bearbeitung"
+    "goalsInProgress": "Ziele in Bearbeitung",
+    "editPost": "Beitrag bearbeiten"
   },
   "post": {
     "createTitle": "Was hast du heute gelernt?",
@@ -251,7 +252,9 @@
       "posts": "Beiträge",
       "circles": "Lernkreise"
     },
-    "viewProfile": "Profil anzeigen"
+    "viewProfile": "Profil anzeigen",
+    "likesCount": "{{count}} Likes",
+    "commentsCount": "{{count}} Kommentare"
   },
   "chat": {
     "title": "Nachrichten",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -84,7 +84,8 @@
     "noNotifications": "No notifications",
     "quickStats": "Quick Stats",
     "goalsCompleted": "Goals Completed",
-    "goalsInProgress": "Goals In Progress"
+    "goalsInProgress": "Goals In Progress",
+    "editPost": "Edit Post"
   },
   "post": {
     "createTitle": "What did you learn today?",
@@ -251,7 +252,9 @@
       "posts": "Posts",
       "circles": "Circles"
     },
-    "viewProfile": "View Profile"
+    "viewProfile": "View Profile",
+    "likesCount": "{{count}} likes",
+    "commentsCount": "{{count}} comments"
   },
   "chat": {
     "title": "Messages",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -84,7 +84,8 @@
     "noNotifications": "Sin notificaciones",
     "quickStats": "Estadísticas rápidas",
     "goalsCompleted": "Objetivos completados",
-    "goalsInProgress": "Objetivos en progreso"
+    "goalsInProgress": "Objetivos en progreso",
+    "editPost": "Editar publicación"
   },
   "post": {
     "createTitle": "¿Qué aprendiste hoy?",
@@ -251,7 +252,9 @@
       "posts": "Publicaciones",
       "circles": "Círculos"
     },
-    "viewProfile": "Ver perfil"
+    "viewProfile": "Ver perfil",
+    "likesCount": "{{count}} me gusta",
+    "commentsCount": "{{count}} comentarios"
   },
   "chat": {
     "title": "Mensajes",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -84,7 +84,8 @@
     "noNotifications": "Aucune notification",
     "quickStats": "Statistiques rapides",
     "goalsCompleted": "Objectifs atteints",
-    "goalsInProgress": "Objectifs en cours"
+    "goalsInProgress": "Objectifs en cours",
+    "editPost": "Modifier la publication"
   },
   "post": {
     "createTitle": "Qu'avez-vous appris aujourd'hui ?",
@@ -251,7 +252,9 @@
       "posts": "Publications",
       "circles": "Cercles"
     },
-    "viewProfile": "Voir le profil"
+    "viewProfile": "Voir le profil",
+    "likesCount": "{{count}} j'aime",
+    "commentsCount": "{{count}} commentaires"
   },
   "chat": {
     "title": "Messages",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -85,7 +85,8 @@
     "noNotifications": "通知はありません",
     "quickStats": "クイック統計",
     "goalsCompleted": "達成した目標",
-    "goalsInProgress": "進行中の目標"
+    "goalsInProgress": "進行中の目標",
+    "editPost": "投稿を編集"
   },
   "post": {
     "createTitle": "今日学んだことは？",
@@ -259,7 +260,9 @@
       "posts": "投稿",
       "circles": "サークル"
     },
-    "viewProfile": "プロフィール"
+    "viewProfile": "プロフィール",
+    "likesCount": "{{count}}件のいいね",
+    "commentsCount": "{{count}}件のコメント"
   },
   "chat": {
     "title": "メッセージ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -84,7 +84,8 @@
     "noNotifications": "알림이 없습니다",
     "quickStats": "빠른 통계",
     "goalsCompleted": "완료한 목표",
-    "goalsInProgress": "진행 중인 목표"
+    "goalsInProgress": "진행 중인 목표",
+    "editPost": "게시물 수정"
   },
   "post": {
     "createTitle": "오늘 무엇을 배웠나요?",
@@ -251,7 +252,9 @@
       "posts": "게시물",
       "circles": "서클"
     },
-    "viewProfile": "프로필 보기"
+    "viewProfile": "프로필 보기",
+    "likesCount": "좋아요 {{count}}개",
+    "commentsCount": "댓글 {{count}}개"
   },
   "chat": {
     "title": "메시지",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -84,7 +84,8 @@
     "noNotifications": "Sem notificações",
     "quickStats": "Estatísticas rápidas",
     "goalsCompleted": "Metas concluídas",
-    "goalsInProgress": "Metas em andamento"
+    "goalsInProgress": "Metas em andamento",
+    "editPost": "Editar publicação"
   },
   "post": {
     "createTitle": "O que você aprendeu hoje?",
@@ -251,7 +252,9 @@
       "posts": "Postagens",
       "circles": "Círculos"
     },
-    "viewProfile": "Ver perfil"
+    "viewProfile": "Ver perfil",
+    "likesCount": "{{count}} curtidas",
+    "commentsCount": "{{count}} comentários"
   },
   "chat": {
     "title": "Mensagens",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -84,7 +84,8 @@
     "noNotifications": "Нет уведомлений",
     "quickStats": "Быстрая статистика",
     "goalsCompleted": "Достигнутые цели",
-    "goalsInProgress": "Цели в процессе"
+    "goalsInProgress": "Цели в процессе",
+    "editPost": "Редактировать пост"
   },
   "post": {
     "createTitle": "Что вы узнали сегодня?",
@@ -251,7 +252,9 @@
       "posts": "Посты",
       "circles": "Группы"
     },
-    "viewProfile": "Посмотреть профиль"
+    "viewProfile": "Посмотреть профиль",
+    "likesCount": "{{count}} лайков",
+    "commentsCount": "{{count}} комментариев"
   },
   "chat": {
     "title": "Сообщения",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -84,7 +84,8 @@
     "noNotifications": "没有通知",
     "quickStats": "快速统计",
     "goalsCompleted": "已完成目标",
-    "goalsInProgress": "进行中目标"
+    "goalsInProgress": "进行中目标",
+    "editPost": "编辑帖子"
   },
   "post": {
     "createTitle": "今天你学到了什么？",
@@ -251,7 +252,9 @@
       "posts": "帖子",
       "circles": "圈子"
     },
-    "viewProfile": "查看资料"
+    "viewProfile": "查看资料",
+    "likesCount": "{{count}} 个赞",
+    "commentsCount": "{{count}} 条评论"
   },
   "chat": {
     "title": "消息",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -84,7 +84,8 @@
     "noNotifications": "沒有通知",
     "quickStats": "快速統計",
     "goalsCompleted": "已完成目標",
-    "goalsInProgress": "進行中目標"
+    "goalsInProgress": "進行中目標",
+    "editPost": "編輯貼文"
   },
   "post": {
     "createTitle": "今天你學到了什麼？",
@@ -251,7 +252,9 @@
       "posts": "貼文",
       "circles": "圈子"
     },
-    "viewProfile": "查看資料"
+    "viewProfile": "查看資料",
+    "likesCount": "{{count}} 個讚",
+    "commentsCount": "{{count}} 則留言"
   },
   "chat": {
     "title": "訊息",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -166,7 +166,7 @@ export default function DashboardPage() {
         <Modal
           isOpen={!!editingPost}
           onClose={() => setEditingPost(null)}
-          title="投稿を編集"
+          title={t('dashboard.editPost')}
         >
           {editingPost && (
             <PostForm

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -206,6 +206,7 @@ function PostResults({ posts, query }: { posts: Post[]; query: string }) {
 }
 
 function PostCard({ post }: { post: Post }) {
+  const { t } = useTranslation();
   return (
     <Link
       to={`/posts/${post.id}`}
@@ -222,8 +223,8 @@ function PostCard({ post }: { post: Post }) {
           <h3 className="font-semibold text-white mb-1">{post.title}</h3>
           <p className="text-sm text-gray-400 line-clamp-2">{post.content}</p>
           <div className="flex items-center gap-4 mt-3 text-xs text-gray-500">
-            <span>{post.like_count || 0} likes</span>
-            <span>{post.comment_count || 0} comments</span>
+            <span>{t('search.likesCount', { count: post.like_count || 0 })}</span>
+            <span>{t('search.commentsCount', { count: post.comment_count || 0 })}</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## 概要
- DashboardPage: `title="投稿を編集"` ハードコード日本語を`t('dashboard.editPost')`に置換
- SearchPage: `likes`/`comments` ハードコード英語を`t('search.likesCount')`/`t('search.commentsCount')`に置換
- PostCard: いいね操作の空catchに`console.warn`追加
- 全10言語に3キー追加（dashboard.editPost・search.likesCount・search.commentsCount）

## テスト
- TypeScriptチェック パス

Closes #470