### PR TITLE
i18n: ContributionCalendar/LogCalendarのカレンダー月名・曜日を多言語対応

### DIFF
--- a/frontend/src/components/learning-logs/LogCalendar.tsx
+++ b/frontend/src/components/learning-logs/LogCalendar.tsx
@@ -50,7 +50,7 @@ export default function LogCalendar({ entries, onDateClick }: LogCalendarProps) 
   const totalLogs = entries.reduce((sum, e) => sum + e.count, 0);
 
   const monthLabels: { label: string; weekIndex: number }[] = [];
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const months = t('common.monthsShort', { returnObjects: true }) as string[];
   let lastMonth = -1;
 
   weeks.forEach((week, weekIndex) => {
@@ -64,7 +64,7 @@ export default function LogCalendar({ entries, onDateClick }: LogCalendarProps) 
     }
   });
 
-  const dayLabels = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+  const dayLabels = t('common.dayLabelsShort', { returnObjects: true }) as string[];
 
   return (
     <div>
@@ -97,7 +97,7 @@ export default function LogCalendar({ entries, onDateClick }: LogCalendarProps) 
                   {week.map((day, di) => (
                     <div
                       key={di}
-                      title={`${day.date}: ${day.count} logs`}
+                      title={t('common.dateLogs', { date: day.date, count: day.count })}
                       className={`w-3 h-3 rounded-sm ${onDateClick && day.count > 0 ? 'cursor-pointer hover:ring-1 hover:ring-purple-400' : ''}`}
                       style={{ backgroundColor: getColor(day.count, resolvedTheme) }}
                       onClick={() => onDateClick && day.count > 0 && onDateClick(day.date)}

--- a/frontend/src/components/profile/ContributionCalendar.tsx
+++ b/frontend/src/components/profile/ContributionCalendar.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import type { GitHubContribution } from '../../types/github';
 import { useThemeStore } from '../../store/themeStore';
 
@@ -14,6 +15,7 @@ function getColor(count: number, resolvedTheme: 'dark' | 'light'): string {
 }
 
 export default function ContributionCalendar({ contributions }: ContributionCalendarProps) {
+  const { t } = useTranslation();
   const resolvedTheme = useThemeStore((state) => state.resolvedTheme);
   const contributionMap = new Map(
     contributions.map((c) => [c.date.split('T')[0], c.count])
@@ -51,7 +53,7 @@ export default function ContributionCalendar({ contributions }: ContributionCale
 
   // Calculate month labels for header
   const monthLabels: { label: string; weekIndex: number }[] = [];
-  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  const months = t('common.monthsShort', { returnObjects: true }) as string[];
   let lastMonth = -1;
 
   weeks.forEach((week, weekIndex) => {
@@ -65,7 +67,7 @@ export default function ContributionCalendar({ contributions }: ContributionCale
     }
   });
 
-  const dayLabels = ['', 'Mon', '', 'Wed', '', 'Fri', ''];
+  const dayLabels = t('common.dayLabelsShort', { returnObjects: true }) as string[];
 
   return (
     <div>
@@ -102,7 +104,7 @@ export default function ContributionCalendar({ contributions }: ContributionCale
                   {week.map((day, di) => (
                     <div
                       key={di}
-                      title={`${day.date}: ${day.count} contributions`}
+                      title={t('common.dateContributions', { date: day.date, count: day.count })}
                       className="w-3 h-3 rounded-sm"
                       style={{ backgroundColor: getColor(day.count, resolvedTheme) }}
                     />
@@ -114,7 +116,7 @@ export default function ContributionCalendar({ contributions }: ContributionCale
         </div>
       </div>
       <p className="text-sm text-gray-500 mt-3">
-        {totalContributions.toLocaleString()} contributions in the last year
+        {t('common.contributionsInLastYear', { count: totalContributions })}
       </p>
     </div>
   );

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -22,7 +22,12 @@
     "and": "und",
     "menu": "Menü",
     "scrollToTop": "Nach oben",
-    "selectLanguage": "Sprache auswählen"
+    "selectLanguage": "Sprache auswählen",
+    "monthsShort": ["Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez"],
+    "dayLabelsShort": ["", "Mo", "", "Mi", "", "Fr", ""],
+    "contributionsInLastYear": "{{count}} Beiträge im letzten Jahr",
+    "dateContributions": "{{date}}: {{count}} Beiträge",
+    "dateLogs": "{{date}}: {{count}} Einträge"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -22,7 +22,12 @@
     "add": "Add",
     "menu": "Menu",
     "scrollToTop": "Back to top",
-    "selectLanguage": "Select language"
+    "selectLanguage": "Select language",
+    "monthsShort": ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"],
+    "dayLabelsShort": ["", "Mon", "", "Wed", "", "Fri", ""],
+    "contributionsInLastYear": "{{count}} contributions in the last year",
+    "dateContributions": "{{date}}: {{count}} contributions",
+    "dateLogs": "{{date}}: {{count}} logs"
   },
   "nav": {
     "dashboard": "Dashboard",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -22,7 +22,12 @@
     "and": "y",
     "menu": "Menú",
     "scrollToTop": "Volver arriba",
-    "selectLanguage": "Seleccionar idioma"
+    "selectLanguage": "Seleccionar idioma",
+    "monthsShort": ["Ene", "Feb", "Mar", "Abr", "May", "Jun", "Jul", "Ago", "Sep", "Oct", "Nov", "Dic"],
+    "dayLabelsShort": ["", "Lun", "", "Mié", "", "Vie", ""],
+    "contributionsInLastYear": "{{count}} contribuciones en el último año",
+    "dateContributions": "{{date}}: {{count}} contribuciones",
+    "dateLogs": "{{date}}: {{count}} registros"
   },
   "nav": {
     "dashboard": "Panel",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -22,7 +22,12 @@
     "and": "et",
     "menu": "Menu",
     "scrollToTop": "Retour en haut",
-    "selectLanguage": "Choisir la langue"
+    "selectLanguage": "Choisir la langue",
+    "monthsShort": ["Jan", "Fév", "Mar", "Avr", "Mai", "Juin", "Juil", "Aoû", "Sep", "Oct", "Nov", "Déc"],
+    "dayLabelsShort": ["", "Lun", "", "Mer", "", "Ven", ""],
+    "contributionsInLastYear": "{{count}} contributions au cours de l'année écoulée",
+    "dateContributions": "{{date}} : {{count}} contributions",
+    "dateLogs": "{{date}} : {{count}} entrées"
   },
   "nav": {
     "dashboard": "Tableau de bord",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -23,7 +23,12 @@
     "menu": "メニュー",
     "scrollToTop": "ページ上部に戻る",
     "dismiss": "閉じる",
-    "selectLanguage": "言語を選択"
+    "selectLanguage": "言語を選択",
+    "monthsShort": ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"],
+    "dayLabelsShort": ["", "月", "", "水", "", "金", ""],
+    "contributionsInLastYear": "過去1年間に{{count}}コントリビューション",
+    "dateContributions": "{{date}}: {{count}}コントリビューション",
+    "dateLogs": "{{date}}: {{count}}件のログ"
   },
   "nav": {
     "dashboard": "ダッシュボード",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -22,7 +22,12 @@
     "and": "그리고",
     "menu": "메뉴",
     "scrollToTop": "맨 위로",
-    "selectLanguage": "언어 선택"
+    "selectLanguage": "언어 선택",
+    "monthsShort": ["1월", "2월", "3월", "4월", "5월", "6월", "7월", "8월", "9월", "10월", "11월", "12월"],
+    "dayLabelsShort": ["", "월", "", "수", "", "금", ""],
+    "contributionsInLastYear": "지난 1년간 {{count}}개의 기여",
+    "dateContributions": "{{date}}: {{count}}개의 기여",
+    "dateLogs": "{{date}}: {{count}}개의 로그"
   },
   "nav": {
     "dashboard": "대시보드",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -22,7 +22,12 @@
     "and": "e",
     "menu": "Menu",
     "scrollToTop": "Voltar ao topo",
-    "selectLanguage": "Selecionar idioma"
+    "selectLanguage": "Selecionar idioma",
+    "monthsShort": ["Jan", "Fev", "Mar", "Abr", "Mai", "Jun", "Jul", "Ago", "Set", "Out", "Nov", "Dez"],
+    "dayLabelsShort": ["", "Seg", "", "Qua", "", "Sex", ""],
+    "contributionsInLastYear": "{{count}} contribuições no último ano",
+    "dateContributions": "{{date}}: {{count}} contribuições",
+    "dateLogs": "{{date}}: {{count}} registros"
   },
   "nav": {
     "dashboard": "Painel",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -22,7 +22,12 @@
     "and": "и",
     "menu": "Меню",
     "scrollToTop": "Наверх",
-    "selectLanguage": "Выбрать язык"
+    "selectLanguage": "Выбрать язык",
+    "monthsShort": ["Янв", "Фев", "Мар", "Апр", "Май", "Июн", "Июл", "Авг", "Сен", "Окт", "Ноя", "Дек"],
+    "dayLabelsShort": ["", "Пн", "", "Ср", "", "Пт", ""],
+    "contributionsInLastYear": "{{count}} вкладов за последний год",
+    "dateContributions": "{{date}}: {{count}} вкладов",
+    "dateLogs": "{{date}}: {{count}} записей"
   },
   "nav": {
     "dashboard": "Панель",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -22,7 +22,12 @@
     "and": "和",
     "menu": "菜单",
     "scrollToTop": "返回顶部",
-    "selectLanguage": "选择语言"
+    "selectLanguage": "选择语言",
+    "monthsShort": ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"],
+    "dayLabelsShort": ["", "一", "", "三", "", "五", ""],
+    "contributionsInLastYear": "过去一年 {{count}} 次贡献",
+    "dateContributions": "{{date}}: {{count}} 次贡献",
+    "dateLogs": "{{date}}: {{count}} 条日志"
   },
   "nav": {
     "dashboard": "仪表板",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -22,7 +22,12 @@
     "and": "和",
     "menu": "選單",
     "scrollToTop": "返回頂部",
-    "selectLanguage": "選擇語言"
+    "selectLanguage": "選擇語言",
+    "monthsShort": ["1月", "2月", "3月", "4月", "5月", "6月", "7月", "8月", "9月", "10月", "11月", "12月"],
+    "dayLabelsShort": ["", "一", "", "三", "", "五", ""],
+    "contributionsInLastYear": "過去一年 {{count}} 次貢獻",
+    "dateContributions": "{{date}}: {{count}} 次貢獻",
+    "dateLogs": "{{date}}: {{count}} 條日誌"
   },
   "nav": {
     "dashboard": "儀表板",


### PR DESCRIPTION
## 概要
- ContributionCalendar/LogCalendarのハードコードされた英語テキストをi18nキーに置き換え
- 月名（Jan-Dec）、曜日ラベル（Mon/Wed/Fri）、ツールチップ、サマリーテキストを多言語対応
- 全10言語（ja/en/ko/zh-CN/zh-TW/es/fr/de/pt/ru）に翻訳を追加

## テスト
- [x] TypeScriptチェック通過
- [x] 全10ロケールファイルに同一キーを追加済み
- [x] ContributionCalendar.tsxにuseTranslationインポート追加
- [x] LogCalendar.tsxのハードコード文字列をi18nキーに置き換え

Closes #603