### PR TITLE
IntegrationSection・NotesPageのi18n未対応箇所修正

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -278,6 +278,9 @@
     "emailEnabled": "Aktiviert",
     "emailDisabled": "Deaktiviert",
     "emailPreferencesSaved": "E-Mail-Einstellungen gespeichert",
+    "zennUsernamePlaceholder": "Zenn-Benutzername eingeben",
+    "qiitaUsernamePlaceholder": "Qiita-Benutzername eingeben",
+    "atcoderUsernamePlaceholder": "AtCoder-Benutzername eingeben",
     "setTheme": "{{theme}}-Design einstellen"
   },
   "explore": {
@@ -1238,7 +1241,8 @@
     "confirmDelete": "Möchten Sie diese Notiz wirklich löschen?",
     "favoriteToggled": "Favoritenstatus aktualisiert",
     "lastUpdated": "Zuletzt aktualisiert",
-    "createdAt": "Erstellt am"
+    "createdAt": "Erstellt am",
+    "tagsPlaceholder": "z.B. React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "Fehlende OAuth-Parameter",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -278,6 +278,9 @@
     "emailEnabled": "Enabled",
     "emailDisabled": "Disabled",
     "emailPreferencesSaved": "Email preferences saved",
+    "zennUsernamePlaceholder": "Enter your Zenn username",
+    "qiitaUsernamePlaceholder": "Enter your Qiita username",
+    "atcoderUsernamePlaceholder": "Enter your AtCoder username",
     "setTheme": "Set {{theme}} theme"
   },
   "explore": {
@@ -1238,7 +1241,8 @@
     "confirmDelete": "Are you sure you want to delete this note?",
     "favoriteToggled": "Favorite status updated",
     "lastUpdated": "Last updated",
-    "createdAt": "Created at"
+    "createdAt": "Created at",
+    "tagsPlaceholder": "e.g., React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "Missing OAuth parameters",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -278,6 +278,9 @@
     "emailEnabled": "Habilitado",
     "emailDisabled": "Deshabilitado",
     "emailPreferencesSaved": "Preferencias de correo guardadas",
+    "zennUsernamePlaceholder": "Ingresa tu usuario de Zenn",
+    "qiitaUsernamePlaceholder": "Ingresa tu usuario de Qiita",
+    "atcoderUsernamePlaceholder": "Ingresa tu usuario de AtCoder",
     "setTheme": "Establecer tema {{theme}}"
   },
   "explore": {
@@ -1238,7 +1241,8 @@
     "confirmDelete": "¿Está seguro de que desea eliminar esta nota?",
     "favoriteToggled": "Estado de favorito actualizado",
     "lastUpdated": "Última actualización",
-    "createdAt": "Creado el"
+    "createdAt": "Creado el",
+    "tagsPlaceholder": "Ej: React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "Faltan parámetros OAuth",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -278,6 +278,9 @@
     "emailEnabled": "Activé",
     "emailDisabled": "Désactivé",
     "emailPreferencesSaved": "Préférences e-mail enregistrées",
+    "zennUsernamePlaceholder": "Entrez votre nom d'utilisateur Zenn",
+    "qiitaUsernamePlaceholder": "Entrez votre nom d'utilisateur Qiita",
+    "atcoderUsernamePlaceholder": "Entrez votre nom d'utilisateur AtCoder",
     "setTheme": "Définir le thème {{theme}}"
   },
   "explore": {
@@ -1238,7 +1241,8 @@
     "confirmDelete": "Êtes-vous sûr de vouloir supprimer cette note ?",
     "favoriteToggled": "Statut favori mis à jour",
     "lastUpdated": "Dernière mise à jour",
-    "createdAt": "Créé le"
+    "createdAt": "Créé le",
+    "tagsPlaceholder": "Ex : React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "Paramètres OAuth manquants",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -291,6 +291,9 @@
     "emailEnabled": "有効",
     "emailDisabled": "無効",
     "emailPreferencesSaved": "メール設定を保存しました",
+    "zennUsernamePlaceholder": "Zennのユーザー名を入力",
+    "qiitaUsernamePlaceholder": "Qiitaのユーザー名を入力",
+    "atcoderUsernamePlaceholder": "AtCoderのユーザー名を入力",
     "setTheme": "{{theme}}テーマに設定"
   },
   "explore": {
@@ -1139,7 +1142,8 @@
     "confirmDelete": "このノートを削除しますか？",
     "favoriteToggled": "お気に入りを更新しました",
     "lastUpdated": "最終更新",
-    "createdAt": "作成日時"
+    "createdAt": "作成日時",
+    "tagsPlaceholder": "例: React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuthパラメータが不足しています",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -278,6 +278,9 @@
     "emailEnabled": "활성화",
     "emailDisabled": "비활성화",
     "emailPreferencesSaved": "이메일 설정이 저장되었습니다",
+    "zennUsernamePlaceholder": "Zenn 사용자명 입력",
+    "qiitaUsernamePlaceholder": "Qiita 사용자명 입력",
+    "atcoderUsernamePlaceholder": "AtCoder 사용자명 입력",
     "setTheme": "{{theme}} 테마로 설정"
   },
   "explore": {
@@ -1238,7 +1241,8 @@
     "confirmDelete": "이 노트를 삭제하시겠습니까?",
     "favoriteToggled": "즐겨찾기 상태가 업데이트되었습니다",
     "lastUpdated": "마지막 업데이트",
-    "createdAt": "생성일"
+    "createdAt": "생성일",
+    "tagsPlaceholder": "예: React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuth 매개변수가 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -278,6 +278,9 @@
     "emailEnabled": "Ativado",
     "emailDisabled": "Desativado",
     "emailPreferencesSaved": "Preferências de e-mail salvas",
+    "zennUsernamePlaceholder": "Digite seu nome de usuário Zenn",
+    "qiitaUsernamePlaceholder": "Digite seu nome de usuário Qiita",
+    "atcoderUsernamePlaceholder": "Digite seu nome de usuário AtCoder",
     "setTheme": "Definir tema {{theme}}"
   },
   "explore": {
@@ -1238,7 +1241,8 @@
     "confirmDelete": "Tem certeza de que deseja excluir esta nota?",
     "favoriteToggled": "Status de favorito atualizado",
     "lastUpdated": "Última atualização",
-    "createdAt": "Criado em"
+    "createdAt": "Criado em",
+    "tagsPlaceholder": "Ex: React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "Parâmetros OAuth ausentes",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -278,6 +278,9 @@
     "emailEnabled": "Включено",
     "emailDisabled": "Отключено",
     "emailPreferencesSaved": "Настройки email сохранены",
+    "zennUsernamePlaceholder": "Введите имя пользователя Zenn",
+    "qiitaUsernamePlaceholder": "Введите имя пользователя Qiita",
+    "atcoderUsernamePlaceholder": "Введите имя пользователя AtCoder",
     "setTheme": "Установить тему {{theme}}"
   },
   "explore": {
@@ -1238,7 +1241,8 @@
     "confirmDelete": "Вы уверены, что хотите удалить эту заметку?",
     "favoriteToggled": "Статус избранного обновлен",
     "lastUpdated": "Последнее обновление",
-    "createdAt": "Создано"
+    "createdAt": "Создано",
+    "tagsPlaceholder": "Напр.: React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "Отсутствуют параметры OAuth",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -278,6 +278,9 @@
     "emailEnabled": "已启用",
     "emailDisabled": "已禁用",
     "emailPreferencesSaved": "邮件设置已保存",
+    "zennUsernamePlaceholder": "输入Zenn用户名",
+    "qiitaUsernamePlaceholder": "输入Qiita用户名",
+    "atcoderUsernamePlaceholder": "输入AtCoder用户名",
     "setTheme": "设置{{theme}}主题"
   },
   "explore": {
@@ -1238,7 +1241,8 @@
     "confirmDelete": "确定要删除这条笔记吗？",
     "favoriteToggled": "收藏状态已更新",
     "lastUpdated": "最后更新",
-    "createdAt": "创建时间"
+    "createdAt": "创建时间",
+    "tagsPlaceholder": "例如：React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth参数",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -278,6 +278,9 @@
     "emailEnabled": "已啟用",
     "emailDisabled": "已停用",
     "emailPreferencesSaved": "郵件設定已儲存",
+    "zennUsernamePlaceholder": "輸入Zenn使用者名稱",
+    "qiitaUsernamePlaceholder": "輸入Qiita使用者名稱",
+    "atcoderUsernamePlaceholder": "輸入AtCoder使用者名稱",
     "setTheme": "設置{{theme}}主題"
   },
   "explore": {
@@ -1238,7 +1241,8 @@
     "confirmDelete": "確定要刪除這條筆記嗎？",
     "favoriteToggled": "收藏狀態已更新",
     "lastUpdated": "最後更新",
-    "createdAt": "創建時間"
+    "createdAt": "創建時間",
+    "tagsPlaceholder": "例如：React, TypeScript, Go"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth參數",

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -77,7 +77,7 @@ export default function NotesPage() {
                 type="text"
                 value={tags}
                 onChange={(e) => setTags(e.target.value)}
-                placeholder="React, TypeScript, Go"
+                placeholder={t('notes.tagsPlaceholder')}
                 className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />
             </div>

--- a/frontend/src/pages/settings/IntegrationSection.tsx
+++ b/frontend/src/pages/settings/IntegrationSection.tsx
@@ -139,7 +139,7 @@ export default function IntegrationSection(props: Props) {
                   type="text"
                   value={props.zennUsername}
                   onChange={(e) => props.setZennUsername(e.target.value)}
-                  placeholder="your-zenn-username"
+                  placeholder={t('settings.zennUsernamePlaceholder')}
                   className={inputClass}
                 />
               </div>
@@ -199,7 +199,7 @@ export default function IntegrationSection(props: Props) {
                   type="text"
                   value={props.qiitaUsername}
                   onChange={(e) => props.setQiitaUsername(e.target.value)}
-                  placeholder="your-qiita-username"
+                  placeholder={t('settings.qiitaUsernamePlaceholder')}
                   className={inputClass}
                 />
               </div>
@@ -252,7 +252,7 @@ export default function IntegrationSection(props: Props) {
                   type="text"
                   value={props.atcoderUsername}
                   onChange={(e) => props.setAtcoderUsername(e.target.value)}
-                  placeholder="your-atcoder-username"
+                  placeholder={t('settings.atcoderUsernamePlaceholder')}
                   className={inputClass}
                 />
               </div>


### PR DESCRIPTION
## 概要
- IntegrationSectionのZenn/Qiita/AtCoderユーザー名プレースホルダーをi18nキーに置換
- NotesPageのタグ入力プレースホルダーをi18nキーに置換
- 全10言語ファイルに対応する翻訳キーを追加

## 追加キー
| キー | 説明 |
|------|------|
| `settings.zennUsernamePlaceholder` | Zennユーザー名入力欄のプレースホルダー |
| `settings.qiitaUsernamePlaceholder` | Qiitaユーザー名入力欄のプレースホルダー |
| `settings.atcoderUsernamePlaceholder` | AtCoderユーザー名入力欄のプレースホルダー |
| `notes.tagsPlaceholder` | ノートのタグ入力欄のプレースホルダー |

## テスト
- `npx tsc --noEmit` パス

Closes #591