### PR TITLE
test: 新規ハンドラーのユニットテスト追加（post_view, post_pin, post_tag, mention）

### DIFF
--- a/backend/internal/handler/mention_test.go
+++ b/backend/internal/handler/mention_test.go
@@ -1,0 +1,127 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockMentionService は MentionServiceInterface のモック実装。
+type MockMentionService struct{ mock.Mock }
+
+func (m *MockMentionService) ProcessMentions(actorID uint, text string, postID *uint, commentID *uint) error {
+	return m.Called(actorID, text, postID, commentID).Error(0)
+}
+func (m *MockMentionService) GetMentionsByUserID(userID uint, page, limit int) ([]model.Mention, error) {
+	args := m.Called(userID, page, limit)
+	if v := args.Get(0); v != nil {
+		return v.([]model.Mention), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockMentionService) GetMentionsByPostID(postID uint) ([]model.Mention, error) {
+	args := m.Called(postID)
+	if v := args.Get(0); v != nil {
+		return v.([]model.Mention), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockMentionService) DeleteMentionsByPostID(postID uint) error {
+	return m.Called(postID).Error(0)
+}
+func (m *MockMentionService) DeleteMentionsByCommentID(commentID uint) error {
+	return m.Called(commentID).Error(0)
+}
+
+func setupMentionHandler() (*MentionHandler, *MockMentionService) {
+	svc := new(MockMentionService)
+	h := NewMentionHandler(svc)
+	return h, svc
+}
+
+// ============================================================
+// GetMyMentions テスト
+// ============================================================
+
+func TestMentionGetMyMentions_Success(t *testing.T) {
+	h, svc := setupMentionHandler()
+	mentions := []model.Mention{
+		{UserID: 1, ActorID: 2},
+	}
+	svc.On("GetMentionsByUserID", uint(1), 1, 20).Return(mentions, nil)
+
+	r := newRouter(1)
+	r.GET("/mentions", h.GetMyMentions)
+
+	w := doRequest(r, http.MethodGet, "/mentions", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestMentionGetMyMentions_Empty(t *testing.T) {
+	h, svc := setupMentionHandler()
+	svc.On("GetMentionsByUserID", uint(1), 1, 20).Return([]model.Mention{}, nil)
+
+	r := newRouter(1)
+	r.GET("/mentions", h.GetMyMentions)
+
+	w := doRequest(r, http.MethodGet, "/mentions", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestMentionGetMyMentions_ServiceError(t *testing.T) {
+	h, svc := setupMentionHandler()
+	svc.On("GetMentionsByUserID", uint(1), 1, 20).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/mentions", h.GetMyMentions)
+
+	w := doRequest(r, http.MethodGet, "/mentions", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetPostMentions テスト
+// ============================================================
+
+func TestMentionGetPostMentions_Success(t *testing.T) {
+	h, svc := setupMentionHandler()
+	mentions := []model.Mention{
+		{UserID: 2, ActorID: 1},
+	}
+	svc.On("GetMentionsByPostID", uint(5)).Return(mentions, nil)
+
+	r := newRouter(1)
+	r.GET("/posts/:postId/mentions", h.GetPostMentions)
+
+	w := doRequest(r, http.MethodGet, "/posts/5/mentions", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestMentionGetPostMentions_InvalidID(t *testing.T) {
+	h, _ := setupMentionHandler()
+
+	r := newRouter(1)
+	r.GET("/posts/:postId/mentions", h.GetPostMentions)
+
+	w := doRequest(r, http.MethodGet, "/posts/abc/mentions", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestMentionGetPostMentions_ServiceError(t *testing.T) {
+	h, svc := setupMentionHandler()
+	svc.On("GetMentionsByPostID", uint(5)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/posts/:postId/mentions", h.GetPostMentions)
+
+	w := doRequest(r, http.MethodGet, "/posts/5/mentions", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/post_pin_test.go
+++ b/backend/internal/handler/post_pin_test.go
@@ -1,0 +1,177 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockPostPinService は PostPinServiceInterface のモック実装。
+type MockPostPinService struct{ mock.Mock }
+
+func (m *MockPostPinService) Pin(userID, postID uint) error {
+	return m.Called(userID, postID).Error(0)
+}
+func (m *MockPostPinService) Unpin(userID, postID uint) error {
+	return m.Called(userID, postID).Error(0)
+}
+func (m *MockPostPinService) GetByUserID(userID uint) ([]model.PostPin, error) {
+	args := m.Called(userID)
+	if v := args.Get(0); v != nil {
+		return v.([]model.PostPin), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockPostPinService) Reorder(userID uint, postIDs []uint) error {
+	return m.Called(userID, postIDs).Error(0)
+}
+func (m *MockPostPinService) IsPinned(userID, postID uint) (bool, error) {
+	args := m.Called(userID, postID)
+	return args.Bool(0), args.Error(1)
+}
+
+func setupPostPinHandler() (*PostPinHandler, *MockPostPinService) {
+	svc := new(MockPostPinService)
+	h := NewPostPinHandler(svc)
+	return h, svc
+}
+
+// ============================================================
+// Pin テスト
+// ============================================================
+
+func TestPostPin_Success(t *testing.T) {
+	h, svc := setupPostPinHandler()
+	svc.On("Pin", uint(1), uint(5)).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/pin", h.Pin)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/pin", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostPin_InvalidID(t *testing.T) {
+	h, _ := setupPostPinHandler()
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/pin", h.Pin)
+
+	w := doRequest(r, http.MethodPost, "/posts/abc/pin", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostPin_ServiceError(t *testing.T) {
+	h, svc := setupPostPinHandler()
+	svc.On("Pin", uint(1), uint(5)).Return(errors.New("already pinned"))
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/pin", h.Pin)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/pin", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// Unpin テスト
+// ============================================================
+
+func TestPostUnpin_Success(t *testing.T) {
+	h, svc := setupPostPinHandler()
+	svc.On("Unpin", uint(1), uint(5)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/posts/:postId/pin", h.Unpin)
+
+	w := doRequest(r, http.MethodDelete, "/posts/5/pin", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostUnpin_InvalidID(t *testing.T) {
+	h, _ := setupPostPinHandler()
+
+	r := newRouter(1)
+	r.DELETE("/posts/:postId/pin", h.Unpin)
+
+	w := doRequest(r, http.MethodDelete, "/posts/abc/pin", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// GetByUserID テスト
+// ============================================================
+
+func TestPostPinGetByUserID_Success(t *testing.T) {
+	h, svc := setupPostPinHandler()
+	pins := []model.PostPin{
+		{UserID: 1, PostID: 10, PinOrder: 1},
+		{UserID: 1, PostID: 20, PinOrder: 2},
+	}
+	svc.On("GetByUserID", uint(1)).Return(pins, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/pins", h.GetByUserID)
+
+	w := doRequest(r, http.MethodGet, "/users/1/pins", nil)
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	assert.NotNil(t, body["pins"])
+	svc.AssertExpectations(t)
+}
+
+func TestPostPinGetByUserID_InvalidID(t *testing.T) {
+	h, _ := setupPostPinHandler()
+
+	r := newRouter(1)
+	r.GET("/users/:userId/pins", h.GetByUserID)
+
+	w := doRequest(r, http.MethodGet, "/users/abc/pins", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostPinGetByUserID_ServiceError(t *testing.T) {
+	h, svc := setupPostPinHandler()
+	svc.On("GetByUserID", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/users/:userId/pins", h.GetByUserID)
+
+	w := doRequest(r, http.MethodGet, "/users/1/pins", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// Reorder テスト
+// ============================================================
+
+func TestPostPinReorder_Success(t *testing.T) {
+	h, svc := setupPostPinHandler()
+	svc.On("Reorder", uint(1), []uint{10, 20, 30}).Return(nil)
+
+	r := newRouter(1)
+	r.PUT("/pins/reorder", h.Reorder)
+
+	w := doRequest(r, http.MethodPut, "/pins/reorder", map[string]interface{}{
+		"post_ids": []uint{10, 20, 30},
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostPinReorder_InvalidBody(t *testing.T) {
+	h, _ := setupPostPinHandler()
+
+	r := newRouter(1)
+	r.PUT("/pins/reorder", h.Reorder)
+
+	w := doRequestRaw(r, http.MethodPut, "/pins/reorder", `{invalid}`)
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/post_tag_test.go
+++ b/backend/internal/handler/post_tag_test.go
@@ -1,0 +1,207 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockPostTagService は PostTagServiceInterface のモック実装。
+type MockPostTagService struct{ mock.Mock }
+
+func (m *MockPostTagService) SetTags(postID, userID uint, tags []string) error {
+	return m.Called(postID, userID, tags).Error(0)
+}
+func (m *MockPostTagService) GetByPostID(postID uint) ([]string, error) {
+	args := m.Called(postID)
+	if v := args.Get(0); v != nil {
+		return v.([]string), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockPostTagService) FindPostsByTag(tag string, limit, offset int) ([]model.Post, int64, error) {
+	args := m.Called(tag, limit, offset)
+	if v := args.Get(0); v != nil {
+		return v.([]model.Post), args.Get(1).(int64), args.Error(2)
+	}
+	return nil, args.Get(1).(int64), args.Error(2)
+}
+func (m *MockPostTagService) GetPopularTags(limit int) ([]model.TagCount, error) {
+	args := m.Called(limit)
+	if v := args.Get(0); v != nil {
+		return v.([]model.TagCount), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func setupPostTagHandler() (*PostTagHandler, *MockPostTagService) {
+	svc := new(MockPostTagService)
+	h := NewPostTagHandler(svc)
+	return h, svc
+}
+
+// ============================================================
+// SetTags テスト
+// ============================================================
+
+func TestPostTagSetTags_Success(t *testing.T) {
+	h, svc := setupPostTagHandler()
+	svc.On("SetTags", uint(5), uint(1), []string{"Go", "React"}).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/tags", h.SetTags)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/tags", map[string]interface{}{
+		"tags": []string{"Go", "React"},
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTagSetTags_InvalidID(t *testing.T) {
+	h, _ := setupPostTagHandler()
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/tags", h.SetTags)
+
+	w := doRequest(r, http.MethodPost, "/posts/abc/tags", map[string]interface{}{
+		"tags": []string{"Go"},
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTagSetTags_InvalidBody(t *testing.T) {
+	h, _ := setupPostTagHandler()
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/tags", h.SetTags)
+
+	w := doRequestRaw(r, http.MethodPost, "/posts/5/tags", `{invalid}`)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTagSetTags_ServiceError(t *testing.T) {
+	h, svc := setupPostTagHandler()
+	svc.On("SetTags", uint(5), uint(1), []string{"Go"}).Return(errors.New("db error"))
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/tags", h.SetTags)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/tags", map[string]interface{}{
+		"tags": []string{"Go"},
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetByPostID テスト
+// ============================================================
+
+func TestPostTagGetByPostID_Success(t *testing.T) {
+	h, svc := setupPostTagHandler()
+	svc.On("GetByPostID", uint(5)).Return([]string{"Go", "React"}, nil)
+
+	r := newRouter(1)
+	r.GET("/posts/:postId/tags", h.GetByPostID)
+
+	w := doRequest(r, http.MethodGet, "/posts/5/tags", nil)
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	assert.NotNil(t, body["tags"])
+	svc.AssertExpectations(t)
+}
+
+func TestPostTagGetByPostID_InvalidID(t *testing.T) {
+	h, _ := setupPostTagHandler()
+
+	r := newRouter(1)
+	r.GET("/posts/:postId/tags", h.GetByPostID)
+
+	w := doRequest(r, http.MethodGet, "/posts/abc/tags", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTagGetByPostID_ServiceError(t *testing.T) {
+	h, svc := setupPostTagHandler()
+	svc.On("GetByPostID", uint(5)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/posts/:postId/tags", h.GetByPostID)
+
+	w := doRequest(r, http.MethodGet, "/posts/5/tags", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// FindPostsByTag テスト
+// ============================================================
+
+func TestPostTagFindPostsByTag_Success(t *testing.T) {
+	h, svc := setupPostTagHandler()
+	posts := []model.Post{{Title: "Go入門", UserID: 1}}
+	svc.On("FindPostsByTag", "Go", 20, 0).Return(posts, int64(1), nil)
+
+	r := newRouter(1)
+	r.GET("/posts/tags/search", h.FindPostsByTag)
+
+	w := doRequest(r, http.MethodGet, "/posts/tags/search?tag=Go", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTagFindPostsByTag_MissingTag(t *testing.T) {
+	h, _ := setupPostTagHandler()
+
+	r := newRouter(1)
+	r.GET("/posts/tags/search", h.FindPostsByTag)
+
+	w := doRequest(r, http.MethodGet, "/posts/tags/search", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTagFindPostsByTag_ServiceError(t *testing.T) {
+	h, svc := setupPostTagHandler()
+	svc.On("FindPostsByTag", "Go", 20, 0).Return(nil, int64(0), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/posts/tags/search", h.FindPostsByTag)
+
+	w := doRequest(r, http.MethodGet, "/posts/tags/search?tag=Go", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetPopularTags テスト
+// ============================================================
+
+func TestPostTagGetPopularTags_Success(t *testing.T) {
+	h, svc := setupPostTagHandler()
+	tags := []model.TagCount{{Tag: "Go", Count: 100}, {Tag: "React", Count: 50}}
+	svc.On("GetPopularTags", 20).Return(tags, nil)
+
+	r := newRouter(1)
+	r.GET("/posts/tags/popular", h.GetPopularTags)
+
+	w := doRequest(r, http.MethodGet, "/posts/tags/popular", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTagGetPopularTags_ServiceError(t *testing.T) {
+	h, svc := setupPostTagHandler()
+	svc.On("GetPopularTags", 20).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/posts/tags/popular", h.GetPopularTags)
+
+	w := doRequest(r, http.MethodGet, "/posts/tags/popular", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/post_view_test.go
+++ b/backend/internal/handler/post_view_test.go
@@ -1,0 +1,151 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// MockPostViewService は PostViewServiceInterface のモック実装。
+type MockPostViewService struct{ mock.Mock }
+
+func (m *MockPostViewService) RecordView(userID, postID uint) error {
+	return m.Called(userID, postID).Error(0)
+}
+func (m *MockPostViewService) GetViewCount(postID uint) (int64, error) {
+	args := m.Called(postID)
+	return args.Get(0).(int64), args.Error(1)
+}
+func (m *MockPostViewService) HasViewed(userID, postID uint) (bool, error) {
+	args := m.Called(userID, postID)
+	return args.Bool(0), args.Error(1)
+}
+func (m *MockPostViewService) GetMostViewed(limit int) ([]model.ViewCount, error) {
+	args := m.Called(limit)
+	if v := args.Get(0); v != nil {
+		return v.([]model.ViewCount), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func setupPostViewHandler() (*PostViewHandler, *MockPostViewService) {
+	svc := new(MockPostViewService)
+	h := NewPostViewHandler(svc)
+	return h, svc
+}
+
+// ============================================================
+// RecordView テスト
+// ============================================================
+
+func TestPostViewRecordView_Success(t *testing.T) {
+	h, svc := setupPostViewHandler()
+	svc.On("RecordView", uint(1), uint(5)).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/views", h.RecordView)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/views", nil)
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	assert.Equal(t, true, body["recorded"])
+	svc.AssertExpectations(t)
+}
+
+func TestPostViewRecordView_InvalidID(t *testing.T) {
+	h, _ := setupPostViewHandler()
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/views", h.RecordView)
+
+	w := doRequest(r, http.MethodPost, "/posts/abc/views", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostViewRecordView_ServiceError(t *testing.T) {
+	h, svc := setupPostViewHandler()
+	svc.On("RecordView", uint(1), uint(5)).Return(errors.New("db error"))
+
+	r := newRouter(1)
+	r.POST("/posts/:postId/views", h.RecordView)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/views", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetViewCount テスト
+// ============================================================
+
+func TestPostViewGetViewCount_Success(t *testing.T) {
+	h, svc := setupPostViewHandler()
+	svc.On("GetViewCount", uint(5)).Return(int64(42), nil)
+
+	r := newRouter(1)
+	r.GET("/posts/:postId/view-count", h.GetViewCount)
+
+	w := doRequest(r, http.MethodGet, "/posts/5/view-count", nil)
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	assert.Equal(t, float64(42), body["view_count"])
+	svc.AssertExpectations(t)
+}
+
+func TestPostViewGetViewCount_InvalidID(t *testing.T) {
+	h, _ := setupPostViewHandler()
+
+	r := newRouter(1)
+	r.GET("/posts/:postId/view-count", h.GetViewCount)
+
+	w := doRequest(r, http.MethodGet, "/posts/abc/view-count", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostViewGetViewCount_ServiceError(t *testing.T) {
+	h, svc := setupPostViewHandler()
+	svc.On("GetViewCount", uint(5)).Return(int64(0), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/posts/:postId/view-count", h.GetViewCount)
+
+	w := doRequest(r, http.MethodGet, "/posts/5/view-count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetMostViewed テスト
+// ============================================================
+
+func TestPostViewGetMostViewed_Success(t *testing.T) {
+	h, svc := setupPostViewHandler()
+	viewCounts := []model.ViewCount{
+		{PostID: 1, Count: 100},
+		{PostID: 2, Count: 50},
+	}
+	svc.On("GetMostViewed", 20).Return(viewCounts, nil)
+
+	r := newRouter(1)
+	r.GET("/posts/trending/most-viewed", h.GetMostViewed)
+
+	w := doRequest(r, http.MethodGet, "/posts/trending/most-viewed", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostViewGetMostViewed_ServiceError(t *testing.T) {
+	h, svc := setupPostViewHandler()
+	svc.On("GetMostViewed", 20).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/posts/trending/most-viewed", h.GetMostViewed)
+
+	w := doRequest(r, http.MethodGet, "/posts/trending/most-viewed", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -139,6 +139,10 @@ func (m *MockPostRepository) FindDraftsByUserID(userID uint) ([]model.Post, erro
 	args := m.Called(userID)
 	return args.Get(0).([]model.Post), args.Error(1)
 }
+func (m *MockPostRepository) GetReplies(parentID uint) ([]model.Comment, error) {
+	args := m.Called(parentID)
+	return args.Get(0).([]model.Comment), args.Error(1)
+}
 
 // MockNotificationRepository は NotificationRepositoryInterface のモック実装。
 type MockNotificationRepository struct{ mock.Mock }

--- a/backend/internal/handler/user_test.go
+++ b/backend/internal/handler/user_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -42,6 +43,14 @@ func (m *MockUserService) GetByUsername(username string) (*model.User, error) {
 
 func (m *MockUserService) Update(user *model.User) error {
 	return m.Called(user).Error(0)
+}
+
+func (m *MockUserService) GetProfileCompleteness(userID uint) (*service.ProfileCompleteness, error) {
+	args := m.Called(userID)
+	if p := args.Get(0); p != nil {
+		return p.(*service.ProfileCompleteness), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func newTestUserHandler() (*UserHandler, *MockUserService) {


### PR DESCRIPTION
## 概要
テストが未作成だった4つのハンドラーにユニットテストを追加。

## 変更内容
- **post_view_test.go** (8テスト): RecordView, GetViewCount, GetMostViewedの正常系・エラー系
- **post_pin_test.go** (10テスト): Pin, Unpin, GetByUserID, Reorderの正常系・エラー系
- **post_tag_test.go** (11テスト): SetTags, GetByPostID, FindPostsByTag, GetPopularTagsの正常系・エラー系
- **mention_test.go** (6テスト): GetMyMentions, GetPostMentionsの正常系・エラー系
- **testutil_test.go**: MockPostRepositoryにGetReplies追加（インターフェース準拠修正）
- **user_test.go**: MockUserServiceにGetProfileCompleteness追加（インターフェース準拠修正）

## テスト計画
- [x] `go test ./internal/handler/...` 全テストPASS
- [x] 新規35テストケース全てPASS

Closes #548