### PR TITLE
feat: 投稿リアクション（絵文字）機能をTDDで実装

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -42,3 +42,14 @@ type BookmarkedPostsResponse struct {
 	Posts []model.Post `json:"posts"`
 	Total int64        `json:"total"`
 }
+
+// ReactionRequest はリアクション追加/削除リクエスト。
+type ReactionRequest struct {
+	Emoji string `json:"emoji" binding:"required"`
+}
+
+// ReactionResponse はリアクション一覧レスポンス。
+type ReactionResponse struct {
+	Reactions     []model.ReactionCount `json:"reactions"`
+	UserReactions []string              `json:"user_reactions"`
+}

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -28,6 +28,10 @@ type PostServiceInterface interface {
 	Unbookmark(userID, postID uint) error
 	HasBookmarked(userID, postID uint) bool
 	GetBookmarks(userID uint, page, limit int) ([]model.Post, int64, error)
+	AddReaction(userID, postID uint, emoji string) error
+	RemoveReaction(userID, postID uint, emoji string) error
+	GetReactionsByPostID(postID uint) ([]model.ReactionCount, error)
+	GetUserReactions(userID, postID uint) ([]string, error)
 }
 
 // CodeSnippetServiceInterface はCodeSnippetServiceが実装すべきインターフェース。
@@ -338,4 +342,70 @@ func (h *PostHandler) GetBookmarks(c *gin.Context) {
 		return
 	}
 	respondOK(c, dto.BookmarkedPostsResponse{Posts: posts, Total: total})
+}
+
+// AddReaction は投稿にリアクション（絵文字）を追加する。
+func (h *PostHandler) AddReaction(c *gin.Context) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	input := bindJSON[dto.ReactionRequest](c)
+	if input == nil {
+		return
+	}
+
+	if err := h.service.AddReaction(userID, id, input.Emoji); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, domain.NewMessageResponse("reaction_added"))
+}
+
+// RemoveReaction は投稿のリアクションを削除する。
+func (h *PostHandler) RemoveReaction(c *gin.Context) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	input := bindJSON[dto.ReactionRequest](c)
+	if input == nil {
+		return
+	}
+
+	if err := h.service.RemoveReaction(userID, id, input.Emoji); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, domain.NewMessageResponse("reaction_removed"))
+}
+
+// GetReactions は投稿のリアクション一覧を返す。
+func (h *PostHandler) GetReactions(c *gin.Context) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	reactions, err := h.service.GetReactionsByPostID(id)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	userReactions, err := h.service.GetUserReactions(userID, id)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.ReactionResponse{
+		Reactions:     reactions,
+		UserReactions: userReactions,
+	})
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -117,6 +117,20 @@ func (m *MockPostRepository) FindBookmarkedByUserID(userID uint, page, limit int
 	args := m.Called(userID, page, limit)
 	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
 }
+func (m *MockPostRepository) AddReaction(userID, postID uint, emoji string) error {
+	return m.Called(userID, postID, emoji).Error(0)
+}
+func (m *MockPostRepository) RemoveReaction(userID, postID uint, emoji string) error {
+	return m.Called(userID, postID, emoji).Error(0)
+}
+func (m *MockPostRepository) GetReactionsByPostID(postID uint) ([]model.ReactionCount, error) {
+	args := m.Called(postID)
+	return args.Get(0).([]model.ReactionCount), args.Error(1)
+}
+func (m *MockPostRepository) GetUserReactions(userID, postID uint) ([]string, error) {
+	args := m.Called(userID, postID)
+	return args.Get(0).([]string), args.Error(1)
+}
 func (m *MockPostRepository) Search(query string, limit, offset int) (interface{}, int64, error) {
 	args := m.Called(query, limit, offset)
 	return args.Get(0), args.Get(1).(int64), args.Error(2)

--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -37,6 +37,22 @@ type Bookmark struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// Reaction は投稿への絵文字リアクションを記録する。
+// uniqueIndex制約でユーザーごとに1投稿1絵文字1リアクションを保証する。
+type Reaction struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	UserID    uint      `json:"user_id" gorm:"not null;uniqueIndex:idx_user_post_emoji"`
+	PostID    uint      `json:"post_id" gorm:"not null;uniqueIndex:idx_user_post_emoji;index"`
+	Emoji     string    `json:"emoji" gorm:"not null;uniqueIndex:idx_user_post_emoji;size:10"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ReactionCount はリアクション種別ごとの集計。
+type ReactionCount struct {
+	Emoji string `json:"emoji"`
+	Count int    `json:"count"`
+}
+
 // Comment は投稿へのコメントを表す。
 type Comment struct {
 	ID        uint      `json:"id" gorm:"primaryKey"`

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -40,6 +40,10 @@ type PostRepositoryInterface interface {
 	Unbookmark(userID, postID uint) error
 	HasBookmarked(userID, postID uint) bool
 	FindBookmarkedByUserID(userID uint, page, limit int) ([]model.Post, int64, error)
+	AddReaction(userID, postID uint, emoji string) error
+	RemoveReaction(userID, postID uint, emoji string) error
+	GetReactionsByPostID(postID uint) ([]model.ReactionCount, error)
+	GetUserReactions(userID, postID uint) ([]string, error)
 }
 
 // FollowRepositoryInterface はフォロー関係データ操作の契約を定義する。

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -179,6 +179,38 @@ func (r *PostRepository) FindBookmarkedByUserID(userID uint, page, limit int) ([
 	return posts, total, err
 }
 
+// AddReaction は投稿にリアクション（絵文字）を追加する。
+func (r *PostRepository) AddReaction(userID, postID uint, emoji string) error {
+	return r.db.Create(&model.Reaction{UserID: userID, PostID: postID, Emoji: emoji}).Error
+}
+
+// RemoveReaction は投稿のリアクションを削除する。
+func (r *PostRepository) RemoveReaction(userID, postID uint, emoji string) error {
+	return r.db.Where("user_id = ? AND post_id = ? AND emoji = ?", userID, postID, emoji).Delete(&model.Reaction{}).Error
+}
+
+// GetReactionsByPostID は指定投稿のリアクション集計を絵文字ごとに返す。
+func (r *PostRepository) GetReactionsByPostID(postID uint) ([]model.ReactionCount, error) {
+	var counts []model.ReactionCount
+	err := r.db.Model(&model.Reaction{}).
+		Select("emoji, COUNT(*) as count").
+		Where("post_id = ?", postID).
+		Group("emoji").
+		Order("count DESC").
+		Find(&counts).Error
+	return counts, err
+}
+
+// GetUserReactions は指定ユーザーが投稿に付けたリアクション絵文字一覧を返す。
+func (r *PostRepository) GetUserReactions(userID, postID uint) ([]string, error) {
+	var emojis []string
+	err := r.db.Model(&model.Reaction{}).
+		Select("emoji").
+		Where("user_id = ? AND post_id = ?", userID, postID).
+		Pluck("emoji", &emojis).Error
+	return emojis, err
+}
+
 // FindDraftsByUserID は指定ユーザーの下書き一覧を取得する（新しい順）。
 func (r *PostRepository) FindDraftsByUserID(userID uint) ([]model.Post, error) {
 	var posts []model.Post

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -134,6 +134,9 @@ func registerPostRoutes(g *gin.RouterGroup, c *di.Container) {
 		posts.GET("/:id/comments", c.PostHandler.GetComments)
 		posts.POST("/:id/comments", c.PostHandler.CreateComment)
 		posts.DELETE("/:id/comments/:commentId", c.PostHandler.DeleteComment)
+		posts.GET("/:id/reactions", c.PostHandler.GetReactions)
+		posts.POST("/:id/reactions", c.PostHandler.AddReaction)
+		posts.DELETE("/:id/reactions", c.PostHandler.RemoveReaction)
 		posts.POST("/:id/snippets", c.CodeSnippetHandler.Create)
 		posts.GET("/:id/snippets", c.CodeSnippetHandler.GetByPostID)
 	}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -183,6 +183,24 @@ func (m *MockPostRepository) FindBookmarkedByUserID(userID uint, page, limit int
 	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockPostRepository) AddReaction(userID, postID uint, emoji string) error {
+	return m.Called(userID, postID, emoji).Error(0)
+}
+
+func (m *MockPostRepository) RemoveReaction(userID, postID uint, emoji string) error {
+	return m.Called(userID, postID, emoji).Error(0)
+}
+
+func (m *MockPostRepository) GetReactionsByPostID(postID uint) ([]model.ReactionCount, error) {
+	args := m.Called(postID)
+	return args.Get(0).([]model.ReactionCount), args.Error(1)
+}
+
+func (m *MockPostRepository) GetUserReactions(userID, postID uint) ([]string, error) {
+	args := m.Called(userID, postID)
+	return args.Get(0).([]string), args.Error(1)
+}
+
 // ============================================================
 // MockFollowRepository は repository.FollowRepositoryInterface のテスト用モック実装。
 // ============================================================

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -1,10 +1,21 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
+
+// allowedEmojis はリアクションに使用可能な絵文字一覧。
+var allowedEmojis = map[string]bool{
+	"👍": true,
+	"🎉": true,
+	"❤️": true,
+	"🔥": true,
+	"👀": true,
+}
 
 // PostService は投稿に関するビジネスロジックを提供する。
 // 投稿のCRUD操作に加え、フォロワーへの通知連携を行う。
@@ -167,6 +178,30 @@ func (s *PostService) HasBookmarked(userID, postID uint) bool {
 // GetBookmarks は指定ユーザーのブックマーク済み投稿一覧を取得する。
 func (s *PostService) GetBookmarks(userID uint, page, limit int) ([]model.Post, int64, error) {
 	return s.repo.FindBookmarkedByUserID(userID, page, limit)
+}
+
+// AddReaction は投稿にリアクション（絵文字）を追加する。
+// 許可された絵文字のみ使用可能。
+func (s *PostService) AddReaction(userID, postID uint, emoji string) error {
+	if !allowedEmojis[emoji] {
+		return fmt.Errorf("許可されていない絵文字です: %s", emoji)
+	}
+	return s.repo.AddReaction(userID, postID, emoji)
+}
+
+// RemoveReaction は投稿のリアクションを削除する。
+func (s *PostService) RemoveReaction(userID, postID uint, emoji string) error {
+	return s.repo.RemoveReaction(userID, postID, emoji)
+}
+
+// GetReactionsByPostID は指定投稿のリアクション集計を取得する。
+func (s *PostService) GetReactionsByPostID(postID uint) ([]model.ReactionCount, error) {
+	return s.repo.GetReactionsByPostID(postID)
+}
+
+// GetUserReactions は指定ユーザーが投稿に付けたリアクション絵文字一覧を取得する。
+func (s *PostService) GetUserReactions(userID, postID uint) ([]string, error) {
+	return s.repo.GetUserReactions(userID, postID)
 }
 
 // Publish は下書き投稿を公開し、フォロワーに通知する。

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -454,3 +454,95 @@ func TestPostGetBookmarks_Empty(t *testing.T) {
 	assert.Len(t, result, 0)
 	assert.Equal(t, int64(0), total)
 }
+
+// ============================================================
+// リアクションテスト
+// ============================================================
+
+func TestPostAddReaction_Success(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("AddReaction", uint(1), uint(10), "👍").Return(nil)
+
+	err := svc.AddReaction(1, 10, "👍")
+	assert.NoError(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostAddReaction_InvalidEmoji(t *testing.T) {
+	svc, _, _ := newTestPostService()
+
+	err := svc.AddReaction(1, 10, "invalid")
+	assert.Error(t, err)
+}
+
+func TestPostAddReaction_Error(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("AddReaction", uint(1), uint(10), "🎉").Return(errors.New("duplicate"))
+
+	err := svc.AddReaction(1, 10, "🎉")
+	assert.Error(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostRemoveReaction_Success(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("RemoveReaction", uint(1), uint(10), "👍").Return(nil)
+
+	err := svc.RemoveReaction(1, 10, "👍")
+	assert.NoError(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostRemoveReaction_Error(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("RemoveReaction", uint(1), uint(10), "👍").Return(errors.New("not found"))
+
+	err := svc.RemoveReaction(1, 10, "👍")
+	assert.Error(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostGetReactionsByPostID_Success(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	counts := []model.ReactionCount{
+		{Emoji: "👍", Count: 5},
+		{Emoji: "❤️", Count: 3},
+	}
+	postRepo.On("GetReactionsByPostID", uint(10)).Return(counts, nil)
+
+	result, err := svc.GetReactionsByPostID(10)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "👍", result[0].Emoji)
+	assert.Equal(t, 5, result[0].Count)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostGetReactionsByPostID_Empty(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("GetReactionsByPostID", uint(10)).Return([]model.ReactionCount{}, nil)
+
+	result, err := svc.GetReactionsByPostID(10)
+	assert.NoError(t, err)
+	assert.Len(t, result, 0)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostGetUserReactions_Success(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("GetUserReactions", uint(1), uint(10)).Return([]string{"👍", "🎉"}, nil)
+
+	result, err := svc.GetUserReactions(1, 10)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Contains(t, result, "👍")
+	assert.Contains(t, result, "🎉")
+	postRepo.AssertExpectations(t)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -67,6 +67,7 @@ func main() {
 		&model.Post{},
 		&model.Like{},
 		&model.Bookmark{},
+		&model.Reaction{},
 		&model.Comment{},
 		&model.Message{},
 		&model.Notification{},

--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -1,5 +1,5 @@
 import client from './client';
-import type { Post, Comment } from '../types/post';
+import type { Post, Comment, ReactionResponse } from '../types/post';
 
 export const getPosts = (page = 1, limit = 20) =>
   client.get<Post[]>('/posts', { params: { page, limit } });
@@ -77,3 +77,12 @@ export const getDrafts = () =>
 
 export const publishPost = (id: number) =>
   client.put<Post>(`/posts/${id}/publish`);
+
+export const getReactions = (postId: number) =>
+  client.get<ReactionResponse>(`/posts/${postId}/reactions`);
+
+export const addReaction = (postId: number, emoji: string) =>
+  client.post(`/posts/${postId}/reactions`, { emoji });
+
+export const removeReaction = (postId: number, emoji: string) =>
+  client.delete(`/posts/${postId}/reactions`, { data: { emoji } });

--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -5,11 +5,11 @@ import rehypeSanitize from 'rehype-sanitize';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useTranslation } from 'react-i18next';
-import { likePost, unlikePost, bookmarkPost, unbookmarkPost } from '../../api/posts';
-import type { Post } from '../../types/post';
+import { likePost, unlikePost, bookmarkPost, unbookmarkPost, getReactions, addReaction, removeReaction } from '../../api/posts';
+import type { Post, ReactionCount } from '../../types/post';
 import Avatar from '../common/Avatar';
 import { format } from 'date-fns';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Code2 } from 'lucide-react';
 import { cardDarkClass } from '../../constants/styles';
 
@@ -26,6 +26,43 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
   const [liked, setLiked] = useState(post.liked || false);
   const [likeCount, setLikeCount] = useState(post.like_count);
   const [bookmarked, setBookmarked] = useState(post.bookmarked || false);
+  const [reactions, setReactions] = useState<ReactionCount[]>([]);
+  const [userReactions, setUserReactions] = useState<string[]>([]);
+  const [showReactionPicker, setShowReactionPicker] = useState(false);
+
+  const availableEmojis = ['👍', '🎉', '❤️', '🔥', '👀'];
+
+  useEffect(() => {
+    getReactions(post.id).then((res) => {
+      setReactions(res.data.reactions || []);
+      setUserReactions(res.data.user_reactions || []);
+    }).catch(() => {});
+  }, [post.id]);
+
+  const handleReaction = async (emoji: string) => {
+    try {
+      if (userReactions.includes(emoji)) {
+        await removeReaction(post.id, emoji);
+        setUserReactions((prev) => prev.filter((e) => e !== emoji));
+        setReactions((prev) =>
+          prev.map((r) => r.emoji === emoji ? { ...r, count: r.count - 1 } : r).filter((r) => r.count > 0)
+        );
+      } else {
+        await addReaction(post.id, emoji);
+        setUserReactions((prev) => [...prev, emoji]);
+        setReactions((prev) => {
+          const existing = prev.find((r) => r.emoji === emoji);
+          if (existing) {
+            return prev.map((r) => r.emoji === emoji ? { ...r, count: r.count + 1 } : r);
+          }
+          return [...prev, { emoji, count: 1 }];
+        });
+      }
+      setShowReactionPicker(false);
+    } catch (e) {
+      console.warn('Failed to toggle reaction:', e);
+    }
+  };
 
   const handleLike = async () => {
     try {
@@ -213,6 +250,26 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
         </Link>
       )}
 
+      {/* Reactions display */}
+      {reactions.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mt-3">
+          {reactions.map((r) => (
+            <button
+              key={r.emoji}
+              onClick={() => handleReaction(r.emoji)}
+              className={`flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border transition-colors ${
+                userReactions.includes(r.emoji)
+                  ? 'border-blue-500/50 bg-blue-500/10 text-blue-400'
+                  : 'border-gray-700 bg-gray-800/50 text-gray-400 hover:border-gray-600'
+              }`}
+            >
+              <span>{r.emoji}</span>
+              <span>{r.count}</span>
+            </button>
+          ))}
+        </div>
+      )}
+
       <div className="flex items-center gap-4 mt-4 pt-3 border-t border-gray-800">
         <button
           onClick={handleLike}
@@ -234,6 +291,32 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
           </svg>
           {post.comment_count}
         </Link>
+        <div className="relative">
+          <button
+            onClick={() => setShowReactionPicker(!showReactionPicker)}
+            className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-300 transition-colors"
+            title={t('post.addReaction')}
+          >
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
+            </svg>
+          </button>
+          {showReactionPicker && (
+            <div className="absolute bottom-8 left-0 z-10 flex gap-1 p-1.5 bg-gray-800 border border-gray-700 rounded-lg shadow-lg">
+              {availableEmojis.map((emoji) => (
+                <button
+                  key={emoji}
+                  onClick={() => handleReaction(emoji)}
+                  className={`text-lg p-1 rounded hover:bg-gray-700 transition-colors ${
+                    userReactions.includes(emoji) ? 'bg-blue-500/20' : ''
+                  }`}
+                >
+                  {emoji}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
         <button
           onClick={handleBookmark}
           className={`flex items-center gap-1.5 text-sm transition-colors ml-auto ${

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -135,7 +135,8 @@
     "bookmark": "Lesezeichen",
     "unbookmark": "Lesezeichen entfernen",
     "bookmarks": "Lesezeichen",
-    "noBookmarks": "Keine markierten Beiträge"
+    "noBookmarks": "Keine markierten Beiträge",
+    "addReaction": "Reagieren"
   },
   "follow": {
     "noFollowers": "Noch keine Follower",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -135,7 +135,8 @@
     "bookmark": "Bookmark",
     "unbookmark": "Remove Bookmark",
     "bookmarks": "Bookmarks",
-    "noBookmarks": "No bookmarked posts"
+    "noBookmarks": "No bookmarked posts",
+    "addReaction": "React"
   },
   "follow": {
     "noFollowers": "No followers yet",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -135,7 +135,8 @@
     "bookmark": "Marcador",
     "unbookmark": "Quitar marcador",
     "bookmarks": "Marcadores",
-    "noBookmarks": "No hay publicaciones marcadas"
+    "noBookmarks": "No hay publicaciones marcadas",
+    "addReaction": "Reaccionar"
   },
   "follow": {
     "noFollowers": "Aún no hay seguidores",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -135,7 +135,8 @@
     "bookmark": "Signet",
     "unbookmark": "Retirer le signet",
     "bookmarks": "Signets",
-    "noBookmarks": "Aucune publication enregistrée"
+    "noBookmarks": "Aucune publication enregistrée",
+    "addReaction": "Réagir"
   },
   "follow": {
     "noFollowers": "Pas encore d'abonnés",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -152,7 +152,8 @@
     "bookmark": "ブックマーク",
     "unbookmark": "ブックマーク解除",
     "bookmarks": "ブックマーク一覧",
-    "noBookmarks": "ブックマークした投稿はありません"
+    "noBookmarks": "ブックマークした投稿はありません",
+    "addReaction": "リアクション"
   },
   "follow": {
     "noFollowers": "まだフォロワーはいません",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -135,7 +135,8 @@
     "bookmark": "북마크",
     "unbookmark": "북마크 해제",
     "bookmarks": "북마크 목록",
-    "noBookmarks": "북마크한 게시물이 없습니다"
+    "noBookmarks": "북마크한 게시물이 없습니다",
+    "addReaction": "리액션"
   },
   "follow": {
     "noFollowers": "아직 팔로워가 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -135,7 +135,8 @@
     "bookmark": "Favorito",
     "unbookmark": "Remover favorito",
     "bookmarks": "Favoritos",
-    "noBookmarks": "Nenhuma publicação favoritada"
+    "noBookmarks": "Nenhuma publicação favoritada",
+    "addReaction": "Reagir"
   },
   "follow": {
     "noFollowers": "Ainda sem seguidores",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -135,7 +135,8 @@
     "bookmark": "Закладка",
     "unbookmark": "Удалить закладку",
     "bookmarks": "Закладки",
-    "noBookmarks": "Нет сохранённых публикаций"
+    "noBookmarks": "Нет сохранённых публикаций",
+    "addReaction": "Реакция"
   },
   "follow": {
     "noFollowers": "Пока нет подписчиков",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -135,7 +135,8 @@
     "bookmark": "书签",
     "unbookmark": "取消书签",
     "bookmarks": "书签列表",
-    "noBookmarks": "没有收藏的帖子"
+    "noBookmarks": "没有收藏的帖子",
+    "addReaction": "表情回应"
   },
   "follow": {
     "noFollowers": "暂无粉丝",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -135,7 +135,8 @@
     "bookmark": "書籤",
     "unbookmark": "取消書籤",
     "bookmarks": "書籤列表",
-    "noBookmarks": "沒有收藏的貼文"
+    "noBookmarks": "沒有收藏的貼文",
+    "addReaction": "表情回應"
   },
   "follow": {
     "noFollowers": "尚無追蹤者",

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -39,6 +39,16 @@ export interface CodeSnippet {
   updated_at: string;
 }
 
+export interface ReactionCount {
+  emoji: string;
+  count: number;
+}
+
+export interface ReactionResponse {
+  reactions: ReactionCount[];
+  user_reactions: string[];
+}
+
 export interface SnippetComment {
   id: number;
   snippet_id: number;


### PR DESCRIPTION
## 概要
投稿に対して5種類の絵文字（👍🎉❤️🔥👀）でリアクションできる機能を追加。
TDDアプローチで8テスト先行作成→実装→全テスト通過を確認。

## 変更内容

### バックエンド
- `model/post.go`: Reaction・ReactionCountモデル追加（uniqueIndex制約付き）
- `repository/interfaces.go`: PostRepositoryInterfaceに4メソッド追加
- `repository/post.go`: リアクションCRUD実装（絵文字ごとの集計含む）
- `service/post.go`: allowedEmojisバリデーション付き4メソッド追加
- `handler/post.go`: PostServiceInterfaceにリアクション4メソッド追加、ハンドラ3メソッド追加
- `dto/post_dto.go`: ReactionRequest・ReactionResponseDTO追加
- `router/router.go`: GET/POST/DELETE /posts/:id/reactions ルート追加
- `main.go`: AutoMigrateにReactionモデル追加
- `service/post_test.go`: 8件のTDDテスト追加（全PASS）

### フロントエンド
- `types/post.ts`: ReactionCount・ReactionResponse型追加
- `api/posts.ts`: getReactions・addReaction・removeReaction関数追加
- `components/posts/PostCard.tsx`: リアクション表示・絵文字ピッカーUI追加
- i18n: 10言語にaddReactionキー追加

## テスト結果
- バックエンド: service 8テスト + handler 全テスト PASS
- フロントエンド: TypeScript型チェック通過

Closes #496