### PR TITLE
feat: PostViewServiceにバリデーション追加

### DIFF
--- a/backend/internal/service/post_view.go
+++ b/backend/internal/service/post_view.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"fmt"
+
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,6 +20,12 @@ func NewPostViewService(repo repository.PostViewRepositoryInterface) *PostViewSe
 // RecordView はユーザーの投稿閲覧を記録する。
 // 既に閲覧済みの場合は何もしない（ユニーク閲覧のみカウント）。
 func (s *PostViewService) RecordView(userID, postID uint) error {
+	if userID == 0 {
+		return fmt.Errorf("%w: userIDは必須です", ErrBadRequest)
+	}
+	if postID == 0 {
+		return fmt.Errorf("%w: postIDは必須です", ErrBadRequest)
+	}
 	viewed, err := s.repo.HasViewed(userID, postID)
 	if err != nil {
 		return err
@@ -33,15 +41,29 @@ func (s *PostViewService) RecordView(userID, postID uint) error {
 
 // GetViewCount は投稿のユニーク閲覧数を取得する。
 func (s *PostViewService) GetViewCount(postID uint) (int64, error) {
+	if postID == 0 {
+		return 0, fmt.Errorf("%w: postIDは必須です", ErrBadRequest)
+	}
 	return s.repo.GetViewCount(postID)
 }
 
 // HasViewed はユーザーが投稿を閲覧済みかどうかを判定する。
 func (s *PostViewService) HasViewed(userID, postID uint) (bool, error) {
+	if userID == 0 {
+		return false, fmt.Errorf("%w: userIDは必須です", ErrBadRequest)
+	}
+	if postID == 0 {
+		return false, fmt.Errorf("%w: postIDは必須です", ErrBadRequest)
+	}
 	return s.repo.HasViewed(userID, postID)
 }
 
+const maxMostViewedLimit = 100
+
 // GetMostViewed は閲覧数が多い投稿のランキングを取得する。
 func (s *PostViewService) GetMostViewed(limit int) ([]model.ViewCount, error) {
+	if limit <= 0 || limit > maxMostViewedLimit {
+		return nil, fmt.Errorf("%w: limitは1〜100の範囲で指定してください", ErrBadRequest)
+	}
 	return s.repo.GetMostViewed(limit)
 }

--- a/backend/internal/service/post_view_test.go
+++ b/backend/internal/service/post_view_test.go
@@ -158,3 +158,88 @@ func TestPostViewGetMostViewed_RepoError(t *testing.T) {
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// バリデーションテスト
+// ============================================================
+
+func TestPostViewRecordView_InvalidUserID(t *testing.T) {
+	svc, repo := newTestPostViewService()
+
+	err := svc.RecordView(0, 10)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	repo.AssertNotCalled(t, "HasViewed")
+}
+
+func TestPostViewRecordView_InvalidPostID(t *testing.T) {
+	svc, repo := newTestPostViewService()
+
+	err := svc.RecordView(1, 0)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	repo.AssertNotCalled(t, "HasViewed")
+}
+
+func TestPostViewGetViewCount_InvalidPostID(t *testing.T) {
+	svc, repo := newTestPostViewService()
+
+	count, err := svc.GetViewCount(0)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Equal(t, int64(0), count)
+	repo.AssertNotCalled(t, "GetViewCount")
+}
+
+func TestPostViewHasViewed_InvalidUserID(t *testing.T) {
+	svc, repo := newTestPostViewService()
+
+	viewed, err := svc.HasViewed(0, 10)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.False(t, viewed)
+	repo.AssertNotCalled(t, "HasViewed")
+}
+
+func TestPostViewHasViewed_InvalidPostID(t *testing.T) {
+	svc, repo := newTestPostViewService()
+
+	viewed, err := svc.HasViewed(1, 0)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.False(t, viewed)
+	repo.AssertNotCalled(t, "HasViewed")
+}
+
+func TestPostViewGetMostViewed_InvalidLimit_Zero(t *testing.T) {
+	svc, repo := newTestPostViewService()
+
+	result, err := svc.GetMostViewed(0)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Nil(t, result)
+	repo.AssertNotCalled(t, "GetMostViewed")
+}
+
+func TestPostViewGetMostViewed_InvalidLimit_Negative(t *testing.T) {
+	svc, repo := newTestPostViewService()
+
+	result, err := svc.GetMostViewed(-5)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Nil(t, result)
+	repo.AssertNotCalled(t, "GetMostViewed")
+}
+
+func TestPostViewGetMostViewed_InvalidLimit_TooLarge(t *testing.T) {
+	svc, repo := newTestPostViewService()
+
+	result, err := svc.GetMostViewed(200)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Nil(t, result)
+	repo.AssertNotCalled(t, "GetMostViewed")
+}
+
+func TestPostViewHasViewed_RepoError(t *testing.T) {
+	svc, repo := newTestPostViewService()
+
+	repo.On("HasViewed", uint(1), uint(10)).Return(false, errors.New("db error"))
+
+	viewed, err := svc.HasViewed(1, 10)
+	assert.Error(t, err)
+	assert.False(t, viewed)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
PostViewServiceの全メソッドに入力バリデーションを追加し、不正なパラメータを早期にリジェクトするように改善。

## 変更内容
- `RecordView`/`HasViewed`: userID・postIDの0値チェック
- `GetViewCount`: postIDの0値チェック
- `GetMostViewed`: limitの範囲チェック（1〜100）
- 9件の新規テストケース追加（全テストPASS、カバレッジ80.4%維持）

## テスト計画
- [x] `go test ./internal/service/... -run TestPostView` 全22テストPASS
- [x] カバレッジ80.4%維持

Closes #547