### PR TITLE
a11y: GoalsPage/LoginPage/RegisterPageのlabel-input関連付け追加

### DIFF
--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -97,10 +97,11 @@ export default function GoalsPage() {
       >
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
-            <label className={labelClass}>
+            <label htmlFor="goal-title" className={labelClass}>
               {t('goals.goalTitle')}
             </label>
             <input
+              id="goal-title"
               type="text"
               value={title}
               onChange={(e) => setTitle(e.target.value)}
@@ -110,10 +111,11 @@ export default function GoalsPage() {
             />
           </div>
           <div>
-            <label className={labelClass}>
+            <label htmlFor="goal-description" className={labelClass}>
               {t('goals.description')}
             </label>
             <textarea
+              id="goal-description"
               value={description}
               onChange={(e) => setDescription(e.target.value)}
               placeholder={t('goals.descriptionPlaceholder')}
@@ -122,10 +124,11 @@ export default function GoalsPage() {
             />
           </div>
           <div>
-            <label className={labelClass}>
+            <label htmlFor="goal-category" className={labelClass}>
               {t('goals.category')}
             </label>
             <select
+              id="goal-category"
               value={category}
               onChange={(e) => setCategory(e.target.value as GoalCategory)}
               className={inputClass}
@@ -138,10 +141,11 @@ export default function GoalsPage() {
             </select>
           </div>
           <div>
-            <label className={labelClass}>
+            <label htmlFor="goal-target-date" className={labelClass}>
               {t('goals.targetDate')}
             </label>
             <input
+              id="goal-target-date"
               type="date"
               value={targetDate}
               onChange={(e) => setTargetDate(e.target.value)}

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -72,10 +72,11 @@ export default function LoginPage() {
 
           <form onSubmit={handleSubmit} className="space-y-3">
             <div>
-              <label className={labelClass}>
+              <label htmlFor="login-email" className={labelClass}>
                 {t('auth.email')}
               </label>
               <input
+                id="login-email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -84,10 +85,11 @@ export default function LoginPage() {
               />
             </div>
             <div>
-              <label className={labelClass}>
+              <label htmlFor="login-password" className={labelClass}>
                 {t('auth.password')}
               </label>
               <input
+                id="login-password"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -76,10 +76,11 @@ export default function RegisterPage() {
 
           <form onSubmit={handleSubmit} className="space-y-3">
             <div>
-              <label className={labelClass}>
+              <label htmlFor="register-name" className={labelClass}>
                 {t('auth.name')}
               </label>
               <input
+                id="register-name"
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
@@ -88,10 +89,11 @@ export default function RegisterPage() {
               />
             </div>
             <div>
-              <label className={labelClass}>
+              <label htmlFor="register-email" className={labelClass}>
                 {t('auth.email')}
               </label>
               <input
+                id="register-email"
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
@@ -100,10 +102,11 @@ export default function RegisterPage() {
               />
             </div>
             <div>
-              <label className={labelClass}>
+              <label htmlFor="register-password" className={labelClass}>
                 {t('auth.password')}
               </label>
               <input
+                id="register-password"
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}


### PR DESCRIPTION
## 概要
- GoalsPageのフォーム4箇所（タイトル、説明、カテゴリ、目標日）にhtmlFor/id属性追加
- LoginPageの2箇所（メール、パスワード）にhtmlFor/id属性追加
- RegisterPageの3箇所（名前、メール、パスワード）にhtmlFor/id属性追加

## テスト
- TypeScript型チェック通過

Closes #595