### PR TITLE
feat: DTOバリデーション強化第3弾（roadmap/message/project/reminder_settings）

### DIFF
--- a/backend/internal/dto/message_dto.go
+++ b/backend/internal/dto/message_dto.go
@@ -2,5 +2,5 @@ package dto
 
 // SendMessageRequest はDMメッセージ送信リクエスト。
 type SendMessageRequest struct {
-	Content string `json:"content" binding:"required" validate:"required"`
+	Content string `json:"content" binding:"required,max=5000" validate:"required,max=5000"`
 }

--- a/backend/internal/dto/project_dto.go
+++ b/backend/internal/dto/project_dto.go
@@ -5,29 +5,29 @@ import "github.com/norman6464/devsync/backend/internal/model"
 // CreateProjectRequest はプロジェクト作成のリクエストボディ。
 type CreateProjectRequest struct {
 	Title        string `json:"title" binding:"required,max=200" validate:"required,max=200"`
-	Description  string `json:"description"`
-	TechStack    string `json:"tech_stack"`
-	DemoURL      string `json:"demo_url"`
-	GithubURL    string `json:"github_url"`
-	ImageURL     string `json:"image_url"`
-	Role         string `json:"role"`
-	StartDate    string `json:"start_date"`
-	EndDate      string `json:"end_date"`
+	Description  string `json:"description" binding:"omitempty,max=5000"`
+	TechStack    string `json:"tech_stack" binding:"omitempty,max=500"`
+	DemoURL      string `json:"demo_url" binding:"omitempty,max=2000"`
+	GithubURL    string `json:"github_url" binding:"omitempty,max=2000"`
+	ImageURL     string `json:"image_url" binding:"omitempty,max=2000"`
+	Role         string `json:"role" binding:"omitempty,max=200"`
+	StartDate    string `json:"start_date" binding:"omitempty,max=20"`
+	EndDate      string `json:"end_date" binding:"omitempty,max=20"`
 	Featured     bool   `json:"featured"`
 	GithubRepoID *uint  `json:"github_repo_id"`
 }
 
 // UpdateProjectRequest はプロジェクト更新のリクエストボディ。
 type UpdateProjectRequest struct {
-	Title        string `json:"title" binding:"max=200" validate:"max=200"`
-	Description  string `json:"description"`
-	TechStack    string `json:"tech_stack"`
-	DemoURL      string `json:"demo_url"`
-	GithubURL    string `json:"github_url"`
-	ImageURL     string `json:"image_url"`
-	Role         string `json:"role"`
-	StartDate    string `json:"start_date"`
-	EndDate      string `json:"end_date"`
+	Title        string `json:"title" binding:"omitempty,max=200" validate:"omitempty,max=200"`
+	Description  string `json:"description" binding:"omitempty,max=5000"`
+	TechStack    string `json:"tech_stack" binding:"omitempty,max=500"`
+	DemoURL      string `json:"demo_url" binding:"omitempty,max=2000"`
+	GithubURL    string `json:"github_url" binding:"omitempty,max=2000"`
+	ImageURL     string `json:"image_url" binding:"omitempty,max=2000"`
+	Role         string `json:"role" binding:"omitempty,max=200"`
+	StartDate    string `json:"start_date" binding:"omitempty,max=20"`
+	EndDate      string `json:"end_date" binding:"omitempty,max=20"`
 	Featured     *bool  `json:"featured"`
 	GithubRepoID *uint  `json:"github_repo_id"`
 }

--- a/backend/internal/dto/reminder_settings_dto.go
+++ b/backend/internal/dto/reminder_settings_dto.go
@@ -5,9 +5,9 @@ import "github.com/norman6464/devsync/backend/internal/model"
 // UpdateReminderSettingsRequest はリマインダー設定更新のリクエストボディ。
 type UpdateReminderSettingsRequest struct {
 	Enabled          bool                    `json:"enabled"`
-	Frequency        model.ReminderFrequency `json:"frequency"`
-	NotificationTime string                  `json:"notification_time"`
-	InactiveDays     int                     `json:"inactive_days"`
+	Frequency        model.ReminderFrequency `json:"frequency" binding:"omitempty,max=50"`
+	NotificationTime string                  `json:"notification_time" binding:"omitempty,max=10"`
+	InactiveDays     int                     `json:"inactive_days" binding:"omitempty,min=0,max=365"`
 	EnableWeb        bool                    `json:"enable_web"`
 	EnableEmail      bool                    `json:"enable_email"`
 }

--- a/backend/internal/dto/roadmap_dto.go
+++ b/backend/internal/dto/roadmap_dto.go
@@ -7,34 +7,34 @@ import (
 
 // CreateRoadmapRequest はロードマップ作成リクエストのDTO。
 type CreateRoadmapRequest struct {
-	Title       string `json:"title" binding:"required"`
-	Description string `json:"description"`
-	Category    string `json:"category"`
+	Title       string `json:"title" binding:"required,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
+	Category    string `json:"category" binding:"omitempty,max=100"`
 	IsPublic    bool   `json:"is_public"`
 }
 
 // UpdateRoadmapRequest はロードマップ更新リクエストのDTO。
 type UpdateRoadmapRequest struct {
-	Title       *string `json:"title"`
-	Description *string `json:"description"`
-	Category    *string `json:"category"`
+	Title       *string `json:"title" binding:"omitempty,max=200"`
+	Description *string `json:"description" binding:"omitempty,max=2000"`
+	Category    *string `json:"category" binding:"omitempty,max=100"`
 	IsPublic    *bool   `json:"is_public"`
-	Status      *string `json:"status"`
+	Status      *string `json:"status" binding:"omitempty,max=50"`
 }
 
 // CreateRoadmapStepRequest はロードマップステップ作成リクエストのDTO。
 type CreateRoadmapStepRequest struct {
-	Title       string `json:"title" binding:"required"`
-	Description string `json:"description"`
-	ResourceURL string `json:"resource_url"`
+	Title       string `json:"title" binding:"required,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
+	ResourceURL string `json:"resource_url" binding:"omitempty,max=2000"`
 	OrderIndex  *int   `json:"order_index"`
 }
 
 // UpdateRoadmapStepRequest はロードマップステップ更新リクエストのDTO。
 type UpdateRoadmapStepRequest struct {
-	Title       *string `json:"title"`
-	Description *string `json:"description"`
-	ResourceURL *string `json:"resource_url"`
+	Title       *string `json:"title" binding:"omitempty,max=200"`
+	Description *string `json:"description" binding:"omitempty,max=2000"`
+	ResourceURL *string `json:"resource_url" binding:"omitempty,max=2000"`
 	IsCompleted *bool   `json:"is_completed"`
 }
 


### PR DESCRIPTION
## 概要
- roadmap_dto.go: Title max=200, Description max=2000, Category max=100, ResourceURL max=2000, Status max=50追加
- message_dto.go: Content max=5000追加
- project_dto.go: Description max=5000, TechStack max=500, URL系 max=2000, Role max=200, 日付 max=20追加
- reminder_settings_dto.go: Frequency max=50, NotificationTime max=10, InactiveDays min=0/max=365追加

## テスト
- 既存DTO・ハンドラーテスト全パス確認済み

Closes #565