### PR TITLE
feat: DTOバリデーションタグの統一・強化

### DIFF
--- a/backend/internal/dto/book_review_dto.go
+++ b/backend/internal/dto/book_review_dto.go
@@ -14,11 +14,11 @@ type CreateBookReviewRequest struct {
 
 // UpdateBookReviewRequest は書籍レビュー更新のリクエストボディ。
 type UpdateBookReviewRequest struct {
-	Title    string `json:"title" binding:"max=300" validate:"max=300"`
-	Author   string `json:"author" binding:"max=200" validate:"max=200"`
-	ISBN     string `json:"isbn" binding:"max=20" validate:"max=20"`
+	Title    string `json:"title" binding:"omitempty,max=300" validate:"omitempty,max=300"`
+	Author   string `json:"author" binding:"omitempty,max=200" validate:"omitempty,max=200"`
+	ISBN     string `json:"isbn" binding:"omitempty,max=20" validate:"omitempty,max=20"`
 	Rating   *int   `json:"rating" binding:"omitempty,min=1,max=5" validate:"omitempty,min=1,max=5"`
-	Review   string `json:"review"`
+	Review   string `json:"review" binding:"omitempty,max=5000"`
 	ImageURL string `json:"image_url"`
 }
 

--- a/backend/internal/dto/code_snippet_dto.go
+++ b/backend/internal/dto/code_snippet_dto.go
@@ -2,20 +2,20 @@ package dto
 
 // CreateCodeSnippetRequest はコードスニペット作成リクエスト。
 type CreateCodeSnippetRequest struct {
-	Language string `json:"language" binding:"required" validate:"required"`
-	FileName string `json:"file_name"`
-	Code     string `json:"code" binding:"required" validate:"required"`
+	Language string `json:"language" binding:"required,max=100" validate:"required,max=100"`
+	FileName string `json:"file_name" binding:"omitempty,max=255"`
+	Code     string `json:"code" binding:"required,max=50000" validate:"required,max=50000"`
 }
 
 // UpdateCodeSnippetRequest はコードスニペット更新リクエスト。
 type UpdateCodeSnippetRequest struct {
-	Language string `json:"language"`
-	FileName string `json:"file_name"`
-	Code     string `json:"code"`
+	Language string `json:"language" binding:"omitempty,max=100"`
+	FileName string `json:"file_name" binding:"omitempty,max=255"`
+	Code     string `json:"code" binding:"omitempty,max=50000"`
 }
 
 // CreateSnippetCommentRequest はスニペットコメント作成リクエスト。
 type CreateSnippetCommentRequest struct {
 	LineNumber int    `json:"line_number" binding:"required" validate:"required"`
-	Content    string `json:"content" binding:"required" validate:"required"`
+	Content    string `json:"content" binding:"required,max=5000" validate:"required,max=5000"`
 }

--- a/backend/internal/dto/post_collection_dto.go
+++ b/backend/internal/dto/post_collection_dto.go
@@ -3,19 +3,19 @@ package dto
 // CreatePostCollectionRequest はコレクション作成のリクエストボディ。
 type CreatePostCollectionRequest struct {
 	Title       string `json:"title" binding:"required,max=200"`
-	Description string `json:"description"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
 	IsPublic    bool   `json:"is_public"`
 }
 
 // UpdatePostCollectionRequest はコレクション更新のリクエストボディ。
 type UpdatePostCollectionRequest struct {
-	Title       string `json:"title" binding:"required,max=200"`
-	Description string `json:"description"`
+	Title       string `json:"title" binding:"omitempty,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
 	IsPublic    bool   `json:"is_public"`
 }
 
 // AddPostToCollectionRequest はコレクションへの投稿追加リクエスト。
 type AddPostToCollectionRequest struct {
 	PostID uint   `json:"post_id" binding:"required"`
-	Note   string `json:"note"`
+	Note   string `json:"note" binding:"omitempty,max=1000"`
 }

--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -11,8 +11,8 @@ type CodeSnippetInput struct {
 
 // CreatePostRequest は投稿作成リクエスト。
 type CreatePostRequest struct {
-	Title        string             `json:"title" binding:"required"`
-	Content      string             `json:"content" binding:"required"`
+	Title        string             `json:"title" binding:"required,max=200"`
+	Content      string             `json:"content" binding:"required,max=50000"`
 	ImageURLs    string             `json:"image_urls"`
 	IsDraft      bool               `json:"is_draft"`
 	CodeSnippets []CodeSnippetInput `json:"code_snippets"`
@@ -27,7 +27,7 @@ type UpdatePostRequest struct {
 
 // CreateCommentRequest はコメント作成リクエスト。
 type CreateCommentRequest struct {
-	Content string `json:"content" binding:"required"`
+	Content string `json:"content" binding:"required,max=5000"`
 }
 
 // PostDetailResponse は投稿詳細レスポンス（いいね済み・ブックマーク済みフラグ付き）。

--- a/backend/internal/dto/post_series_dto.go
+++ b/backend/internal/dto/post_series_dto.go
@@ -3,13 +3,13 @@ package dto
 // CreatePostSeriesRequest はシリーズ作成のリクエストボディ。
 type CreatePostSeriesRequest struct {
 	Title       string `json:"title" binding:"required,max=200"`
-	Description string `json:"description"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
 }
 
 // UpdatePostSeriesRequest はシリーズ更新のリクエストボディ。
 type UpdatePostSeriesRequest struct {
-	Title       string `json:"title" binding:"max=200"`
-	Description string `json:"description"`
+	Title       string `json:"title" binding:"omitempty,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
 }
 
 // AddPostToSeriesRequest はシリーズへの投稿追加リクエスト。


### PR DESCRIPTION
## 概要
- Update系DTOの`required`を`omitempty`に変更し、部分更新に対応
- Description/Content等の文字列フィールドにmax制約を追加
- CodeSnippetのLanguage/Code/FileNameに適切な上限値を設定
- BookReview UpdateDTOのバリデーションタグを統一

## 変更ファイル
- `post_collection_dto.go` — UpdateのTitle: required→omitempty、Description/Noteにmax追加
- `post_series_dto.go` — Descriptionにmax=2000追加、Updateにomitempty追加
- `code_snippet_dto.go` — Language: max=100、Code: max=50000、FileName: max=255追加
- `post_dto.go` — Title: max=200、Content: max=50000、Comment: max=5000追加
- `book_review_dto.go` — Update DTOにomitempty統一、Reviewにmax=5000追加

## テスト計画
- [x] 既存DTOテスト全件合格
- [x] 既存ハンドラーテスト全件合格

Closes #554