### PR TITLE
test: SchedulerServiceのユニットテスト追加

### DIFF
--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2,8 +2,11 @@
 package service
 
 import (
+	"context"
+
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
+	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -1699,5 +1702,44 @@ func (m *MockMentionRepository) DeleteByPostID(postID uint) error {
 
 func (m *MockMentionRepository) DeleteByCommentID(commentID uint) error {
 	args := m.Called(commentID)
+	return args.Error(0)
+}
+
+// ============================================================
+// MockCronScheduler は CronScheduler のテスト用モック実装。
+// ============================================================
+
+type MockCronScheduler struct {
+	mock.Mock
+}
+
+var _ CronScheduler = (*MockCronScheduler)(nil)
+
+func (m *MockCronScheduler) AddFunc(spec string, cmd func()) (cron.EntryID, error) {
+	args := m.Called(spec, cmd)
+	return args.Get(0).(cron.EntryID), args.Error(1)
+}
+
+func (m *MockCronScheduler) Start() {
+	m.Called()
+}
+
+func (m *MockCronScheduler) Stop() context.Context {
+	args := m.Called()
+	return args.Get(0).(context.Context)
+}
+
+// ============================================================
+// MockWeeklyReportSender は WeeklyReportSender のテスト用モック実装。
+// ============================================================
+
+type MockWeeklyReportSender struct {
+	mock.Mock
+}
+
+var _ WeeklyReportSender = (*MockWeeklyReportSender)(nil)
+
+func (m *MockWeeklyReportSender) SendAllWeeklyReports() error {
+	args := m.Called()
 	return args.Error(0)
 }

--- a/backend/internal/service/scheduler.go
+++ b/backend/internal/service/scheduler.go
@@ -1,16 +1,29 @@
 package service
 
 import (
+	"context"
 	"log"
 
 	"github.com/robfig/cron/v3"
 )
 
+// CronScheduler はcronスケジューラの抽象インターフェース。
+type CronScheduler interface {
+	AddFunc(spec string, cmd func()) (cron.EntryID, error)
+	Start()
+	Stop() context.Context
+}
+
+// WeeklyReportSender はウィークリーレポート送信の抽象インターフェース。
+type WeeklyReportSender interface {
+	SendAllWeeklyReports() error
+}
+
 // Scheduler はcronベースの定期実行サービス。
 // ウィークリーレポートメールなどの定期タスクをスケジュール実行する。
 type Scheduler struct {
-	cron     *cron.Cron
-	emailSvc *WeeklyReportEmailService
+	cron     CronScheduler
+	emailSvc WeeklyReportSender
 }
 
 // NewScheduler は新しいSchedulerインスタンスを生成する。

--- a/backend/internal/service/scheduler_test.go
+++ b/backend/internal/service/scheduler_test.go
@@ -1,0 +1,107 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func newTestScheduler() (*Scheduler, *MockCronScheduler, *MockWeeklyReportSender) {
+	cronMock := new(MockCronScheduler)
+	senderMock := new(MockWeeklyReportSender)
+	s := &Scheduler{
+		cron:     cronMock,
+		emailSvc: senderMock,
+	}
+	return s, cronMock, senderMock
+}
+
+func TestNewScheduler(t *testing.T) {
+	s := NewScheduler(nil)
+	assert.NotNil(t, s)
+	assert.NotNil(t, s.cron)
+}
+
+func TestStart_Success(t *testing.T) {
+	s, cronMock, _ := newTestScheduler()
+
+	cronMock.On("AddFunc", "0 9 * * 1", mock.AnythingOfType("func()")).
+		Return(cron.EntryID(1), nil)
+	cronMock.On("Start").Return()
+
+	s.Start()
+
+	cronMock.AssertExpectations(t)
+}
+
+func TestStart_AddFuncError(t *testing.T) {
+	s, cronMock, _ := newTestScheduler()
+
+	cronMock.On("AddFunc", "0 9 * * 1", mock.AnythingOfType("func()")).
+		Return(cron.EntryID(0), errors.New("invalid cron spec"))
+
+	s.Start()
+
+	cronMock.AssertExpectations(t)
+	cronMock.AssertNotCalled(t, "Start")
+}
+
+func TestStart_JobExecutes_SendSuccess(t *testing.T) {
+	s, cronMock, senderMock := newTestScheduler()
+
+	var capturedJob func()
+	cronMock.On("AddFunc", "0 9 * * 1", mock.AnythingOfType("func()")).
+		Run(func(args mock.Arguments) {
+			capturedJob = args.Get(1).(func())
+		}).
+		Return(cron.EntryID(1), nil)
+	cronMock.On("Start").Return()
+
+	senderMock.On("SendAllWeeklyReports").Return(nil)
+
+	s.Start()
+	assert.NotNil(t, capturedJob)
+
+	// ジョブを手動実行
+	capturedJob()
+
+	senderMock.AssertExpectations(t)
+}
+
+func TestStart_JobExecutes_SendError(t *testing.T) {
+	s, cronMock, senderMock := newTestScheduler()
+
+	var capturedJob func()
+	cronMock.On("AddFunc", "0 9 * * 1", mock.AnythingOfType("func()")).
+		Run(func(args mock.Arguments) {
+			capturedJob = args.Get(1).(func())
+		}).
+		Return(cron.EntryID(1), nil)
+	cronMock.On("Start").Return()
+
+	senderMock.On("SendAllWeeklyReports").Return(errors.New("smtp error"))
+
+	s.Start()
+	assert.NotNil(t, capturedJob)
+
+	// ジョブを手動実行（エラーでもpanicしない）
+	capturedJob()
+
+	senderMock.AssertExpectations(t)
+}
+
+func TestStop(t *testing.T) {
+	s, cronMock, _ := newTestScheduler()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // 即座にDoneになるcontextを作成
+	cronMock.On("Stop").Return(ctx)
+
+	s.Stop()
+
+	cronMock.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
SchedulerServiceのテストカバレッジを0%から100%に引き上げ。

## 変更内容
- `CronScheduler`/`WeeklyReportSender`インターフェースを導入し、cron依存をモック可能に
- 6つのテストケースを追加:
  - `TestNewScheduler`: コンストラクタの正常生成
  - `TestStart_Success`: cronジョブ登録・起動の正常系
  - `TestStart_AddFuncError`: cronジョブ登録失敗時のearly return
  - `TestStart_JobExecutes_SendSuccess`: ジョブ実行時のメール送信成功
  - `TestStart_JobExecutes_SendError`: ジョブ実行時のメール送信エラー（panicしない）
  - `TestStop`: 停止処理の正常系

Closes #567