### PR TITLE
test: Service層テストカバレッジを80%超に向上

### DIFF
--- a/backend/internal/service/ai_rule_engine_test.go
+++ b/backend/internal/service/ai_rule_engine_test.go
@@ -408,3 +408,119 @@ func TestGenerateAdvice_EmptyContext(t *testing.T) {
 		assert.Equal(t, "advice.exploreResources", advices[0].TitleKey)
 	})
 }
+
+func TestGenerateAdvice_ContextCollectionError_StreakInfo(t *testing.T) {
+	t.Run("StreakInfo取得エラー時は空スライスを返す", func(t *testing.T) {
+		svc, logRepo, _, _, _, _, _ := setupRuleEngineService()
+
+		logRepo.On("GetStreakInfo", uint(1)).Return(nil, assert.AnError)
+
+		advices := svc.GenerateAdvice(1)
+		assert.Empty(t, advices)
+	})
+}
+
+func TestGenerateAdvice_ContextCollectionError_Goals(t *testing.T) {
+	t.Run("Goals取得エラー時は空スライスを返す", func(t *testing.T) {
+		svc, logRepo, goalRepo, _, _, _, _ := setupRuleEngineService()
+
+		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, assert.AnError)
+
+		advices := svc.GenerateAdvice(1)
+		assert.Empty(t, advices)
+	})
+}
+
+func TestGenerateAdvice_ContextCollectionError_GoalStats(t *testing.T) {
+	t.Run("GoalStats取得エラー時は空スライスを返す", func(t *testing.T) {
+		svc, logRepo, goalRepo, _, _, _, _ := setupRuleEngineService()
+
+		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetStats", uint(1)).Return(nil, assert.AnError)
+
+		advices := svc.GenerateAdvice(1)
+		assert.Empty(t, advices)
+	})
+}
+
+func TestGenerateAdvice_ContextCollectionError_Roadmaps(t *testing.T) {
+	t.Run("Roadmap取得エラー時は空スライスを返す", func(t *testing.T) {
+		svc, logRepo, goalRepo, roadmapRepo, _, _, _ := setupRuleEngineService()
+
+		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
+		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, assert.AnError)
+
+		advices := svc.GenerateAdvice(1)
+		assert.Empty(t, advices)
+	})
+}
+
+func TestGenerateAdvice_ContextCollectionError_LanguageStats(t *testing.T) {
+	t.Run("LanguageStats取得エラー時は空スライスを返す", func(t *testing.T) {
+		svc, logRepo, goalRepo, roadmapRepo, githubRepo, _, _ := setupRuleEngineService()
+
+		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
+		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, assert.AnError)
+
+		advices := svc.GenerateAdvice(1)
+		assert.Empty(t, advices)
+	})
+}
+
+func TestGenerateAdvice_ContextCollectionError_Logs(t *testing.T) {
+	t.Run("Logs取得エラー時は空スライスを返す", func(t *testing.T) {
+		svc, logRepo, goalRepo, roadmapRepo, githubRepo, _, _ := setupRuleEngineService()
+
+		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
+		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
+		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, assert.AnError)
+
+		advices := svc.GenerateAdvice(1)
+		assert.Empty(t, advices)
+	})
+}
+
+func TestGenerateAdvice_ContextCollectionError_Resources(t *testing.T) {
+	t.Run("Resources取得エラー時は空スライスを返す", func(t *testing.T) {
+		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, _ := setupRuleEngineService()
+
+		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
+		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
+		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, assert.AnError)
+
+		advices := svc.GenerateAdvice(1)
+		assert.Empty(t, advices)
+	})
+}
+
+func TestGenerateAdvice_ContextCollectionError_User(t *testing.T) {
+	t.Run("User取得エラー時は空スライスを返す", func(t *testing.T) {
+		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
+
+		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
+		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
+		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+		userRepo.On("FindByID", uint(1)).Return(nil, assert.AnError)
+
+		advices := svc.GenerateAdvice(1)
+		assert.Empty(t, advices)
+	})
+}

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -80,6 +80,32 @@ func TestAnswerUpdate_Forbidden(t *testing.T) {
 	answerRepo.AssertExpectations(t)
 }
 
+func TestAnswerUpdate_NotFound(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answerRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	result, err := svc.Update(999, 1, "New Body")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	answerRepo.AssertExpectations(t)
+}
+
+func TestAnswerUpdate_RepoError(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	existing := &model.Answer{Body: "Old Body", UserID: 1}
+	existing.ID = 1
+
+	answerRepo.On("FindByID", uint(1)).Return(existing, nil)
+	answerRepo.On("Update", existing).Return(errors.New("db error"))
+
+	result, err := svc.Update(1, 1, "New Body")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	answerRepo.AssertExpectations(t)
+}
+
 // ============================================================
 // 回答削除テスト
 // ============================================================
@@ -108,6 +134,30 @@ func TestAnswerDelete_Forbidden(t *testing.T) {
 
 	err := svc.Delete(1, 999)
 	assert.ErrorIs(t, err, ErrForbidden)
+	answerRepo.AssertExpectations(t)
+}
+
+func TestAnswerDelete_NotFound(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answerRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.Delete(999, 1)
+	assert.Error(t, err)
+	answerRepo.AssertExpectations(t)
+}
+
+func TestAnswerDelete_RepoError(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	existing := &model.Answer{UserID: 1}
+	existing.ID = 1
+
+	answerRepo.On("FindByID", uint(1)).Return(existing, nil)
+	answerRepo.On("Delete", existing).Return(errors.New("db error"))
+
+	err := svc.Delete(1, 1)
+	assert.Error(t, err)
 	answerRepo.AssertExpectations(t)
 }
 
@@ -171,6 +221,39 @@ func TestSetBestAnswer_QuestionNotFound(t *testing.T) {
 
 	err := svc.SetBestAnswer(999, 5, 1)
 	assert.ErrorIs(t, err, ErrNotFound)
+	questionRepo.AssertExpectations(t)
+}
+
+func TestSetBestAnswer_AnswerNotFound(t *testing.T) {
+	svc, answerRepo, questionRepo := newTestAnswerService()
+
+	question := &model.Question{UserID: 1}
+	question.ID = 10
+	questionRepo.On("FindByID", uint(10)).Return(question, nil)
+
+	answerRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.SetBestAnswer(10, 999, 1)
+	assert.ErrorIs(t, err, ErrNotFound)
+	answerRepo.AssertExpectations(t)
+	questionRepo.AssertExpectations(t)
+}
+
+func TestSetBestAnswer_RepoError(t *testing.T) {
+	svc, answerRepo, questionRepo := newTestAnswerService()
+
+	question := &model.Question{UserID: 1}
+	question.ID = 10
+	questionRepo.On("FindByID", uint(10)).Return(question, nil)
+
+	answer := &model.Answer{QuestionID: 10}
+	answer.ID = 5
+	answerRepo.On("FindByID", uint(5)).Return(answer, nil)
+	answerRepo.On("SetBestAnswer", uint(10), uint(5)).Return(errors.New("db error"))
+
+	err := svc.SetBestAnswer(10, 5, 1)
+	assert.Error(t, err)
+	answerRepo.AssertExpectations(t)
 	questionRepo.AssertExpectations(t)
 }
 

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -63,6 +63,62 @@ func TestRegister_DuplicateEmail(t *testing.T) {
 	userRepo.AssertExpectations(t)
 }
 
+func TestRegister_InvalidEmail(t *testing.T) {
+	svc, _, _ := newTestAuthService()
+
+	resp, err := svc.Register(RegisterInput{
+		Name:     "testuser",
+		Email:    "invalid-email",
+		Password: "password123",
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestRegister_InvalidPassword(t *testing.T) {
+	svc, _, _ := newTestAuthService()
+
+	resp, err := svc.Register(RegisterInput{
+		Name:     "testuser",
+		Email:    "test@example.com",
+		Password: "short",
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestRegister_InvalidUsername(t *testing.T) {
+	svc, _, _ := newTestAuthService()
+
+	resp, err := svc.Register(RegisterInput{
+		Name:     "",
+		Email:    "test@example.com",
+		Password: "password123",
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+}
+
+func TestRegister_CreateUserError(t *testing.T) {
+	svc, userRepo, _ := newTestAuthService()
+
+	userRepo.On("FindByEmail", "new@example.com").Return(nil, errors.New("not found"))
+	userRepo.On("Create", mock.AnythingOfType("*model.User")).Return(errors.New("db error"))
+
+	resp, err := svc.Register(RegisterInput{
+		Name:     "testuser",
+		Email:    "new@example.com",
+		Password: "password123",
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	userRepo.AssertExpectations(t)
+}
+
 // ============================================================
 // ログインテスト
 // ============================================================

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -160,6 +160,21 @@ func TestBookReviewUpdate_NotFound(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestBookReviewUpdate_RepoError(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Old", Rating: 4}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+
+	updates := &model.BookReview{Title: "New"}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
 // ============================================================
 // 書籍レビュー削除テスト
 // ============================================================
@@ -189,4 +204,11 @@ func TestBookReviewDelete_Forbidden(t *testing.T) {
 	err := svc.Delete(1, 999)
 	assert.ErrorIs(t, err, ErrForbidden)
 	repo.AssertExpectations(t)
+}
+
+func TestBookReviewDelete_NotFound(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.Delete(99, 1)
+	assert.Error(t, err)
 }

--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -65,6 +66,52 @@ func TestChatRoomCreate_SkipDuplicateOwner(t *testing.T) {
 	assert.NotNil(t, result)
 	// AddMember は ownerID=1 の1回のみ呼ばれる
 	roomRepo.AssertNumberOfCalls(t, "AddMember", 1)
+}
+
+func TestChatRoomCreate_RepoError(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{Name: "Test Room", OwnerID: 1}
+	roomRepo.On("Create", room).Return(errors.New("db error"))
+
+	result, err := svc.Create(room, []uint{2})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	roomRepo.AssertExpectations(t)
+}
+
+func TestChatRoomCreate_AddMemberError(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{Name: "Test Room", OwnerID: 1}
+	roomRepo.On("Create", room).Run(func(args mock.Arguments) {
+		r := args.Get(0).(*model.ChatRoom)
+		r.ID = 10
+	}).Return(nil)
+	roomRepo.On("AddMember", uint(10), uint(1)).Return(errors.New("add member error"))
+
+	result, err := svc.Create(room, []uint{2})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	roomRepo.AssertExpectations(t)
+}
+
+func TestChatRoomCreate_FindByIDError(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{Name: "Test Room", OwnerID: 1}
+	roomRepo.On("Create", room).Run(func(args mock.Arguments) {
+		r := args.Get(0).(*model.ChatRoom)
+		r.ID = 10
+	}).Return(nil)
+	roomRepo.On("AddMember", uint(10), uint(1)).Return(nil)
+	roomRepo.On("FindByID", uint(10)).Return(nil, errors.New("not found"))
+
+	// FindByID失敗時はフォールバックでroomを返す
+	result, err := svc.Create(room, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	roomRepo.AssertExpectations(t)
 }
 
 // ============================================================
@@ -437,4 +484,37 @@ func TestChatRoomIsMember_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, result)
 	roomRepo.AssertExpectations(t)
+}
+
+func TestChatRoomUpdate_NotFound(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+	roomRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	result, err := svc.Update(99, 1, "Name", "Desc")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestChatRoomUpdate_RepoError(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+	room := &model.ChatRoom{Name: "Room", OwnerID: 1}
+	room.ID = 10
+	roomRepo.On("FindByID", uint(10)).Return(room, nil)
+	roomRepo.On("Update", room).Return(errors.New("db error"))
+	result, err := svc.Update(10, 1, "New", "Desc")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestChatRoomDelete_NotFound(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+	roomRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.Delete(99, 1)
+	assert.Error(t, err)
+}
+
+func TestChatRoomRemoveMember_NotFound(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+	roomRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.RemoveMember(99, 1, 2)
+	assert.Error(t, err)
 }

--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -159,6 +159,23 @@ func TestSnippetCommentCreate_Success(t *testing.T) {
 	snippetRepo.AssertCalled(t, "CreateComment", comment)
 }
 
+func TestSnippetCommentCreate_SnippetNotFound(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippetRepo.On("FindByID", uint(999)).Return(nil, gorm.ErrRecordNotFound)
+
+	comment := &model.SnippetComment{
+		SnippetID:  999,
+		UserID:     2,
+		LineNumber: 1,
+		Content:    "コメント",
+	}
+
+	err := svc.CreateComment(comment)
+	assert.Error(t, err)
+	snippetRepo.AssertExpectations(t)
+}
+
 func TestSnippetCommentDelete_Success(t *testing.T) {
 	svc, snippetRepo, _ := newTestCodeSnippetService()
 
@@ -234,4 +251,58 @@ func TestSnippetGetComments_Empty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, result)
 	snippetRepo.AssertExpectations(t)
+}
+
+func TestSnippetCreate_RepoError(t *testing.T) {
+	svc, snippetRepo, postRepo := newTestCodeSnippetService()
+	post := &model.Post{Title: "Test", Content: "Content", UserID: 1}
+	post.ID = 5
+	postRepo.On("FindByID", uint(5)).Return(post, nil)
+	snippet := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", Code: "package main"}
+	snippetRepo.On("Create", snippet).Return(gorm.ErrInvalidDB)
+	result, err := svc.Create(snippet)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestSnippetCreate_FindByIDAfterCreateFails(t *testing.T) {
+	svc, snippetRepo, postRepo := newTestCodeSnippetService()
+	post := &model.Post{Title: "Test", Content: "Content", UserID: 1}
+	post.ID = 5
+	postRepo.On("FindByID", uint(5)).Return(post, nil)
+	snippet := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", Code: "package main"}
+	snippetRepo.On("Create", snippet).Run(func(args mock.Arguments) {
+		s := args.Get(0).(*model.CodeSnippet)
+		s.ID = 10
+	}).Return(nil)
+	snippetRepo.On("FindByID", uint(10)).Return(nil, gorm.ErrRecordNotFound)
+	result, err := svc.Create(snippet)
+	assert.NoError(t, err)
+	assert.NotNil(t, result) // フォールバックでsnippetを返す
+}
+
+func TestSnippetDelete_NotFound(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+	snippetRepo.On("FindByID", uint(99)).Return(nil, gorm.ErrRecordNotFound)
+	err := svc.Delete(99, 1)
+	assert.Error(t, err)
+}
+
+func TestSnippetUpdate_NotFound(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+	snippetRepo.On("FindByID", uint(99)).Return(nil, gorm.ErrRecordNotFound)
+	result, err := svc.Update(99, 1, "go", "", "")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestSnippetUpdate_RepoError(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+	existing := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", Code: "package main"}
+	existing.ID = 10
+	snippetRepo.On("FindByID", uint(10)).Return(existing, nil)
+	snippetRepo.On("Update", existing).Return(gorm.ErrInvalidDB)
+	result, err := svc.Update(10, 1, "python", "", "")
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -453,3 +453,42 @@ func TestGetDeadlineAlerts_RepoError(t *testing.T) {
 	assert.Nil(t, alerts)
 	repo.AssertExpectations(t)
 }
+
+func TestLearningGoalUpdate_RepoError(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	existing := &model.LearningGoal{Title: "Goal", UserID: 1, Status: model.GoalStatusActive}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+	updates := &model.LearningGoal{Title: "New Title"}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestLearningGoalDelete_NotFound(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.Delete(99, 1)
+	assert.Error(t, err)
+}
+
+func TestLearningGoalUpdate_WithTargetDate(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	existing := &model.LearningGoal{Title: "Goal", UserID: 1, Status: model.GoalStatusActive}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+	targetDate := time.Now().AddDate(0, 1, 0)
+	updates := &model.LearningGoal{
+		Title:       "Updated",
+		Description: "Desc",
+		Category:    model.GoalCategoryOther,
+		TargetDate:  &targetDate,
+	}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "Updated", result.Title)
+	assert.Equal(t, "Desc", result.Description)
+	assert.NotNil(t, result.TargetDate)
+}

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -268,3 +268,22 @@ func TestLearningLogGetByUserID_Empty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, result)
 }
+
+func TestLearningLogUpdate_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+	existing := &model.LearningLog{Title: "Old", UserID: 1, Duration: 30}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+	updates := &model.LearningLog{Title: "New"}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestLearningLogDelete_NotFound(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.Delete(99, 1)
+	assert.Error(t, err)
+}

--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -147,6 +147,64 @@ func TestLearningResourceUpdate_Forbidden(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestLearningResourceUpdate_AllFields(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	existing := &model.LearningResource{Title: "Old", Description: "Old Desc", URL: "https://old.com", UserID: 1, Category: "article", Difficulty: "beginner"}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	updates := &model.LearningResource{
+		Title:       "New Title",
+		Description: "New Desc",
+		URL:         "https://new.com",
+		Category:    "video",
+		Difficulty:  "intermediate",
+		Tags:        "go,web",
+		ImageURL:    "https://img.com/pic.png",
+	}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "New Title", result.Title)
+	assert.Equal(t, "New Desc", result.Description)
+	assert.Equal(t, "https://new.com", result.URL)
+	assert.Equal(t, model.ResourceCategory("video"), result.Category)
+	assert.Equal(t, model.ResourceDifficulty("intermediate"), result.Difficulty)
+	assert.Equal(t, "go,web", result.Tags)
+	assert.Equal(t, "https://img.com/pic.png", result.ImageURL)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceUpdate_RepoError(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	existing := &model.LearningResource{Title: "Old", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+
+	updates := &model.LearningResource{Title: "New"}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceUpdate_NotFound(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	updates := &model.LearningResource{Title: "New"}
+	result, err := svc.Update(999, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
 // ============================================================
 // 公開設定変更テスト
 // ============================================================

--- a/backend/internal/service/level_test.go
+++ b/backend/internal/service/level_test.go
@@ -273,6 +273,16 @@ func TestGetXPBreakdown_EmptyStats(t *testing.T) {
 	levelRepo.AssertExpectations(t)
 }
 
+func TestGetXPBreakdown_RepoError(t *testing.T) {
+	svc, levelRepo, _ := newTestLevelService()
+	levelRepo.On("GetXPStats", uint(1)).Return((*model.XPStats)(nil), assert.AnError)
+
+	breakdown, err := svc.GetXPBreakdown(1)
+	assert.Error(t, err)
+	assert.Nil(t, breakdown)
+	levelRepo.AssertExpectations(t)
+}
+
 func TestCheckAndNotifyLevelUp_LevelUp(t *testing.T) {
 	svc, levelRepo, notifRepo := newTestLevelService()
 	// previousXP = 90 (Lv0), 現在のXP = 160 (Lv1) → レベルアップ

--- a/backend/internal/service/note_folder_test.go
+++ b/backend/internal/service/note_folder_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -152,6 +153,49 @@ func TestNoteFolderService_Update(t *testing.T) {
 	result, err := service.Update(1, 1, "更新後の名前", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "更新後の名前", result.Name)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestNoteFolderService_Create_ValidationError(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	folder := &model.NoteFolder{
+		UserID: 1,
+		Name:   "", // 空名前 → バリデーションエラー
+	}
+
+	err := service.Create(folder)
+	assert.Error(t, err)
+}
+
+func TestNoteFolderService_Create_RepoError(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	folder := &model.NoteFolder{
+		UserID: 1,
+		Name:   "テストフォルダ",
+	}
+
+	mockRepo.On("Create", folder).Return(errors.New("db error"))
+
+	err := service.Create(folder)
+	assert.Error(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestNoteFolderService_Update_RepoError(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	existing := &model.NoteFolder{ID: 1, UserID: 1, Name: "元の名前"}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+	mockRepo.On("Update", mock.AnythingOfType("*model.NoteFolder")).Return(errors.New("db error"))
+
+	result, err := service.Update(1, 1, "更新後", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
 	mockRepo.AssertExpectations(t)
 }
 

--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -110,6 +110,57 @@ func TestNoteTemplateService_Create_WithDefaultFlag(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestNoteTemplateService_Create_ValidationError(t *testing.T) {
+	svc, _, _ := newTestNoteTemplateService()
+
+	// Name空 → バリデーションエラー
+	template := &model.NoteTemplate{
+		UserID:          1,
+		Name:            "",
+		ContentTemplate: "本文",
+	}
+
+	err := svc.Create(template)
+	assert.Error(t, err)
+}
+
+func TestNoteTemplateService_Create_DescriptionValidationError(t *testing.T) {
+	svc, _, _ := newTestNoteTemplateService()
+
+	// 超長い説明文 → バリデーションエラー
+	longDesc := ""
+	for i := 0; i < 600; i++ {
+		longDesc += "あ"
+	}
+
+	template := &model.NoteTemplate{
+		UserID:          1,
+		Name:            "テンプレート",
+		ContentTemplate: "本文",
+		Description:     longDesc,
+	}
+
+	err := svc.Create(template)
+	assert.Error(t, err)
+}
+
+func TestNoteTemplateService_Create_ClearDefaultFlagError(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	template := &model.NoteTemplate{
+		UserID:          1,
+		Name:            "テンプレート",
+		ContentTemplate: "本文",
+		IsDefault:       true,
+	}
+
+	repo.On("ClearDefaultFlag", uint(1)).Return(errors.New("db error"))
+
+	err := svc.Create(template)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
 // ============================================================
 // GetByID テスト
 // ============================================================
@@ -189,6 +240,72 @@ func TestNoteTemplateService_Update_Forbidden(t *testing.T) {
 
 	_, err := svc.Update(1, 999, "", "", "", "", "", nil)
 	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_Update_WithAllFields(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	existing := &model.NoteTemplate{
+		ID:              1,
+		UserID:          1,
+		Name:            "元テンプレート",
+		ContentTemplate: "元本文",
+		IsDefault:       false,
+	}
+
+	isDefault := true
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("ClearDefaultFlag", uint(1)).Return(nil)
+	repo.On("Update", mock.AnythingOfType("*model.NoteTemplate")).Return(nil)
+
+	result, err := svc.Update(1, 1, "新名前", "新説明", "新タイトル", "新本文", "tag1,tag2", &isDefault)
+	assert.NoError(t, err)
+	assert.Equal(t, "新名前", result.Name)
+	assert.Equal(t, "新説明", result.Description)
+	assert.Equal(t, "新タイトル", result.DefaultTitle)
+	assert.Equal(t, "新本文", result.ContentTemplate)
+	assert.Equal(t, "tag1,tag2", result.DefaultTags)
+	assert.True(t, result.IsDefault)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_Update_RepoError(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	existing := &model.NoteTemplate{
+		ID:              1,
+		UserID:          1,
+		Name:            "テンプレ",
+		ContentTemplate: "本文",
+	}
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.AnythingOfType("*model.NoteTemplate")).Return(errors.New("db error"))
+
+	result, err := svc.Update(1, 1, "新名前", "", "", "", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_Update_ClearDefaultFlagError(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	existing := &model.NoteTemplate{
+		ID:              1,
+		UserID:          1,
+		Name:            "テンプレ",
+		ContentTemplate: "本文",
+	}
+
+	isDefault := true
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("ClearDefaultFlag", uint(1)).Return(errors.New("db error"))
+
+	result, err := svc.Update(1, 1, "", "", "", "", "", &isDefault)
+	assert.Error(t, err)
+	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
 

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -104,6 +104,35 @@ func TestNoteService_Create(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestNoteService_Create_ValidationError(t *testing.T) {
+	svc, _ := newTestNoteService()
+
+	note := &model.Note{
+		UserID:  1,
+		Title:   "",
+		Content: "内容",
+	}
+
+	err := svc.Create(note)
+	assert.Error(t, err)
+}
+
+func TestNoteService_Create_RepoError(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	note := &model.Note{
+		UserID:  1,
+		Title:   "テストノート",
+		Content: "内容",
+	}
+
+	repo.On("Create", note).Return(errors.New("db error"))
+
+	err := svc.Create(note)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
 // ============================================================
 // GetByID テスト
 // ============================================================
@@ -404,4 +433,38 @@ func TestNoteService_Duplicate_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
+}
+
+func TestNoteService_Update_RepoError(t *testing.T) {
+	svc, repo := newTestNoteService()
+	existing := &model.Note{ID: 1, UserID: 1, Title: "元タイトル", Content: "内容"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.Anything).Return(errors.New("db error"))
+	result, err := svc.Update(1, 1, "新タイトル", "", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestNoteService_Duplicate_RepoError(t *testing.T) {
+	svc, repo := newTestNoteService()
+	original := &model.Note{ID: 1, UserID: 1, Title: "元ノート", Content: "内容", Tags: "Go"}
+	repo.On("FindByID", uint(1)).Return(original, nil)
+	repo.On("Create", mock.Anything).Return(errors.New("db error"))
+	result, err := svc.Duplicate(1, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestNoteService_Update_WithAllFields(t *testing.T) {
+	svc, repo := newTestNoteService()
+	folderID := uint(5)
+	existing := &model.Note{ID: 1, UserID: 1, Title: "元", Content: "元内容", Tags: "Go"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.Anything).Return(nil)
+	result, err := svc.Update(1, 1, "新タイトル", "新内容", "React,Go", &folderID)
+	assert.NoError(t, err)
+	assert.Equal(t, "新タイトル", result.Title)
+	assert.Equal(t, "新内容", result.Content)
+	assert.Equal(t, "React,Go", result.Tags)
+	assert.Equal(t, &folderID, result.FolderID)
 }

--- a/backend/internal/service/notification_test.go
+++ b/backend/internal/service/notification_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -129,6 +130,21 @@ func TestCreateNotificationWithoutHub_Success(t *testing.T) {
 	// hubがnilでもエラーにならないことを確認
 	err := svc.CreateNotification(notification)
 	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestCreateNotification_RepoError(t *testing.T) {
+	svc, repo := newTestNotificationService()
+
+	notification := &model.Notification{
+		UserID:  1,
+		Type:    model.NotificationTypePost,
+		ActorID: 2,
+	}
+	repo.On("Create", notification).Return(errors.New("db error"))
+
+	err := svc.CreateNotification(notification)
+	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }
 

--- a/backend/internal/service/roadmap_test.go
+++ b/backend/internal/service/roadmap_test.go
@@ -229,6 +229,24 @@ func TestRoadmapUpdateStep_NotOwner(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestRoadmapUpdateStep_RepoError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+
+	step := &model.RoadmapStep{RoadmapID: 10, Title: "Old"}
+	step.ID = 5
+
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+	repo.On("UpdateStep", step).Return(errors.New("db error"))
+
+	_, err := svc.UpdateStep(10, 5, 1, &model.RoadmapStep{Title: "New"})
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
 // ============================================================
 // ステップ削除テスト
 // ============================================================
@@ -265,6 +283,24 @@ func TestRoadmapDeleteStep_StepBelongsToDifferentRoadmap(t *testing.T) {
 
 	err := svc.DeleteStep(10, 5, 1)
 	assert.ErrorIs(t, err, ErrBadRequest)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapDeleteStep_RepoError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+
+	step := &model.RoadmapStep{RoadmapID: 10}
+	step.ID = 5
+
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+	repo.On("DeleteStep", uint(5)).Return(errors.New("db error"))
+
+	err := svc.DeleteStep(10, 5, 1)
+	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }
 
@@ -687,4 +723,140 @@ func TestRoadmapReorderSteps_Forbidden(t *testing.T) {
 	err := svc.ReorderSteps(10, 999, orders)
 	assert.ErrorIs(t, err, ErrForbidden)
 	repo.AssertExpectations(t)
+}
+
+func TestRoadmapUpdate_NotFound(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	updates := &model.Roadmap{Title: "New"}
+	result, err := svc.Update(99, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestRoadmapUpdate_RepoError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	existing := &model.Roadmap{Title: "Old", UserID: 1, Status: model.RoadmapStatusActive}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+	updates := &model.Roadmap{Title: "New"}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestRoadmapUpdateVisibility_NotFound(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	result, err := svc.UpdateVisibility(99, 1, true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestRoadmapUpdateVisibility_RepoError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	existing := &model.Roadmap{UserID: 1, IsPublic: false}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+	result, err := svc.UpdateVisibility(1, 1, true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestRoadmapUpdateStepCompletion_Forbidden(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	result, err := svc.UpdateStepCompletion(10, 5, 999, true)
+	assert.ErrorIs(t, err, ErrForbidden)
+	assert.Nil(t, result)
+}
+
+func TestRoadmapUpdateStepCompletion_StepNotFound(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(99)).Return(nil, errors.New("not found"))
+	result, err := svc.UpdateStepCompletion(10, 99, 1, true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestRoadmapUpdateStepCompletion_WrongRoadmap(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+	step := &model.RoadmapStep{RoadmapID: 20}
+	step.ID = 5
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+	result, err := svc.UpdateStepCompletion(10, 5, 1, true)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Nil(t, result)
+}
+
+func TestRoadmapUpdateStepCompletion_RepoError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+	step := &model.RoadmapStep{RoadmapID: 10, IsCompleted: false}
+	step.ID = 5
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+	repo.On("UpdateStep", step).Return(errors.New("db error"))
+	result, err := svc.UpdateStepCompletion(10, 5, 1, true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestRoadmapDeleteStep_NotOwner(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	err := svc.DeleteStep(10, 5, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+func TestRoadmapDeleteStep_StepNotFound(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.DeleteStep(10, 99, 1)
+	assert.Error(t, err)
+}
+
+func TestRoadmapDelete_NotFound(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.Delete(99, 1)
+	assert.Error(t, err)
+}
+
+func TestRoadmapCreateStep_NotFound(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	step := &model.RoadmapStep{Title: "New Step"}
+	err := svc.CreateStep(99, 1, step)
+	assert.Error(t, err)
+}
+
+func TestRoadmapUpdate_WithAllFields(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	existing := &model.Roadmap{Title: "Old", UserID: 1, Status: model.RoadmapStatusActive}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+	updates := &model.Roadmap{Title: "New", Description: "Desc", Category: model.RoadmapCategorySkill}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "New", result.Title)
+	assert.Equal(t, "Desc", result.Description)
+	assert.Equal(t, model.RoadmapCategorySkill, result.Category)
 }

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -121,6 +121,20 @@ func TestStudyCircleUpdate_Forbidden(t *testing.T) {
 	assert.ErrorIs(t, err, ErrForbidden)
 }
 
+func TestStudyCircleUpdate_RepoError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	circle := &model.StudyCircle{ID: 1, Name: "旧名", OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("Update", circle).Return(errors.New("db error"))
+
+	newName := "新名"
+	result, err := svc.Update(1, 1, &newName, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
 // --- Delete ---
 
 func TestStudyCircleDelete_Success(t *testing.T) {
@@ -551,4 +565,184 @@ func TestStudyCircleGetCheckins_Forbidden(t *testing.T) {
 	result, err := svc.GetCheckins(1, 99)
 	assert.Nil(t, result)
 	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+// --- エラーパステスト ---
+
+func TestStudyCircleCreate_AddMemberOwnerError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{Name: "Test", Topic: "Go", OwnerID: 1, MaxMembers: 5}
+	repo.On("Create", circle).Return(nil)
+	repo.On("AddMember", uint(0), uint(1), model.StudyCircleRoleOwner).Return(errors.New("db error"))
+	err := svc.Create(circle, nil)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleGetByID_IsMemberError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("IsMember", uint(1), uint(2)).Return(false, errors.New("db error"))
+	result, err := svc.GetByID(1, 2)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleUpdate_NotFound(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	name := "新名"
+	result, err := svc.Update(99, 1, &name, nil, nil)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStudyCircleDelete_NotFound(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.Delete(99, 1)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStudyCircleDeleteStep_StepNotFound(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("FindStepByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.DeleteStep(1, 1, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStudyCircleDeleteStep_StepBelongsToDifferentCircle(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	step := &model.StudyCircleStep{CircleID: 2}
+	step.ID = 5
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+	err := svc.DeleteStep(1, 1, 5)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStudyCircleUpdateStep_StepNotFound(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("FindStepByID", uint(99)).Return(nil, errors.New("not found"))
+	title := "新タイトル"
+	result, err := svc.UpdateStep(1, 1, 99, &title, nil)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStudyCircleUpdateStep_RepoError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	step := &model.StudyCircleStep{CircleID: 1, Title: "旧"}
+	step.ID = 5
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+	repo.On("UpdateStep", step).Return(errors.New("db error"))
+	title := "新"
+	result, err := svc.UpdateStep(1, 1, 5, &title, nil)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleAddMember_IsMemberError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(1)).Return(false, errors.New("db error"))
+	err := svc.AddMember(1, 1, 5)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleAddMember_FindByIDError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(1)).Return(true, nil)
+	repo.On("FindByID", uint(1)).Return(nil, errors.New("not found"))
+	err := svc.AddMember(1, 1, 5)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStudyCircleAddMember_GetMemberCountError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, MaxMembers: 5}
+	repo.On("IsMember", uint(1), uint(1)).Return(true, nil)
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("GetMemberCount", uint(1)).Return(0, errors.New("db error"))
+	err := svc.AddMember(1, 1, 5)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleRemoveMember_NotFound(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.RemoveMember(99, 1, 2)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStudyCircleGetMembers_IsMemberError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(1)).Return(false, errors.New("db error"))
+	result, err := svc.GetMembers(1, 1)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleGetProgress_IsMemberError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(1)).Return(false, errors.New("db error"))
+	result, err := svc.GetProgress(1, 1)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleGetCheckins_IsMemberError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(1)).Return(false, errors.New("db error"))
+	result, err := svc.GetCheckins(1, 1)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleGetStreakRanking_IsMemberError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(1)).Return(false, errors.New("db error"))
+	result, err := svc.GetStreakRanking(1, 1)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleCreateCheckin_HasCheckedInTodayError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(2)).Return(true, nil)
+	repo.On("HasCheckedInToday", uint(1), uint(2)).Return(false, errors.New("db error"))
+	result, err := svc.CreateCheckin(1, 2, "test")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleCreateCheckin_RepoError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(2)).Return(true, nil)
+	repo.On("HasCheckedInToday", uint(1), uint(2)).Return(false, nil)
+	repo.On("CreateCheckin", mock.AnythingOfType("*model.StudyCircleCheckin")).Return(errors.New("db error"))
+	result, err := svc.CreateCheckin(1, 2, "test")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestStudyCircleCreateStep_NotFound(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	step := &model.StudyCircleStep{Title: "ステップ1"}
+	err := svc.CreateStep(99, 1, step)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestStudyCircleUpdateProgress_IsMemberError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(1)).Return(false, errors.New("db error"))
+	err := svc.UpdateProgress(1, 1, 5, true)
+	assert.Error(t, err)
 }


### PR DESCRIPTION
## 概要
- Service層のテストカバレッジを **75.9% → 80.3%** に向上
- 全16テストファイルにエラーパス・バリデーション・境界条件テストを網羅的に追加

## 追加テスト内訳
| ファイル | 追加件数 | 主な内容 |
|----------|----------|----------|
| study_circle_test.go | 22件 | IsMemberエラー、NotFound、StepBelongs、RepoError等 |
| roadmap_test.go | 14件 | UpdateStepCompletion全パス、Visibility、RepoError等 |
| ai_rule_engine_test.go | 8件 | collectContext各リポジトリエラーパス |
| note_template_test.go | 6件 | バリデーション、ClearDefault、RepoError |
| code_snippet_test.go | 5件 | Create/Update/Delete NotFound・RepoError |
| auth_test.go | 4件 | Register バリデーション・RepoError |
| chat_room_test.go | 4件 | Update/Delete NotFound・RepoError |
| answer_test.go | 6件 | Update/Delete/SetBestAnswer エラーパス |
| その他8ファイル | 各1-3件 | エラーパス・境界条件 |

## テスト結果
```
ok  github.com/norman6464/devsync/backend/internal/service  coverage: 80.3%
```

## テスト方法
- [x] `go test ./internal/service/... -cover -count=1` で全テスト通過・カバレッジ80%超を確認