### PR TITLE
refactor: NoteService.Updateの所有権チェックをservice層に移動

### DIFF
--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -13,7 +13,7 @@ type NoteServiceInterface interface {
 	GetByID(id uint) (*model.Note, error)
 	GetByUserID(userID uint, page, limit int) ([]model.Note, error)
 	GetByFolderID(folderID uint) ([]model.Note, error)
-	Update(note *model.Note) error
+	Update(id, userID uint, title, content, tags string, folderID *uint) (*model.Note, error)
 	Delete(id uint) error
 	Search(userID uint, query string, page, limit int) ([]model.Note, int64, error)
 	CountByUserID(userID uint) (int64, error)
@@ -141,34 +141,8 @@ func (h *NoteHandler) Update(c *gin.Context) {
 		return
 	}
 
-	// 既存のノートを取得して所有者確認
-	note, err := h.service.GetByID(id)
+	note, err := h.service.Update(id, userID, input.Title, input.Content, input.Tags, input.FolderID)
 	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	// 所有者チェック
-	if note.UserID != userID {
-		respondForbidden(c, "この操作を行う権限がありません")
-		return
-	}
-
-	// 更新フィールドを適用（空でない場合のみ）
-	if input.Title != "" {
-		note.Title = input.Title
-	}
-	if input.Content != "" {
-		note.Content = input.Content
-	}
-	if input.Tags != "" {
-		note.Tags = input.Tags
-	}
-	if input.FolderID != nil {
-		note.FolderID = input.FolderID
-	}
-
-	if err := h.service.Update(note); err != nil {
 		respondError(c, err)
 		return
 	}

--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -40,8 +40,12 @@ func (m *MockNoteService) GetByFolderID(folderID uint) ([]model.Note, error) {
 	return args.Get(0).([]model.Note), args.Error(1)
 }
 
-func (m *MockNoteService) Update(note *model.Note) error {
-	return m.Called(note).Error(0)
+func (m *MockNoteService) Update(id, userID uint, title, content, tags string, folderID *uint) (*model.Note, error) {
+	args := m.Called(id, userID, title, content, tags, folderID)
+	if n := args.Get(0); n != nil {
+		return n.(*model.Note), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (m *MockNoteService) Delete(id uint) error {
@@ -215,8 +219,7 @@ func TestNoteHandler_Update(t *testing.T) {
 		Content: "更新後内容",
 	}
 
-	mockService.On("GetByID", uint(1)).Return(updatedNote, nil)
-	mockService.On("Update", mock.AnythingOfType("*model.Note")).Return(nil)
+	mockService.On("Update", uint(1), uint(1), "更新後タイトル", "更新後内容", "", (*uint)(nil)).Return(updatedNote, nil)
 
 	req, _ := http.NewRequest("PUT", "/notes/1", bytes.NewBuffer(body))
 	req.Header.Set("Content-Type", "application/json")

--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -43,15 +43,39 @@ func (s *NoteService) GetByFolderID(folderID uint) ([]model.Note, error) {
 	return s.repo.FindByFolderID(folderID)
 }
 
-// Update はノートを更新する。
-func (s *NoteService) Update(note *model.Note) error {
-	// バリデーション（部分更新対応）
-	v := validator.NewNoteValidator()
-	if err := v.ValidateUpdateNote(note.Title, note.Content, note.Tags); err != nil {
-		return err
+// Update は所有権を検証した後、ノートを更新する。
+func (s *NoteService) Update(id, userID uint, title, content, tags string, folderID *uint) (*model.Note, error) {
+	note, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, err
 	}
 
-	return s.repo.Update(note)
+	if note.UserID != userID {
+		return nil, domain.NewError(domain.ErrCodeForbidden, "この操作を行う権限がありません", nil)
+	}
+
+	if title != "" {
+		note.Title = title
+	}
+	if content != "" {
+		note.Content = content
+	}
+	if tags != "" {
+		note.Tags = tags
+	}
+	if folderID != nil {
+		note.FolderID = folderID
+	}
+
+	v := validator.NewNoteValidator()
+	if err := v.ValidateUpdateNote(note.Title, note.Content, note.Tags); err != nil {
+		return nil, err
+	}
+
+	if err := s.repo.Update(note); err != nil {
+		return nil, err
+	}
+	return note, nil
 }
 
 // Delete はノートを削除する。

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -164,17 +164,45 @@ func TestNoteService_GetByUserID(t *testing.T) {
 func TestNoteService_Update(t *testing.T) {
 	svc, repo := newTestNoteService()
 
-	note := &model.Note{
+	existing := &model.Note{
 		ID:      1,
 		UserID:  1,
-		Title:   "更新後タイトル",
-		Content: "更新後内容",
+		Title:   "元タイトル",
+		Content: "元内容",
 	}
 
-	repo.On("Update", note).Return(nil)
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.MatchedBy(func(n *model.Note) bool {
+		return n.Title == "更新後タイトル" && n.Content == "更新後内容"
+	})).Return(nil)
 
-	err := svc.Update(note)
+	result, err := svc.Update(1, 1, "更新後タイトル", "更新後内容", "", nil)
 	assert.NoError(t, err)
+	assert.Equal(t, "更新後タイトル", result.Title)
+	assert.Equal(t, "更新後内容", result.Content)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteService_Update_Forbidden(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	existing := &model.Note{ID: 1, UserID: 1, Title: "元タイトル"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	result, err := svc.Update(1, 999, "更新", "", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteService_Update_NotFound(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	result, err := svc.Update(99, 1, "更新", "", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
- NoteHandler.Updateにあった所有権チェック（GetByID→UserID比較→Forbidden）をNoteService.Updateに移動
- NoteService.Updateの署名を `Update(id, userID uint, title, content, tags string, folderID *uint) (*model.Note, error)` に変更
- handler側を簡素化（入力受け取り→service呼び出しのみ）
- service層にForbidden・NotFoundの2テストを追加

## テスト
- [x] handler/service全テスト通過（既存+新規2件）

Closes #484