### PR TITLE
feat: PostCardコンポーネントのアクセシビリティ改善

### DIFF
--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -135,18 +135,18 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
             <button
               onClick={onEdit}
               className="p-1.5 text-gray-400 hover:text-white transition-colors"
-              title={t('common.edit')}
+              aria-label={t('common.edit')}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
               </svg>
             </button>
             <button
               onClick={onDelete}
               className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
-              title={t('common.delete')}
+              aria-label={t('common.delete')}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
               </svg>
             </button>
@@ -255,11 +255,13 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
 
       {/* Reactions display */}
       {reactions.length > 0 && (
-        <div className="flex flex-wrap gap-1.5 mt-3">
+        <div className="flex flex-wrap gap-1.5 mt-3" role="group" aria-label={t('post.addReaction')}>
           {reactions.map((r) => (
             <button
               key={r.emoji}
               onClick={() => handleReaction(r.emoji)}
+              aria-label={`${r.emoji} ${r.count}`}
+              aria-pressed={userReactions.includes(r.emoji)}
               className={`flex items-center gap-1 px-2 py-0.5 rounded-full text-xs border transition-colors ${
                 userReactions.includes(r.emoji)
                   ? 'border-blue-500/50 bg-blue-500/10 text-blue-400'
@@ -276,20 +278,23 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
       <div className="flex items-center gap-4 mt-4 pt-3 border-t border-gray-800">
         <button
           onClick={handleLike}
+          aria-label={liked ? t('post.unlike') : t('post.like')}
+          aria-pressed={liked}
           className={`flex items-center gap-1.5 text-sm transition-colors ${
             liked ? 'text-red-400' : 'text-gray-500 hover:text-red-400'
           }`}
         >
-          <svg className="w-4 h-4" fill={liked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <svg className="w-4 h-4" fill={liked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z" />
           </svg>
           {likeCount}
         </button>
         <Link
           to={`/posts/${post.id}`}
+          aria-label={`${t('post.comment')} ${post.comment_count}`}
           className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-blue-400 transition-colors"
         >
-          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
           </svg>
           {post.comment_count}
@@ -297,19 +302,23 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
         <div className="relative">
           <button
             onClick={() => setShowReactionPicker(!showReactionPicker)}
+            aria-label={t('post.addReaction')}
+            aria-expanded={showReactionPicker}
+            aria-haspopup="true"
             className="flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-300 transition-colors"
-            title={t('post.addReaction')}
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M15.182 15.182a4.5 4.5 0 0 1-6.364 0M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0ZM9.75 9.75c0 .414-.168.75-.375.75S9 10.164 9 9.75 9.168 9 9.375 9s.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Zm5.625 0c0 .414-.168.75-.375.75s-.375-.336-.375-.75.168-.75.375-.75.375.336.375.75Zm-.375 0h.008v.015h-.008V9.75Z" />
             </svg>
           </button>
           {showReactionPicker && (
-            <div className="absolute bottom-8 left-0 z-10 flex gap-1 p-1.5 bg-gray-800 border border-gray-700 rounded-lg shadow-lg">
+            <div className="absolute bottom-8 left-0 z-10 flex gap-1 p-1.5 bg-gray-800 border border-gray-700 rounded-lg shadow-lg" role="menu" aria-label={t('post.addReaction')}>
               {availableEmojis.map((emoji) => (
                 <button
                   key={emoji}
                   onClick={() => handleReaction(emoji)}
+                  role="menuitem"
+                  aria-label={emoji}
                   className={`text-lg p-1 rounded hover:bg-gray-700 transition-colors ${
                     userReactions.includes(emoji) ? 'bg-blue-500/20' : ''
                   }`}
@@ -321,8 +330,8 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
           )}
         </div>
         {post.view_count > 0 && (
-          <span className="flex items-center gap-1.5 text-sm text-gray-500">
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <span className="flex items-center gap-1.5 text-sm text-gray-500" aria-label={t('postViews.views', { count: post.view_count })}>
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M2.036 12.322a1.012 1.012 0 0 1 0-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178Z" />
               <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
             </svg>
@@ -331,12 +340,13 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
         )}
         <button
           onClick={handleBookmark}
+          aria-label={bookmarked ? t('post.unbookmark') : t('post.bookmark')}
+          aria-pressed={bookmarked}
           className={`flex items-center gap-1.5 text-sm transition-colors ml-auto ${
             bookmarked ? 'text-yellow-400' : 'text-gray-500 hover:text-yellow-400'
           }`}
-          title={bookmarked ? t('post.unbookmark') : t('post.bookmark')}
         >
-          <svg className="w-4 h-4" fill={bookmarked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+          <svg className="w-4 h-4" fill={bookmarked ? 'currentColor' : 'none'} stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
             <path strokeLinecap="round" strokeLinejoin="round" d="M17.593 3.322c1.1.128 1.907 1.077 1.907 2.185V21L12 17.25 4.5 21V5.507c0-1.108.806-2.057 1.907-2.185a48.507 48.507 0 0 1 11.186 0Z" />
           </svg>
           {post.bookmark_count > 0 && <span>{post.bookmark_count}</span>}


### PR DESCRIPTION
## 概要
PostCardの全インタラクティブ要素にWCAG 2.1準拠のaria属性を追加。

## 変更内容
- いいね/ブックマークボタン: aria-label（状態別テキスト）+ aria-pressed
- 編集/削除ボタン: titleをaria-labelに変更
- コメントリンク: aria-label追加
- リアクションピッカー: role="menu", aria-expanded, aria-haspopup
- リアクション絵文字: role="menuitem", aria-label
- リアクション表示: role="group", aria-pressed
- 閲覧数: aria-label追加
- 全SVGアイコン: aria-hidden="true"（スクリーンリーダーで無視）

## テスト計画
- [x] `npx tsc --noEmit` 型エラーなし
- [x] 既存i18nキーで全aria-label対応済み

Closes #549