### PR TITLE
ResourcesPage/BookReviewsPage/ProjectsPageのuseCallback最適化

### DIFF
--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BookOpen } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
@@ -22,10 +22,25 @@ export default function BookReviewsPage() {
   const [showForm, setShowForm] = useState(false);
   const [editingReview, setEditingReview] = useState<BookReview | null>(null);
 
-  const handleDeleteReview = async (review: BookReview) => {
+  const handleDeleteReview = useCallback(async (review: BookReview) => {
     const ok = await confirm({ title: t('common.confirm'), message: t('bookReviews.confirmDelete'), variant: 'danger' });
     if (ok) deleteReview(review);
-  };
+  }, [confirm, t, deleteReview]);
+
+  const handleFormClose = useCallback(() => {
+    setShowForm(false);
+    setEditingReview(null);
+  }, []);
+
+  const handleFormSubmit = useCallback(async (data: Parameters<typeof createReview>[0]) => {
+    if (editingReview) {
+      const result = await updateReview(editingReview.id, data);
+      if (result) setEditingReview(null);
+    } else {
+      const result = await createReview(data);
+      if (result) setShowForm(false);
+    }
+  }, [editingReview, updateReview, createReview]);
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8">
@@ -39,25 +54,14 @@ export default function BookReviewsPage() {
       {/* Form Modal */}
       <Modal
         isOpen={showForm || !!editingReview}
-        onClose={() => { setShowForm(false); setEditingReview(null); }}
+        onClose={handleFormClose}
         title={editingReview ? t('bookReviews.editReview') : t('bookReviews.newReview')}
         maxWidth="max-w-lg"
       >
         <BookReviewForm
           review={editingReview || undefined}
-          onSubmit={async (data) => {
-            if (editingReview) {
-              const result = await updateReview(editingReview.id, data);
-              if (result) setEditingReview(null);
-            } else {
-              const result = await createReview(data);
-              if (result) setShowForm(false);
-            }
-          }}
-          onCancel={() => {
-            setShowForm(false);
-            setEditingReview(null);
-          }}
+          onSubmit={handleFormSubmit}
+          onCancel={handleFormClose}
           loading={saving}
         />
       </Modal>

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { FolderOpen } from 'lucide-react';
 import type { Project } from '../types/project';
@@ -21,10 +21,25 @@ export default function ProjectsPage() {
   const [showForm, setShowForm] = useState(false);
   const [editingProject, setEditingProject] = useState<Project | null>(null);
 
-  const handleDeleteProject = async (project: Project) => {
+  const handleDeleteProject = useCallback(async (project: Project) => {
     const ok = await confirm({ title: t('common.confirm'), message: t('projects.confirmDelete'), variant: 'danger' });
     if (ok) deleteProject(project);
-  };
+  }, [confirm, t, deleteProject]);
+
+  const handleFormClose = useCallback(() => {
+    setShowForm(false);
+    setEditingProject(null);
+  }, []);
+
+  const handleFormSubmit = useCallback(async (data: Parameters<typeof createProject>[0]) => {
+    if (editingProject) {
+      const result = await updateProject(editingProject.id, data);
+      if (result) setEditingProject(null);
+    } else {
+      const result = await createProject(data);
+      if (result) setShowForm(false);
+    }
+  }, [editingProject, updateProject, createProject]);
 
   if (loading) {
     return <PageLoader />;
@@ -42,25 +57,14 @@ export default function ProjectsPage() {
       {/* Form Modal */}
       <Modal
         isOpen={showForm || !!editingProject}
-        onClose={() => { setShowForm(false); setEditingProject(null); }}
+        onClose={handleFormClose}
         title={editingProject ? t('projects.editProject') : t('projects.newProject')}
       >
         <ProjectForm
           project={editingProject || undefined}
           repos={repos}
-          onSubmit={async (data) => {
-            if (editingProject) {
-              const result = await updateProject(editingProject.id, data);
-              if (result) setEditingProject(null);
-            } else {
-              const result = await createProject(data);
-              if (result) setShowForm(false);
-            }
-          }}
-          onCancel={() => {
-            setShowForm(false);
-            setEditingProject(null);
-          }}
+          onSubmit={handleFormSubmit}
+          onCancel={handleFormClose}
           loading={saving}
         />
       </Modal>

--- a/frontend/src/pages/ResourcesPage.tsx
+++ b/frontend/src/pages/ResourcesPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BookOpen } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
@@ -31,6 +31,21 @@ export default function ResourcesPage() {
 
   const [showForm, setShowForm] = useState(false);
   const [editingResource, setEditingResource] = useState<LearningResource | null>(null);
+
+  const handleFormClose = useCallback(() => {
+    setShowForm(false);
+    setEditingResource(null);
+  }, []);
+
+  const handleFormSubmit = useCallback(async (data: Parameters<typeof createResource>[0]) => {
+    if (editingResource) {
+      const result = await updateResource(editingResource.id, data);
+      if (result) setEditingResource(null);
+    } else {
+      const result = await createResource(data);
+      if (result) setShowForm(false);
+    }
+  }, [editingResource, updateResource, createResource]);
 
   // デバウンス処理（300ms）
   const debouncedQuery = useDebounce(searchQuery, 300);
@@ -121,24 +136,13 @@ export default function ResourcesPage() {
       {/* Form Modal */}
       <Modal
         isOpen={showForm || !!editingResource}
-        onClose={() => { setShowForm(false); setEditingResource(null); }}
+        onClose={handleFormClose}
         title={editingResource ? t('resources.editResource') : t('resources.newResource')}
       >
         <ResourceForm
           resource={editingResource || undefined}
-          onSubmit={async (data) => {
-            if (editingResource) {
-              const result = await updateResource(editingResource.id, data);
-              if (result) setEditingResource(null);
-            } else {
-              const result = await createResource(data);
-              if (result) setShowForm(false);
-            }
-          }}
-          onCancel={() => {
-            setShowForm(false);
-            setEditingResource(null);
-          }}
+          onSubmit={handleFormSubmit}
+          onCancel={handleFormClose}
           loading={saving}
         />
       </Modal>


### PR DESCRIPTION
## 概要
- ResourcesPage, BookReviewsPage, ProjectsPageのインラインコールバックを`useCallback`でメモ化
- 各ページのフォーム操作（onSubmit, onCancel, onClose）と削除ハンドラをuseCallbackで包む

## 変更内容
- **ResourcesPage**: `handleFormClose`, `handleFormSubmit` を追加
- **BookReviewsPage**: `handleDeleteReview`, `handleFormClose`, `handleFormSubmit` をuseCallbackで包む
- **ProjectsPage**: `handleDeleteProject`, `handleFormClose`, `handleFormSubmit` をuseCallbackで包む

## テスト
- `npx tsc --noEmit` パス

Closes #590