### PR TITLE
feat: 投稿タグ機能をTDDで実装

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -55,6 +55,7 @@ type Container struct {
 	NoteLinkHandler          *handler.NoteLinkHandler
 	PostSeriesHandler        *handler.PostSeriesHandler
 	PostCollectionHandler    *handler.PostCollectionHandler
+	PostTagHandler           *handler.PostTagHandler
 
 	// ミドルウェア・コールバック用
 	AuthService      *service.AuthService
@@ -221,6 +222,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	postCollectionRepo := repository.NewPostCollectionRepository(db)
 	postCollectionService := service.NewPostCollectionService(postCollectionRepo)
 	c.PostCollectionHandler = handler.NewPostCollectionHandler(postCollectionService)
+
+	postTagRepo := repository.NewPostTagRepository(db)
+	postTagService := service.NewPostTagService(postTagRepo, postRepo)
+	c.PostTagHandler = handler.NewPostTagHandler(postTagService)
 
 	// HubのGetRoomMembersコールバックを設定
 	hub.GetRoomMembers = groupMessageRepo.GetMemberUserIDs

--- a/backend/internal/dto/post_tag_dto.go
+++ b/backend/internal/dto/post_tag_dto.go
@@ -1,0 +1,6 @@
+package dto
+
+// SetTagsRequest はタグ設定のリクエスト。
+type SetTagsRequest struct {
+	Tags []string `json:"tags" binding:"required"`
+}

--- a/backend/internal/handler/post_tag.go
+++ b/backend/internal/handler/post_tag.go
@@ -1,0 +1,90 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// PostTagServiceInterface はPostTagHandlerが依存するサービスインターフェース。
+type PostTagServiceInterface interface {
+	SetTags(postID, userID uint, tags []string) error
+	GetByPostID(postID uint) ([]string, error)
+	FindPostsByTag(tag string, limit, offset int) ([]model.Post, int64, error)
+	GetPopularTags(limit int) ([]model.TagCount, error)
+}
+
+// PostTagHandler は投稿タグのHTTPハンドラー。
+type PostTagHandler struct {
+	service PostTagServiceInterface
+}
+
+// NewPostTagHandler は新しいPostTagHandlerを生成する。
+func NewPostTagHandler(service PostTagServiceInterface) *PostTagHandler {
+	return &PostTagHandler{service: service}
+}
+
+// SetTags は投稿のタグを設定する。
+func (h *PostTagHandler) SetTags(c *gin.Context) {
+	postID, ok := parseID(c, "postId")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	req := bindJSON[struct {
+		Tags []string `json:"tags"`
+	}](c)
+	if req == nil {
+		return
+	}
+
+	if err := h.service.SetTags(postID, userID, req.Tags); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"message": "タグを更新しました"})
+}
+
+// GetByPostID は投稿のタグ一覧を取得する。
+func (h *PostTagHandler) GetByPostID(c *gin.Context) {
+	postID, ok := parseID(c, "postId")
+	if !ok {
+		return
+	}
+
+	tags, err := h.service.GetByPostID(postID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"tags": tags})
+}
+
+// FindPostsByTag はタグで投稿を検索する。
+func (h *PostTagHandler) FindPostsByTag(c *gin.Context) {
+	tag := c.Query("tag")
+	if tag == "" {
+		respondBadRequest(c, "tagパラメータが必要です")
+		return
+	}
+
+	page, limit := parsePagination(c)
+	offset := (page - 1) * limit
+
+	posts, total, err := h.service.FindPostsByTag(tag, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondPaginated(c, posts, total, page, limit)
+}
+
+// GetPopularTags は人気タグ一覧を取得する。
+func (h *PostTagHandler) GetPopularTags(c *gin.Context) {
+	tags, err := h.service.GetPopularTags(20)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"tags": tags})
+}

--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -99,6 +99,20 @@ type PostCollectionItem struct {
 	CreatedAt    time.Time `json:"created_at"`
 }
 
+// PostTag は投稿に付与されたタグを表す。
+// uniqueIndex制約で同一投稿に同じタグが重複しないことを保証する。
+type PostTag struct {
+	ID     uint   `json:"id" gorm:"primaryKey"`
+	PostID uint   `json:"post_id" gorm:"not null;uniqueIndex:idx_post_tag;index"`
+	Tag    string `json:"tag" gorm:"not null;uniqueIndex:idx_post_tag;index;size:50"`
+}
+
+// TagCount はタグとその使用回数を表す集計結果。
+type TagCount struct {
+	Tag   string `json:"tag"`
+	Count int    `json:"count"`
+}
+
 // Comment は投稿へのコメントを表す。
 type Comment struct {
 	ID        uint      `json:"id" gorm:"primaryKey"`

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -437,3 +437,11 @@ type PostSeriesRepositoryInterface interface {
 	RemovePost(seriesID, postID uint) error
 	GetPostsBySeriesID(seriesID uint) ([]model.PostSeriesItem, error)
 }
+
+// PostTagRepositoryInterface は投稿タグデータ操作の契約を定義する。
+type PostTagRepositoryInterface interface {
+	SetTags(postID uint, tags []string) error
+	GetByPostID(postID uint) ([]string, error)
+	FindPostsByTag(tag string, limit, offset int) ([]model.Post, int64, error)
+	GetPopularTags(limit int) ([]model.TagCount, error)
+}

--- a/backend/internal/repository/post_tag.go
+++ b/backend/internal/repository/post_tag.go
@@ -1,0 +1,94 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// PostTagRepository は PostTagRepositoryInterface の GORM 実装。
+type PostTagRepository struct {
+	db *gorm.DB
+}
+
+// NewPostTagRepository は新しい PostTagRepository を生成する。
+func NewPostTagRepository(db *gorm.DB) *PostTagRepository {
+	return &PostTagRepository{db: db}
+}
+
+// SetTags は投稿のタグを全て置き換える。
+func (r *PostTagRepository) SetTags(postID uint, tags []string) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		// 既存タグ削除
+		if err := tx.Where("post_id = ?", postID).Delete(&model.PostTag{}).Error; err != nil {
+			return err
+		}
+		// 新タグ挿入
+		for _, tag := range tags {
+			postTag := &model.PostTag{PostID: postID, Tag: tag}
+			if err := tx.Create(postTag).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// GetByPostID は投稿のタグ一覧を取得する。
+func (r *PostTagRepository) GetByPostID(postID uint) ([]string, error) {
+	var postTags []model.PostTag
+	if err := r.db.Where("post_id = ?", postID).Find(&postTags).Error; err != nil {
+		return nil, err
+	}
+	tags := make([]string, len(postTags))
+	for i, pt := range postTags {
+		tags[i] = pt.Tag
+	}
+	return tags, nil
+}
+
+// FindPostsByTag はタグで投稿を検索する。
+func (r *PostTagRepository) FindPostsByTag(tag string, limit, offset int) ([]model.Post, int64, error) {
+	var count int64
+	r.db.Model(&model.PostTag{}).Where("tag = ?", tag).
+		Joins("JOIN posts ON posts.id = post_tags.post_id AND posts.is_draft = false").
+		Count(&count)
+
+	var postTags []model.PostTag
+	if err := r.db.Where("tag = ?", tag).
+		Joins("JOIN posts ON posts.id = post_tags.post_id AND posts.is_draft = false").
+		Order("post_tags.id DESC").
+		Limit(limit).Offset(offset).
+		Find(&postTags).Error; err != nil {
+		return nil, 0, err
+	}
+
+	if len(postTags) == 0 {
+		return []model.Post{}, 0, nil
+	}
+
+	postIDs := make([]uint, len(postTags))
+	for i, pt := range postTags {
+		postIDs[i] = pt.PostID
+	}
+
+	var posts []model.Post
+	if err := r.db.Preload("User").Where("id IN ?", postIDs).
+		Order("created_at DESC").Find(&posts).Error; err != nil {
+		return nil, 0, err
+	}
+	return posts, count, nil
+}
+
+// GetPopularTags は使用回数の多いタグ一覧を取得する。
+func (r *PostTagRepository) GetPopularTags(limit int) ([]model.TagCount, error) {
+	var results []model.TagCount
+	if err := r.db.Model(&model.PostTag{}).
+		Select("tag, COUNT(*) as count").
+		Group("tag").
+		Order("count DESC").
+		Limit(limit).
+		Find(&results).Error; err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -73,6 +73,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerPostRoutes(protected, c)
 		registerPostSeriesRoutes(protected, c)
 		registerPostCollectionRoutes(protected, c)
+		registerPostTagRoutes(protected, c)
 		registerSnippetRoutes(protected, c)
 		registerRankingRoutes(protected, c)
 		registerMessageRoutes(protected, c)
@@ -169,6 +170,16 @@ func registerPostCollectionRoutes(g *gin.RouterGroup, c *di.Container) {
 		collections.POST("/:id/posts", c.PostCollectionHandler.AddPost)
 		collections.DELETE("/:id/posts/:postId", c.PostCollectionHandler.RemovePost)
 		collections.GET("/user/:userId", c.PostCollectionHandler.GetByUserID)
+	}
+}
+
+func registerPostTagRoutes(g *gin.RouterGroup, c *di.Container) {
+	tags := g.Group("/post-tags")
+	{
+		tags.PUT("/posts/:postId", c.PostTagHandler.SetTags)
+		tags.GET("/posts/:postId", c.PostTagHandler.GetByPostID)
+		tags.GET("/search", c.PostTagHandler.FindPostsByTag)
+		tags.GET("/popular", c.PostTagHandler.GetPopularTags)
 	}
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1551,3 +1551,33 @@ func (m *MockPostCollectionRepository) GetPostsByCollectionID(collectionID uint)
 	args := m.Called(collectionID)
 	return args.Get(0).([]model.PostCollectionItem), args.Error(1)
 }
+
+// ============================================================
+// MockPostTagRepository は repository.PostTagRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockPostTagRepository struct {
+	mock.Mock
+}
+
+var _ repository.PostTagRepositoryInterface = (*MockPostTagRepository)(nil)
+
+func (m *MockPostTagRepository) SetTags(postID uint, tags []string) error {
+	args := m.Called(postID, tags)
+	return args.Error(0)
+}
+
+func (m *MockPostTagRepository) GetByPostID(postID uint) ([]string, error) {
+	args := m.Called(postID)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockPostTagRepository) FindPostsByTag(tag string, limit, offset int) ([]model.Post, int64, error) {
+	args := m.Called(tag, limit, offset)
+	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockPostTagRepository) GetPopularTags(limit int) ([]model.TagCount, error) {
+	args := m.Called(limit)
+	return args.Get(0).([]model.TagCount), args.Error(1)
+}

--- a/backend/internal/service/post_tag.go
+++ b/backend/internal/service/post_tag.go
@@ -1,0 +1,72 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+const maxTagsPerPost = 10
+
+// PostTagService は投稿タグのビジネスロジックを提供する。
+type PostTagService struct {
+	tagRepo  repository.PostTagRepositoryInterface
+	postRepo repository.PostRepositoryInterface
+}
+
+// NewPostTagService は新しいPostTagServiceインスタンスを生成する。
+func NewPostTagService(tagRepo repository.PostTagRepositoryInterface, postRepo repository.PostRepositoryInterface) *PostTagService {
+	return &PostTagService{tagRepo: tagRepo, postRepo: postRepo}
+}
+
+// SetTags は投稿のタグを設定する。所有権チェック・バリデーション付き。
+func (s *PostTagService) SetTags(postID, userID uint, tags []string) error {
+	post, err := s.postRepo.FindByID(postID)
+	if err != nil {
+		return err
+	}
+	if post.UserID != userID {
+		return ErrForbidden
+	}
+
+	// 正規化: 小文字変換・トリム・空文字除外・重複除外
+	normalized := normalizeTags(tags)
+
+	if len(normalized) > maxTagsPerPost {
+		return domain.NewError(domain.ErrCodeBadRequest, "タグは最大10個までです", nil)
+	}
+
+	return s.tagRepo.SetTags(postID, normalized)
+}
+
+// GetByPostID は投稿のタグ一覧を取得する。
+func (s *PostTagService) GetByPostID(postID uint) ([]string, error) {
+	return s.tagRepo.GetByPostID(postID)
+}
+
+// FindPostsByTag はタグで投稿を検索する。
+func (s *PostTagService) FindPostsByTag(tag string, limit, offset int) ([]model.Post, int64, error) {
+	return s.tagRepo.FindPostsByTag(tag, limit, offset)
+}
+
+// GetPopularTags は人気タグ一覧を取得する。
+func (s *PostTagService) GetPopularTags(limit int) ([]model.TagCount, error) {
+	return s.tagRepo.GetPopularTags(limit)
+}
+
+// normalizeTags はタグを正規化する（小文字変換・トリム・空文字除外・重複除外）。
+func normalizeTags(tags []string) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, tag := range tags {
+		t := strings.ToLower(strings.TrimSpace(tag))
+		if t == "" || seen[t] {
+			continue
+		}
+		seen[t] = true
+		result = append(result, t)
+	}
+	return result
+}

--- a/backend/internal/service/post_tag_test.go
+++ b/backend/internal/service/post_tag_test.go
@@ -1,0 +1,224 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// newTestPostTagService はPostTagServiceのテスト用インスタンスを生成するヘルパー。
+func newTestPostTagService() (*PostTagService, *MockPostTagRepository, *MockPostRepository) {
+	tagRepo := new(MockPostTagRepository)
+	postRepo := new(MockPostRepository)
+	svc := NewPostTagService(tagRepo, postRepo)
+	return svc, tagRepo, postRepo
+}
+
+// ============================================================
+// SetTags（タグ設定 — 所有権チェック + バリデーション）
+// ============================================================
+
+func TestPostTagSetTags_Success(t *testing.T) {
+	svc, tagRepo, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+	tagRepo.On("SetTags", uint(10), []string{"go", "react"}).Return(nil)
+
+	err := svc.SetTags(10, 1, []string{"Go", "React"})
+	assert.NoError(t, err)
+	tagRepo.AssertExpectations(t)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostTagSetTags_Forbidden(t *testing.T) {
+	svc, _, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	err := svc.SetTags(10, 999, []string{"go"})
+	assert.ErrorIs(t, err, ErrForbidden)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostTagSetTags_PostNotFound(t *testing.T) {
+	svc, _, postRepo := newTestPostTagService()
+
+	postRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.SetTags(999, 1, []string{"go"})
+	assert.Error(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostTagSetTags_TooManyTags(t *testing.T) {
+	svc, _, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	tags := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k"}
+	err := svc.SetTags(10, 1, tags)
+	assert.Error(t, err) // 最大10個
+}
+
+func TestPostTagSetTags_EmptyTagFiltered(t *testing.T) {
+	svc, tagRepo, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+	tagRepo.On("SetTags", uint(10), []string{"go"}).Return(nil)
+
+	// 空文字タグはフィルタされる
+	err := svc.SetTags(10, 1, []string{"go", "", "  "})
+	assert.NoError(t, err)
+	tagRepo.AssertExpectations(t)
+}
+
+func TestPostTagSetTags_DuplicateTagDeduped(t *testing.T) {
+	svc, tagRepo, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+	tagRepo.On("SetTags", uint(10), []string{"go"}).Return(nil)
+
+	// 重複タグは1つにまとめられる
+	err := svc.SetTags(10, 1, []string{"Go", "go", "GO"})
+	assert.NoError(t, err)
+	tagRepo.AssertExpectations(t)
+}
+
+func TestPostTagSetTags_RepoError(t *testing.T) {
+	svc, tagRepo, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+	tagRepo.On("SetTags", uint(10), mock.Anything).Return(errors.New("db error"))
+
+	err := svc.SetTags(10, 1, []string{"go"})
+	assert.Error(t, err)
+}
+
+// ============================================================
+// GetByPostID
+// ============================================================
+
+func TestPostTagGetByPostID_Success(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	tagRepo.On("GetByPostID", uint(10)).Return([]string{"go", "react"}, nil)
+
+	tags, err := svc.GetByPostID(10)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"go", "react"}, tags)
+	tagRepo.AssertExpectations(t)
+}
+
+func TestPostTagGetByPostID_Empty(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	tagRepo.On("GetByPostID", uint(10)).Return([]string{}, nil)
+
+	tags, err := svc.GetByPostID(10)
+	assert.NoError(t, err)
+	assert.Empty(t, tags)
+	tagRepo.AssertExpectations(t)
+}
+
+func TestPostTagGetByPostID_Error(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	tagRepo.On("GetByPostID", uint(10)).Return([]string{}, errors.New("db error"))
+
+	tags, err := svc.GetByPostID(10)
+	assert.Error(t, err)
+	assert.Empty(t, tags)
+	tagRepo.AssertExpectations(t)
+}
+
+// ============================================================
+// FindPostsByTag
+// ============================================================
+
+func TestPostTagFindPostsByTag_Success(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	posts := []model.Post{{Title: "Go Tips"}}
+	tagRepo.On("FindPostsByTag", "go", 10, 0).Return(posts, int64(1), nil)
+
+	result, total, err := svc.FindPostsByTag("go", 10, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
+	tagRepo.AssertExpectations(t)
+}
+
+func TestPostTagFindPostsByTag_Empty(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	tagRepo.On("FindPostsByTag", "nonexistent", 10, 0).Return([]model.Post{}, int64(0), nil)
+
+	result, total, err := svc.FindPostsByTag("nonexistent", 10, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	tagRepo.AssertExpectations(t)
+}
+
+// ============================================================
+// GetPopularTags
+// ============================================================
+
+func TestPostTagGetPopularTags_Success(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	tags := []model.TagCount{
+		{Tag: "go", Count: 15},
+		{Tag: "react", Count: 10},
+	}
+	tagRepo.On("GetPopularTags", 10).Return(tags, nil)
+
+	result, err := svc.GetPopularTags(10)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "go", result[0].Tag)
+	assert.Equal(t, 15, result[0].Count)
+	tagRepo.AssertExpectations(t)
+}
+
+func TestPostTagGetPopularTags_Empty(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	tagRepo.On("GetPopularTags", 10).Return([]model.TagCount{}, nil)
+
+	result, err := svc.GetPopularTags(10)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	tagRepo.AssertExpectations(t)
+}
+
+func TestPostTagGetPopularTags_Error(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	tagRepo.On("GetPopularTags", 10).Return([]model.TagCount{}, errors.New("db error"))
+
+	result, err := svc.GetPopularTags(10)
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	tagRepo.AssertExpectations(t)
+}

--- a/frontend/src/api/postTags.ts
+++ b/frontend/src/api/postTags.ts
@@ -1,0 +1,16 @@
+import client from './client';
+import type { Post, TagCount } from '../types/post';
+
+export const setPostTags = (postId: number, tags: string[]) =>
+  client.put(`/post-tags/posts/${postId}`, { tags });
+
+export const getPostTags = (postId: number) =>
+  client.get<{ tags: string[] }>(`/post-tags/posts/${postId}`);
+
+export const searchPostsByTag = (tag: string, page = 1, limit = 20) =>
+  client.get<{ data: Post[]; total: number; page: number; limit: number }>(
+    `/post-tags/search?tag=${encodeURIComponent(tag)}&page=${page}&limit=${limit}`
+  );
+
+export const getPopularTags = () =>
+  client.get<{ tags: TagCount[] }>('/post-tags/popular');

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -36,6 +36,7 @@ export { useNoteTemplates, useDefaultNoteTemplate } from './useNoteTemplates';
 export { useNoteLinks, useNoteBacklinks } from './useNoteLinks';
 export { usePostSeries, useSeriesPosts } from './usePostSeries';
 export { usePostCollections, useCollectionPosts } from './usePostCollections';
+export { usePostTags, useTagSearch, usePopularTags } from './usePostTags';
 export { useBookmarks } from './useBookmarks';
 export { useToast } from './useToast';
 export { useDebounce } from './useDebounce';

--- a/frontend/src/hooks/usePostTags.ts
+++ b/frontend/src/hooks/usePostTags.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { setPostTags, getPostTags, searchPostsByTag, getPopularTags } from '../api/postTags';
+import { useAsyncData } from './useAsyncData';
+import type { Post, TagCount } from '../types/post';
+
+export function usePostTags(postId?: number) {
+  const { t } = useTranslation();
+  const [saving, setSaving] = useState(false);
+
+  const { data: tags, loading, refetch } = useAsyncData(
+    async () => {
+      if (!postId) return [];
+      const { data } = await getPostTags(postId);
+      return data?.tags || [];
+    },
+    { initialData: [] as string[], deps: [postId], enabled: !!postId }
+  );
+
+  const handleSetTags = useCallback(async (newTags: string[]) => {
+    if (!postId) return false;
+    setSaving(true);
+    try {
+      await setPostTags(postId, newTags);
+      await refetch();
+      toast.success(t('tags.updateSuccess'));
+      return true;
+    } catch {
+      toast.error(t('tags.updateFailed'));
+      return false;
+    } finally {
+      setSaving(false);
+    }
+  }, [postId, t, refetch]);
+
+  return { tags, loading, saving, setTags: handleSetTags, refetch };
+}
+
+export function useTagSearch(tag: string, page = 1) {
+  const { data, loading } = useAsyncData(
+    async () => {
+      if (!tag) return { posts: [] as Post[], total: 0 };
+      const { data } = await searchPostsByTag(tag, page);
+      return { posts: data?.data || [], total: data?.total || 0 };
+    },
+    { initialData: { posts: [] as Post[], total: 0 }, deps: [tag, page], enabled: !!tag }
+  );
+
+  return { posts: data.posts, total: data.total, loading };
+}
+
+export function usePopularTags() {
+  const { data: tags, loading } = useAsyncData(
+    async () => {
+      const { data } = await getPopularTags();
+      return data?.tags || [];
+    },
+    { initialData: [] as TagCount[], deps: [] }
+  );
+
+  return { tags, loading };
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1260,5 +1260,17 @@
     "uploadedImage": "Hochgeladenes Bild {{number}}",
     "markdownSupported": "Markdown unterstützt",
     "pasteOrDragImages": "Bilder einfügen oder ziehen zum Hochladen"
+  },
+  "tags": {
+    "title": "Tags",
+    "popularTags": "Beliebte Tags",
+    "searchByTag": "Nach Tag suchen",
+    "addTags": "Tags hinzufügen",
+    "editTags": "Tags bearbeiten",
+    "noTags": "Keine Tags",
+    "updateSuccess": "Tags aktualisiert",
+    "updateFailed": "Tags konnten nicht aktualisiert werden",
+    "maxTags": "Maximal 10 Tags",
+    "tagPlaceholder": "Tag eingeben und Enter drücken"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1260,5 +1260,17 @@
     "uploadedImage": "Uploaded {{number}}",
     "markdownSupported": "Markdown supported",
     "pasteOrDragImages": "Paste or drag images to upload"
+  },
+  "tags": {
+    "title": "Tags",
+    "popularTags": "Popular Tags",
+    "searchByTag": "Search by Tag",
+    "addTags": "Add Tags",
+    "editTags": "Edit Tags",
+    "noTags": "No tags",
+    "updateSuccess": "Tags updated",
+    "updateFailed": "Failed to update tags",
+    "maxTags": "Maximum 10 tags",
+    "tagPlaceholder": "Type a tag and press Enter"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1260,5 +1260,17 @@
     "uploadedImage": "Imagen subida {{number}}",
     "markdownSupported": "Markdown compatible",
     "pasteOrDragImages": "Pega o arrastra imágenes para subir"
+  },
+  "tags": {
+    "title": "Etiquetas",
+    "popularTags": "Etiquetas Populares",
+    "searchByTag": "Buscar por Etiqueta",
+    "addTags": "Agregar Etiquetas",
+    "editTags": "Editar Etiquetas",
+    "noTags": "Sin etiquetas",
+    "updateSuccess": "Etiquetas actualizadas",
+    "updateFailed": "Error al actualizar etiquetas",
+    "maxTags": "Máximo 10 etiquetas",
+    "tagPlaceholder": "Escribe una etiqueta y presiona Enter"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1260,5 +1260,17 @@
     "uploadedImage": "Image téléchargée {{number}}",
     "markdownSupported": "Markdown pris en charge",
     "pasteOrDragImages": "Collez ou glissez des images pour télécharger"
+  },
+  "tags": {
+    "title": "Tags",
+    "popularTags": "Tags Populaires",
+    "searchByTag": "Rechercher par Tag",
+    "addTags": "Ajouter des Tags",
+    "editTags": "Modifier les Tags",
+    "noTags": "Aucun tag",
+    "updateSuccess": "Tags mis à jour",
+    "updateFailed": "Échec de la mise à jour des tags",
+    "maxTags": "Maximum 10 tags",
+    "tagPlaceholder": "Saisissez un tag et appuyez sur Entrée"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1161,5 +1161,17 @@
     "uploadedImage": "アップロード画像 {{number}}",
     "markdownSupported": "Markdown対応",
     "pasteOrDragImages": "画像を貼り付けまたはドラッグしてアップロード"
+  },
+  "tags": {
+    "title": "タグ",
+    "popularTags": "人気タグ",
+    "searchByTag": "タグで検索",
+    "addTags": "タグを追加",
+    "editTags": "タグを編集",
+    "noTags": "タグなし",
+    "updateSuccess": "タグを更新しました",
+    "updateFailed": "タグの更新に失敗しました",
+    "maxTags": "タグは最大10個まで",
+    "tagPlaceholder": "タグを入力してEnter"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1260,5 +1260,17 @@
     "uploadedImage": "업로드된 이미지 {{number}}",
     "markdownSupported": "마크다운 지원",
     "pasteOrDragImages": "이미지를 붙여넣거나 드래그하여 업로드"
+  },
+  "tags": {
+    "title": "태그",
+    "popularTags": "인기 태그",
+    "searchByTag": "태그로 검색",
+    "addTags": "태그 추가",
+    "editTags": "태그 편집",
+    "noTags": "태그 없음",
+    "updateSuccess": "태그가 업데이트되었습니다",
+    "updateFailed": "태그 업데이트에 실패했습니다",
+    "maxTags": "태그는 최대 10개",
+    "tagPlaceholder": "태그를 입력하고 Enter"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1260,5 +1260,17 @@
     "uploadedImage": "Imagem enviada {{number}}",
     "markdownSupported": "Markdown suportado",
     "pasteOrDragImages": "Cole ou arraste imagens para enviar"
+  },
+  "tags": {
+    "title": "Tags",
+    "popularTags": "Tags Populares",
+    "searchByTag": "Pesquisar por Tag",
+    "addTags": "Adicionar Tags",
+    "editTags": "Editar Tags",
+    "noTags": "Sem tags",
+    "updateSuccess": "Tags atualizadas",
+    "updateFailed": "Falha ao atualizar tags",
+    "maxTags": "Máximo de 10 tags",
+    "tagPlaceholder": "Digite uma tag e pressione Enter"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1260,5 +1260,17 @@
     "uploadedImage": "Загруженное изображение {{number}}",
     "markdownSupported": "Поддерживается Markdown",
     "pasteOrDragImages": "Вставьте или перетащите изображения для загрузки"
+  },
+  "tags": {
+    "title": "Теги",
+    "popularTags": "Популярные теги",
+    "searchByTag": "Поиск по тегу",
+    "addTags": "Добавить теги",
+    "editTags": "Редактировать теги",
+    "noTags": "Нет тегов",
+    "updateSuccess": "Теги обновлены",
+    "updateFailed": "Не удалось обновить теги",
+    "maxTags": "Максимум 10 тегов",
+    "tagPlaceholder": "Введите тег и нажмите Enter"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1260,5 +1260,17 @@
     "uploadedImage": "已上传图片 {{number}}",
     "markdownSupported": "支持Markdown",
     "pasteOrDragImages": "粘贴或拖拽图片上传"
+  },
+  "tags": {
+    "title": "标签",
+    "popularTags": "热门标签",
+    "searchByTag": "按标签搜索",
+    "addTags": "添加标签",
+    "editTags": "编辑标签",
+    "noTags": "暂无标签",
+    "updateSuccess": "标签已更新",
+    "updateFailed": "标签更新失败",
+    "maxTags": "最多10个标签",
+    "tagPlaceholder": "输入标签后按回车"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1260,5 +1260,17 @@
     "uploadedImage": "已上傳圖片 {{number}}",
     "markdownSupported": "支援Markdown",
     "pasteOrDragImages": "貼上或拖曳圖片上傳"
+  },
+  "tags": {
+    "title": "標籤",
+    "popularTags": "熱門標籤",
+    "searchByTag": "依標籤搜尋",
+    "addTags": "新增標籤",
+    "editTags": "編輯標籤",
+    "noTags": "無標籤",
+    "updateSuccess": "標籤已更新",
+    "updateFailed": "標籤更新失敗",
+    "maxTags": "最多10個標籤",
+    "tagPlaceholder": "輸入標籤後按Enter"
   }
 }

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -13,8 +13,14 @@ export interface Post {
   code_snippets?: CodeSnippet[];
   liked?: boolean;
   bookmarked?: boolean;
+  tags?: string[];
   created_at: string;
   updated_at: string;
+}
+
+export interface TagCount {
+  tag: string;
+  count: number;
 }
 
 export interface Comment {


### PR DESCRIPTION
## 概要
投稿にタグを付与・検索できる機能をTDDで実装。

## 変更内容
### バックエンド
- PostTag / TagCount モデル追加
- PostTagRepositoryInterface（SetTags, GetByPostID, FindPostsByTag, GetPopularTags）
- PostTagService（所有権チェック・タグ正規化・最大10個制限）
- 15件のユニットテスト（全通過）
- PostTagHandler / Repository / DTO
- DI・ルーター統合

### フロントエンド
- Post型にtags追加、TagCount型定義
- postTags API関数（4つ）
- usePostTags / useTagSearch / usePopularTags フック

### i18n
- 全10言語にtagsセクション（10キー）追加

closes #514