### PR TITLE
feat: ShareModal/PostForm/QuickPostFormのアクセシビリティ改善

### DIFF
--- a/frontend/src/components/posts/PostForm.tsx
+++ b/frontend/src/components/posts/PostForm.tsx
@@ -96,7 +96,7 @@ export default function PostForm({ post, onSubmit, onCancel, loading: externalLo
 
           {/* Code Snippets Section */}
           {snippets.length > 0 && (
-            <div className="mt-3 space-y-3">
+            <div className="mt-3 space-y-3" role="group" aria-label={t('post.addSnippet')}>
               {snippets.map((snippet, i) => (
                 <CodeSnippetInput
                   key={i}
@@ -119,7 +119,7 @@ export default function PostForm({ post, onSubmit, onCancel, loading: externalLo
                 onClick={addSnippet}
                 className="flex items-center gap-1 px-2.5 py-1.5 text-xs text-blue-400 hover:text-blue-300 hover:bg-blue-500/10 rounded-lg transition-colors"
               >
-                <Plus className="w-3.5 h-3.5" />
+                <Plus className="w-3.5 h-3.5" aria-hidden="true" />
                 {t('post.addSnippet')}
               </button>
             </div>

--- a/frontend/src/components/posts/QuickPostForm.tsx
+++ b/frontend/src/components/posts/QuickPostForm.tsx
@@ -78,9 +78,9 @@ export default function QuickPostForm({ onSubmit }: QuickPostFormProps) {
     <div className="bg-gray-900/50 backdrop-blur-sm border border-gray-800 rounded-xl p-4 transition-all">
       {/* 復元プロンプト */}
       {showRestorePrompt && (
-        <div className="mb-3 p-3 bg-blue-900/20 border border-blue-800/30 rounded-lg flex items-center justify-between">
+        <div role="alert" className="mb-3 p-3 bg-blue-900/20 border border-blue-800/30 rounded-lg flex items-center justify-between">
           <div className="flex items-center gap-2">
-            <Clock className="w-4 h-4 text-blue-400" />
+            <Clock className="w-4 h-4 text-blue-400" aria-hidden="true" />
             <p className="text-sm text-blue-300">{t('post.restorePrompt')}</p>
           </div>
           <div className="flex gap-2">
@@ -125,12 +125,12 @@ export default function QuickPostForm({ onSubmit }: QuickPostFormProps) {
                   <div className="flex items-center gap-1 text-xs text-gray-400">
                     {saveStatus === 'saving' ? (
                       <>
-                        <Clock className="w-3 h-3 animate-pulse" />
+                        <Clock className="w-3 h-3 animate-pulse" aria-hidden="true" />
                         <span>{getSaveStatusText()}</span>
                       </>
                     ) : (
                       <>
-                        <Check className="w-3 h-3 text-green-500" />
+                        <Check className="w-3 h-3 text-green-500" aria-hidden="true" />
                         <span>{getSaveStatusText()}</span>
                       </>
                     )}

--- a/frontend/src/components/profile/ShareModal.tsx
+++ b/frontend/src/components/profile/ShareModal.tsx
@@ -107,12 +107,18 @@ export default function ShareModal({
       />
 
       {/* Modal */}
-      <div className="relative bg-gray-900 border border-gray-800 rounded-md shadow-sm max-w-3xl w-full mx-4 max-h-[90vh] overflow-y-auto">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="share-modal-title"
+        className="relative bg-gray-900 border border-gray-800 rounded-md shadow-sm max-w-3xl w-full mx-4 max-h-[90vh] overflow-y-auto"
+      >
         {/* Header */}
         <div className="flex items-center justify-between p-4 border-b border-gray-800">
-          <h2 className="text-lg font-semibold">{t('sharing.title')}</h2>
+          <h2 id="share-modal-title" className="text-lg font-semibold">{t('sharing.title')}</h2>
           <button
             onClick={onClose}
+            aria-label={t('common.close')}
             className="p-2 text-gray-400 hover:text-white hover:bg-gray-800 rounded-lg transition-colors"
           >
             <svg
@@ -120,6 +126,7 @@ export default function ShareModal({
               fill="none"
               viewBox="0 0 24 24"
               stroke="currentColor"
+              aria-hidden="true"
             >
               <path
                 strokeLinecap="round"
@@ -147,15 +154,16 @@ export default function ShareModal({
           </div>
 
           {/* Share buttons */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3" role="group" aria-label={t('sharing.title')}>
             {/* Download */}
             <button
               onClick={handleDownload}
               disabled={generating}
+              aria-label={t('sharing.download')}
               className="flex flex-col items-center gap-2 p-4 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors disabled:opacity-50"
             >
               <div className="w-10 h-10 flex items-center justify-center bg-green-500/20 text-green-400 rounded-full">
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
                 </svg>
               </div>
@@ -167,10 +175,11 @@ export default function ShareModal({
             {/* Copy Link */}
             <button
               onClick={handleCopyLink}
+              aria-label={t('sharing.copyLink')}
               className="flex flex-col items-center gap-2 p-4 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors"
             >
               <div className="w-10 h-10 flex items-center justify-center bg-blue-500/20 text-blue-400 rounded-full">
-                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
                 </svg>
               </div>
@@ -180,10 +189,11 @@ export default function ShareModal({
             {/* Twitter */}
             <button
               onClick={handleShareTwitter}
+              aria-label="Twitter"
               className="flex flex-col items-center gap-2 p-4 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors"
             >
               <div className="w-10 h-10 flex items-center justify-center bg-sky-500/20 text-sky-400 rounded-full">
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
                 </svg>
               </div>
@@ -193,10 +203,11 @@ export default function ShareModal({
             {/* LinkedIn */}
             <button
               onClick={handleShareLinkedIn}
+              aria-label="LinkedIn"
               className="flex flex-col items-center gap-2 p-4 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors"
             >
               <div className="w-10 h-10 flex items-center justify-center bg-blue-600/20 text-blue-500 rounded-full">
-                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                   <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
                 </svg>
               </div>


### PR DESCRIPTION
## 概要
フォーム系コンポーネントのWCAG 2.1 AA準拠を強化。

## 変更内容
- **ShareModal**: `role="dialog"`/`aria-modal="true"`/`aria-labelledby`追加、閉じるボタンに`aria-label`追加、シェアボタングループに`role="group"`追加、各シェアボタンに`aria-label`追加、全SVGに`aria-hidden="true"`追加
- **PostForm**: コードスニペットセクションに`role="group"`/`aria-label`追加、Plusアイコンに`aria-hidden="true"`追加
- **QuickPostForm**: 復元プロンプトに`role="alert"`追加、Clock/Checkアイコンに`aria-hidden="true"`追加

Closes #572