### PR TITLE
test: MessageServiceの未テストメソッドにエラーケーステスト追加

### DIFF
--- a/backend/internal/service/message_test.go
+++ b/backend/internal/service/message_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -86,5 +87,93 @@ func TestMessageMarkAsRead_Success(t *testing.T) {
 
 	err := svc.MarkAsRead(2, 1)
 	assert.NoError(t, err)
+	msgRepo.AssertExpectations(t)
+}
+
+// ============================================================
+// 会話一覧取得エラーテスト
+// ============================================================
+
+func TestMessageGetConversations_RepoError(t *testing.T) {
+	svc, msgRepo, _ := newTestMessageService()
+
+	msgRepo.On("GetConversations", uint(1)).Return([]repository.ConversationSummary(nil), errors.New("db error"))
+
+	result, err := svc.GetConversations(1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	msgRepo.AssertExpectations(t)
+}
+
+func TestMessageGetConversations_Empty(t *testing.T) {
+	svc, msgRepo, _ := newTestMessageService()
+
+	msgRepo.On("GetConversations", uint(1)).Return([]repository.ConversationSummary{}, nil)
+
+	result, err := svc.GetConversations(1)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	msgRepo.AssertExpectations(t)
+}
+
+// ============================================================
+// GetConversation エラー・エッジケーステスト
+// ============================================================
+
+func TestMessageGetConversation_MarkAsReadFails_StillReturnsMessages(t *testing.T) {
+	svc, msgRepo, _ := newTestMessageService()
+
+	// MarkAsReadが失敗してもメッセージ取得は成功する
+	msgRepo.On("MarkAsRead", uint(2), uint(1)).Return(errors.New("mark read failed"))
+
+	messages := []model.Message{{Content: "Hello"}}
+	msgRepo.On("GetConversation", uint(1), uint(2), 1, 20).Return(messages, nil)
+
+	result, err := svc.GetConversation(1, 2, 1, 20)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	msgRepo.AssertExpectations(t)
+}
+
+func TestMessageGetConversation_RepoError(t *testing.T) {
+	svc, msgRepo, _ := newTestMessageService()
+
+	msgRepo.On("MarkAsRead", uint(2), uint(1)).Return(nil)
+	msgRepo.On("GetConversation", uint(1), uint(2), 1, 20).Return([]model.Message(nil), errors.New("db error"))
+
+	result, err := svc.GetConversation(1, 2, 1, 20)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	msgRepo.AssertExpectations(t)
+}
+
+// ============================================================
+// メッセージ送信エラーテスト
+// ============================================================
+
+func TestMessageSendMessage_CreateError(t *testing.T) {
+	svc, msgRepo, notifRepo := newTestMessageService()
+
+	msg := &model.Message{SenderID: 1, ReceiverID: 2, Content: "Hello!"}
+	msgRepo.On("Create", msg).Return(errors.New("db error"))
+
+	err := svc.SendMessage(msg)
+	assert.Error(t, err)
+	msgRepo.AssertExpectations(t)
+	// Create失敗時は通知が送られないことを確認
+	notifRepo.AssertNotCalled(t, "Create")
+}
+
+// ============================================================
+// 既読マークエラーテスト
+// ============================================================
+
+func TestMessageMarkAsRead_RepoError(t *testing.T) {
+	svc, msgRepo, _ := newTestMessageService()
+
+	msgRepo.On("MarkAsRead", uint(2), uint(1)).Return(errors.New("db error"))
+
+	err := svc.MarkAsRead(2, 1)
+	assert.Error(t, err)
 	msgRepo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
MessageServiceの既存4テスト（成功ケースのみ）に6件のエラー・エッジケーステストを追加。

## 追加テスト
- `TestMessageGetConversations_RepoError` — リポジトリエラー時
- `TestMessageGetConversations_Empty` — 空結果ケース
- `TestMessageGetConversation_MarkAsReadFails_StillReturnsMessages` — MarkAsRead失敗でもメッセージ返却
- `TestMessageGetConversation_RepoError` — GetConversationリポジトリエラー
- `TestMessageSendMessage_CreateError` — Create失敗時に通知未送信を確認
- `TestMessageMarkAsRead_RepoError` — 既読マーク失敗

## テスト計画
- [x] 全10テスト通過
- [ ] CI通過確認

closes #524