### PR TITLE
test: ProjectServiceの未テストメソッドにユニットテスト追加

### DIFF
--- a/backend/internal/service/project_test.go
+++ b/backend/internal/service/project_test.go
@@ -127,3 +127,193 @@ func TestProjectDelete_Forbidden(t *testing.T) {
 	assert.ErrorIs(t, err, ErrForbidden)
 	repo.AssertExpectations(t)
 }
+
+func TestProjectDelete_NotFound(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.Delete(999, 1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// プロジェクト作成テスト
+// ============================================================
+
+func TestProjectCreate_Success(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	project := &model.Project{
+		Title:       "My Project",
+		Description: "A great project",
+		UserID:      1,
+	}
+
+	repo.On("Create", project).Return(nil)
+
+	err := svc.Create(project)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectCreate_ValidationError(t *testing.T) {
+	svc, _ := newTestProjectService()
+
+	project := &model.Project{
+		Title:       "",
+		Description: "A great project",
+		UserID:      1,
+	}
+
+	err := svc.Create(project)
+	assert.Error(t, err)
+}
+
+func TestProjectCreate_RepoError(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	project := &model.Project{
+		Title:       "My Project",
+		Description: "A great project",
+		UserID:      1,
+	}
+
+	repo.On("Create", project).Return(errors.New("db error"))
+
+	err := svc.Create(project)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// プロジェクト取得テスト
+// ============================================================
+
+func TestProjectGetByID_Success(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	expected := &model.Project{Title: "Test", UserID: 1}
+	expected.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetByID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, "Test", result.Title)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectGetByID_NotFound(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	result, err := svc.GetByID(999)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectGetByUserID_Success(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	expected := []model.Project{
+		{Title: "Project 1", UserID: 1},
+		{Title: "Project 2", UserID: 1},
+	}
+
+	repo.On("FindByUserID", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetByUserID(1)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectGetByUserID_Empty(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	repo.On("FindByUserID", uint(1)).Return([]model.Project{}, nil)
+
+	result, err := svc.GetByUserID(1)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectGetFeaturedByUserID_Success(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	expected := []model.Project{
+		{Title: "Featured 1", UserID: 1, Featured: true},
+	}
+
+	repo.On("FindFeaturedByUserID", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetFeaturedByUserID(1)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.True(t, result[0].Featured)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectGetFeaturedByUserID_Empty(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	repo.On("FindFeaturedByUserID", uint(1)).Return([]model.Project{}, nil)
+
+	result, err := svc.GetFeaturedByUserID(1)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectGetAll_Success(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	expected := []model.Project{
+		{Title: "Project 1"},
+		{Title: "Project 2"},
+	}
+
+	repo.On("FindAll", 10, 0).Return(expected, int64(2), nil)
+
+	result, total, err := svc.GetAll(10, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// 更新・削除エラーケーステスト
+// ============================================================
+
+func TestProjectUpdate_UpdateError(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	existing := &model.Project{Title: "Old", Description: "Desc", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+
+	updates := &model.Project{Title: "New"}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectUpdateFeatured_NotFound(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	result, err := svc.UpdateFeatured(999, 1, true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- ProjectServiceの未テストメソッドに12件のユニットテストを追加
- テスト数: 8件 → 20件（全公開メソッドをカバー）

## 追加テスト一覧
- **Create**: 正常系、バリデーションエラー、リポジトリエラー（3件）
- **GetByID**: 正常系、NotFound（2件）
- **GetByUserID**: 正常系、空結果（2件）
- **GetFeaturedByUserID**: 正常系、空結果（2件）
- **GetAll**: 正常系（1件）
- **Update**: リポジトリ更新エラー（1件）
- **UpdateFeatured**: NotFound（1件）
- **Delete**: NotFound（1件）（計12件追加）

## 対象 Issue
Closes #500