### PR TITLE
feat: DTOバリデーション強化第4弾（post/post_series/post_pin/question/roadmap）

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -4,25 +4,25 @@ import "github.com/norman6464/devsync/backend/internal/model"
 
 // CodeSnippetInput はコードスニペットの入力データ。
 type CodeSnippetInput struct {
-	Language string `json:"language"`
-	FileName string `json:"file_name"`
-	Code     string `json:"code"`
+	Language string `json:"language" binding:"omitempty,max=100"`
+	FileName string `json:"file_name" binding:"omitempty,max=255"`
+	Code     string `json:"code" binding:"omitempty,max=50000"`
 }
 
 // CreatePostRequest は投稿作成リクエスト。
 type CreatePostRequest struct {
 	Title        string             `json:"title" binding:"required,max=200"`
 	Content      string             `json:"content" binding:"required,max=50000"`
-	ImageURLs    string             `json:"image_urls"`
+	ImageURLs    string             `json:"image_urls" binding:"omitempty,max=2000"`
 	IsDraft      bool               `json:"is_draft"`
-	CodeSnippets []CodeSnippetInput `json:"code_snippets"`
+	CodeSnippets []CodeSnippetInput `json:"code_snippets" binding:"omitempty,max=20"`
 }
 
 // UpdatePostRequest は投稿更新リクエスト。
 type UpdatePostRequest struct {
-	Title     string `json:"title"`
-	Content   string `json:"content"`
-	ImageURLs string `json:"image_urls"`
+	Title     string `json:"title" binding:"omitempty,max=200"`
+	Content   string `json:"content" binding:"omitempty,max=50000"`
+	ImageURLs string `json:"image_urls" binding:"omitempty,max=2000"`
 }
 
 // CreateCommentRequest はコメント作成リクエスト。

--- a/backend/internal/dto/post_pin_dto.go
+++ b/backend/internal/dto/post_pin_dto.go
@@ -2,5 +2,5 @@ package dto
 
 // ReorderPinsRequest はピン留め順序変更のリクエスト。
 type ReorderPinsRequest struct {
-	PostIDs []uint `json:"post_ids" binding:"required"`
+	PostIDs []uint `json:"post_ids" binding:"required,max=100"`
 }

--- a/backend/internal/dto/post_series_dto.go
+++ b/backend/internal/dto/post_series_dto.go
@@ -15,5 +15,5 @@ type UpdatePostSeriesRequest struct {
 // AddPostToSeriesRequest はシリーズへの投稿追加リクエスト。
 type AddPostToSeriesRequest struct {
 	PostID     uint `json:"post_id" binding:"required"`
-	OrderIndex int  `json:"order_index"`
+	OrderIndex int  `json:"order_index" binding:"omitempty,min=0"`
 }

--- a/backend/internal/dto/question_dto.go
+++ b/backend/internal/dto/question_dto.go
@@ -5,15 +5,15 @@ import "github.com/norman6464/devsync/backend/internal/model"
 // CreateQuestionRequest は質問作成のリクエストボディ。
 type CreateQuestionRequest struct {
 	Title string `json:"title" binding:"required,max=500" validate:"required,max=500"`
-	Body  string `json:"body" binding:"required" validate:"required"`
-	Tags  string `json:"tags"`
+	Body  string `json:"body" binding:"required,max=50000" validate:"required,max=50000"`
+	Tags  string `json:"tags" binding:"omitempty,max=5000"`
 }
 
 // UpdateQuestionRequest は質問更新のリクエストボディ。
 type UpdateQuestionRequest struct {
 	Title string `json:"title" binding:"max=500" validate:"max=500"`
-	Body  string `json:"body"`
-	Tags  string `json:"tags"`
+	Body  string `json:"body" binding:"omitempty,max=50000"`
+	Tags  string `json:"tags" binding:"omitempty,max=5000"`
 }
 
 // QuestionListResponse は質問一覧レスポンス。

--- a/backend/internal/dto/roadmap_dto.go
+++ b/backend/internal/dto/roadmap_dto.go
@@ -27,7 +27,7 @@ type CreateRoadmapStepRequest struct {
 	Title       string `json:"title" binding:"required,max=200"`
 	Description string `json:"description" binding:"omitempty,max=2000"`
 	ResourceURL string `json:"resource_url" binding:"omitempty,max=2000"`
-	OrderIndex  *int   `json:"order_index"`
+	OrderIndex  *int   `json:"order_index" binding:"omitempty,min=0"`
 }
 
 // UpdateRoadmapStepRequest はロードマップステップ更新リクエストのDTO。


### PR DESCRIPTION
## 概要
残存するDTOのバリデーション不足を修正し、API入力値の安全性を向上。

## 変更内容
- **post_dto.go**: CodeSnippetInputにLanguage max=100/FileName max=255/Code max=50000追加、CreatePostRequestのImageURLs max=2000/CodeSnippets max=20追加、UpdatePostRequestにTitle max=200/Content max=50000/ImageURLs max=2000追加
- **post_series_dto.go**: AddPostToSeriesRequestのOrderIndexにmin=0追加
- **post_pin_dto.go**: ReorderPinsRequestのPostIDsにmax=100追加
- **question_dto.go**: CreateのBody max=50000/Tags max=5000追加、UpdateのBody/Tagsにもmax制約追加
- **roadmap_dto.go**: CreateRoadmapStepRequestのOrderIndexにmin=0追加

Closes #571