### PR TITLE
refactor: UseTemplateのビジネスロジックをservice層に移動

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -136,7 +136,7 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	studyCircleService := service.NewStudyCircleService(studyCircleRepo)
 	noteService := service.NewNoteService(noteRepo)
 	noteFolderService := service.NewNoteFolderService(noteFolderRepo)
-	noteTemplateService := service.NewNoteTemplateService(noteTemplateRepo)
+	noteTemplateService := service.NewNoteTemplateService(noteTemplateRepo, noteService)
 	noteLinkService := service.NewNoteLinkService(noteLinkRepo, noteRepo)
 
 	// テンプレートロードマップの初期登録
@@ -210,7 +210,7 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	c.SearchHandler = handler.NewSearchHandler(postRepo, studyCircleRepo)
 	c.NoteHandler = handler.NewNoteHandler(noteService)
 	c.NoteFolderHandler = handler.NewNoteFolderHandler(noteFolderService)
-	c.NoteTemplateHandler = handler.NewNoteTemplateHandler(noteTemplateService, noteService)
+	c.NoteTemplateHandler = handler.NewNoteTemplateHandler(noteTemplateService)
 	c.NoteLinkHandler = handler.NewNoteLinkHandler(noteLinkService)
 
 	// HubのGetRoomMembersコールバックを設定

--- a/backend/internal/handler/note_template.go
+++ b/backend/internal/handler/note_template.go
@@ -13,20 +13,17 @@ type NoteTemplateServiceInterface interface {
 	GetDefaultByUserID(userID uint) (*model.NoteTemplate, error)
 	Update(id, userID uint, name, description, defaultTitle, contentTemplate, defaultTags string, isDefault *bool) (*model.NoteTemplate, error)
 	Delete(id, userID uint) error
+	UseTemplate(id, userID uint) (*model.Note, error)
 }
 
 // NoteTemplateHandler はノートテンプレート関連のHTTPハンドラ。
 type NoteTemplateHandler struct {
-	service     NoteTemplateServiceInterface
-	noteService NoteServiceInterface
+	service NoteTemplateServiceInterface
 }
 
 // NewNoteTemplateHandler は新しいNoteTemplateHandlerインスタンスを生成する。
-func NewNoteTemplateHandler(s NoteTemplateServiceInterface, noteService NoteServiceInterface) *NoteTemplateHandler {
-	return &NoteTemplateHandler{
-		service:     s,
-		noteService: noteService,
-	}
+func NewNoteTemplateHandler(s NoteTemplateServiceInterface) *NoteTemplateHandler {
+	return &NoteTemplateHandler{service: s}
 }
 
 // CreateTemplateInput はテンプレート作成のリクエストボディ。
@@ -163,36 +160,8 @@ func (h *NoteTemplateHandler) UseTemplate(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	// NoteServiceからNoteRepositoryを取得する必要があるが、
-	// 簡便化のため、NoteServiceのインターフェースを使用する想定
-	// 実装上は、noteServiceを経由してノートを作成する
-	template, err := h.service.GetByID(id)
+	note, err := h.service.UseTemplate(id, userID)
 	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	// 所有者チェック
-	if template.UserID != userID {
-		respondForbidden(c, "この操作を行う権限がありません")
-		return
-	}
-
-	// テンプレートからノートを作成
-	note := &model.Note{
-		UserID:  userID,
-		Title:   template.DefaultTitle,
-		Content: template.ContentTemplate,
-		Tags:    template.DefaultTags,
-	}
-
-	// タイトルが空の場合、デフォルト値を設定
-	if note.Title == "" {
-		note.Title = "新しいノート"
-	}
-
-	// NoteServiceを使ってノートを作成（バリデーション含む）
-	if err := h.noteService.Create(note); err != nil {
 		respondError(c, err)
 		return
 	}

--- a/backend/internal/handler/note_template_test.go
+++ b/backend/internal/handler/note_template_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestNoteTemplateCreate_Success(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	svc.On("Create", mock.AnythingOfType("*model.NoteTemplate")).Return(nil)
 
 	r := newRouter(1)
@@ -25,7 +25,7 @@ func TestNoteTemplateCreate_Success(t *testing.T) {
 }
 
 func TestNoteTemplateCreate_ServiceError(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	svc.On("Create", mock.AnythingOfType("*model.NoteTemplate")).Return(service.ErrBadRequest)
 
 	r := newRouter(1)
@@ -40,7 +40,7 @@ func TestNoteTemplateCreate_ServiceError(t *testing.T) {
 }
 
 func TestNoteTemplateGetByID_Success(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	tmpl := &model.NoteTemplate{ID: 1, UserID: 1, Name: "テスト"}
 	svc.On("GetByID", uint(1)).Return(tmpl, nil)
 
@@ -53,7 +53,7 @@ func TestNoteTemplateGetByID_Success(t *testing.T) {
 }
 
 func TestNoteTemplateGetByID_NotFound(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	svc.On("GetByID", uint(99)).Return(nil, service.ErrNotFound)
 
 	r := newRouter(1)
@@ -65,7 +65,7 @@ func TestNoteTemplateGetByID_NotFound(t *testing.T) {
 }
 
 func TestNoteTemplateGetByUserID_Success(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	templates := []model.NoteTemplate{{ID: 1, UserID: 1, Name: "テスト"}}
 	svc.On("GetByUserID", uint(1)).Return(templates, nil)
 
@@ -78,7 +78,7 @@ func TestNoteTemplateGetByUserID_Success(t *testing.T) {
 }
 
 func TestNoteTemplateGetDefault_Success(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	tmpl := &model.NoteTemplate{ID: 1, UserID: 1, Name: "デフォルト", IsDefault: true}
 	svc.On("GetDefaultByUserID", uint(1)).Return(tmpl, nil)
 
@@ -91,7 +91,7 @@ func TestNoteTemplateGetDefault_Success(t *testing.T) {
 }
 
 func TestNoteTemplateUpdate_Success(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	updated := &model.NoteTemplate{ID: 1, UserID: 1, Name: "新名"}
 	svc.On("Update", uint(1), uint(1), "新名", "", "", "", "", (*bool)(nil)).Return(updated, nil)
 
@@ -106,7 +106,7 @@ func TestNoteTemplateUpdate_Success(t *testing.T) {
 }
 
 func TestNoteTemplateUpdate_Forbidden(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	svc.On("Update", uint(1), uint(1), "変更", "", "", "", "", (*bool)(nil)).Return(nil, service.ErrForbidden)
 
 	r := newRouter(1)
@@ -120,7 +120,7 @@ func TestNoteTemplateUpdate_Forbidden(t *testing.T) {
 }
 
 func TestNoteTemplateDelete_Success(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	svc.On("Delete", uint(1), uint(1)).Return(nil)
 
 	r := newRouter(1)
@@ -132,7 +132,7 @@ func TestNoteTemplateDelete_Success(t *testing.T) {
 }
 
 func TestNoteTemplateDelete_Forbidden(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
+	h, svc := setupNoteTemplateHandler()
 	svc.On("Delete", uint(1), uint(1)).Return(service.ErrForbidden)
 
 	r := newRouter(1)
@@ -144,16 +144,9 @@ func TestNoteTemplateDelete_Forbidden(t *testing.T) {
 }
 
 func TestNoteTemplateUseTemplate_Success(t *testing.T) {
-	h, svc, noteSvc := setupNoteTemplateHandler()
-	tmpl := &model.NoteTemplate{
-		ID:              1,
-		UserID:          1,
-		DefaultTitle:    "テンプレタイトル",
-		ContentTemplate: "テンプレ内容",
-		DefaultTags:     "tag1",
-	}
-	svc.On("GetByID", uint(1)).Return(tmpl, nil)
-	noteSvc.On("Create", mock.AnythingOfType("*model.Note")).Return(nil)
+	h, svc := setupNoteTemplateHandler()
+	note := &model.Note{UserID: 1, Title: "テンプレタイトル", Content: "テンプレ内容", Tags: "tag1"}
+	svc.On("UseTemplate", uint(1), uint(1)).Return(note, nil)
 
 	r := newRouter(1)
 	r.POST("/note-templates/:id/use", h.UseTemplate)
@@ -161,13 +154,11 @@ func TestNoteTemplateUseTemplate_Success(t *testing.T) {
 
 	assertStatus(t, w, http.StatusCreated)
 	svc.AssertExpectations(t)
-	noteSvc.AssertExpectations(t)
 }
 
 func TestNoteTemplateUseTemplate_Forbidden(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
-	tmpl := &model.NoteTemplate{ID: 1, UserID: 99}
-	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+	h, svc := setupNoteTemplateHandler()
+	svc.On("UseTemplate", uint(1), uint(1)).Return(nil, service.ErrForbidden)
 
 	r := newRouter(1)
 	r.POST("/note-templates/:id/use", h.UseTemplate)
@@ -178,8 +169,8 @@ func TestNoteTemplateUseTemplate_Forbidden(t *testing.T) {
 }
 
 func TestNoteTemplateUseTemplate_NotFound(t *testing.T) {
-	h, svc, _ := setupNoteTemplateHandler()
-	svc.On("GetByID", uint(99)).Return(nil, service.ErrNotFound)
+	h, svc := setupNoteTemplateHandler()
+	svc.On("UseTemplate", uint(99), uint(1)).Return(nil, service.ErrNotFound)
 
 	r := newRouter(1)
 	r.POST("/note-templates/:id/use", h.UseTemplate)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1620,60 +1620,7 @@ func (m *MockNoteTemplateService) Update(id, userID uint, name, description, def
 func (m *MockNoteTemplateService) Delete(id, userID uint) error {
 	return m.Called(id, userID).Error(0)
 }
-
-// MockNoteServiceForTemplate は NoteTemplateHandler 用のノートサービスモック。
-type MockNoteServiceForTemplate struct{ mock.Mock }
-
-func (m *MockNoteServiceForTemplate) Create(note *model.Note) error {
-	return m.Called(note).Error(0)
-}
-func (m *MockNoteServiceForTemplate) GetByID(id uint) (*model.Note, error) {
-	args := m.Called(id)
-	if n := args.Get(0); n != nil {
-		return n.(*model.Note), args.Error(1)
-	}
-	return nil, args.Error(1)
-}
-func (m *MockNoteServiceForTemplate) GetByUserID(userID uint, page, limit int) ([]model.Note, error) {
-	args := m.Called(userID, page, limit)
-	return args.Get(0).([]model.Note), args.Error(1)
-}
-func (m *MockNoteServiceForTemplate) GetByFolderID(folderID uint) ([]model.Note, error) {
-	args := m.Called(folderID)
-	return args.Get(0).([]model.Note), args.Error(1)
-}
-func (m *MockNoteServiceForTemplate) Update(note *model.Note) error {
-	return m.Called(note).Error(0)
-}
-func (m *MockNoteServiceForTemplate) Delete(id uint) error {
-	return m.Called(id).Error(0)
-}
-func (m *MockNoteServiceForTemplate) Search(userID uint, query string, page, limit int) ([]model.Note, int64, error) {
-	args := m.Called(userID, query, page, limit)
-	return args.Get(0).([]model.Note), args.Get(1).(int64), args.Error(2)
-}
-func (m *MockNoteServiceForTemplate) CountByUserID(userID uint) (int64, error) {
-	args := m.Called(userID)
-	return args.Get(0).(int64), args.Error(1)
-}
-func (m *MockNoteServiceForTemplate) ToggleFavorite(id uint) error {
-	return m.Called(id).Error(0)
-}
-func (m *MockNoteServiceForTemplate) Archive(id uint) error {
-	return m.Called(id).Error(0)
-}
-func (m *MockNoteServiceForTemplate) Unarchive(id uint) error {
-	return m.Called(id).Error(0)
-}
-func (m *MockNoteServiceForTemplate) GetArchived(userID uint, page, limit int) ([]model.Note, error) {
-	args := m.Called(userID, page, limit)
-	return args.Get(0).([]model.Note), args.Error(1)
-}
-func (m *MockNoteServiceForTemplate) CountArchivedByUserID(userID uint) (int64, error) {
-	args := m.Called(userID)
-	return args.Get(0).(int64), args.Error(1)
-}
-func (m *MockNoteServiceForTemplate) Duplicate(id uint, userID uint) (*model.Note, error) {
+func (m *MockNoteTemplateService) UseTemplate(id, userID uint) (*model.Note, error) {
 	args := m.Called(id, userID)
 	if n := args.Get(0); n != nil {
 		return n.(*model.Note), args.Error(1)
@@ -1681,9 +1628,8 @@ func (m *MockNoteServiceForTemplate) Duplicate(id uint, userID uint) (*model.Not
 	return nil, args.Error(1)
 }
 
-func setupNoteTemplateHandler() (*NoteTemplateHandler, *MockNoteTemplateService, *MockNoteServiceForTemplate) {
+func setupNoteTemplateHandler() (*NoteTemplateHandler, *MockNoteTemplateService) {
 	svc := new(MockNoteTemplateService)
-	noteSvc := new(MockNoteServiceForTemplate)
-	h := NewNoteTemplateHandler(svc, noteSvc)
-	return h, svc, noteSvc
+	h := NewNoteTemplateHandler(svc)
+	return h, svc
 }

--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -16,14 +16,20 @@ type NoteTemplateRepositoryInterface interface {
 	ClearDefaultFlag(userID uint) error
 }
 
+// NoteCreatorInterface はノート作成機能のインターフェース。
+type NoteCreatorInterface interface {
+	Create(note *model.Note) error
+}
+
 // NoteTemplateService はノートテンプレートのビジネスロジック。
 type NoteTemplateService struct {
-	repo NoteTemplateRepositoryInterface
+	repo        NoteTemplateRepositoryInterface
+	noteCreator NoteCreatorInterface
 }
 
 // NewNoteTemplateService は新しいNoteTemplateServiceインスタンスを生成する。
-func NewNoteTemplateService(repo NoteTemplateRepositoryInterface) *NoteTemplateService {
-	return &NoteTemplateService{repo: repo}
+func NewNoteTemplateService(repo NoteTemplateRepositoryInterface, noteCreator NoteCreatorInterface) *NoteTemplateService {
+	return &NoteTemplateService{repo: repo, noteCreator: noteCreator}
 }
 
 // Create は新しいテンプレートを作成する。
@@ -141,4 +147,30 @@ func (s *NoteTemplateService) Delete(id, userID uint) error {
 		return ErrForbidden
 	}
 	return s.repo.Delete(id)
+}
+
+// UseTemplate は所有権を検証した後、テンプレートからノートを作成する。
+func (s *NoteTemplateService) UseTemplate(id, userID uint) (*model.Note, error) {
+	template, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if template.UserID != userID {
+		return nil, ErrForbidden
+	}
+
+	note := &model.Note{
+		UserID:  userID,
+		Title:   template.DefaultTitle,
+		Content: template.ContentTemplate,
+		Tags:    template.DefaultTags,
+	}
+	if note.Title == "" {
+		note.Title = "新しいノート"
+	}
+
+	if err := s.noteCreator.Create(note); err != nil {
+		return nil, err
+	}
+	return note, nil
 }

--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -50,11 +51,21 @@ func (m *MockNoteTemplateRepository) ClearDefaultFlag(userID uint) error {
 	return m.Called(userID).Error(0)
 }
 
+// MockNoteCreator はNoteCreatorInterfaceのモック実装。
+type MockNoteCreator struct {
+	mock.Mock
+}
+
+func (m *MockNoteCreator) Create(note *model.Note) error {
+	return m.Called(note).Error(0)
+}
+
 // newTestNoteTemplateService はテスト用のNoteTemplateServiceを生成する。
-func newTestNoteTemplateService() (*NoteTemplateService, *MockNoteTemplateRepository) {
+func newTestNoteTemplateService() (*NoteTemplateService, *MockNoteTemplateRepository, *MockNoteCreator) {
 	repo := new(MockNoteTemplateRepository)
-	svc := NewNoteTemplateService(repo)
-	return svc, repo
+	noteCreator := new(MockNoteCreator)
+	svc := NewNoteTemplateService(repo, noteCreator)
+	return svc, repo, noteCreator
 }
 
 // ============================================================
@@ -62,7 +73,7 @@ func newTestNoteTemplateService() (*NoteTemplateService, *MockNoteTemplateReposi
 // ============================================================
 
 func TestNoteTemplateService_Create(t *testing.T) {
-	svc, repo := newTestNoteTemplateService()
+	svc, repo, _ := newTestNoteTemplateService()
 
 	template := &model.NoteTemplate{
 		UserID:          1,
@@ -82,7 +93,7 @@ func TestNoteTemplateService_Create(t *testing.T) {
 }
 
 func TestNoteTemplateService_Create_WithDefaultFlag(t *testing.T) {
-	svc, repo := newTestNoteTemplateService()
+	svc, repo, _ := newTestNoteTemplateService()
 
 	template := &model.NoteTemplate{
 		UserID:          1,
@@ -104,7 +115,7 @@ func TestNoteTemplateService_Create_WithDefaultFlag(t *testing.T) {
 // ============================================================
 
 func TestNoteTemplateService_GetByID(t *testing.T) {
-	svc, repo := newTestNoteTemplateService()
+	svc, repo, _ := newTestNoteTemplateService()
 
 	template := &model.NoteTemplate{
 		ID:              1,
@@ -126,7 +137,7 @@ func TestNoteTemplateService_GetByID(t *testing.T) {
 // ============================================================
 
 func TestNoteTemplateService_GetByUserID(t *testing.T) {
-	svc, repo := newTestNoteTemplateService()
+	svc, repo, _ := newTestNoteTemplateService()
 
 	templates := []model.NoteTemplate{
 		{ID: 1, UserID: 1, Name: "テンプレート1", ContentTemplate: "本文1"},
@@ -146,7 +157,7 @@ func TestNoteTemplateService_GetByUserID(t *testing.T) {
 // ============================================================
 
 func TestNoteTemplateService_Update(t *testing.T) {
-	svc, repo := newTestNoteTemplateService()
+	svc, repo, _ := newTestNoteTemplateService()
 
 	existing := &model.NoteTemplate{
 		ID:              1,
@@ -167,7 +178,7 @@ func TestNoteTemplateService_Update(t *testing.T) {
 }
 
 func TestNoteTemplateService_Update_Forbidden(t *testing.T) {
-	svc, repo := newTestNoteTemplateService()
+	svc, repo, _ := newTestNoteTemplateService()
 
 	existing := &model.NoteTemplate{
 		ID:     1,
@@ -186,7 +197,7 @@ func TestNoteTemplateService_Update_Forbidden(t *testing.T) {
 // ============================================================
 
 func TestNoteTemplateService_Delete(t *testing.T) {
-	svc, repo := newTestNoteTemplateService()
+	svc, repo, _ := newTestNoteTemplateService()
 
 	existing := &model.NoteTemplate{ID: 1, UserID: 1}
 	repo.On("FindByID", uint(1)).Return(existing, nil)
@@ -198,7 +209,7 @@ func TestNoteTemplateService_Delete(t *testing.T) {
 }
 
 func TestNoteTemplateService_Delete_Forbidden(t *testing.T) {
-	svc, repo := newTestNoteTemplateService()
+	svc, repo, _ := newTestNoteTemplateService()
 
 	existing := &model.NoteTemplate{ID: 1, UserID: 1}
 	repo.On("FindByID", uint(1)).Return(existing, nil)
@@ -206,4 +217,92 @@ func TestNoteTemplateService_Delete_Forbidden(t *testing.T) {
 	err := svc.Delete(1, 999)
 	assert.ErrorIs(t, err, ErrForbidden)
 	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// UseTemplate テスト
+// ============================================================
+
+func TestNoteTemplateService_UseTemplate_Success(t *testing.T) {
+	svc, repo, noteCreator := newTestNoteTemplateService()
+
+	template := &model.NoteTemplate{
+		ID:              1,
+		UserID:          1,
+		DefaultTitle:    "テンプレタイトル",
+		ContentTemplate: "テンプレ内容",
+		DefaultTags:     "tag1",
+	}
+
+	repo.On("FindByID", uint(1)).Return(template, nil)
+	noteCreator.On("Create", mock.AnythingOfType("*model.Note")).Return(nil)
+
+	note, err := svc.UseTemplate(1, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "テンプレタイトル", note.Title)
+	assert.Equal(t, "テンプレ内容", note.Content)
+	assert.Equal(t, "tag1", note.Tags)
+	assert.Equal(t, uint(1), note.UserID)
+	repo.AssertExpectations(t)
+	noteCreator.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_UseTemplate_DefaultTitle(t *testing.T) {
+	svc, repo, noteCreator := newTestNoteTemplateService()
+
+	template := &model.NoteTemplate{
+		ID:              1,
+		UserID:          1,
+		DefaultTitle:    "",
+		ContentTemplate: "内容",
+	}
+
+	repo.On("FindByID", uint(1)).Return(template, nil)
+	noteCreator.On("Create", mock.AnythingOfType("*model.Note")).Return(nil)
+
+	note, err := svc.UseTemplate(1, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "新しいノート", note.Title)
+	repo.AssertExpectations(t)
+	noteCreator.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_UseTemplate_Forbidden(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	template := &model.NoteTemplate{ID: 1, UserID: 1}
+	repo.On("FindByID", uint(1)).Return(template, nil)
+
+	_, err := svc.UseTemplate(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_UseTemplate_NotFound(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	repo.On("FindByID", uint(99)).Return(nil, ErrNotFound)
+
+	_, err := svc.UseTemplate(99, 1)
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_UseTemplate_CreateError(t *testing.T) {
+	svc, repo, noteCreator := newTestNoteTemplateService()
+
+	template := &model.NoteTemplate{
+		ID:              1,
+		UserID:          1,
+		DefaultTitle:    "タイトル",
+		ContentTemplate: "内容",
+	}
+
+	repo.On("FindByID", uint(1)).Return(template, nil)
+	noteCreator.On("Create", mock.AnythingOfType("*model.Note")).Return(errors.New("db error"))
+
+	_, err := svc.UseTemplate(1, 1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+	noteCreator.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
NoteTemplateHandler.UseTemplateメソッドの所有権チェックとノート作成ビジネスロジックをNoteTemplateServiceに移動し、handlerを薄いルーティング層に保つ。

## 変更内容
- `NoteTemplateService.UseTemplate(id, userID)` メソッドを追加
- `NoteCreatorInterface` によるインターフェース分離で循環依存を回避
- handler から `noteService` 依存を除去、UseTemplate を `h.service.UseTemplate(id, userID)` のみに簡素化
- DI container の NoteTemplateService/Handler 初期化を更新
- service テスト5件追加（成功/デフォルトタイトル/権限エラー/404/DB error）
- handler テストを新インターフェースに更新

## テスト
- service: 13テスト全パス
- handler: 13テスト全パス

Closes #478