### PR TITLE
feat: 投稿閲覧数をPostモデルに統合しカード上にリアルタイム表示

### DIFF
--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -14,6 +14,7 @@ type Post struct {
 	LikeCount         int            `json:"like_count" gorm:"default:0"`
 	CommentCount      int            `json:"comment_count" gorm:"default:0"`
 	BookmarkCount     int            `json:"bookmark_count" gorm:"default:0"`
+	ViewCount         int            `json:"view_count" gorm:"default:0"`
 	EstimatedReadTime int            `json:"estimated_read_time" gorm:"default:0"`
 	CodeSnippets      []CodeSnippet  `json:"code_snippets,omitempty" gorm:"foreignKey:PostID"`
 	CreatedAt    time.Time      `json:"created_at"`

--- a/backend/internal/repository/post_view.go
+++ b/backend/internal/repository/post_view.go
@@ -16,7 +16,12 @@ func NewPostViewRepository(db *gorm.DB) *PostViewRepository {
 }
 
 func (r *PostViewRepository) RecordView(view *model.PostView) error {
-	return r.db.Create(view).Error
+	err := r.db.Create(view).Error
+	if err != nil {
+		return err
+	}
+	return r.db.Model(&model.Post{}).Where("id = ?", view.PostID).
+		UpdateColumn("view_count", gorm.Expr("view_count + 1")).Error
 }
 
 func (r *PostViewRepository) GetViewCount(postID uint) (int64, error) {

--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -320,6 +320,15 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
             </div>
           )}
         </div>
+        {post.view_count > 0 && (
+          <span className="flex items-center gap-1.5 text-sm text-gray-500">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+            </svg>
+            {post.view_count}
+          </span>
+        )}
         <button
           onClick={handleBookmark}
           className={`flex items-center gap-1.5 text-sm transition-colors ml-auto ${

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -11,6 +11,7 @@ export interface Post {
   like_count: number;
   comment_count: number;
   bookmark_count: number;
+  view_count: number;
   estimated_read_time: number;
   code_snippets?: CodeSnippet[];
   liked?: boolean;


### PR DESCRIPTION
## 概要
- Post構造体に`ViewCount`フィールドを追加（like_count/bookmark_countと同パターン）
- `RecordView`時に`view_count`をアトミックにインクリメント
- PostCardに目アイコン付き閲覧数を表示（0件時は非表示）
- フロントエンドのPost型に`view_count`フィールドを追加

## 変更ファイル
- `backend/internal/model/post.go` — ViewCountフィールド追加
- `backend/internal/repository/post_view.go` — RecordViewでview_countインクリメント
- `frontend/src/types/post.ts` — view_countプロパティ追加
- `frontend/src/components/posts/PostCard.tsx` — 閲覧数表示UI追加

## テスト
- [x] Go service テスト全件PASS
- [x] TypeScript型チェック通過

Closes #541