### PR TITLE
test: LearningResourceServiceの未テストメソッドにユニットテスト追加

### DIFF
--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -210,3 +210,298 @@ func TestLearningResourceDelete_Forbidden(t *testing.T) {
 	assert.ErrorIs(t, err, ErrForbidden)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// Create（バリデーション＋リポジトリ呼び出し）
+// ============================================================
+
+func TestLearningResourceCreate_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	resource := &model.LearningResource{
+		Title:       "Go入門",
+		Description: "Go言語の基礎",
+		URL:         "https://example.com/go",
+		Category:    "article",
+		Difficulty:  "beginner",
+		UserID:      1,
+	}
+
+	repo.On("Create", resource).Return(nil)
+
+	err := svc.Create(resource)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceCreate_ValidationError(t *testing.T) {
+	svc, _ := newTestLearningResourceService()
+
+	// タイトル空 → バリデーションエラー
+	resource := &model.LearningResource{
+		Title:       "",
+		Description: "説明",
+		URL:         "https://example.com",
+		Category:    "article",
+		Difficulty:  "beginner",
+	}
+
+	err := svc.Create(resource)
+	assert.Error(t, err)
+}
+
+func TestLearningResourceCreate_RepoError(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	resource := &model.LearningResource{
+		Title:       "Go入門",
+		Description: "Go言語の基礎",
+		URL:         "https://example.com/go",
+		Category:    "article",
+		Difficulty:  "beginner",
+	}
+
+	repo.On("Create", resource).Return(errors.New("db error"))
+
+	err := svc.Create(resource)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// HasLiked
+// ============================================================
+
+func TestLearningResourceHasLiked_True(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("HasLiked", uint(1), uint(10)).Return(true, nil)
+
+	liked, err := svc.HasLiked(1, 10)
+	assert.NoError(t, err)
+	assert.True(t, liked)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceHasLiked_False(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("HasLiked", uint(1), uint(10)).Return(false, nil)
+
+	liked, err := svc.HasLiked(1, 10)
+	assert.NoError(t, err)
+	assert.False(t, liked)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceHasLiked_Error(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("HasLiked", uint(1), uint(10)).Return(false, errors.New("db error"))
+
+	liked, err := svc.HasLiked(1, 10)
+	assert.Error(t, err)
+	assert.False(t, liked)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// HasSaved
+// ============================================================
+
+func TestLearningResourceHasSaved_True(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("HasSaved", uint(1), uint(10)).Return(true, nil)
+
+	saved, err := svc.HasSaved(1, 10)
+	assert.NoError(t, err)
+	assert.True(t, saved)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceHasSaved_False(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("HasSaved", uint(1), uint(10)).Return(false, nil)
+
+	saved, err := svc.HasSaved(1, 10)
+	assert.NoError(t, err)
+	assert.False(t, saved)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceHasSaved_Error(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("HasSaved", uint(1), uint(10)).Return(false, errors.New("db error"))
+
+	saved, err := svc.HasSaved(1, 10)
+	assert.Error(t, err)
+	assert.False(t, saved)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// GetPublic（ページネーション・フィルタ）
+// ============================================================
+
+func TestLearningResourceGetPublic_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	resources := []model.LearningResource{
+		{Title: "Resource1"},
+		{Title: "Resource2"},
+	}
+	repo.On("FindPublic", 10, 0, "article", "beginner").Return(resources, int64(2), nil)
+
+	result, total, err := svc.GetPublic(10, 0, "article", "beginner")
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceGetPublic_Empty(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("FindPublic", 10, 0, "", "").Return([]model.LearningResource{}, int64(0), nil)
+
+	result, total, err := svc.GetPublic(10, 0, "", "")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// Search
+// ============================================================
+
+func TestLearningResourceSearch_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	resources := []model.LearningResource{{Title: "Go Tutorial"}}
+	repo.On("Search", "Go", 10, 0).Return(resources, int64(1), nil)
+
+	result, total, err := svc.Search("Go", 10, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceSearch_Empty(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("Search", "nonexistent", 10, 0).Return([]model.LearningResource{}, int64(0), nil)
+
+	result, total, err := svc.Search("nonexistent", 10, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// Like / Unlike
+// ============================================================
+
+func TestLearningResourceLike_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("Like", uint(1), uint(10)).Return(nil)
+
+	err := svc.Like(1, 10)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceLike_Error(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("Like", uint(1), uint(10)).Return(errors.New("already liked"))
+
+	err := svc.Like(1, 10)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceUnlike_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("Unlike", uint(1), uint(10)).Return(nil)
+
+	err := svc.Unlike(1, 10)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceUnlike_Error(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("Unlike", uint(1), uint(10)).Return(errors.New("not liked"))
+
+	err := svc.Unlike(1, 10)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// Save / Unsave
+// ============================================================
+
+func TestLearningResourceSave_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("Save", uint(1), uint(10)).Return(nil)
+
+	err := svc.Save(1, 10)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceSave_Error(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("Save", uint(1), uint(10)).Return(errors.New("already saved"))
+
+	err := svc.Save(1, 10)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceUnsave_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("Unsave", uint(1), uint(10)).Return(nil)
+
+	err := svc.Unsave(1, 10)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceUnsave_Error(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("Unsave", uint(1), uint(10)).Return(errors.New("not saved"))
+
+	err := svc.Unsave(1, 10)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// GetSavedByUserID
+// ============================================================
+
+func TestLearningResourceGetSavedByUserID_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	resources := []model.LearningResource{{Title: "Saved Resource"}}
+	repo.On("FindSavedByUserID", uint(1), 10, 0).Return(resources, int64(1), nil)
+
+	result, total, err := svc.GetSavedByUserID(1, 10, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceGetSavedByUserID_Empty(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("FindSavedByUserID", uint(1), 10, 0).Return([]model.LearningResource{}, int64(0), nil)
+
+	result, total, err := svc.GetSavedByUserID(1, 10, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- LearningResourceServiceの10個の未テストメソッドに23件のユニットテストを追加
- 既存12件と合わせ全35件で、全15公開メソッドを完全カバー

## 追加テスト
- Create: 成功/バリデーションエラー/リポジトリエラー（3件）
- HasLiked: true/false/エラー（3件）
- HasSaved: true/false/エラー（3件）
- GetPublic: 成功/空結果（2件）
- Search: 成功/空結果（2件）
- Like/Unlike: 成功/エラー（各2件）
- Save/Unsave: 成功/エラー（各2件）
- GetSavedByUserID: 成功/空結果（2件）

## テスト計画
- [x] `go test ./internal/service/... -run TestLearningResource -v` 全35件PASS

Closes #512