### PR TITLE
fix: 空catchブロックにconsole.warnエラーハンドリング追加

### DIFF
--- a/frontend/src/components/common/PomodoroTimer.tsx
+++ b/frontend/src/components/common/PomodoroTimer.tsx
@@ -48,8 +48,8 @@ export default function PomodoroTimer() {
         duration: 25,
         source: 'pomodoro',
       });
-    } catch {
-      // エラーは無視
+    } catch (e) {
+      console.warn('Failed to create pomodoro learning log:', e);
     }
   }, [autoLog, category, t]);
 

--- a/frontend/src/components/dashboard/RecommendedUsersWidget.tsx
+++ b/frontend/src/components/dashboard/RecommendedUsersWidget.tsx
@@ -17,8 +17,8 @@ export default function RecommendedUsersWidget() {
     try {
       await followUser(userId);
       setFollowedIds((prev) => new Set(prev).add(userId));
-    } catch {
-      // エラー時は何もしない
+    } catch (e) {
+      console.warn('Failed to follow user:', e);
     } finally {
       setFollowingId(null);
     }

--- a/frontend/src/hooks/useAdvice.ts
+++ b/frontend/src/hooks/useAdvice.ts
@@ -30,8 +30,8 @@ export function useAdvice() {
       try {
         await markAdviceRead(id);
         await refetch();
-      } catch {
-        // エラーは無視
+      } catch (e) {
+        console.warn('Failed to mark advice as read:', e);
       }
     },
     [refetch]
@@ -76,8 +76,8 @@ export function useAIChat() {
           setMessages(conv.messages.filter((m) => m.role !== 'system'));
         }
         return conv;
-      } catch {
-        // エラー時はユーザーメッセージを残す
+      } catch (e) {
+        console.warn('Failed to send AI message:', e);
         return null;
       } finally {
         setSending(false);


### PR DESCRIPTION
## 概要
- 3ファイル4箇所の空catchブロックにconsole.warnを追加し、サイレントエラーを防止
- エラーの原因がデバッグしやすくなる

## 変更箇所
- `RecommendedUsersWidget.tsx:20` — followUser失敗時
- `PomodoroTimer.tsx:51` — createLog失敗時
- `useAdvice.ts:33` — markAdviceRead失敗時
- `useAdvice.ts:79` — chatWithAI失敗時

## テスト
- TypeScriptビルド パス

Closes #476