### PR TITLE
refactor: NotesPageのフォーム状態をuseNoteFormフックに抽出

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -32,6 +32,7 @@ export { useChat } from './useChat';
 export { useRecommendedUsers, useTrendingPosts, useTrendingResources } from './useRecommendations';
 export { useStudyCircles, useStudyCircleDetail, useStudyCircleActivity } from './useStudyCircles';
 export { useNotes, useNoteSearch, useArchivedNotes } from './useNotes';
+export { useNoteForm } from './useNoteForm';
 export { useNoteFolders, useRootFolders, useFolderChildren } from './useNoteFolders';
 export { useNoteTemplates, useDefaultNoteTemplate } from './useNoteTemplates';
 export { useNoteLinks, useNoteBacklinks } from './useNoteLinks';

--- a/frontend/src/hooks/useNoteForm.ts
+++ b/frontend/src/hooks/useNoteForm.ts
@@ -1,0 +1,63 @@
+import { useState, useCallback, useMemo } from 'react';
+import { useNotes } from './useNotes';
+import type { Note } from '../api/notes';
+
+export function useNoteForm() {
+  const { notes, loading, saving, favoriteNotes, createNote, updateNote, deleteNote, toggleFavorite } = useNotes();
+
+  const [showForm, setShowForm] = useState(false);
+  const [editingNote, setEditingNote] = useState<Note | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [tags, setTags] = useState('');
+
+  const resetForm = useCallback(() => {
+    setTitle('');
+    setContent('');
+    setTags('');
+    setEditingNote(null);
+    setShowForm(false);
+  }, []);
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !content.trim()) return;
+
+    if (editingNote) {
+      const result = await updateNote(editingNote.id, { title, content, tags });
+      if (result) resetForm();
+    } else {
+      const result = await createNote({ title, content, tags });
+      if (result) resetForm();
+    }
+  }, [title, content, tags, editingNote, updateNote, createNote, resetForm]);
+
+  const handleEdit = useCallback((note: Note) => {
+    setEditingNote(note);
+    setTitle(note.title);
+    setContent(note.content);
+    setTags(note.tags);
+    setShowForm(true);
+  }, []);
+
+  const filteredNotes = useMemo(() =>
+    searchQuery
+      ? notes.filter(note =>
+          note.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
+          note.content.toLowerCase().includes(searchQuery.toLowerCase())
+        )
+      : notes,
+    [notes, searchQuery]
+  );
+
+  return {
+    // Data
+    notes, favoriteNotes, filteredNotes, loading, saving,
+    // Form state
+    showForm, setShowForm, editingNote, searchQuery, setSearchQuery,
+    title, setTitle, content, setContent, tags, setTags,
+    // Actions
+    resetForm, handleSubmit, handleEdit, deleteNote, toggleFavorite,
+  };
+}

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,68 +1,18 @@
-import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BookOpen, Star, Plus, Edit, Trash2 } from 'lucide-react';
-import { useNotes } from '../hooks';
+import { useNoteForm } from '../hooks';
 import { PageLoader, SearchInput } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 import { buttonPrimaryClass, buttonSecondaryClass } from '../constants/styles';
-import type { Note } from '../api/notes';
 
 export default function NotesPage() {
   const { t } = useTranslation();
-  const { notes, loading, saving, favoriteNotes, createNote, updateNote, deleteNote, toggleFavorite } = useNotes();
-
-  const [showForm, setShowForm] = useState(false);
-  const [editingNote, setEditingNote] = useState<Note | null>(null);
-  const [searchQuery, setSearchQuery] = useState('');
-
-  // Form state
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
-  const [tags, setTags] = useState('');
-
-  const resetForm = () => {
-    setTitle('');
-    setContent('');
-    setTags('');
-    setEditingNote(null);
-    setShowForm(false);
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!title.trim() || !content.trim()) return;
-
-    if (editingNote) {
-      const result = await updateNote(editingNote.id, { title, content, tags });
-      if (result) resetForm();
-    } else {
-      const result = await createNote({ title, content, tags });
-      if (result) resetForm();
-    }
-  };
-
-  const handleEdit = (note: Note) => {
-    setEditingNote(note);
-    setTitle(note.title);
-    setContent(note.content);
-    setTags(note.tags);
-    setShowForm(true);
-  };
-
-  const handleDelete = async (id: number) => {
-    await deleteNote(id);
-  };
-
-  const handleToggleFavorite = async (id: number) => {
-    await toggleFavorite(id);
-  };
-
-  const filteredNotes = searchQuery
-    ? notes.filter(note =>
-        note.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
-        note.content.toLowerCase().includes(searchQuery.toLowerCase())
-      )
-    : notes;
+  const {
+    filteredNotes, loading, saving,
+    showForm, setShowForm, editingNote, searchQuery, setSearchQuery,
+    title, setTitle, content, setContent, tags, setTags,
+    resetForm, handleSubmit, handleEdit, deleteNote, toggleFavorite,
+  } = useNoteForm();
 
   if (loading) return <PageLoader />;
 
@@ -189,7 +139,7 @@ export default function NotesPage() {
                 </div>
                 <div className="flex gap-2 ml-4">
                   <button
-                    onClick={() => handleToggleFavorite(note.id)}
+                    onClick={() => toggleFavorite(note.id)}
                     className="p-2 text-gray-400 hover:text-yellow-500 transition-colors"
                     title={t('notes.favorites')}
                   >
@@ -203,7 +153,7 @@ export default function NotesPage() {
                     <Edit className="w-5 h-5" />
                   </button>
                   <button
-                    onClick={() => handleDelete(note.id)}
+                    onClick={() => deleteNote(note.id)}
                     className="p-2 text-gray-400 hover:text-red-500 transition-colors"
                     title={t('common.delete')}
                   >


### PR DESCRIPTION
## 概要
NotesPageに散在していた6つのuseStateとフォームハンドラーをuseNoteFormフックに抽出。

## 変更内容
- `hooks/useNoteForm.ts` 新規作成（フォーム状態・ハンドラー・検索フィルター）
- `NotesPage.tsx` をUIのみに簡素化（useState直接使用を排除）
- バレルエクスポート更新

## テスト計画
- [x] TypeScriptチェック通過
- [ ] CI通過確認

closes #522