### PR TITLE
feat: DTOバリデーション強化第2弾（user/chat_room/learning_log/learning_goal/study_circle/common/post_tag）

### DIFF
--- a/backend/internal/dto/chat_room_dto.go
+++ b/backend/internal/dto/chat_room_dto.go
@@ -2,15 +2,15 @@ package dto
 
 // CreateChatRoomRequest はチャットルーム作成リクエスト。
 type CreateChatRoomRequest struct {
-	Name        string `json:"name" binding:"required" validate:"required"`
-	Description string `json:"description"`
-	MemberIDs   []uint `json:"member_ids"`
+	Name        string `json:"name" binding:"required,max=200" validate:"required,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
+	MemberIDs   []uint `json:"member_ids" binding:"omitempty,max=100"`
 }
 
 // UpdateChatRoomRequest はチャットルーム更新リクエスト。
 type UpdateChatRoomRequest struct {
-	Name        string `json:"name"`
-	Description string `json:"description"`
+	Name        string `json:"name" binding:"omitempty,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
 }
 
 // AddChatRoomMemberRequest はメンバー追加リクエスト。
@@ -20,5 +20,5 @@ type AddChatRoomMemberRequest struct {
 
 // SendChatRoomMessageRequest はチャットルームメッセージ送信リクエスト。
 type SendChatRoomMessageRequest struct {
-	Content string `json:"content" binding:"required" validate:"required"`
+	Content string `json:"content" binding:"required,max=5000" validate:"required,max=5000"`
 }

--- a/backend/internal/dto/common_dto.go
+++ b/backend/internal/dto/common_dto.go
@@ -9,7 +9,7 @@ type VoteRequest struct {
 // ConnectUsernameRequest は外部サービスのユーザー名接続リクエスト。
 // AtCoder・Zenn・Qiitaなど共通で使用する。
 type ConnectUsernameRequest struct {
-	Username string `json:"username" binding:"required" validate:"required"`
+	Username string `json:"username" binding:"required,max=100" validate:"required,max=100"`
 }
 
 // ConnectSyncResponse は外部サービス接続・同期のレスポンス。

--- a/backend/internal/dto/learning_goal_dto.go
+++ b/backend/internal/dto/learning_goal_dto.go
@@ -2,18 +2,18 @@ package dto
 
 // CreateGoalRequest は学習目標作成のリクエストボディ。
 type CreateGoalRequest struct {
-	Title       string `json:"title" binding:"required" validate:"required"`
-	Description string `json:"description"`
-	Category    string `json:"category"`
-	TargetDate  string `json:"target_date"`
+	Title       string `json:"title" binding:"required,max=200" validate:"required,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
+	Category    string `json:"category" binding:"omitempty,max=100"`
+	TargetDate  string `json:"target_date" binding:"omitempty,max=20"`
 }
 
 // UpdateGoalRequest は学習目標更新のリクエストボディ。
 type UpdateGoalRequest struct {
-	Title       *string `json:"title"`
-	Description *string `json:"description"`
-	Category    *string `json:"category"`
-	TargetDate  *string `json:"target_date"`
-	Progress    *int    `json:"progress"`
-	Status      *string `json:"status"`
+	Title       *string `json:"title" binding:"omitempty,max=200"`
+	Description *string `json:"description" binding:"omitempty,max=2000"`
+	Category    *string `json:"category" binding:"omitempty,max=100"`
+	TargetDate  *string `json:"target_date" binding:"omitempty,max=20"`
+	Progress    *int    `json:"progress" binding:"omitempty,min=0,max=100"`
+	Status      *string `json:"status" binding:"omitempty,max=50"`
 }

--- a/backend/internal/dto/learning_log_dto.go
+++ b/backend/internal/dto/learning_log_dto.go
@@ -2,17 +2,17 @@ package dto
 
 // CreateLearningLogRequest は学習ログ作成リクエスト。
 type CreateLearningLogRequest struct {
-	Title    string `json:"title" binding:"required" validate:"required"`
-	Content  string `json:"content" binding:"required" validate:"required"`
-	Category string `json:"category"`
-	Duration int    `json:"duration"`
-	Source   string `json:"source"`
+	Title    string `json:"title" binding:"required,max=200" validate:"required,max=200"`
+	Content  string `json:"content" binding:"required,max=50000" validate:"required,max=50000"`
+	Category string `json:"category" binding:"omitempty,max=100"`
+	Duration int    `json:"duration" binding:"omitempty,min=0,max=1440"`
+	Source   string `json:"source" binding:"omitempty,max=500"`
 }
 
 // UpdateLearningLogRequest は学習ログ更新リクエスト。
 type UpdateLearningLogRequest struct {
-	Title    *string `json:"title"`
-	Content  *string `json:"content"`
-	Category *string `json:"category"`
-	Duration *int    `json:"duration"`
+	Title    *string `json:"title" binding:"omitempty,max=200"`
+	Content  *string `json:"content" binding:"omitempty,max=50000"`
+	Category *string `json:"category" binding:"omitempty,max=100"`
+	Duration *int    `json:"duration" binding:"omitempty,min=0,max=1440"`
 }

--- a/backend/internal/dto/post_tag_dto.go
+++ b/backend/internal/dto/post_tag_dto.go
@@ -2,5 +2,5 @@ package dto
 
 // SetTagsRequest はタグ設定のリクエスト。
 type SetTagsRequest struct {
-	Tags []string `json:"tags" binding:"required"`
+	Tags []string `json:"tags" binding:"required,max=10,dive,max=50"`
 }

--- a/backend/internal/dto/study_circle_dto.go
+++ b/backend/internal/dto/study_circle_dto.go
@@ -4,18 +4,18 @@ import "github.com/norman6464/devsync/backend/internal/repository"
 
 // CreateStudyCircleRequest はスタディサークル作成リクエストのDTO。
 type CreateStudyCircleRequest struct {
-	Name        string `json:"name" binding:"required"`
-	Topic       string `json:"topic" binding:"required"`
-	Description string `json:"description"`
-	MaxMembers  int    `json:"max_members"`
-	MemberIDs   []uint `json:"member_ids"`
+	Name        string `json:"name" binding:"required,max=200"`
+	Topic       string `json:"topic" binding:"required,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
+	MaxMembers  int    `json:"max_members" binding:"omitempty,min=0,max=1000"`
+	MemberIDs   []uint `json:"member_ids" binding:"omitempty,max=100"`
 }
 
 // UpdateStudyCircleRequest はスタディサークル更新リクエストのDTO。
 type UpdateStudyCircleRequest struct {
-	Name        *string `json:"name"`
-	Topic       *string `json:"topic"`
-	Description *string `json:"description"`
+	Name        *string `json:"name" binding:"omitempty,max=200"`
+	Topic       *string `json:"topic" binding:"omitempty,max=200"`
+	Description *string `json:"description" binding:"omitempty,max=2000"`
 }
 
 // AddStudyCircleMemberRequest はスタディサークルメンバー追加リクエストのDTO。
@@ -25,16 +25,16 @@ type AddStudyCircleMemberRequest struct {
 
 // CreateStudyCircleStepRequest はスタディサークルステップ作成リクエストのDTO。
 type CreateStudyCircleStepRequest struct {
-	Title       string `json:"title" binding:"required"`
-	Description string `json:"description"`
-	ResourceURL string `json:"resource_url"`
-	OrderIndex  int    `json:"order_index"`
+	Title       string `json:"title" binding:"required,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
+	ResourceURL string `json:"resource_url" binding:"omitempty,max=2000"`
+	OrderIndex  int    `json:"order_index" binding:"omitempty,min=0"`
 }
 
 // UpdateStudyCircleStepRequest はスタディサークルステップ更新リクエストのDTO。
 type UpdateStudyCircleStepRequest struct {
-	Title       *string `json:"title"`
-	Description *string `json:"description"`
+	Title       *string `json:"title" binding:"omitempty,max=200"`
+	Description *string `json:"description" binding:"omitempty,max=2000"`
 }
 
 // ReorderStudyCircleStepsRequest はスタディサークルステップ並べ替えリクエストのDTO。
@@ -49,5 +49,5 @@ type UpdateStudyCircleProgressRequest struct {
 
 // CreateStudyCircleCheckinRequest はスタディサークルチェックイン作成リクエストのDTO。
 type CreateStudyCircleCheckinRequest struct {
-	Content string `json:"content" binding:"required"`
+	Content string `json:"content" binding:"required,max=5000"`
 }

--- a/backend/internal/dto/user_dto.go
+++ b/backend/internal/dto/user_dto.go
@@ -2,12 +2,12 @@ package dto
 
 // UpdateUserRequest はユーザープロフィール更新リクエスト。
 type UpdateUserRequest struct {
-	Name                string  `json:"name"`
-	Bio                 string  `json:"bio"`
-	AvatarURL           string  `json:"avatar_url"`
-	SkillsLanguages     *string `json:"skills_languages"`
-	SkillsFrameworks    *string `json:"skills_frameworks"`
-	AtCoderUsername     *string `json:"atcoder_username"`
-	PaizaRank           *string `json:"paiza_rank"`
+	Name                string  `json:"name" binding:"omitempty,max=200"`
+	Bio                 string  `json:"bio" binding:"omitempty,max=500"`
+	AvatarURL           string  `json:"avatar_url" binding:"omitempty,max=2000"`
+	SkillsLanguages     *string `json:"skills_languages" binding:"omitempty,max=1000"`
+	SkillsFrameworks    *string `json:"skills_frameworks" binding:"omitempty,max=1000"`
+	AtCoderUsername     *string `json:"atcoder_username" binding:"omitempty,max=100"`
+	PaizaRank           *string `json:"paiza_rank" binding:"omitempty,max=20"`
 	OnboardingCompleted *bool   `json:"onboarding_completed"`
 }


### PR DESCRIPTION
## 概要
- user_dto, chat_room_dto, learning_log_dto, learning_goal_dto, study_circle_dto, common_dto, post_tag_dto の7ファイルにmax制約を追加
- 文字列フィールドに適切なmax値を設定（Title系: max=200, Content系: max=50000, Description系: max=2000等）
- 数値フィールドにmin/max制約を追加（Duration: 0-1440, Progress: 0-100等）
- 配列フィールドにmax制約とdiveバリデーションを追加（Tags: max=10,dive,max=50）
- Update系DTOにomitemptyを統一的に追加

## テスト
- 既存DTO・ハンドラーテスト全パス確認済み

Closes #559