### PR TITLE
refactor: handler層の残存インラインstruct→DTO抽出（6ファイル）

### DIFF
--- a/backend/internal/dto/book_review_dto.go
+++ b/backend/internal/dto/book_review_dto.go
@@ -2,6 +2,26 @@ package dto
 
 import "github.com/norman6464/devsync/backend/internal/model"
 
+// CreateBookReviewRequest は書籍レビュー作成のリクエストボディ。
+type CreateBookReviewRequest struct {
+	Title    string `json:"title" binding:"required,max=300" validate:"required,max=300"`
+	Author   string `json:"author" binding:"max=200" validate:"max=200"`
+	ISBN     string `json:"isbn" binding:"max=20" validate:"max=20"`
+	Rating   int    `json:"rating" binding:"required,min=1,max=5" validate:"required,min=1,max=5"`
+	Review   string `json:"review"`
+	ImageURL string `json:"image_url"`
+}
+
+// UpdateBookReviewRequest は書籍レビュー更新のリクエストボディ。
+type UpdateBookReviewRequest struct {
+	Title    string `json:"title" binding:"max=300" validate:"max=300"`
+	Author   string `json:"author" binding:"max=200" validate:"max=200"`
+	ISBN     string `json:"isbn" binding:"max=20" validate:"max=20"`
+	Rating   *int   `json:"rating" binding:"omitempty,min=1,max=5" validate:"omitempty,min=1,max=5"`
+	Review   string `json:"review"`
+	ImageURL string `json:"image_url"`
+}
+
 // BookReviewListResponse は書籍レビュー一覧レスポンス。
 type BookReviewListResponse struct {
 	Reviews []model.BookReview `json:"reviews"`

--- a/backend/internal/dto/common_dto.go
+++ b/backend/internal/dto/common_dto.go
@@ -1,5 +1,11 @@
 package dto
 
+// VoteRequest は投票のリクエストボディ。
+// 質問・回答の投票で共通使用する。
+type VoteRequest struct {
+	Value int `json:"value" binding:"required,oneof=1 -1" validate:"required,oneof=1 -1"`
+}
+
 // ConnectUsernameRequest は外部サービスのユーザー名接続リクエスト。
 // AtCoder・Zenn・Qiitaなど共通で使用する。
 type ConnectUsernameRequest struct {

--- a/backend/internal/dto/learning_goal_dto.go
+++ b/backend/internal/dto/learning_goal_dto.go
@@ -1,0 +1,19 @@
+package dto
+
+// CreateGoalRequest は学習目標作成のリクエストボディ。
+type CreateGoalRequest struct {
+	Title       string `json:"title" binding:"required" validate:"required"`
+	Description string `json:"description"`
+	Category    string `json:"category"`
+	TargetDate  string `json:"target_date"`
+}
+
+// UpdateGoalRequest は学習目標更新のリクエストボディ。
+type UpdateGoalRequest struct {
+	Title       *string `json:"title"`
+	Description *string `json:"description"`
+	Category    *string `json:"category"`
+	TargetDate  *string `json:"target_date"`
+	Progress    *int    `json:"progress"`
+	Status      *string `json:"status"`
+}

--- a/backend/internal/dto/notification_settings_dto.go
+++ b/backend/internal/dto/notification_settings_dto.go
@@ -1,0 +1,13 @@
+package dto
+
+// UpdateNotificationSettingsRequest は通知設定更新のリクエストボディ。
+type UpdateNotificationSettingsRequest struct {
+	EnableLikes    bool `json:"enable_likes"`
+	EnableComments bool `json:"enable_comments"`
+	EnableFollows  bool `json:"enable_follows"`
+	EnableMessages bool `json:"enable_messages"`
+	EnableMentions bool `json:"enable_mentions"`
+	EnableWebPush  bool `json:"enable_web_push"`
+	EnableEmail    bool `json:"enable_email"`
+	EnableSound    bool `json:"enable_sound"`
+}

--- a/backend/internal/dto/project_dto.go
+++ b/backend/internal/dto/project_dto.go
@@ -2,6 +2,36 @@ package dto
 
 import "github.com/norman6464/devsync/backend/internal/model"
 
+// CreateProjectRequest はプロジェクト作成のリクエストボディ。
+type CreateProjectRequest struct {
+	Title        string `json:"title" binding:"required,max=200" validate:"required,max=200"`
+	Description  string `json:"description"`
+	TechStack    string `json:"tech_stack"`
+	DemoURL      string `json:"demo_url"`
+	GithubURL    string `json:"github_url"`
+	ImageURL     string `json:"image_url"`
+	Role         string `json:"role"`
+	StartDate    string `json:"start_date"`
+	EndDate      string `json:"end_date"`
+	Featured     bool   `json:"featured"`
+	GithubRepoID *uint  `json:"github_repo_id"`
+}
+
+// UpdateProjectRequest はプロジェクト更新のリクエストボディ。
+type UpdateProjectRequest struct {
+	Title        string `json:"title" binding:"max=200" validate:"max=200"`
+	Description  string `json:"description"`
+	TechStack    string `json:"tech_stack"`
+	DemoURL      string `json:"demo_url"`
+	GithubURL    string `json:"github_url"`
+	ImageURL     string `json:"image_url"`
+	Role         string `json:"role"`
+	StartDate    string `json:"start_date"`
+	EndDate      string `json:"end_date"`
+	Featured     *bool  `json:"featured"`
+	GithubRepoID *uint  `json:"github_repo_id"`
+}
+
 // ProjectListResponse はプロジェクト一覧レスポンス。
 type ProjectListResponse struct {
 	Projects []model.Project `json:"projects"`

--- a/backend/internal/dto/question_dto.go
+++ b/backend/internal/dto/question_dto.go
@@ -2,6 +2,20 @@ package dto
 
 import "github.com/norman6464/devsync/backend/internal/model"
 
+// CreateQuestionRequest は質問作成のリクエストボディ。
+type CreateQuestionRequest struct {
+	Title string `json:"title" binding:"required,max=500" validate:"required,max=500"`
+	Body  string `json:"body" binding:"required" validate:"required"`
+	Tags  string `json:"tags"`
+}
+
+// UpdateQuestionRequest は質問更新のリクエストボディ。
+type UpdateQuestionRequest struct {
+	Title string `json:"title" binding:"max=500" validate:"max=500"`
+	Body  string `json:"body"`
+	Tags  string `json:"tags"`
+}
+
 // QuestionListResponse は質問一覧レスポンス。
 type QuestionListResponse struct {
 	Questions []model.Question `json:"questions"`

--- a/backend/internal/dto/reminder_settings_dto.go
+++ b/backend/internal/dto/reminder_settings_dto.go
@@ -1,0 +1,13 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// UpdateReminderSettingsRequest はリマインダー設定更新のリクエストボディ。
+type UpdateReminderSettingsRequest struct {
+	Enabled          bool                    `json:"enabled"`
+	Frequency        model.ReminderFrequency `json:"frequency"`
+	NotificationTime string                  `json:"notification_time"`
+	InactiveDays     int                     `json:"inactive_days"`
+	EnableWeb        bool                    `json:"enable_web"`
+	EnableEmail      bool                    `json:"enable_email"`
+}

--- a/backend/internal/handler/answer.go
+++ b/backend/internal/handler/answer.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -149,7 +150,7 @@ func (h *AnswerHandler) Vote(c *gin.Context) {
 		return
 	}
 
-	req := bindJSON[VoteRequest](c)
+	req := bindJSON[dto.VoteRequest](c)
 	if req == nil {
 		return
 	}

--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -29,31 +29,11 @@ func NewBookReviewHandler(s BookReviewServiceInterface) *BookReviewHandler {
 	return &BookReviewHandler{service: s}
 }
 
-// CreateBookReviewRequest は書籍レビュー作成のリクエストボディ。
-type CreateBookReviewRequest struct {
-	Title    string `json:"title" binding:"required,max=300"`
-	Author   string `json:"author" binding:"max=200"`
-	ISBN     string `json:"isbn" binding:"max=20"`
-	Rating   int    `json:"rating" binding:"required,min=1,max=5"`
-	Review   string `json:"review"`
-	ImageURL string `json:"image_url"`
-}
-
-// UpdateBookReviewRequest は書籍レビュー更新のリクエストボディ。
-type UpdateBookReviewRequest struct {
-	Title    string `json:"title" binding:"max=300"`
-	Author   string `json:"author" binding:"max=200"`
-	ISBN     string `json:"isbn" binding:"max=20"`
-	Rating   *int   `json:"rating" binding:"omitempty,min=1,max=5"`
-	Review   string `json:"review"`
-	ImageURL string `json:"image_url"`
-}
-
 // Create は新しい書籍レビューを作成する。
 func (h *BookReviewHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	req := bindJSON[CreateBookReviewRequest](c)
+	req := bindJSON[dto.CreateBookReviewRequest](c)
 	if req == nil {
 		return
 	}
@@ -139,7 +119,7 @@ func (h *BookReviewHandler) Update(c *gin.Context) {
 		return
 	}
 
-	req := bindJSON[UpdateBookReviewRequest](c)
+	req := bindJSON[dto.UpdateBookReviewRequest](c)
 	if req == nil {
 		return
 	}

--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -28,19 +29,11 @@ func NewLearningGoalHandler(s LearningGoalServiceInterface) *LearningGoalHandler
 	return &LearningGoalHandler{service: s}
 }
 
-// CreateGoalInput は学習目標作成のリクエストボディ。
-type CreateGoalInput struct {
-	Title       string `json:"title" binding:"required"`
-	Description string `json:"description"`
-	Category    string `json:"category"`
-	TargetDate  string `json:"target_date"`
-}
-
 // Create は新しい学習目標を作成する。
 func (h *LearningGoalHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	req := bindJSON[CreateGoalInput](c)
+	req := bindJSON[dto.CreateGoalRequest](c)
 	if req == nil {
 		return
 	}
@@ -75,16 +68,6 @@ func (h *LearningGoalHandler) Create(c *gin.Context) {
 	respondCreated(c, goal)
 }
 
-// UpdateGoalInput は学習目標更新のリクエストボディ。
-type UpdateGoalInput struct {
-	Title       *string `json:"title"`
-	Description *string `json:"description"`
-	Category    *string `json:"category"`
-	TargetDate  *string `json:"target_date"`
-	Progress    *int    `json:"progress"`
-	Status      *string `json:"status"`
-}
-
 // Update は指定された学習目標を更新する。
 func (h *LearningGoalHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")
@@ -93,7 +76,7 @@ func (h *LearningGoalHandler) Update(c *gin.Context) {
 		return
 	}
 
-	req := bindJSON[UpdateGoalInput](c)
+	req := bindJSON[dto.UpdateGoalRequest](c)
 	if req == nil {
 		return
 	}

--- a/backend/internal/handler/notification_settings.go
+++ b/backend/internal/handler/notification_settings.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -21,18 +22,6 @@ func NewNotificationSettingsHandler(s NotificationSettingsServiceInterface) *Not
 	return &NotificationSettingsHandler{service: s}
 }
 
-// UpdateNotificationSettingsInput は通知設定更新のリクエストボディ。
-type UpdateNotificationSettingsInput struct {
-	EnableLikes    bool `json:"enable_likes"`
-	EnableComments bool `json:"enable_comments"`
-	EnableFollows  bool `json:"enable_follows"`
-	EnableMessages bool `json:"enable_messages"`
-	EnableMentions bool `json:"enable_mentions"`
-	EnableWebPush  bool `json:"enable_web_push"`
-	EnableEmail    bool `json:"enable_email"`
-	EnableSound    bool `json:"enable_sound"`
-}
-
 // GetSettings は認証ユーザーの通知設定を取得する。
 func (h *NotificationSettingsHandler) GetSettings(c *gin.Context) {
 	userID := c.GetUint("userID")
@@ -50,7 +39,7 @@ func (h *NotificationSettingsHandler) GetSettings(c *gin.Context) {
 func (h *NotificationSettingsHandler) UpdateSettings(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	req := bindJSON[UpdateNotificationSettingsInput](c)
+	req := bindJSON[dto.UpdateNotificationSettingsRequest](c)
 	if req == nil {
 		return
 	}

--- a/backend/internal/handler/post_test.go
+++ b/backend/internal/handler/post_test.go
@@ -89,6 +89,7 @@ func TestPostGetByID_Success(t *testing.T) {
 
 	postRepo.On("FindByID", uint(10)).Return(&model.Post{Title: "Found"}, nil)
 	postRepo.On("HasLiked", uint(1), uint(0)).Return(false)
+	postRepo.On("HasBookmarked", uint(1), uint(0)).Return(false)
 
 	w := doRequest(r, http.MethodGet, "/posts/10", nil)
 	assertStatus(t, w, http.StatusOK)

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -37,41 +37,11 @@ func NewProjectHandler(s ProjectServiceInterface) *ProjectHandler {
 	return &ProjectHandler{service: s}
 }
 
-// CreateProjectRequest はプロジェクト作成のリクエストボディ。
-type CreateProjectRequest struct {
-	Title        string `json:"title" binding:"required,max=200"`
-	Description  string `json:"description"`
-	TechStack    string `json:"tech_stack"`
-	DemoURL      string `json:"demo_url"`
-	GithubURL    string `json:"github_url"`
-	ImageURL     string `json:"image_url"`
-	Role         string `json:"role"`
-	StartDate    string `json:"start_date"`
-	EndDate      string `json:"end_date"`
-	Featured     bool   `json:"featured"`
-	GithubRepoID *uint  `json:"github_repo_id"`
-}
-
-// UpdateProjectRequest はプロジェクト更新のリクエストボディ。
-type UpdateProjectRequest struct {
-	Title        string `json:"title" binding:"max=200"`
-	Description  string `json:"description"`
-	TechStack    string `json:"tech_stack"`
-	DemoURL      string `json:"demo_url"`
-	GithubURL    string `json:"github_url"`
-	ImageURL     string `json:"image_url"`
-	Role         string `json:"role"`
-	StartDate    string `json:"start_date"`
-	EndDate      string `json:"end_date"`
-	Featured     *bool  `json:"featured"`
-	GithubRepoID *uint  `json:"github_repo_id"`
-}
-
 // Create は新しいプロジェクトを作成する。
 func (h *ProjectHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	req := bindJSON[CreateProjectRequest](c)
+	req := bindJSON[dto.CreateProjectRequest](c)
 	if req == nil {
 		return
 	}
@@ -166,7 +136,7 @@ func (h *ProjectHandler) Update(c *gin.Context) {
 		return
 	}
 
-	req := bindJSON[UpdateProjectRequest](c)
+	req := bindJSON[dto.UpdateProjectRequest](c)
 	if req == nil {
 		return
 	}

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -34,30 +34,11 @@ func NewQuestionHandler(s QuestionServiceInterface) *QuestionHandler {
 	return &QuestionHandler{service: s}
 }
 
-// CreateQuestionRequest は質問作成のリクエストボディ。
-type CreateQuestionRequest struct {
-	Title string `json:"title" binding:"required,max=500"`
-	Body  string `json:"body" binding:"required"`
-	Tags  string `json:"tags"`
-}
-
-// UpdateQuestionRequest は質問更新のリクエストボディ。
-type UpdateQuestionRequest struct {
-	Title string `json:"title" binding:"max=500"`
-	Body  string `json:"body"`
-	Tags  string `json:"tags"`
-}
-
-// VoteRequest は投票のリクエストボディ。
-type VoteRequest struct {
-	Value int `json:"value" binding:"required,oneof=1 -1"`
-}
-
 // Create は新しい質問を作成する。
 func (h *QuestionHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	req := bindJSON[CreateQuestionRequest](c)
+	req := bindJSON[dto.CreateQuestionRequest](c)
 	if req == nil {
 		return
 	}
@@ -177,7 +158,7 @@ func (h *QuestionHandler) Update(c *gin.Context) {
 		return
 	}
 
-	req := bindJSON[UpdateQuestionRequest](c)
+	req := bindJSON[dto.UpdateQuestionRequest](c)
 	if req == nil {
 		return
 	}
@@ -215,7 +196,7 @@ func (h *QuestionHandler) Vote(c *gin.Context) {
 		return
 	}
 
-	req := bindJSON[VoteRequest](c)
+	req := bindJSON[dto.VoteRequest](c)
 	if req == nil {
 		return
 	}

--- a/backend/internal/handler/reminder_settings.go
+++ b/backend/internal/handler/reminder_settings.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -21,16 +22,6 @@ func NewReminderSettingsHandler(s ReminderSettingsServiceInterface) *ReminderSet
 	return &ReminderSettingsHandler{service: s}
 }
 
-// UpdateReminderSettingsInput はリマインダー設定更新リクエストの入力構造体。
-type UpdateReminderSettingsInput struct {
-	Enabled          bool                      `json:"enabled"`
-	Frequency        model.ReminderFrequency   `json:"frequency"`
-	NotificationTime string                    `json:"notification_time"`
-	InactiveDays     int                       `json:"inactive_days"`
-	EnableWeb        bool                      `json:"enable_web"`
-	EnableEmail      bool                      `json:"enable_email"`
-}
-
 // GetSettings は認証ユーザーのリマインダー設定を取得する。
 func (h *ReminderSettingsHandler) GetSettings(c *gin.Context) {
 	userID := c.GetUint("userID")
@@ -48,9 +39,8 @@ func (h *ReminderSettingsHandler) GetSettings(c *gin.Context) {
 func (h *ReminderSettingsHandler) UpdateSettings(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req UpdateReminderSettingsInput
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+	req := bindJSON[dto.UpdateReminderSettingsRequest](c)
+	if req == nil {
 		return
 	}
 

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -104,6 +104,19 @@ func (m *MockPostRepository) GetComments(postID uint) ([]model.Comment, error) {
 func (m *MockPostRepository) DeleteComment(id, userID uint) error {
 	return m.Called(id, userID).Error(0)
 }
+func (m *MockPostRepository) Bookmark(userID, postID uint) error {
+	return m.Called(userID, postID).Error(0)
+}
+func (m *MockPostRepository) Unbookmark(userID, postID uint) error {
+	return m.Called(userID, postID).Error(0)
+}
+func (m *MockPostRepository) HasBookmarked(userID, postID uint) bool {
+	return m.Called(userID, postID).Bool(0)
+}
+func (m *MockPostRepository) FindBookmarkedByUserID(userID uint, page, limit int) ([]model.Post, int64, error) {
+	args := m.Called(userID, page, limit)
+	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
+}
 func (m *MockPostRepository) Search(query string, limit, offset int) (interface{}, int64, error) {
 	args := m.Called(query, limit, offset)
 	return args.Get(0), args.Get(1).(int64), args.Error(2)


### PR DESCRIPTION
## 概要
handler層に残存していた6ファイルのインラインstruct定義をdto層に抽出し、クリーンアーキテクチャの一貫性を向上。

## 変更内容
- `learning_goal.go` — CreateGoalInput/UpdateGoalInput → dto.CreateGoalRequest/dto.UpdateGoalRequest
- `question.go` — CreateQuestionRequest/UpdateQuestionRequest/VoteRequest → dto層に移動
- `book_review.go` — CreateBookReviewRequest/UpdateBookReviewRequest → dto層に移動
- `project.go` — CreateProjectRequest/UpdateProjectRequest → dto層に移動
- `notification_settings.go` — UpdateNotificationSettingsInput → dto.UpdateNotificationSettingsRequest
- `reminder_settings.go` — UpdateReminderSettingsInput → dto.UpdateReminderSettingsRequest
- `answer.go` — VoteRequest参照をdto.VoteRequest（common_dto.go）に変更
- handler層テストのMockPostRepositoryにBookmarkメソッド4件追加

## テスト
- `go test ./internal/handler/...` 全テスト通過
- `go test ./internal/service/...` 全テスト通過

Closes #492