### PR TITLE
feat: 学習目標のデッドラインアラート機能をTDDで実装

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -16,6 +16,7 @@ type LearningGoalServiceInterface interface {
 	GetStats(userID uint) (*model.LearningGoalStats, error)
 	Update(id, userID uint, updates *model.LearningGoal) (*model.LearningGoal, error)
 	Delete(id, userID uint) error
+	GetDeadlineAlerts(userID uint) ([]model.GoalDeadlineAlert, error)
 }
 
 // LearningGoalHandler は学習目標関連のHTTPハンドラ。
@@ -176,6 +177,22 @@ func (h *LearningGoalHandler) GetMyGoals(c *gin.Context) {
 	}
 
 	respondOK(c, goals)
+}
+
+// GetDeadlineAlerts は認証ユーザーのデッドラインアラートを取得する。
+func (h *LearningGoalHandler) GetDeadlineAlerts(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	alerts, err := h.service.GetDeadlineAlerts(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if alerts == nil {
+		alerts = []model.GoalDeadlineAlert{}
+	}
+
+	respondOK(c, alerts)
 }
 
 // GetStats は指定されたユーザーの学習目標統計情報を取得する。

--- a/backend/internal/model/learning_goal.go
+++ b/backend/internal/model/learning_goal.go
@@ -40,6 +40,13 @@ type LearningGoal struct {
 	CompletedAt *time.Time   `json:"completed_at"`                      // 完了日時（完了時に自動設定）
 }
 
+// GoalDeadlineAlert はデッドラインが近い・超過した目標のアラート情報を表す。
+type GoalDeadlineAlert struct {
+	Goal     LearningGoal `json:"goal"`
+	Status   string       `json:"status"`    // "overdue" or "approaching"
+	DaysLeft int          `json:"days_left"` // 残り日数（超過時は負数）
+}
+
 // LearningGoalStats はユーザーの学習目標統計情報を表す。
 type LearningGoalStats struct {
 	TotalGoals      int `json:"total_goals"`

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -298,6 +298,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		goals.DELETE("/:id", c.LearningGoalHandler.Delete)
 		goals.GET("/user/:userId", c.LearningGoalHandler.GetByUserID)
 		goals.GET("/stats/:userId", c.LearningGoalHandler.GetStats)
+		goals.GET("/deadline-alerts", c.LearningGoalHandler.GetDeadlineAlerts)
 	}
 
 	// アクティビティレポート

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -94,6 +94,57 @@ func (s *LearningGoalService) Update(id, userID uint, updates *model.LearningGoa
 	return goal, nil
 }
 
+// DeadlineStatus はアクティブな目標のデッドライン状態を判定する純粋関数。
+// "overdue"（期限超過）、"approaching"（3日以内）、""（安全/対象外）を返す。
+func DeadlineStatus(goal *model.LearningGoal, now time.Time) string {
+	if goal.TargetDate == nil || goal.Status != model.GoalStatusActive {
+		return ""
+	}
+	days := int(goal.TargetDate.Sub(now).Hours() / 24)
+	if goal.TargetDate.Before(now) && days < 0 {
+		return "overdue"
+	}
+	if days <= 3 {
+		return "approaching"
+	}
+	return ""
+}
+
+// DaysUntilDeadline は目標の期限までの残り日数を返す。
+// TargetDateがnilまたは期限超過の場合は-1を返す。
+func DaysUntilDeadline(goal *model.LearningGoal, now time.Time) int {
+	if goal.TargetDate == nil {
+		return -1
+	}
+	days := int(goal.TargetDate.Sub(now).Hours() / 24)
+	if days < 0 {
+		return -1
+	}
+	return days
+}
+
+// GetDeadlineAlerts はユーザーのアクティブ目標からデッドラインアラートを取得する。
+func (s *LearningGoalService) GetDeadlineAlerts(userID uint) ([]model.GoalDeadlineAlert, error) {
+	goals, err := s.repo.GetActiveByUserID(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	var alerts []model.GoalDeadlineAlert
+	for _, g := range goals {
+		status := DeadlineStatus(&g, now)
+		if status != "" {
+			alerts = append(alerts, model.GoalDeadlineAlert{
+				Goal:     g,
+				Status:   status,
+				DaysLeft: DaysUntilDeadline(&g, now),
+			})
+		}
+	}
+	return alerts, nil
+}
+
 // Delete は所有権を検証した後、学習目標を削除する。
 func (s *LearningGoalService) Delete(id, userID uint) error {
 	goal, err := s.repo.FindByID(id)

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -304,5 +305,151 @@ func TestLearningGoalDelete_Forbidden(t *testing.T) {
 
 	err := svc.Delete(1, 999)
 	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// デッドラインステータス判定テスト（純粋関数）
+// ============================================================
+
+func TestDeadlineStatus_NoTargetDate(t *testing.T) {
+	now := time.Now()
+	goal := model.LearningGoal{Status: model.GoalStatusActive}
+	assert.Equal(t, "", DeadlineStatus(&goal, now))
+}
+
+func TestDeadlineStatus_CompletedGoal(t *testing.T) {
+	now := time.Now()
+	yesterday := now.AddDate(0, 0, -1)
+	goal := model.LearningGoal{
+		Status:     model.GoalStatusCompleted,
+		TargetDate: &yesterday,
+	}
+	assert.Equal(t, "", DeadlineStatus(&goal, now))
+}
+
+func TestDeadlineStatus_PausedGoal(t *testing.T) {
+	now := time.Now()
+	yesterday := now.AddDate(0, 0, -1)
+	goal := model.LearningGoal{
+		Status:     model.GoalStatusPaused,
+		TargetDate: &yesterday,
+	}
+	assert.Equal(t, "", DeadlineStatus(&goal, now))
+}
+
+func TestDeadlineStatus_Overdue(t *testing.T) {
+	now := time.Now()
+	pastDate := now.AddDate(0, 0, -2)
+	goal := model.LearningGoal{
+		Status:     model.GoalStatusActive,
+		TargetDate: &pastDate,
+	}
+	assert.Equal(t, "overdue", DeadlineStatus(&goal, now))
+}
+
+func TestDeadlineStatus_Approaching_Today(t *testing.T) {
+	now := time.Now()
+	today := now
+	goal := model.LearningGoal{
+		Status:     model.GoalStatusActive,
+		TargetDate: &today,
+	}
+	assert.Equal(t, "approaching", DeadlineStatus(&goal, now))
+}
+
+func TestDeadlineStatus_Approaching_3Days(t *testing.T) {
+	now := time.Now()
+	threeDays := now.AddDate(0, 0, 3)
+	goal := model.LearningGoal{
+		Status:     model.GoalStatusActive,
+		TargetDate: &threeDays,
+	}
+	assert.Equal(t, "approaching", DeadlineStatus(&goal, now))
+}
+
+func TestDeadlineStatus_Safe_4Days(t *testing.T) {
+	now := time.Now()
+	fourDays := now.AddDate(0, 0, 4)
+	goal := model.LearningGoal{
+		Status:     model.GoalStatusActive,
+		TargetDate: &fourDays,
+	}
+	assert.Equal(t, "", DeadlineStatus(&goal, now))
+}
+
+// ============================================================
+// DaysUntilDeadline テスト
+// ============================================================
+
+func TestDaysUntilDeadline_NoTargetDate(t *testing.T) {
+	now := time.Now()
+	goal := model.LearningGoal{}
+	assert.Equal(t, -1, DaysUntilDeadline(&goal, now))
+}
+
+func TestDaysUntilDeadline_Tomorrow(t *testing.T) {
+	now := time.Now()
+	tomorrow := now.AddDate(0, 0, 1)
+	goal := model.LearningGoal{TargetDate: &tomorrow}
+	assert.Equal(t, 1, DaysUntilDeadline(&goal, now))
+}
+
+func TestDaysUntilDeadline_Yesterday(t *testing.T) {
+	now := time.Now()
+	yesterday := now.AddDate(0, 0, -1)
+	goal := model.LearningGoal{TargetDate: &yesterday}
+	assert.Equal(t, -1, DaysUntilDeadline(&goal, now))
+}
+
+// ============================================================
+// GetDeadlineAlerts サービステスト
+// ============================================================
+
+func TestGetDeadlineAlerts_Success(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	now := time.Now()
+	overdue := now.AddDate(0, 0, -2)
+	approaching := now.AddDate(0, 0, 2)
+	safe := now.AddDate(0, 0, 10)
+
+	goals := []model.LearningGoal{
+		{Title: "Overdue Goal", Status: model.GoalStatusActive, TargetDate: &overdue},
+		{Title: "Approaching Goal", Status: model.GoalStatusActive, TargetDate: &approaching},
+		{Title: "Safe Goal", Status: model.GoalStatusActive, TargetDate: &safe},
+		{Title: "No Deadline", Status: model.GoalStatusActive},
+	}
+	repo.On("GetActiveByUserID", uint(1)).Return(goals, nil)
+
+	alerts, err := svc.GetDeadlineAlerts(1)
+	assert.NoError(t, err)
+	assert.Len(t, alerts, 2)
+	assert.Equal(t, "overdue", alerts[0].Status)
+	assert.Equal(t, "Overdue Goal", alerts[0].Goal.Title)
+	assert.Equal(t, "approaching", alerts[1].Status)
+	assert.Equal(t, "Approaching Goal", alerts[1].Goal.Title)
+	repo.AssertExpectations(t)
+}
+
+func TestGetDeadlineAlerts_Empty(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	repo.On("GetActiveByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+
+	alerts, err := svc.GetDeadlineAlerts(1)
+	assert.NoError(t, err)
+	assert.Empty(t, alerts)
+	repo.AssertExpectations(t)
+}
+
+func TestGetDeadlineAlerts_RepoError(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	repo.On("GetActiveByUserID", uint(1)).Return([]model.LearningGoal{}, assert.AnError)
+
+	alerts, err := svc.GetDeadlineAlerts(1)
+	assert.Error(t, err)
+	assert.Nil(t, alerts)
 	repo.AssertExpectations(t)
 }

--- a/frontend/src/api/goals.ts
+++ b/frontend/src/api/goals.ts
@@ -24,6 +24,12 @@ export interface LearningGoalStats {
   average_progress: number;
 }
 
+export interface GoalDeadlineAlert {
+  goal: LearningGoal;
+  status: 'overdue' | 'approaching';
+  days_left: number;
+}
+
 export interface CreateGoalRequest {
   title: string;
   description?: string;
@@ -60,3 +66,6 @@ export const getUserGoals = (userId: number) =>
 
 export const getGoalStats = (userId: number) =>
   client.get<LearningGoalStats>(`/goals/stats/${userId}`);
+
+export const getDeadlineAlerts = () =>
+  client.get<GoalDeadlineAlert[]>('/goals/deadline-alerts');

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -508,6 +508,8 @@
     "goalDescriptionPlaceholder": "Beschreiben Sie Ihr Ziel...",
     "category": "Kategorie",
     "targetDate": "Zieldatum",
+    "deadlineOverdue": "Überfällig",
+    "deadlineApproaching": "Noch {{days}} Tage",
     "status": "Status",
     "active": "Aktiv",
     "completed": "Abgeschlossen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -508,6 +508,8 @@
     "goalDescriptionPlaceholder": "Describe your goal...",
     "category": "Category",
     "targetDate": "Target Date",
+    "deadlineOverdue": "Overdue",
+    "deadlineApproaching": "{{days}} days left",
     "status": "Status",
     "active": "Active",
     "completed": "Completed",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -508,6 +508,8 @@
     "goalDescriptionPlaceholder": "Describe tu objetivo...",
     "category": "Categoría",
     "targetDate": "Fecha Objetivo",
+    "deadlineOverdue": "Vencido",
+    "deadlineApproaching": "{{days}} días restantes",
     "status": "Estado",
     "active": "Activo",
     "completed": "Completado",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -508,6 +508,8 @@
     "goalDescriptionPlaceholder": "Décrivez votre objectif...",
     "category": "Catégorie",
     "targetDate": "Date cible",
+    "deadlineOverdue": "En retard",
+    "deadlineApproaching": "{{days}} jours restants",
     "status": "Statut",
     "active": "Actif",
     "completed": "Terminé",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -497,6 +497,8 @@
     "category": "カテゴリ",
     "targetDate": "目標日",
     "targetDateLabel": "目標日",
+    "deadlineOverdue": "期限超過",
+    "deadlineApproaching": "あと{{days}}日",
     "progress": "進捗",
     "status": "ステータス",
     "active": "進行中",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -508,6 +508,8 @@
     "goalDescriptionPlaceholder": "목표를 설명하세요...",
     "category": "카테고리",
     "targetDate": "목표 날짜",
+    "deadlineOverdue": "기한 초과",
+    "deadlineApproaching": "{{days}}일 남음",
     "status": "상태",
     "active": "진행 중",
     "completed": "완료",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -508,6 +508,8 @@
     "goalDescriptionPlaceholder": "Descreva sua meta...",
     "category": "Categoria",
     "targetDate": "Data Alvo",
+    "deadlineOverdue": "Atrasado",
+    "deadlineApproaching": "{{days}} dias restantes",
     "status": "Status",
     "active": "Ativo",
     "completed": "Concluído",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -508,6 +508,8 @@
     "goalDescriptionPlaceholder": "Опишите свою цель...",
     "category": "Категория",
     "targetDate": "Целевая дата",
+    "deadlineOverdue": "Просрочено",
+    "deadlineApproaching": "Осталось {{days}} дн.",
     "status": "Статус",
     "active": "Активная",
     "completed": "Завершена",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -508,6 +508,8 @@
     "goalDescriptionPlaceholder": "描述你的目标...",
     "category": "类别",
     "targetDate": "目标日期",
+    "deadlineOverdue": "已逾期",
+    "deadlineApproaching": "还剩{{days}}天",
     "status": "状态",
     "active": "进行中",
     "completed": "已完成",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -508,6 +508,8 @@
     "goalDescriptionPlaceholder": "描述你的目標...",
     "category": "類別",
     "targetDate": "目標日期",
+    "deadlineOverdue": "已逾期",
+    "deadlineApproaching": "還剩{{days}}天",
     "status": "狀態",
     "active": "進行中",
     "completed": "已完成",

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -30,6 +30,17 @@ const getStatusColor = (status: GoalStatus) => {
   }
 };
 
+const getDeadlineInfo = (goal: LearningGoal): { status: 'overdue' | 'approaching' | ''; daysLeft: number } => {
+  if (!goal.target_date || goal.status !== 'active') return { status: '', daysLeft: -1 };
+  const now = new Date();
+  const target = new Date(goal.target_date);
+  const diffMs = target.getTime() - now.getTime();
+  const days = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+  if (days < 0) return { status: 'overdue', daysLeft: days };
+  if (days <= 3) return { status: 'approaching', daysLeft: days };
+  return { status: '', daysLeft: days };
+};
+
 export default function GoalsPage() {
   const { t } = useTranslation();
   const {
@@ -289,6 +300,24 @@ function GoalCard({
                   {t('goals.targetDateLabel')}: {new Date(goal.target_date).toLocaleDateString()}
                 </span>
               )}
+              {(() => {
+                const deadline = getDeadlineInfo(goal);
+                if (deadline.status === 'overdue') {
+                  return (
+                    <span className="px-2 py-0.5 rounded-full text-red-400 bg-red-400/10 font-medium">
+                      {t('goals.deadlineOverdue')}
+                    </span>
+                  );
+                }
+                if (deadline.status === 'approaching') {
+                  return (
+                    <span className="px-2 py-0.5 rounded-full text-orange-400 bg-orange-400/10 font-medium">
+                      {t('goals.deadlineApproaching', { days: deadline.daysLeft })}
+                    </span>
+                  );
+                }
+                return null;
+              })()}
             </div>
 
             {/* Progress Bar */}


### PR DESCRIPTION
## 概要
学習目標の期限が迫っている・超過した場合にGoalCardにアラートバッジを表示する機能を追加。

## 変更内容
### バックエンド
- `DeadlineStatus` 純粋関数: 期限超過("overdue") / 3日以内("approaching") / 安全("") を判定
- `DaysUntilDeadline` 純粋関数: 期限までの残り日数を計算
- `GetDeadlineAlerts` サービスメソッド: アクティブ目標からアラート対象を取得
- `GET /goals/deadline-alerts` APIエンドポイント追加
- `GoalDeadlineAlert` モデル追加

### フロントエンド
- GoalCardにデッドラインバッジ表示（赤: 期限超過、オレンジ: 残り日数）
- API関数 `getDeadlineAlerts()` 追加
- 全10言語のi18n対応

## テスト（TDD: 13件追加）
- DeadlineStatus: 7パターン（対象外3 + overdue1 + approaching2 + safe1）
- DaysUntilDeadline: 3パターン（なし/明日/昨日）
- GetDeadlineAlerts: 3パターン（正常/空/エラー）

Closes #536