### PR TITLE
fix: useResourcesの空catchハンドリングとi18n未対応箇所を修正

### DIFF
--- a/frontend/src/hooks/useResources.ts
+++ b/frontend/src/hooks/useResources.ts
@@ -107,20 +107,20 @@ export function useResources() {
   }, [t, resources]);
 
   const handleLike = useCallback(async (id: number) => {
-    try { await likeResource(id); } catch { /* noop */ }
-  }, []);
+    try { await likeResource(id); } catch { toast.error(t('resource.likeFailed')); }
+  }, [t]);
 
   const handleUnlike = useCallback(async (id: number) => {
-    try { await unlikeResource(id); } catch { /* noop */ }
-  }, []);
+    try { await unlikeResource(id); } catch { toast.error(t('resource.unlikeFailed')); }
+  }, [t]);
 
   const handleSave = useCallback(async (id: number) => {
-    try { await saveResource(id); } catch { /* noop */ }
-  }, []);
+    try { await saveResource(id); } catch { toast.error(t('resource.saveFailed')); }
+  }, [t]);
 
   const handleUnsave = useCallback(async (id: number) => {
-    try { await unsaveResource(id); } catch { /* noop */ }
-  }, []);
+    try { await unsaveResource(id); } catch { toast.error(t('resource.unsaveFailed')); }
+  }, [t]);
 
   const changeTab = useCallback((newTab: TabType) => {
     setTab(newTab);

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -55,7 +55,8 @@
     "hasAccount": "Bereits ein Konto?",
     "signInWith": "Mit {{provider}} anmelden",
     "signUpWith": "Mit {{provider}} registrieren",
-    "orContinueWith": "Oder weiter mit"
+    "orContinueWith": "Oder weiter mit",
+    "passwordPlaceholder": "Mindestens 6 Zeichen"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -681,7 +682,11 @@
     "createFailed": "Ressource konnte nicht erstellt werden",
     "updateFailed": "Ressource konnte nicht aktualisiert werden",
     "deleteFailed": "Ressource konnte nicht gelöscht werden",
-    "confirmDelete": "Bist du sicher, dass du diese Ressource löschen möchtest?"
+    "confirmDelete": "Bist du sicher, dass du diese Ressource löschen möchtest?",
+    "likeFailed": "Fehler beim Liken",
+    "unlikeFailed": "Fehler beim Entfernen des Likes",
+    "saveFailed": "Fehler beim Speichern",
+    "unsaveFailed": "Fehler beim Entfernen der Speicherung"
   },
   "portfolio": {
     "generate": "Portfolio",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -55,7 +55,8 @@
     "hasAccount": "Already have an account?",
     "signInWith": "Sign in with {{provider}}",
     "signUpWith": "Sign up with {{provider}}",
-    "orContinueWith": "Or continue with"
+    "orContinueWith": "Or continue with",
+    "passwordPlaceholder": "6+ characters"
   },
   "dashboard": {
     "title": "Dashboard",
@@ -681,7 +682,11 @@
     "createFailed": "Failed to create resource",
     "updateFailed": "Failed to update resource",
     "deleteFailed": "Failed to delete resource",
-    "confirmDelete": "Are you sure you want to delete this resource?"
+    "confirmDelete": "Are you sure you want to delete this resource?",
+    "likeFailed": "Failed to like",
+    "unlikeFailed": "Failed to unlike",
+    "saveFailed": "Failed to save",
+    "unsaveFailed": "Failed to unsave"
   },
   "portfolio": {
     "generate": "Portfolio",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -55,7 +55,8 @@
     "hasAccount": "¿Ya tienes cuenta?",
     "signInWith": "Iniciar sesión con {{provider}}",
     "signUpWith": "Registrarse con {{provider}}",
-    "orContinueWith": "O continuar con"
+    "orContinueWith": "O continuar con",
+    "passwordPlaceholder": "6+ caracteres"
   },
   "dashboard": {
     "title": "Panel",
@@ -681,7 +682,11 @@
     "createFailed": "Error al crear recurso",
     "updateFailed": "Error al actualizar recurso",
     "deleteFailed": "Error al eliminar recurso",
-    "confirmDelete": "¿Estás seguro de que deseas eliminar este recurso?"
+    "confirmDelete": "¿Estás seguro de que deseas eliminar este recurso?",
+    "likeFailed": "Error al dar me gusta",
+    "unlikeFailed": "Error al quitar me gusta",
+    "saveFailed": "Error al guardar",
+    "unsaveFailed": "Error al quitar guardado"
   },
   "portfolio": {
     "generate": "Portafolio",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -55,7 +55,8 @@
     "hasAccount": "Déjà un compte ?",
     "signInWith": "Se connecter avec {{provider}}",
     "signUpWith": "S'inscrire avec {{provider}}",
-    "orContinueWith": "Ou continuer avec"
+    "orContinueWith": "Ou continuer avec",
+    "passwordPlaceholder": "6 caractères minimum"
   },
   "dashboard": {
     "title": "Tableau de bord",
@@ -681,7 +682,11 @@
     "createFailed": "Échec de la création de la ressource",
     "updateFailed": "Échec de la mise à jour de la ressource",
     "deleteFailed": "Échec de la suppression de la ressource",
-    "confirmDelete": "Êtes-vous sûr de vouloir supprimer cette ressource ?"
+    "confirmDelete": "Êtes-vous sûr de vouloir supprimer cette ressource ?",
+    "likeFailed": "Échec de l'ajout du j'aime",
+    "unlikeFailed": "Échec du retrait du j'aime",
+    "saveFailed": "Échec de la sauvegarde",
+    "unsaveFailed": "Échec du retrait de la sauvegarde"
   },
   "portfolio": {
     "generate": "Portfolio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -56,7 +56,8 @@
     "hasAccount": "すでにアカウントをお持ちの方",
     "signInWith": "{{provider}}でログイン",
     "signUpWith": "{{provider}}で登録",
-    "orContinueWith": "または"
+    "orContinueWith": "または",
+    "passwordPlaceholder": "6文字以上"
   },
   "dashboard": {
     "title": "ダッシュボード",
@@ -645,7 +646,11 @@
     "createFailed": "教材の追加に失敗しました",
     "updateFailed": "教材の更新に失敗しました",
     "deleteFailed": "教材の削除に失敗しました",
-    "confirmDelete": "この教材を削除してもよろしいですか？"
+    "confirmDelete": "この教材を削除してもよろしいですか？",
+    "likeFailed": "いいねに失敗しました",
+    "unlikeFailed": "いいね解除に失敗しました",
+    "saveFailed": "保存に失敗しました",
+    "unsaveFailed": "保存解除に失敗しました"
   },
   "portfolio": {
     "generate": "ポートフォリオ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -55,7 +55,8 @@
     "hasAccount": "이미 계정이 있으신가요?",
     "signInWith": "{{provider}}로 로그인",
     "signUpWith": "{{provider}}로 가입",
-    "orContinueWith": "또는"
+    "orContinueWith": "또는",
+    "passwordPlaceholder": "6자 이상"
   },
   "dashboard": {
     "title": "대시보드",
@@ -681,7 +682,11 @@
     "createFailed": "리소스 생성에 실패했습니다",
     "updateFailed": "리소스 업데이트에 실패했습니다",
     "deleteFailed": "리소스 삭제에 실패했습니다",
-    "confirmDelete": "이 리소스를 삭제하시겠습니까?"
+    "confirmDelete": "이 리소스를 삭제하시겠습니까?",
+    "likeFailed": "좋아요에 실패했습니다",
+    "unlikeFailed": "좋아요 취소에 실패했습니다",
+    "saveFailed": "저장에 실패했습니다",
+    "unsaveFailed": "저장 취소에 실패했습니다"
   },
   "portfolio": {
     "generate": "포트폴리오",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -55,7 +55,8 @@
     "hasAccount": "Já tem conta?",
     "signInWith": "Entrar com {{provider}}",
     "signUpWith": "Registrar com {{provider}}",
-    "orContinueWith": "Ou continue com"
+    "orContinueWith": "Ou continue com",
+    "passwordPlaceholder": "6+ caracteres"
   },
   "dashboard": {
     "title": "Painel",
@@ -681,7 +682,11 @@
     "createFailed": "Falha ao criar recurso",
     "updateFailed": "Falha ao atualizar recurso",
     "deleteFailed": "Falha ao excluir recurso",
-    "confirmDelete": "Tem certeza de que deseja excluir este recurso?"
+    "confirmDelete": "Tem certeza de que deseja excluir este recurso?",
+    "likeFailed": "Falha ao curtir",
+    "unlikeFailed": "Falha ao descurtir",
+    "saveFailed": "Falha ao salvar",
+    "unsaveFailed": "Falha ao remover dos salvos"
   },
   "portfolio": {
     "generate": "Portfólio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -55,7 +55,8 @@
     "hasAccount": "Уже есть аккаунт?",
     "signInWith": "Войти через {{provider}}",
     "signUpWith": "Регистрация через {{provider}}",
-    "orContinueWith": "Или продолжить с"
+    "orContinueWith": "Или продолжить с",
+    "passwordPlaceholder": "Минимум 6 символов"
   },
   "dashboard": {
     "title": "Панель",
@@ -681,7 +682,11 @@
     "createFailed": "Не удалось создать ресурс",
     "updateFailed": "Не удалось обновить ресурс",
     "deleteFailed": "Не удалось удалить ресурс",
-    "confirmDelete": "Вы уверены, что хотите удалить этот ресурс?"
+    "confirmDelete": "Вы уверены, что хотите удалить этот ресурс?",
+    "likeFailed": "Не удалось поставить лайк",
+    "unlikeFailed": "Не удалось убрать лайк",
+    "saveFailed": "Не удалось сохранить",
+    "unsaveFailed": "Не удалось убрать из сохранённых"
   },
   "portfolio": {
     "generate": "Портфолио",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -55,7 +55,8 @@
     "hasAccount": "已有账号？",
     "signInWith": "使用 {{provider}} 登录",
     "signUpWith": "使用 {{provider}} 注册",
-    "orContinueWith": "或者"
+    "orContinueWith": "或者",
+    "passwordPlaceholder": "6个字符以上"
   },
   "dashboard": {
     "title": "仪表板",
@@ -681,7 +682,11 @@
     "createFailed": "创建资源失败",
     "updateFailed": "更新资源失败",
     "deleteFailed": "删除资源失败",
-    "confirmDelete": "确定要删除这个资源吗？"
+    "confirmDelete": "确定要删除这个资源吗？",
+    "likeFailed": "点赞失败",
+    "unlikeFailed": "取消点赞失败",
+    "saveFailed": "收藏失败",
+    "unsaveFailed": "取消收藏失败"
   },
   "portfolio": {
     "generate": "作品集",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -55,7 +55,8 @@
     "hasAccount": "已有帳號？",
     "signInWith": "使用 {{provider}} 登入",
     "signUpWith": "使用 {{provider}} 註冊",
-    "orContinueWith": "或者"
+    "orContinueWith": "或者",
+    "passwordPlaceholder": "6個字元以上"
   },
   "dashboard": {
     "title": "儀表板",
@@ -681,7 +682,11 @@
     "createFailed": "建立資源失敗",
     "updateFailed": "更新資源失敗",
     "deleteFailed": "刪除資源失敗",
-    "confirmDelete": "確定要刪除這個資源嗎？"
+    "confirmDelete": "確定要刪除這個資源嗎？",
+    "likeFailed": "按讚失敗",
+    "unlikeFailed": "取消按讚失敗",
+    "saveFailed": "收藏失敗",
+    "unsaveFailed": "取消收藏失敗"
   },
   "portfolio": {
     "generate": "作品集",

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -109,7 +109,7 @@ export default function RegisterPage() {
                 onChange={(e) => setPassword(e.target.value)}
                 required
                 minLength={6}
-                placeholder="6+ characters"
+                placeholder={t('auth.passwordPlaceholder')}
                 className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
               />
             </div>

--- a/frontend/src/pages/settings/IntegrationSection.tsx
+++ b/frontend/src/pages/settings/IntegrationSection.tsx
@@ -82,7 +82,7 @@ export default function IntegrationSection(props: Props) {
           ) : (
             <div className="text-center py-4">
               <GitHubIcon className="w-12 h-12 text-gray-600 mx-auto mb-3" />
-              <p className="text-gray-400 text-sm mb-4">Connect your GitHub account to sync contributions, repos, and languages.</p>
+              <p className="text-gray-400 text-sm mb-4">{t('settings.githubDescription')}</p>
               <button
                 onClick={props.onConnectGitHub}
                 className="px-5 py-2.5 bg-white hover:bg-gray-100 text-gray-900 rounded-lg font-semibold text-sm transition-colors inline-flex items-center gap-2"


### PR DESCRIPTION
## 概要
- `useResources.ts`の4箇所の空catchブロックを`toast.error`によるエラー通知に置換
- `RegisterPage.tsx`のパスワードプレースホルダー（ハードコード英語）をi18n化
- `IntegrationSection.tsx`のGitHub説明文をi18n対応キーに置換
- 全10言語ファイルに`auth.passwordPlaceholder`と`resources.likeFailed/unlikeFailed/saveFailed/unsaveFailed`キーを追加

## テスト計画
- [x] TypeScript型チェック通過
- [ ] CI通過確認