### PR TITLE
feat: 投稿のブックマーク数表示機能を実装

### DIFF
--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -11,8 +11,9 @@ type Post struct {
 	Content      string    `json:"content" gorm:"type:text;not null"`
 	ImageURLs    string    `json:"image_urls" gorm:"type:text"` // カンマ区切りの画像URL
 	IsDraft      bool      `json:"is_draft" gorm:"default:false;index"` // 下書きフラグ
-	LikeCount    int       `json:"like_count" gorm:"default:0"`
+	LikeCount         int            `json:"like_count" gorm:"default:0"`
 	CommentCount      int            `json:"comment_count" gorm:"default:0"`
+	BookmarkCount     int            `json:"bookmark_count" gorm:"default:0"`
 	EstimatedReadTime int            `json:"estimated_read_time" gorm:"default:0"`
 	CodeSnippets      []CodeSnippet  `json:"code_snippets,omitempty" gorm:"foreignKey:PostID"`
 	CreatedAt    time.Time      `json:"created_at"`

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -152,12 +152,20 @@ func (r *PostRepository) Search(query string, limit, offset int) (interface{}, i
 
 // Bookmark は投稿をブックマークする。
 func (r *PostRepository) Bookmark(userID, postID uint) error {
-	return r.db.Create(&model.Bookmark{UserID: userID, PostID: postID}).Error
+	err := r.db.Create(&model.Bookmark{UserID: userID, PostID: postID}).Error
+	if err != nil {
+		return err
+	}
+	return r.db.Model(&model.Post{}).Where("id = ?", postID).UpdateColumn("bookmark_count", gorm.Expr("bookmark_count + 1")).Error
 }
 
-// Unbookmark は投稿のブックマークを解除する。
+// Unbookmark は投稿のブックマークを解除し、bookmark_countをデクリメントする。
 func (r *PostRepository) Unbookmark(userID, postID uint) error {
-	return r.db.Where("user_id = ? AND post_id = ?", userID, postID).Delete(&model.Bookmark{}).Error
+	result := r.db.Where("user_id = ? AND post_id = ?", userID, postID).Delete(&model.Bookmark{})
+	if result.RowsAffected > 0 {
+		r.db.Model(&model.Post{}).Where("id = ?", postID).UpdateColumn("bookmark_count", gorm.Expr("GREATEST(bookmark_count - 1, 0)"))
+	}
+	return result.Error
 }
 
 // HasBookmarked は指定ユーザーが投稿をブックマーク済みかどうかを判定する。

--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -330,6 +330,7 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
           <svg className="w-4 h-4" fill={bookmarked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
           </svg>
+          {post.bookmark_count > 0 && <span>{post.bookmark_count}</span>}
         </button>
       </div>
     </div>

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -10,6 +10,7 @@ export interface Post {
   is_draft: boolean;
   like_count: number;
   comment_count: number;
+  bookmark_count: number;
   estimated_read_time: number;
   code_snippets?: CodeSnippet[];
   liked?: boolean;


### PR DESCRIPTION
## 概要
投稿カードにブックマーク数を表示する機能を追加。

## 変更内容
### バックエンド
- `Post` モデルに `BookmarkCount int` フィールドを追加（`gorm:"default:0"`）
- `Bookmark` リポジトリメソッド: ブックマーク追加時に `bookmark_count` をインクリメント
- `Unbookmark` リポジトリメソッド: ブックマーク解除時に `bookmark_count` をデクリメント（`GREATEST(..., 0)`で負数防止）

### フロントエンド
- `Post` 型に `bookmark_count: number` を追加
- `PostCard` のブックマークボタン横にカウント数を表示

## テスト
- 既存の Bookmark/Unbookmark テスト全パス
- TypeScript型チェック OK

Closes #537