### PR TITLE
perf: ChatPage/RankingsPage/AdvicePageのuseCallback最適化

### DIFF
--- a/frontend/src/pages/AdvicePage.tsx
+++ b/frontend/src/pages/AdvicePage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Lightbulb, MessageSquare } from 'lucide-react';
 import { useAdvice, useAIChat, useConversations } from '../hooks/useAdvice';
@@ -13,29 +13,29 @@ export default function AdvicePage() {
   const { conversations, loading: convsLoading, refetch: refetchConvs, removeConversation } = useConversations();
   const [activeTab, setActiveTab] = useState<'advice' | 'chat'>('advice');
 
-  const handleSend = async (message: string) => {
+  const handleSend = useCallback(async (message: string) => {
     await sendMessage(message);
     refetchConvs();
-  };
+  }, [sendMessage, refetchConvs]);
 
-  const handleSelectConversation = (id: number) => {
+  const handleSelectConversation = useCallback((id: number) => {
     loadConversation(id);
     setActiveTab('chat');
-  };
+  }, [loadConversation]);
 
-  const handleDeleteConversation = async (id: number) => {
+  const handleDeleteConversation = useCallback(async (id: number) => {
     const success = await removeConversation(id);
     if (success && conversationId === id) {
       startNewChat();
     }
-  };
+  }, [removeConversation, conversationId, startNewChat]);
 
-  const handleDeleteCurrentConversation = async () => {
+  const handleDeleteCurrentConversation = useCallback(async () => {
     const success = await deleteCurrentConversation();
     if (success) {
       refetchConvs();
     }
-  };
+  }, [deleteCurrentConversation, refetchConvs]);
 
   return (
     <div className="max-w-7xl mx-auto px-4 py-8">

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -1,7 +1,9 @@
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MessageSquare, Users, Plus, Settings, Send } from 'lucide-react';
 import { useChat } from '../hooks/useChat';
 import type { Message } from '../types/message';
+import type { ChatRoom } from '../types/chat';
 import Avatar from '../components/common/Avatar';
 import CreateRoomModal from '../components/chat/CreateRoomModal';
 import RoomSettingsModal from '../components/chat/RoomSettingsModal';
@@ -10,6 +12,24 @@ import { format } from 'date-fns';
 export default function ChatPage() {
   const { t } = useTranslation();
   const c = useChat();
+
+  const handleRoomCreated = useCallback((room: ChatRoom) => {
+    c.setChatRooms([room, ...c.chatRooms]);
+    c.setActiveRoomId(room.id);
+    c.setShowCreateRoom(false);
+  }, [c]);
+
+  const handleRoomDeleted = useCallback(() => {
+    c.setActiveRoomId(null);
+    c.setShowRoomSettings(false);
+    c.loadChatRooms();
+  }, [c]);
+
+  const handleRoomLeft = useCallback(() => {
+    c.setActiveRoomId(null);
+    c.setShowRoomSettings(false);
+    c.loadChatRooms();
+  }, [c]);
 
   return (
     <div className="flex h-[calc(100vh-7rem)] bg-gray-900 border border-gray-800 rounded-md overflow-hidden">
@@ -317,11 +337,7 @@ export default function ChatPage() {
         <CreateRoomModal
           followingUsers={c.followingUsers}
           onClose={() => c.setShowCreateRoom(false)}
-          onCreated={(room) => {
-            c.setChatRooms([room, ...c.chatRooms]);
-            c.setActiveRoomId(room.id);
-            c.setShowCreateRoom(false);
-          }}
+          onCreated={handleRoomCreated}
         />
       )}
 
@@ -332,16 +348,8 @@ export default function ChatPage() {
           followingUsers={c.followingUsers}
           onClose={() => c.setShowRoomSettings(false)}
           onUpdated={c.loadChatRooms}
-          onDeleted={() => {
-            c.setActiveRoomId(null);
-            c.setShowRoomSettings(false);
-            c.loadChatRooms();
-          }}
-          onLeft={() => {
-            c.setActiveRoomId(null);
-            c.setShowRoomSettings(false);
-            c.loadChatRooms();
-          }}
+          onDeleted={handleRoomDeleted}
+          onLeft={handleRoomLeft}
         />
       )}
     </div>

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useRankings } from '../hooks';
@@ -12,12 +13,12 @@ export default function RankingsPage() {
     tab, setTab, period, setPeriod, language, setLanguage,
   } = useRankings();
 
-  const medalColor = (index: number) => {
+  const medalColor = useCallback((index: number) => {
     if (index === 0) return 'text-yellow-400';
     if (index === 1) return 'text-gray-300';
     if (index === 2) return 'text-amber-600';
     return 'text-gray-600';
-  };
+  }, []);
 
   return (
     <div className="max-w-3xl mx-auto space-y-6">


### PR DESCRIPTION
## 概要
- ChatPage: モーダルコールバック（onCreated/onDeleted/onLeft）をuseCallbackで抽出
- AdvicePage: 4つのハンドラー（handleSend/handleSelectConversation/handleDeleteConversation/handleDeleteCurrentConversation）をuseCallbackでメモ化
- RankingsPage: medalColor関数をuseCallbackでメモ化

## テスト
- TypeScript型チェック通過

Closes #597