### PR TITLE
perf: DashboardPage/ProfilePageのuseMemo/useCallback最適化

### DIFF
--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Target, Bell, TrendingUp, CheckCircle2, Clock, ChevronRight } from 'lucide-react';
@@ -32,10 +32,10 @@ export default function DashboardPage() {
   const { confirm, dialogProps } = useConfirm();
   const [editingPost, setEditingPost] = useState<Post | null>(null);
 
-  const handleDeletePost = async (post: Post) => {
+  const handleDeletePost = useCallback(async (post: Post) => {
     const ok = await confirm({ title: t('common.confirm'), message: t('dashboard.confirmDeletePost'), variant: 'danger' });
     if (ok) deletePost(post);
-  };
+  }, [confirm, deletePost, t]);
   const {
     activeGoals,
     completedGoals,
@@ -56,7 +56,12 @@ export default function DashboardPage() {
   );
   useBadgeNotifier(badges);
 
-  const handleCreatePost = async (
+  const handleQuickPost = useCallback(async (title: string, content: string, isDraft?: boolean) => {
+    await createPost(title, content, undefined, undefined, isDraft);
+    await refetch();
+  }, [createPost, refetch]);
+
+  const handleCreatePost = useCallback(async (
     title: string,
     content: string,
     imageUrls?: string,
@@ -64,31 +69,29 @@ export default function DashboardPage() {
     isDraft?: boolean
   ) => {
     await createPost(title, content, imageUrls, codeSnippets, isDraft);
-  };
+  }, [createPost]);
 
-  const getNotificationText = (notification: { type: string; actor: { name: string } }) => {
-    const nameMap: Record<string, string> = {
-      post: 'notifications.newPost',
-      message: 'notifications.newMessage',
-      like: 'notifications.newLike',
-      comment: 'notifications.newComment',
-      follow: 'notifications.newFollow',
-      answer: 'notifications.newAnswer',
-      badge: 'notifications.newBadge',
-    };
-    return t(nameMap[notification.type] || 'notifications.newPost', {
+  const notificationNameMap = useMemo<Record<string, string>>(() => ({
+    post: 'notifications.newPost',
+    message: 'notifications.newMessage',
+    like: 'notifications.newLike',
+    comment: 'notifications.newComment',
+    follow: 'notifications.newFollow',
+    answer: 'notifications.newAnswer',
+    badge: 'notifications.newBadge',
+  }), []);
+
+  const getNotificationText = useCallback((notification: { type: string; actor: { name: string } }) => {
+    return t(notificationNameMap[notification.type] || 'notifications.newPost', {
       name: notification.actor?.name || '',
     });
-  };
+  }, [t, notificationNameMap]);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
       {/* Main Feed */}
       <div className="lg:col-span-3 space-y-6">
-        <QuickPostForm onSubmit={async (title, content, isDraft) => {
-          await createPost(title, content, undefined, undefined, isDraft);
-          await refetch();
-        }} />
+        <QuickPostForm onSubmit={handleQuickPost} />
 
         <div>
           <h2 className="section-heading">{t('dashboard.timeline')}</h2>

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Sparkles, Rocket, FileText, Monitor, Target, FolderOpen, Pin } from 'lucide-react';
@@ -18,6 +18,9 @@ import PostSeriesCard from '../components/series/PostSeriesCard';
 import ShareModal from '../components/profile/ShareModal';
 import PortfolioModal from '../components/profile/PortfolioModal';
 
+const categoryIcons: Record<string, typeof Monitor> = { language: Monitor, framework: Rocket, skill: Target, project: FolderOpen, other: FileText };
+const statusColors: Record<string, string> = { active: 'text-green-400 bg-green-400/10', completed: 'text-blue-400 bg-blue-400/10', paused: 'text-yellow-400 bg-yellow-400/10' };
+
 export default function ProfilePage() {
   const { t } = useTranslation();
   const { username } = useParams<{ username: string }>();
@@ -34,6 +37,7 @@ export default function ProfilePage() {
   const { collections } = usePostCollections(user?.id);
   const { pins } = usePinnedPosts(user?.id);
   const { percentage, missingFields } = useProfileCompleteness();
+  const totalContributions = useMemo(() => contributions.reduce((sum, c) => sum + c.count, 0), [contributions]);
 
   if (loading) return <PageLoader />;
   if (!user) return <div className="text-center text-gray-400 py-12">{t('errors.notFound')}</div>;
@@ -336,8 +340,6 @@ export default function ProfilePage() {
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {goals.slice(0, 4).map((goal) => {
-              const categoryIcons: Record<string, typeof Monitor> = { language: Monitor, framework: Rocket, skill: Target, project: FolderOpen, other: FileText };
-              const statusColors: Record<string, string> = { active: 'text-green-400 bg-green-400/10', completed: 'text-blue-400 bg-blue-400/10', paused: 'text-yellow-400 bg-yellow-400/10' };
               const CategoryIcon = categoryIcons[goal.category] || FileText;
               return (
                 <div key={goal.id} className="bg-gray-900 border border-gray-800 rounded-md p-4">
@@ -433,8 +435,8 @@ export default function ProfilePage() {
         )}
       </div>
 
-      <ShareModal isOpen={shareModalOpen} onClose={() => setShareModalOpen(false)} user={user} followerCount={followerCount} followingCount={followingCount} totalContributions={contributions.reduce((sum, c) => sum + c.count, 0)} languages={languages} postCount={posts.length} />
-      <PortfolioModal isOpen={portfolioModalOpen} onClose={() => setPortfolioModalOpen(false)} user={user} languages={languages} repos={repos} goals={goals} totalContributions={contributions.reduce((sum, c) => sum + c.count, 0)} followerCount={followerCount} followingCount={followingCount} />
+      <ShareModal isOpen={shareModalOpen} onClose={() => setShareModalOpen(false)} user={user} followerCount={followerCount} followingCount={followingCount} totalContributions={totalContributions} languages={languages} postCount={posts.length} />
+      <PortfolioModal isOpen={portfolioModalOpen} onClose={() => setPortfolioModalOpen(false)} user={user} languages={languages} repos={repos} goals={goals} totalContributions={totalContributions} followerCount={followerCount} followingCount={followingCount} />
     </div>
   );
 }


### PR DESCRIPTION
## 概要
- DashboardPage: `handleDeletePost`, `handleCreatePost`, `handleQuickPost`, `getNotificationText` を `useCallback` でメモ化
- DashboardPage: `notificationNameMap` を `useMemo` で安定化
- ProfilePage: `totalContributions` を `useMemo` で計算（2回の `.reduce` 呼び出しを1回に削減）
- ProfilePage: `categoryIcons`/`statusColors` をコンポーネント外定数に移動（毎レンダーでの再生成を回避）

## テスト
- [x] TypeScript型チェックパス

Closes #579