### PR TITLE
feat: MarkdownEditor/PostSeriesCardのアクセシビリティ改善

### DIFF
--- a/frontend/src/components/posts/MarkdownEditor.tsx
+++ b/frontend/src/components/posts/MarkdownEditor.tsx
@@ -173,9 +173,12 @@ export default function MarkdownEditor({
   return (
     <div className="border border-gray-700 rounded-lg overflow-hidden bg-gray-800">
       {/* Tabs */}
-      <div className="flex border-b border-gray-700">
+      <div className="flex border-b border-gray-700" role="tablist">
         <button
           type="button"
+          role="tab"
+          aria-selected={activeTab === 'write'}
+          aria-controls="editor-write-panel"
           onClick={() => setActiveTab('write')}
           className={`px-4 py-2 text-sm font-medium transition-colors ${
             activeTab === 'write'
@@ -187,6 +190,9 @@ export default function MarkdownEditor({
         </button>
         <button
           type="button"
+          role="tab"
+          aria-selected={activeTab === 'preview'}
+          aria-controls="editor-preview-panel"
           onClick={() => setActiveTab('preview')}
           className={`px-4 py-2 text-sm font-medium transition-colors ${
             activeTab === 'preview'
@@ -199,16 +205,17 @@ export default function MarkdownEditor({
 
         {/* Toolbar */}
         {activeTab === 'write' && (
-          <div className="flex items-center gap-0.5 ml-auto px-2">
+          <div className="flex items-center gap-0.5 ml-auto px-2" role="toolbar" aria-label={t('editor.toolbar')}>
             {toolbarButtons.map((btn, i) =>
               btn.action === 'divider' ? (
-                <div key={i} className="w-px h-4 bg-gray-600 mx-1" />
+                <div key={i} className="w-px h-4 bg-gray-600 mx-1" aria-hidden="true" />
               ) : (
                 <button
                   key={btn.action}
                   type="button"
                   onClick={() => handleToolbarAction(btn.action)}
                   className={`p-1.5 text-xs text-gray-400 hover:text-white hover:bg-gray-700 rounded transition-colors ${btn.className || ''}`}
+                  aria-label={btn.title}
                   title={btn.title}
                 >
                   {btn.icon}
@@ -222,7 +229,7 @@ export default function MarkdownEditor({
       {/* Content */}
       <div style={{ minHeight }}>
         {activeTab === 'write' ? (
-          <div className="relative">
+          <div className="relative" id="editor-write-panel" role="tabpanel">
             <textarea
               ref={textareaRef}
               value={value}
@@ -235,9 +242,9 @@ export default function MarkdownEditor({
               style={{ minHeight }}
             />
             {uploading && (
-              <div className="absolute inset-0 bg-gray-900/80 flex items-center justify-center">
+              <div className="absolute inset-0 bg-gray-900/80 flex items-center justify-center" aria-live="polite">
                 <div className="flex items-center gap-2 text-blue-400">
-                  <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                  <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24" aria-hidden="true">
                     <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                     <path
                       className="opacity-75"
@@ -253,6 +260,8 @@ export default function MarkdownEditor({
         ) : (
           <div
             className="p-4 prose prose-invert prose-sm max-w-none"
+            id="editor-preview-panel"
+            role="tabpanel"
             style={{ minHeight }}
           >
             {value ? (
@@ -311,6 +320,7 @@ export default function MarkdownEditor({
                 />
                 <button
                   type="button"
+                  aria-label={t('editor.removeImage', { number: i + 1 })}
                   onClick={() => {
                     const newImages = uploadedImages.filter((_, j) => j !== i);
                     setUploadedImages(newImages);
@@ -318,7 +328,7 @@ export default function MarkdownEditor({
                   }}
                   className="absolute -top-1 -right-1 w-5 h-5 bg-red-500 rounded-full text-white text-xs opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
                 >
-                  x
+                  <span aria-hidden="true">x</span>
                 </button>
               </div>
             ))}

--- a/frontend/src/components/series/PostSeriesCard.tsx
+++ b/frontend/src/components/series/PostSeriesCard.tsx
@@ -30,18 +30,20 @@ export default function PostSeriesCard({ series, onEdit, onDelete, isOwner }: Po
             <button
               onClick={onEdit}
               className="p-1.5 text-gray-400 hover:text-white transition-colors"
+              aria-label={t('common.edit')}
               title={t('common.edit')}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
               </svg>
             </button>
             <button
               onClick={onDelete}
               className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+              aria-label={t('common.delete')}
               title={t('common.delete')}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
               </svg>
             </button>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1270,7 +1270,9 @@
     "attachedImages": "Angehängte Bilder:",
     "uploadedImage": "Hochgeladenes Bild {{number}}",
     "markdownSupported": "Markdown unterstützt",
-    "pasteOrDragImages": "Bilder einfügen oder ziehen zum Hochladen"
+    "pasteOrDragImages": "Bilder einfügen oder ziehen zum Hochladen",
+    "toolbar": "Formatierungswerkzeugleiste",
+    "removeImage": "Bild {{number}} entfernen"
   },
   "tags": {
     "title": "Tags",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1270,7 +1270,9 @@
     "attachedImages": "Attached images:",
     "uploadedImage": "Uploaded {{number}}",
     "markdownSupported": "Markdown supported",
-    "pasteOrDragImages": "Paste or drag images to upload"
+    "pasteOrDragImages": "Paste or drag images to upload",
+    "toolbar": "Formatting toolbar",
+    "removeImage": "Remove image {{number}}"
   },
   "tags": {
     "title": "Tags",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1270,7 +1270,9 @@
     "attachedImages": "Imágenes adjuntas:",
     "uploadedImage": "Imagen subida {{number}}",
     "markdownSupported": "Markdown compatible",
-    "pasteOrDragImages": "Pega o arrastra imágenes para subir"
+    "pasteOrDragImages": "Pega o arrastra imágenes para subir",
+    "toolbar": "Barra de herramientas de formato",
+    "removeImage": "Eliminar imagen {{number}}"
   },
   "tags": {
     "title": "Etiquetas",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1270,7 +1270,9 @@
     "attachedImages": "Images jointes :",
     "uploadedImage": "Image téléchargée {{number}}",
     "markdownSupported": "Markdown pris en charge",
-    "pasteOrDragImages": "Collez ou glissez des images pour télécharger"
+    "pasteOrDragImages": "Collez ou glissez des images pour télécharger",
+    "toolbar": "Barre d'outils de mise en forme",
+    "removeImage": "Supprimer l'image {{number}}"
   },
   "tags": {
     "title": "Tags",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1171,7 +1171,9 @@
     "attachedImages": "添付画像:",
     "uploadedImage": "アップロード画像 {{number}}",
     "markdownSupported": "Markdown対応",
-    "pasteOrDragImages": "画像を貼り付けまたはドラッグしてアップロード"
+    "pasteOrDragImages": "画像を貼り付けまたはドラッグしてアップロード",
+    "toolbar": "書式ツールバー",
+    "removeImage": "画像{{number}}を削除"
   },
   "tags": {
     "title": "タグ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1270,7 +1270,9 @@
     "attachedImages": "첨부 이미지:",
     "uploadedImage": "업로드된 이미지 {{number}}",
     "markdownSupported": "마크다운 지원",
-    "pasteOrDragImages": "이미지를 붙여넣거나 드래그하여 업로드"
+    "pasteOrDragImages": "이미지를 붙여넣거나 드래그하여 업로드",
+    "toolbar": "서식 도구 모음",
+    "removeImage": "이미지 {{number}} 삭제"
   },
   "tags": {
     "title": "태그",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1270,7 +1270,9 @@
     "attachedImages": "Imagens anexadas:",
     "uploadedImage": "Imagem enviada {{number}}",
     "markdownSupported": "Markdown suportado",
-    "pasteOrDragImages": "Cole ou arraste imagens para enviar"
+    "pasteOrDragImages": "Cole ou arraste imagens para enviar",
+    "toolbar": "Barra de ferramentas de formatação",
+    "removeImage": "Remover imagem {{number}}"
   },
   "tags": {
     "title": "Tags",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1270,7 +1270,9 @@
     "attachedImages": "Прикреплённые изображения:",
     "uploadedImage": "Загруженное изображение {{number}}",
     "markdownSupported": "Поддерживается Markdown",
-    "pasteOrDragImages": "Вставьте или перетащите изображения для загрузки"
+    "pasteOrDragImages": "Вставьте или перетащите изображения для загрузки",
+    "toolbar": "Панель форматирования",
+    "removeImage": "Удалить изображение {{number}}"
   },
   "tags": {
     "title": "Теги",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1270,7 +1270,9 @@
     "attachedImages": "附加图片：",
     "uploadedImage": "已上传图片 {{number}}",
     "markdownSupported": "支持Markdown",
-    "pasteOrDragImages": "粘贴或拖拽图片上传"
+    "pasteOrDragImages": "粘贴或拖拽图片上传",
+    "toolbar": "格式工具栏",
+    "removeImage": "删除图片{{number}}"
   },
   "tags": {
     "title": "标签",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1270,7 +1270,9 @@
     "attachedImages": "附加圖片：",
     "uploadedImage": "已上傳圖片 {{number}}",
     "markdownSupported": "支援Markdown",
-    "pasteOrDragImages": "貼上或拖曳圖片上傳"
+    "pasteOrDragImages": "貼上或拖曳圖片上傳",
+    "toolbar": "格式工具列",
+    "removeImage": "刪除圖片{{number}}"
   },
   "tags": {
     "title": "標籤",


### PR DESCRIPTION
## 概要
MarkdownEditorとPostSeriesCardにWCAG 2.1 AA準拠のアクセシビリティ属性を追加。

## MarkdownEditor
- タブ: role="tablist"/role="tab"/aria-selected、tabpanelにrole="tabpanel"
- ツールバー: role="toolbar"/aria-label、各ボタンにaria-label
- アップロード中: SVGにaria-hidden、オーバーレイにaria-live="polite"
- 画像削除ボタン: aria-label追加

## PostSeriesCard
- 編集/削除ボタン: aria-label追加
- SVGアイコン: aria-hidden="true"追加

## i18n
- editor.toolbar, editor.removeImage を10言語に追加

## テスト計画
- [x] TypeScript型チェック合格

Closes #555