### PR TITLE
refactor: OnboardingPageのロジックをuseOnboardingフックに抽出

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -37,3 +37,4 @@ export { useToast } from './useToast';
 export { useDebounce } from './useDebounce';
 export { useAutoSave } from './useAutoSave';
 export { useConfirm } from './useConfirm';
+export { useOnboarding } from './useOnboarding';

--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { useAuthStore } from '../store/authStore';
+import { updateUser } from '../api/users';
+import { getGitHubConnectURL } from '../api/github';
+import { connectZenn } from '../api/zenn';
+import { connectQiita } from '../api/qiita';
+import { connectAtCoder } from '../api/atcoder';
+import toast from 'react-hot-toast';
+
+export function useOnboarding() {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+  const { user, setUser } = useAuthStore();
+  const [step, setStep] = useState(1);
+  const [saving, setSaving] = useState(false);
+
+  // Step 1: Profile
+  const [name, setName] = useState(user?.name || '');
+  const [bio, setBio] = useState(user?.bio || '');
+
+  // Step 2: Skills
+  const [selectedLanguages, setSelectedLanguages] = useState<string[]>(
+    user?.skills_languages ? user.skills_languages.split(',').filter(Boolean) : []
+  );
+  const [selectedFrameworks, setSelectedFrameworks] = useState<string[]>(
+    user?.skills_frameworks ? user.skills_frameworks.split(',').filter(Boolean) : []
+  );
+
+  // Step 3: Integrations
+  const [zennUsername, setZennUsername] = useState('');
+  const [qiitaUsername, setQiitaUsername] = useState('');
+  const [atcoderUsername, setAtcoderUsername] = useState('');
+  const [connectingZenn, setConnectingZenn] = useState(false);
+  const [connectingQiita, setConnectingQiita] = useState(false);
+  const [connectingAtcoder, setConnectingAtcoder] = useState(false);
+  const [paizaRank, setPaizaRank] = useState('');
+
+  const toggleLanguage = (lang: string) => {
+    setSelectedLanguages((prev) =>
+      prev.includes(lang) ? prev.filter((l) => l !== lang) : [...prev, lang]
+    );
+  };
+
+  const toggleFramework = (fw: string) => {
+    setSelectedFrameworks((prev) =>
+      prev.includes(fw) ? prev.filter((f) => f !== fw) : [...prev, fw]
+    );
+  };
+
+  const handleSaveProfile = async () => {
+    if (!user) return;
+    setSaving(true);
+    try {
+      const { data } = await updateUser(user.id, { name, bio });
+      setUser(data);
+      setStep(2);
+    } catch {
+      toast.error(t('settings.saveFailed'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleSaveSkills = async () => {
+    if (!user) return;
+    setSaving(true);
+    try {
+      const { data } = await updateUser(user.id, {
+        skills_languages: selectedLanguages.join(','),
+        skills_frameworks: selectedFrameworks.join(','),
+      });
+      setUser(data);
+      setStep(3);
+    } catch {
+      toast.error(t('settings.saveFailed'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleConnectGitHub = async () => {
+    try {
+      localStorage.setItem('onboarding_redirect', 'true');
+      const { data } = await getGitHubConnectURL();
+      window.location.href = data.url;
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  };
+
+  const handleConnectZenn = async () => {
+    if (!user || !zennUsername.trim()) return;
+    setConnectingZenn(true);
+    try {
+      await connectZenn(zennUsername.trim());
+      setUser({ ...user, zenn_username: zennUsername.trim() });
+      setZennUsername('');
+      toast.success(t('settings.zennConnected'));
+    } catch {
+      toast.error(t('settings.zennInvalidUsername'));
+    } finally {
+      setConnectingZenn(false);
+    }
+  };
+
+  const handleConnectQiita = async () => {
+    if (!user || !qiitaUsername.trim()) return;
+    setConnectingQiita(true);
+    try {
+      await connectQiita(qiitaUsername.trim());
+      setUser({ ...user, qiita_username: qiitaUsername.trim() });
+      setQiitaUsername('');
+      toast.success(t('settings.qiitaConnected'));
+    } catch {
+      toast.error(t('settings.qiitaInvalidUsername'));
+    } finally {
+      setConnectingQiita(false);
+    }
+  };
+
+  const handleConnectAtCoder = async () => {
+    if (!atcoderUsername.trim()) return;
+    setConnectingAtcoder(true);
+    try {
+      const { data } = await connectAtCoder(atcoderUsername.trim());
+      setUser(data);
+      setAtcoderUsername('');
+      toast.success(t('settings.atcoderConnected'));
+    } catch {
+      toast.error(t('settings.atcoderInvalidUsername'));
+    } finally {
+      setConnectingAtcoder(false);
+    }
+  };
+
+  const handleSavePaizaRank = async () => {
+    if (!user || !paizaRank) return;
+    try {
+      const { data } = await updateUser(user.id, { paiza_rank: paizaRank });
+      setUser(data);
+      toast.success(t('settings.saved'));
+    } catch {
+      toast.error(t('settings.saveFailed'));
+    }
+  };
+
+  const handleComplete = async () => {
+    if (!user) return;
+    setSaving(true);
+    try {
+      const { data } = await updateUser(user.id, { onboarding_completed: true });
+      setUser(data);
+      navigate('/');
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return {
+    user,
+    step,
+    setStep,
+    saving,
+    // Step 1
+    name,
+    setName,
+    bio,
+    setBio,
+    handleSaveProfile,
+    // Step 2
+    selectedLanguages,
+    selectedFrameworks,
+    toggleLanguage,
+    toggleFramework,
+    handleSaveSkills,
+    // Step 3
+    zennUsername,
+    setZennUsername,
+    qiitaUsername,
+    setQiitaUsername,
+    atcoderUsername,
+    setAtcoderUsername,
+    connectingZenn,
+    connectingQiita,
+    connectingAtcoder,
+    paizaRank,
+    setPaizaRank,
+    handleConnectGitHub,
+    handleConnectZenn,
+    handleConnectQiita,
+    handleConnectAtCoder,
+    handleSavePaizaRank,
+    handleComplete,
+  };
+}

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -1,16 +1,9 @@
-import { useState } from 'react';
-import { Navigate, useNavigate } from 'react-router-dom';
+import { Navigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { User, Code, Link, CheckCircle, ChevronRight, ChevronLeft } from 'lucide-react';
-import { useAuthStore } from '../store/authStore';
-import { updateUser } from '../api/users';
-import { getGitHubConnectURL } from '../api/github';
-import { connectZenn } from '../api/zenn';
-import { connectQiita } from '../api/qiita';
-import { connectAtCoder } from '../api/atcoder';
 import { sectionContainerClass, inputClass, labelClass, buttonPrimaryClass } from '../constants/styles';
-import toast from 'react-hot-toast';
 import { LANGUAGES, FRAMEWORKS } from '../constants/skills';
+import { useOnboarding } from '../hooks/useOnboarding';
 
 const STEPS = [
   { id: 1, icon: User },
@@ -21,155 +14,42 @@ const STEPS = [
 
 export default function OnboardingPage() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
-  const { user, setUser } = useAuthStore();
-  const [step, setStep] = useState(1);
-  const [saving, setSaving] = useState(false);
-
-  // Step 1: Profile
-  const [name, setName] = useState(user?.name || '');
-  const [bio, setBio] = useState(user?.bio || '');
-
-  // Step 2: Skills
-  const [selectedLanguages, setSelectedLanguages] = useState<string[]>(
-    user?.skills_languages ? user.skills_languages.split(',').filter(Boolean) : []
-  );
-  const [selectedFrameworks, setSelectedFrameworks] = useState<string[]>(
-    user?.skills_frameworks ? user.skills_frameworks.split(',').filter(Boolean) : []
-  );
-
-  // Step 3: Integrations
-  const [zennUsername, setZennUsername] = useState('');
-  const [qiitaUsername, setQiitaUsername] = useState('');
-  const [atcoderUsername, setAtcoderUsername] = useState('');
-  const [connectingZenn, setConnectingZenn] = useState(false);
-  const [connectingQiita, setConnectingQiita] = useState(false);
-  const [connectingAtcoder, setConnectingAtcoder] = useState(false);
-  const [paizaRank, setPaizaRank] = useState('');
+  const {
+    user,
+    step,
+    setStep,
+    saving,
+    name,
+    setName,
+    bio,
+    setBio,
+    handleSaveProfile,
+    selectedLanguages,
+    selectedFrameworks,
+    toggleLanguage,
+    toggleFramework,
+    handleSaveSkills,
+    zennUsername,
+    setZennUsername,
+    qiitaUsername,
+    setQiitaUsername,
+    atcoderUsername,
+    setAtcoderUsername,
+    connectingZenn,
+    connectingQiita,
+    connectingAtcoder,
+    paizaRank,
+    setPaizaRank,
+    handleConnectGitHub,
+    handleConnectZenn,
+    handleConnectQiita,
+    handleConnectAtCoder,
+    handleSavePaizaRank,
+    handleComplete,
+  } = useOnboarding();
 
   if (!user) return null;
   if (user.onboarding_completed) return <Navigate to="/" replace />;
-
-  const toggleLanguage = (lang: string) => {
-    setSelectedLanguages((prev) =>
-      prev.includes(lang) ? prev.filter((l) => l !== lang) : [...prev, lang]
-    );
-  };
-
-  const toggleFramework = (fw: string) => {
-    setSelectedFrameworks((prev) =>
-      prev.includes(fw) ? prev.filter((f) => f !== fw) : [...prev, fw]
-    );
-  };
-
-  const handleSaveProfile = async () => {
-    setSaving(true);
-    try {
-      const { data } = await updateUser(user.id, { name, bio });
-      setUser(data);
-      setStep(2);
-    } catch {
-      toast.error(t('settings.saveFailed'));
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleSaveSkills = async () => {
-    setSaving(true);
-    try {
-      const { data } = await updateUser(user.id, {
-        skills_languages: selectedLanguages.join(','),
-        skills_frameworks: selectedFrameworks.join(','),
-      });
-      setUser(data);
-      setStep(3);
-    } catch {
-      toast.error(t('settings.saveFailed'));
-    } finally {
-      setSaving(false);
-    }
-  };
-
-  const handleConnectGitHub = async () => {
-    try {
-      localStorage.setItem('onboarding_redirect', 'true');
-      const { data } = await getGitHubConnectURL();
-      window.location.href = data.url;
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-    }
-  };
-
-  const handleConnectZenn = async () => {
-    if (!zennUsername.trim()) return;
-    setConnectingZenn(true);
-    try {
-      await connectZenn(zennUsername.trim());
-      setUser({ ...user, zenn_username: zennUsername.trim() });
-      setZennUsername('');
-      toast.success(t('settings.zennConnected'));
-    } catch {
-      toast.error(t('settings.zennInvalidUsername'));
-    } finally {
-      setConnectingZenn(false);
-    }
-  };
-
-  const handleConnectQiita = async () => {
-    if (!qiitaUsername.trim()) return;
-    setConnectingQiita(true);
-    try {
-      await connectQiita(qiitaUsername.trim());
-      setUser({ ...user, qiita_username: qiitaUsername.trim() });
-      setQiitaUsername('');
-      toast.success(t('settings.qiitaConnected'));
-    } catch {
-      toast.error(t('settings.qiitaInvalidUsername'));
-    } finally {
-      setConnectingQiita(false);
-    }
-  };
-
-  const handleConnectAtCoder = async () => {
-    if (!atcoderUsername.trim()) return;
-    setConnectingAtcoder(true);
-    try {
-      const { data } = await connectAtCoder(atcoderUsername.trim());
-      setUser(data);
-      setAtcoderUsername('');
-      toast.success(t('settings.atcoderConnected'));
-    } catch {
-      toast.error(t('settings.atcoderInvalidUsername'));
-    } finally {
-      setConnectingAtcoder(false);
-    }
-  };
-
-  const handleSavePaizaRank = async () => {
-    if (!paizaRank) return;
-    try {
-      const { data } = await updateUser(user.id, { paiza_rank: paizaRank });
-      setUser(data);
-      toast.success(t('settings.saved'));
-    } catch {
-      toast.error(t('settings.saveFailed'));
-    }
-  };
-
-  const handleComplete = async () => {
-    setSaving(true);
-    try {
-      const { data } = await updateUser(user.id, { onboarding_completed: true });
-      setUser(data);
-      navigate('/');
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-    } finally {
-      setSaving(false);
-    }
-  };
-
 
   return (
     <div className="min-h-screen bg-gray-950 flex flex-col items-center justify-center px-4 py-12">


### PR DESCRIPTION
## 概要
- OnboardingPage（582行）のAPI呼び出し・状態管理ロジックをuseOnboardingフックに抽出
- ページコンポーネントはUIレンダリングに専念する構成に変更

## 変更内容
- `hooks/useOnboarding.ts` を新規作成（全ハンドラー・状態をフックに移動）
- `pages/OnboardingPage.tsx` をフック使用に簡素化（582行 → 427行相当）
- `hooks/index.ts` にバレルエクスポート追加

## 対象 Issue
Closes #498

## テスト
- `npx tsc --noEmit` 型チェック通過