### PR TITLE
refactor: NoteTemplate/NoteFolderの所有権チェックをservice層に移動

### DIFF
--- a/backend/internal/handler/note_folder.go
+++ b/backend/internal/handler/note_folder.go
@@ -13,8 +13,8 @@ type NoteFolderServiceInterface interface {
 	GetByUserID(userID uint) ([]model.NoteFolder, error)
 	GetChildren(parentID uint) ([]model.NoteFolder, error)
 	GetRootFolders(userID uint) ([]model.NoteFolder, error)
-	Update(folder *model.NoteFolder) error
-	Delete(id uint) error
+	Update(id, userID uint, name string, parentID *uint) (*model.NoteFolder, error)
+	Delete(id, userID uint) error
 }
 
 // NoteFolderHandler はノートフォルダ関連のHTTPハンドラ。
@@ -133,28 +133,8 @@ func (h *NoteFolderHandler) Update(c *gin.Context) {
 		return
 	}
 
-	// 既存のフォルダを取得して所有者確認
-	folder, err := h.service.GetByID(id)
+	folder, err := h.service.Update(id, userID, input.Name, input.ParentID)
 	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	// 所有者チェック
-	if folder.UserID != userID {
-		respondForbidden(c, "この操作を行う権限がありません")
-		return
-	}
-
-	// 更新フィールドを適用（空でない場合のみ）
-	if input.Name != "" {
-		folder.Name = input.Name
-	}
-	if input.ParentID != nil {
-		folder.ParentID = input.ParentID
-	}
-
-	if err := h.service.Update(folder); err != nil {
 		respondError(c, err)
 		return
 	}
@@ -168,8 +148,9 @@ func (h *NoteFolderHandler) Delete(c *gin.Context) {
 	if !ok {
 		return
 	}
+	userID := c.GetUint("userID")
 
-	if err := h.service.Delete(id); err != nil {
+	if err := h.service.Delete(id, userID); err != nil {
 		respondError(c, err)
 		return
 	}

--- a/backend/internal/handler/note_folder_test.go
+++ b/backend/internal/handler/note_folder_test.go
@@ -45,12 +45,16 @@ func (m *MockNoteFolderService) GetRootFolders(userID uint) ([]model.NoteFolder,
 	return args.Get(0).([]model.NoteFolder), args.Error(1)
 }
 
-func (m *MockNoteFolderService) Update(folder *model.NoteFolder) error {
-	return m.Called(folder).Error(0)
+func (m *MockNoteFolderService) Update(id, userID uint, name string, parentID *uint) (*model.NoteFolder, error) {
+	args := m.Called(id, userID, name, parentID)
+	if f := args.Get(0); f != nil {
+		return f.(*model.NoteFolder), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
-func (m *MockNoteFolderService) Delete(id uint) error {
-	return m.Called(id).Error(0)
+func (m *MockNoteFolderService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
 }
 
 // newTestNoteFolderHandler はテスト用のNoteFolderHandlerを生成する。
@@ -222,8 +226,7 @@ func TestNoteFolderHandler_Update(t *testing.T) {
 		Name:   "更新後フォルダ名",
 	}
 
-	mockService.On("GetByID", uint(1)).Return(updatedFolder, nil)
-	mockService.On("Update", mock.AnythingOfType("*model.NoteFolder")).Return(nil)
+	mockService.On("Update", uint(1), uint(1), "更新後フォルダ名", (*uint)(nil)).Return(updatedFolder, nil)
 
 	req, _ := http.NewRequest("PUT", "/folders/1", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -242,9 +245,12 @@ func TestNoteFolderHandler_Delete(t *testing.T) {
 	handler, mockService := newTestNoteFolderHandler()
 	router := setupRouter()
 
-	router.DELETE("/folders/:id", handler.Delete)
+	router.DELETE("/folders/:id", func(c *gin.Context) {
+		c.Set("userID", uint(1))
+		handler.Delete(c)
+	})
 
-	mockService.On("Delete", uint(1)).Return(nil)
+	mockService.On("Delete", uint(1), uint(1)).Return(nil)
 
 	req, _ := http.NewRequest("DELETE", "/folders/1", nil)
 	w := httptest.NewRecorder()

--- a/backend/internal/handler/note_template.go
+++ b/backend/internal/handler/note_template.go
@@ -11,8 +11,8 @@ type NoteTemplateServiceInterface interface {
 	GetByID(id uint) (*model.NoteTemplate, error)
 	GetByUserID(userID uint) ([]model.NoteTemplate, error)
 	GetDefaultByUserID(userID uint) (*model.NoteTemplate, error)
-	Update(template *model.NoteTemplate) error
-	Delete(id uint) error
+	Update(id, userID uint, name, description, defaultTitle, contentTemplate, defaultTags string, isDefault *bool) (*model.NoteTemplate, error)
+	Delete(id, userID uint) error
 }
 
 // NoteTemplateHandler はノートテンプレート関連のHTTPハンドラ。
@@ -130,40 +130,8 @@ func (h *NoteTemplateHandler) Update(c *gin.Context) {
 		return
 	}
 
-	// 既存のテンプレートを取得して所有者確認
-	template, err := h.service.GetByID(id)
+	template, err := h.service.Update(id, userID, input.Name, input.Description, input.DefaultTitle, input.ContentTemplate, input.DefaultTags, input.IsDefault)
 	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	// 所有者チェック
-	if template.UserID != userID {
-		respondForbidden(c, "この操作を行う権限がありません")
-		return
-	}
-
-	// 更新フィールドを適用
-	if input.Name != "" {
-		template.Name = input.Name
-	}
-	if input.Description != "" {
-		template.Description = input.Description
-	}
-	if input.DefaultTitle != "" {
-		template.DefaultTitle = input.DefaultTitle
-	}
-	if input.ContentTemplate != "" {
-		template.ContentTemplate = input.ContentTemplate
-	}
-	if input.DefaultTags != "" {
-		template.DefaultTags = input.DefaultTags
-	}
-	if input.IsDefault != nil {
-		template.IsDefault = *input.IsDefault
-	}
-
-	if err := h.service.Update(template); err != nil {
 		respondError(c, err)
 		return
 	}
@@ -179,19 +147,7 @@ func (h *NoteTemplateHandler) Delete(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	// 所有者確認
-	template, err := h.service.GetByID(id)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	if template.UserID != userID {
-		respondForbidden(c, "この操作を行う権限がありません")
-		return
-	}
-
-	if err := h.service.Delete(id); err != nil {
+	if err := h.service.Delete(id, userID); err != nil {
 		respondError(c, err)
 		return
 	}

--- a/backend/internal/handler/note_template_test.go
+++ b/backend/internal/handler/note_template_test.go
@@ -92,9 +92,8 @@ func TestNoteTemplateGetDefault_Success(t *testing.T) {
 
 func TestNoteTemplateUpdate_Success(t *testing.T) {
 	h, svc, _ := setupNoteTemplateHandler()
-	tmpl := &model.NoteTemplate{ID: 1, UserID: 1, Name: "旧名"}
-	svc.On("GetByID", uint(1)).Return(tmpl, nil)
-	svc.On("Update", mock.AnythingOfType("*model.NoteTemplate")).Return(nil)
+	updated := &model.NoteTemplate{ID: 1, UserID: 1, Name: "新名"}
+	svc.On("Update", uint(1), uint(1), "新名", "", "", "", "", (*bool)(nil)).Return(updated, nil)
 
 	r := newRouter(1)
 	r.PUT("/note-templates/:id", h.Update)
@@ -108,8 +107,7 @@ func TestNoteTemplateUpdate_Success(t *testing.T) {
 
 func TestNoteTemplateUpdate_Forbidden(t *testing.T) {
 	h, svc, _ := setupNoteTemplateHandler()
-	tmpl := &model.NoteTemplate{ID: 1, UserID: 99, Name: "他人の"}
-	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+	svc.On("Update", uint(1), uint(1), "変更", "", "", "", "", (*bool)(nil)).Return(nil, service.ErrForbidden)
 
 	r := newRouter(1)
 	r.PUT("/note-templates/:id", h.Update)
@@ -123,9 +121,7 @@ func TestNoteTemplateUpdate_Forbidden(t *testing.T) {
 
 func TestNoteTemplateDelete_Success(t *testing.T) {
 	h, svc, _ := setupNoteTemplateHandler()
-	tmpl := &model.NoteTemplate{ID: 1, UserID: 1}
-	svc.On("GetByID", uint(1)).Return(tmpl, nil)
-	svc.On("Delete", uint(1)).Return(nil)
+	svc.On("Delete", uint(1), uint(1)).Return(nil)
 
 	r := newRouter(1)
 	r.DELETE("/note-templates/:id", h.Delete)
@@ -137,8 +133,7 @@ func TestNoteTemplateDelete_Success(t *testing.T) {
 
 func TestNoteTemplateDelete_Forbidden(t *testing.T) {
 	h, svc, _ := setupNoteTemplateHandler()
-	tmpl := &model.NoteTemplate{ID: 1, UserID: 99}
-	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+	svc.On("Delete", uint(1), uint(1)).Return(service.ErrForbidden)
 
 	r := newRouter(1)
 	r.DELETE("/note-templates/:id", h.Delete)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1610,11 +1610,15 @@ func (m *MockNoteTemplateService) GetDefaultByUserID(userID uint) (*model.NoteTe
 	}
 	return nil, args.Error(1)
 }
-func (m *MockNoteTemplateService) Update(template *model.NoteTemplate) error {
-	return m.Called(template).Error(0)
+func (m *MockNoteTemplateService) Update(id, userID uint, name, description, defaultTitle, contentTemplate, defaultTags string, isDefault *bool) (*model.NoteTemplate, error) {
+	args := m.Called(id, userID, name, description, defaultTitle, contentTemplate, defaultTags, isDefault)
+	if t := args.Get(0); t != nil {
+		return t.(*model.NoteTemplate), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
-func (m *MockNoteTemplateService) Delete(id uint) error {
-	return m.Called(id).Error(0)
+func (m *MockNoteTemplateService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
 }
 
 // MockNoteServiceForTemplate は NoteTemplateHandler 用のノートサービスモック。

--- a/backend/internal/service/note_folder.go
+++ b/backend/internal/service/note_folder.go
@@ -47,18 +47,42 @@ func (s *NoteFolderService) GetRootFolders(userID uint) ([]model.NoteFolder, err
 	return s.repo.GetRootFolders(userID)
 }
 
-// Update はフォルダを更新する。
-func (s *NoteFolderService) Update(folder *model.NoteFolder) error {
-	// バリデーション
-	v := validator.NewNoteFolderValidator()
-	if err := v.ValidateUpdate(folder.Name); err != nil {
-		return err
+// Update は所有権を検証した後、フォルダを更新する。
+func (s *NoteFolderService) Update(id, userID uint, name string, parentID *uint) (*model.NoteFolder, error) {
+	folder, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if folder.UserID != userID {
+		return nil, ErrForbidden
 	}
 
-	return s.repo.Update(folder)
+	if name != "" {
+		folder.Name = name
+	}
+	if parentID != nil {
+		folder.ParentID = parentID
+	}
+
+	v := validator.NewNoteFolderValidator()
+	if err := v.ValidateUpdate(folder.Name); err != nil {
+		return nil, err
+	}
+
+	if err := s.repo.Update(folder); err != nil {
+		return nil, err
+	}
+	return folder, nil
 }
 
-// Delete はフォルダを削除する。
-func (s *NoteFolderService) Delete(id uint) error {
+// Delete は所有権を検証した後、フォルダを削除する。
+func (s *NoteFolderService) Delete(id, userID uint) error {
+	folder, err := s.repo.FindByID(id)
+	if err != nil {
+		return err
+	}
+	if folder.UserID != userID {
+		return ErrForbidden
+	}
 	return s.repo.Delete(id)
 }

--- a/backend/internal/service/note_folder_test.go
+++ b/backend/internal/service/note_folder_test.go
@@ -140,16 +140,30 @@ func TestNoteFolderService_Update(t *testing.T) {
 	mockRepo := new(MockNoteFolderRepository)
 	service := NewNoteFolderService(mockRepo)
 
-	folder := &model.NoteFolder{
+	existing := &model.NoteFolder{
 		ID:     1,
 		UserID: 1,
-		Name:   "更新後の名前",
+		Name:   "元の名前",
 	}
 
-	mockRepo.On("Update", folder).Return(nil)
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+	mockRepo.On("Update", mock.AnythingOfType("*model.NoteFolder")).Return(nil)
 
-	err := service.Update(folder)
+	result, err := service.Update(1, 1, "更新後の名前", nil)
 	assert.NoError(t, err)
+	assert.Equal(t, "更新後の名前", result.Name)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestNoteFolderService_Update_Forbidden(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	existing := &model.NoteFolder{ID: 1, UserID: 1}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := service.Update(1, 999, "名前", nil)
+	assert.ErrorIs(t, err, ErrForbidden)
 	mockRepo.AssertExpectations(t)
 }
 
@@ -157,9 +171,23 @@ func TestNoteFolderService_Delete(t *testing.T) {
 	mockRepo := new(MockNoteFolderRepository)
 	service := NewNoteFolderService(mockRepo)
 
+	existing := &model.NoteFolder{ID: 1, UserID: 1}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
 	mockRepo.On("Delete", uint(1)).Return(nil)
 
-	err := service.Delete(1)
+	err := service.Delete(1, 1)
 	assert.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestNoteFolderService_Delete_Forbidden(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	existing := &model.NoteFolder{ID: 1, UserID: 1}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	err := service.Delete(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
 	mockRepo.AssertExpectations(t)
 }

--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -68,41 +68,77 @@ func (s *NoteTemplateService) GetDefaultByUserID(userID uint) (*model.NoteTempla
 	return s.repo.FindDefaultByUserID(userID)
 }
 
-// Update はテンプレートを更新する。
-func (s *NoteTemplateService) Update(template *model.NoteTemplate) error {
+// Update は所有権を検証した後、テンプレートを更新する。
+func (s *NoteTemplateService) Update(id, userID uint, name, description, defaultTitle, contentTemplate, defaultTags string, isDefault *bool) (*model.NoteTemplate, error) {
+	template, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if template.UserID != userID {
+		return nil, ErrForbidden
+	}
+
+	if name != "" {
+		template.Name = name
+	}
+	if description != "" {
+		template.Description = description
+	}
+	if defaultTitle != "" {
+		template.DefaultTitle = defaultTitle
+	}
+	if contentTemplate != "" {
+		template.ContentTemplate = contentTemplate
+	}
+	if defaultTags != "" {
+		template.DefaultTags = defaultTags
+	}
+	if isDefault != nil {
+		template.IsDefault = *isDefault
+	}
+
 	v := validator.NewNoteTemplateValidator()
 	if template.Name != "" {
 		if err := v.ValidateName(template.Name); err != nil {
-			return err
+			return nil, err
 		}
 	}
 	if template.ContentTemplate != "" {
 		if err := v.ValidateContentTemplate(template.ContentTemplate); err != nil {
-			return err
+			return nil, err
 		}
 	}
 	if template.Description != "" {
 		if err := v.ValidateDescription(template.Description); err != nil {
-			return err
+			return nil, err
 		}
 	}
 	if template.DefaultTitle != "" {
 		if err := v.ValidateDefaultTitle(template.DefaultTitle); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	// is_default=trueの場合、既存のデフォルトフラグをクリア
 	if template.IsDefault {
 		if err := s.repo.ClearDefaultFlag(template.UserID); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return s.repo.Update(template)
+	if err := s.repo.Update(template); err != nil {
+		return nil, err
+	}
+	return template, nil
 }
 
-// Delete はテンプレートを削除する。
-func (s *NoteTemplateService) Delete(id uint) error {
+// Delete は所有権を検証した後、テンプレートを削除する。
+func (s *NoteTemplateService) Delete(id, userID uint) error {
+	template, err := s.repo.FindByID(id)
+	if err != nil {
+		return err
+	}
+	if template.UserID != userID {
+		return ErrForbidden
+	}
 	return s.repo.Delete(id)
 }

--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -148,18 +148,36 @@ func TestNoteTemplateService_GetByUserID(t *testing.T) {
 func TestNoteTemplateService_Update(t *testing.T) {
 	svc, repo := newTestNoteTemplateService()
 
-	template := &model.NoteTemplate{
+	existing := &model.NoteTemplate{
 		ID:              1,
 		UserID:          1,
-		Name:            "更新後テンプレート",
-		ContentTemplate: "更新後本文",
+		Name:            "元テンプレート",
+		ContentTemplate: "元本文",
 		IsDefault:       false,
 	}
 
-	repo.On("Update", template).Return(nil)
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.AnythingOfType("*model.NoteTemplate")).Return(nil)
 
-	err := svc.Update(template)
+	result, err := svc.Update(1, 1, "更新後テンプレート", "", "", "更新後本文", "", nil)
 	assert.NoError(t, err)
+	assert.Equal(t, "更新後テンプレート", result.Name)
+	assert.Equal(t, "更新後本文", result.ContentTemplate)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_Update_Forbidden(t *testing.T) {
+	svc, repo := newTestNoteTemplateService()
+
+	existing := &model.NoteTemplate{
+		ID:     1,
+		UserID: 1,
+	}
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.Update(1, 999, "", "", "", "", "", nil)
+	assert.ErrorIs(t, err, ErrForbidden)
 	repo.AssertExpectations(t)
 }
 
@@ -170,9 +188,22 @@ func TestNoteTemplateService_Update(t *testing.T) {
 func TestNoteTemplateService_Delete(t *testing.T) {
 	svc, repo := newTestNoteTemplateService()
 
+	existing := &model.NoteTemplate{ID: 1, UserID: 1}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
 	repo.On("Delete", uint(1)).Return(nil)
 
-	err := svc.Delete(1)
+	err := svc.Delete(1, 1)
 	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_Delete_Forbidden(t *testing.T) {
+	svc, repo := newTestNoteTemplateService()
+
+	existing := &model.NoteTemplate{ID: 1, UserID: 1}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	err := svc.Delete(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
 	repo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
- NoteTemplateHandler/NoteFolderHandlerで行っていた所有権チェック（GetByID→UserID比較→Forbidden）をservice層のUpdate/Deleteメソッド内に移動
- PostService/QuestionServiceで確立済みのパターン（`Update(id, userID, fields...)`, `Delete(id, userID)`）に統一
- ハンドラは入力バインド→service呼び出し→レスポンス返却のみの薄い責務に

## 変更内容
- `service/note_template.go`: Update/Delete署名変更、所有権チェック+部分更新ロジックをservice内に移動
- `service/note_folder.go`: Update/Delete署名変更、所有権チェックをservice内に移動
- `handler/note_template.go`: Update/Delete簡素化、インターフェース更新
- `handler/note_folder.go`: Update/Delete簡素化、インターフェース更新
- 全テスト更新（所有権チェックのForbiddenテスト4件追加）

## テスト
- `go build ./...` パス
- NoteTemplate/NoteFolder関連の全ハンドラテスト・サービステスト パス

Closes #472