### PR TITLE
refactor: PostView/Postのエラーハンドリングをdomain.NewErrorに統一

### DIFF
--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -1,9 +1,9 @@
 package service
 
 import (
-	"fmt"
 	"unicode/utf8"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -205,7 +205,7 @@ func (s *PostService) GetBookmarks(userID uint, page, limit int) ([]model.Post, 
 // 許可された絵文字のみ使用可能。
 func (s *PostService) AddReaction(userID, postID uint, emoji string) error {
 	if !allowedEmojis[emoji] {
-		return fmt.Errorf("許可されていない絵文字です: %s", emoji)
+		return domain.NewError(domain.ErrCodeBadRequest, "許可されていない絵文字です: "+emoji, nil)
 	}
 	return s.repo.AddReaction(userID, postID, emoji)
 }

--- a/backend/internal/service/post_view.go
+++ b/backend/internal/service/post_view.go
@@ -1,8 +1,7 @@
 package service
 
 import (
-	"fmt"
-
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -21,10 +20,10 @@ func NewPostViewService(repo repository.PostViewRepositoryInterface) *PostViewSe
 // 既に閲覧済みの場合は何もしない（ユニーク閲覧のみカウント）。
 func (s *PostViewService) RecordView(userID, postID uint) error {
 	if userID == 0 {
-		return fmt.Errorf("%w: userIDは必須です", ErrBadRequest)
+		return domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
 	}
 	if postID == 0 {
-		return fmt.Errorf("%w: postIDは必須です", ErrBadRequest)
+		return domain.NewError(domain.ErrCodeBadRequest, "postIDは必須です", nil)
 	}
 	viewed, err := s.repo.HasViewed(userID, postID)
 	if err != nil {
@@ -42,7 +41,7 @@ func (s *PostViewService) RecordView(userID, postID uint) error {
 // GetViewCount は投稿のユニーク閲覧数を取得する。
 func (s *PostViewService) GetViewCount(postID uint) (int64, error) {
 	if postID == 0 {
-		return 0, fmt.Errorf("%w: postIDは必須です", ErrBadRequest)
+		return 0, domain.NewError(domain.ErrCodeBadRequest, "postIDは必須です", nil)
 	}
 	return s.repo.GetViewCount(postID)
 }
@@ -50,10 +49,10 @@ func (s *PostViewService) GetViewCount(postID uint) (int64, error) {
 // HasViewed はユーザーが投稿を閲覧済みかどうかを判定する。
 func (s *PostViewService) HasViewed(userID, postID uint) (bool, error) {
 	if userID == 0 {
-		return false, fmt.Errorf("%w: userIDは必須です", ErrBadRequest)
+		return false, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
 	}
 	if postID == 0 {
-		return false, fmt.Errorf("%w: postIDは必須です", ErrBadRequest)
+		return false, domain.NewError(domain.ErrCodeBadRequest, "postIDは必須です", nil)
 	}
 	return s.repo.HasViewed(userID, postID)
 }
@@ -63,7 +62,7 @@ const maxMostViewedLimit = 100
 // GetMostViewed は閲覧数が多い投稿のランキングを取得する。
 func (s *PostViewService) GetMostViewed(limit int) ([]model.ViewCount, error) {
 	if limit <= 0 || limit > maxMostViewedLimit {
-		return nil, fmt.Errorf("%w: limitは1〜100の範囲で指定してください", ErrBadRequest)
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "limitは1〜100の範囲で指定してください", nil)
 	}
 	return s.repo.GetMostViewed(limit)
 }

--- a/backend/internal/service/post_view_test.go
+++ b/backend/internal/service/post_view_test.go
@@ -4,10 +4,19 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
+
+// assertBadRequestError はエラーがdomain.ErrCodeBadRequestのDomainErrorであることを検証する。
+func assertBadRequestError(t *testing.T, err error) {
+	t.Helper()
+	var domainErr *domain.DomainError
+	assert.True(t, errors.As(err, &domainErr), "エラーはDomainError型であるべき")
+	assert.Equal(t, domain.ErrCodeBadRequest, domainErr.Code)
+}
 
 // newTestPostViewService はPostViewServiceのテスト用インスタンスを生成するヘルパー。
 func newTestPostViewService() (*PostViewService, *MockPostViewRepository) {
@@ -167,7 +176,7 @@ func TestPostViewRecordView_InvalidUserID(t *testing.T) {
 	svc, repo := newTestPostViewService()
 
 	err := svc.RecordView(0, 10)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assertBadRequestError(t, err)
 	repo.AssertNotCalled(t, "HasViewed")
 }
 
@@ -175,7 +184,7 @@ func TestPostViewRecordView_InvalidPostID(t *testing.T) {
 	svc, repo := newTestPostViewService()
 
 	err := svc.RecordView(1, 0)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assertBadRequestError(t, err)
 	repo.AssertNotCalled(t, "HasViewed")
 }
 
@@ -183,7 +192,7 @@ func TestPostViewGetViewCount_InvalidPostID(t *testing.T) {
 	svc, repo := newTestPostViewService()
 
 	count, err := svc.GetViewCount(0)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assertBadRequestError(t, err)
 	assert.Equal(t, int64(0), count)
 	repo.AssertNotCalled(t, "GetViewCount")
 }
@@ -192,7 +201,7 @@ func TestPostViewHasViewed_InvalidUserID(t *testing.T) {
 	svc, repo := newTestPostViewService()
 
 	viewed, err := svc.HasViewed(0, 10)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assertBadRequestError(t, err)
 	assert.False(t, viewed)
 	repo.AssertNotCalled(t, "HasViewed")
 }
@@ -201,7 +210,7 @@ func TestPostViewHasViewed_InvalidPostID(t *testing.T) {
 	svc, repo := newTestPostViewService()
 
 	viewed, err := svc.HasViewed(1, 0)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assertBadRequestError(t, err)
 	assert.False(t, viewed)
 	repo.AssertNotCalled(t, "HasViewed")
 }
@@ -210,7 +219,7 @@ func TestPostViewGetMostViewed_InvalidLimit_Zero(t *testing.T) {
 	svc, repo := newTestPostViewService()
 
 	result, err := svc.GetMostViewed(0)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assertBadRequestError(t, err)
 	assert.Nil(t, result)
 	repo.AssertNotCalled(t, "GetMostViewed")
 }
@@ -219,7 +228,7 @@ func TestPostViewGetMostViewed_InvalidLimit_Negative(t *testing.T) {
 	svc, repo := newTestPostViewService()
 
 	result, err := svc.GetMostViewed(-5)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assertBadRequestError(t, err)
 	assert.Nil(t, result)
 	repo.AssertNotCalled(t, "GetMostViewed")
 }
@@ -228,7 +237,7 @@ func TestPostViewGetMostViewed_InvalidLimit_TooLarge(t *testing.T) {
 	svc, repo := newTestPostViewService()
 
 	result, err := svc.GetMostViewed(200)
-	assert.ErrorIs(t, err, ErrBadRequest)
+	assertBadRequestError(t, err)
 	assert.Nil(t, result)
 	repo.AssertNotCalled(t, "GetMostViewed")
 }


### PR DESCRIPTION
## 概要
- PostViewService: `fmt.Errorf("%w: ...", ErrBadRequest)` → `domain.NewError(domain.ErrCodeBadRequest, ...)` に6箇所変更
- PostService: `fmt.Errorf("許可されていない絵文字です: %s", emoji)` → `domain.NewError(domain.ErrCodeBadRequest, ...)` に1箇所変更
- テスト: `assert.ErrorIs(t, err, ErrBadRequest)` → `errors.As` + コードチェックのヘルパー関数に8箇所更新

## テスト
- [x] 全PostViewテスト(20件)パス
- [x] 全Service層テストパス

Closes #577