### PR TITLE
refactor: RoadmapsPageのフォームロジックをuseRoadmapFormフックに抽出

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -16,6 +16,7 @@ export { useNotifications } from './useNotifications';
 export { useQuestions } from './useQuestions';
 export { useQuestionDetail } from './useQuestionDetail';
 export { useRoadmaps, useRoadmapDetail, useRoadmapTemplates } from './useRoadmaps';
+export { useRoadmapForm } from './useRoadmapForm';
 export { useDashboard } from './useDashboard';
 export { useBadgeNotifier } from './useBadgeNotifier';
 export { useLearningLogs, useLearningLogCalendar, useStreak } from './useLearningLogs';

--- a/frontend/src/hooks/useRoadmapForm.ts
+++ b/frontend/src/hooks/useRoadmapForm.ts
@@ -1,0 +1,108 @@
+import { useState, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
+import { useRoadmaps, useRoadmapTemplates } from './useRoadmaps';
+
+export function useRoadmapForm() {
+  const navigate = useNavigate();
+  const {
+    roadmaps, loading, saving, activeRoadmaps, completedRoadmaps,
+    createRoadmap, updateRoadmap, deleteRoadmap, refetch,
+  } = useRoadmaps();
+  const { templates, loading: templatesLoading, creating, createFromTemplate } = useRoadmapTemplates();
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingRoadmap, setEditingRoadmap] = useState<Roadmap | null>(null);
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [category, setCategory] = useState<RoadmapCategory>('other');
+  const [isPublic, setIsPublic] = useState(false);
+  const [showTemplates, setShowTemplates] = useState(false);
+  const [expandedTemplate, setExpandedTemplate] = useState<number | null>(null);
+
+  const resetForm = useCallback(() => {
+    setTitle('');
+    setDescription('');
+    setCategory('other');
+    setIsPublic(false);
+    setEditingRoadmap(null);
+    setShowForm(false);
+  }, []);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim()) return;
+
+    if (editingRoadmap) {
+      const result = await updateRoadmap(editingRoadmap.id, { title, description, category, is_public: isPublic });
+      if (result) resetForm();
+    } else {
+      const result = await createRoadmap({ title, description, category, is_public: isPublic });
+      if (result) {
+        resetForm();
+        navigate(`/roadmaps/${result.id}`);
+      }
+    }
+  }, [title, description, category, isPublic, editingRoadmap, updateRoadmap, createRoadmap, resetForm, navigate]);
+
+  const handleEdit = useCallback((roadmap: Roadmap) => {
+    setEditingRoadmap(roadmap);
+    setTitle(roadmap.title);
+    setDescription(roadmap.description);
+    setCategory(roadmap.category);
+    setIsPublic(roadmap.is_public);
+    setShowForm(true);
+  }, []);
+
+  const handleUseTemplate = useCallback(async (templateId: number) => {
+    const result = await createFromTemplate(templateId);
+    if (result) {
+      await refetch();
+      navigate(`/roadmaps/${result.id}`);
+    }
+  }, [createFromTemplate, refetch, navigate]);
+
+  const toggleTemplates = useCallback(() => {
+    setShowTemplates(prev => !prev);
+  }, []);
+
+  const toggleExpandedTemplate = useCallback((templateId: number) => {
+    setExpandedTemplate(prev => prev === templateId ? null : templateId);
+  }, []);
+
+  return {
+    // データ
+    roadmaps,
+    activeRoadmaps,
+    completedRoadmaps,
+    templates,
+    loading,
+    saving,
+    templatesLoading,
+    creating,
+    // フォーム状態
+    showForm,
+    setShowForm,
+    editingRoadmap,
+    title,
+    setTitle,
+    description,
+    setDescription,
+    category,
+    setCategory,
+    isPublic,
+    setIsPublic,
+    // テンプレート状態
+    showTemplates,
+    expandedTemplate,
+    // アクション
+    resetForm,
+    handleSubmit,
+    handleEdit,
+    handleUseTemplate,
+    deleteRoadmap,
+    toggleTemplates,
+    toggleExpandedTemplate,
+    navigate,
+  };
+}

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -1,9 +1,7 @@
-import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Monitor, Rocket, Target, FolderOpen, FileText, BookOpen, ChevronDown, ChevronUp, MapPin, type LucideIcon } from 'lucide-react';
 import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
-import { useRoadmaps, useRoadmapTemplates } from '../hooks';
+import { useRoadmapForm } from '../hooks';
 import EmptyState from '../components/common/EmptyState';
 import { Modal, PageHeader, PageLoader } from '../components/common';
 import { inputClass, buttonSecondaryClass, labelClass } from '../constants/styles';
@@ -16,73 +14,25 @@ const CATEGORIES: { value: RoadmapCategory; label: string; icon: string; Icon: L
   { value: 'other', label: 'roadmaps.categoryOther', icon: '📝', Icon: FileText },
 ];
 
+const getCategoryInfo = (cat: RoadmapCategory) =>
+  CATEGORIES.find(c => c.value === cat) || CATEGORIES[4];
+
 export default function RoadmapsPage() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const {
-    roadmaps, loading, saving, activeRoadmaps, completedRoadmaps,
-    createRoadmap, updateRoadmap, deleteRoadmap, refetch,
-  } = useRoadmaps();
-  const { templates, loading: templatesLoading, creating, createFromTemplate } = useRoadmapTemplates();
-
-  const [showForm, setShowForm] = useState(false);
-  const [editingRoadmap, setEditingRoadmap] = useState<Roadmap | null>(null);
-  const [title, setTitle] = useState('');
-  const [description, setDescription] = useState('');
-  const [category, setCategory] = useState<RoadmapCategory>('other');
-  const [isPublic, setIsPublic] = useState(false);
-  const [showTemplates, setShowTemplates] = useState(false);
-  const [expandedTemplate, setExpandedTemplate] = useState<number | null>(null);
-
-  const resetForm = () => {
-    setTitle('');
-    setDescription('');
-    setCategory('other');
-    setIsPublic(false);
-    setEditingRoadmap(null);
-    setShowForm(false);
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!title.trim()) return;
-
-    if (editingRoadmap) {
-      const result = await updateRoadmap(editingRoadmap.id, { title, description, category, is_public: isPublic });
-      if (result) resetForm();
-    } else {
-      const result = await createRoadmap({ title, description, category, is_public: isPublic });
-      if (result) {
-        resetForm();
-        navigate(`/roadmaps/${result.id}`);
-      }
-    }
-  };
-
-  const handleEdit = (roadmap: Roadmap) => {
-    setEditingRoadmap(roadmap);
-    setTitle(roadmap.title);
-    setDescription(roadmap.description);
-    setCategory(roadmap.category);
-    setIsPublic(roadmap.is_public);
-    setShowForm(true);
-  };
-
-  const handleUseTemplate = async (templateId: number) => {
-    const result = await createFromTemplate(templateId);
-    if (result) {
-      await refetch();
-      navigate(`/roadmaps/${result.id}`);
-    }
-  };
-
-  const getCategoryInfo = (cat: RoadmapCategory) =>
-    CATEGORIES.find(c => c.value === cat) || CATEGORIES[4];
+    roadmaps, activeRoadmaps, completedRoadmaps, templates,
+    loading, saving, templatesLoading, creating,
+    showForm, setShowForm, editingRoadmap,
+    title, setTitle, description, setDescription,
+    category, setCategory, isPublic, setIsPublic,
+    showTemplates, expandedTemplate,
+    resetForm, handleSubmit, handleEdit, handleUseTemplate,
+    deleteRoadmap, toggleTemplates, toggleExpandedTemplate, navigate,
+  } = useRoadmapForm();
 
   if (loading) {
     return <PageLoader />;
   }
-
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
@@ -113,7 +63,7 @@ export default function RoadmapsPage() {
       {!templatesLoading && templates.length > 0 && (
         <div className="mb-6">
           <button
-            onClick={() => setShowTemplates(!showTemplates)}
+            onClick={toggleTemplates}
             className="w-full flex items-center justify-between p-4 bg-gray-800 border border-gray-700 rounded-md hover:border-gray-600 transition-colors"
           >
             <div className="flex items-center gap-3">
@@ -169,7 +119,7 @@ export default function RoadmapsPage() {
                         </div>
                         <div className="flex items-center gap-2">
                           <button
-                            onClick={() => setExpandedTemplate(isExpanded ? null : template.id)}
+                            onClick={() => toggleExpandedTemplate(template.id)}
                             className="p-2 text-gray-400 hover:text-white transition-colors"
                             title={t('roadmaps.viewSteps')}
                           >


### PR DESCRIPTION
## 概要
RoadmapsPage（434行）からフォーム状態管理・ハンドラー・テンプレート展開ロジックを`useRoadmapForm`フックに抽出。

## 変更内容
- `useRoadmapForm` フック新規作成
  - useState 8個（showForm/editingRoadmap/title/description/category/isPublic/showTemplates/expandedTemplate）
  - ハンドラー: resetForm/handleSubmit/handleEdit/handleUseTemplate/toggleTemplates/toggleExpandedTemplate
  - useCallback化によるパフォーマンス最適化
- `RoadmapsPage` リファクタリング
  - useState/useNavigate/APIインポート削除
  - `useRoadmapForm` フック利用に切り替え
  - `getCategoryInfo` をモジュールレベル関数に移動
- バレルエクスポート更新

## テスト
- `npx tsc --noEmit` → 型エラーなし

closes #504