### PR TITLE
NotificationsPageのa11y・セマンティック構造改善

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -462,6 +462,8 @@
     "filterBadge": "Abzeichen",
     "showUnreadOnly": "Nur ungelesene anzeigen",
     "deleteNotification": "Benachrichtigung löschen",
+    "filterGroup": "Benachrichtigungsfilter",
+    "listLabel": "Benachrichtigungsliste",
     "deleted": "Benachrichtigung gelöscht",
     "levelUp": "Sie haben Stufe {{level}} erreicht!",
     "filterLevel": "Aufgestiegen"

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -462,6 +462,8 @@
     "filterBadge": "Badge",
     "showUnreadOnly": "Show unread only",
     "deleteNotification": "Delete notification",
+    "filterGroup": "Notification filters",
+    "listLabel": "Notification list",
     "deleted": "Notification deleted",
     "levelUp": "You reached Level {{level}}!",
     "filterLevel": "Level Up"

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -462,6 +462,8 @@
     "filterBadge": "Insignia",
     "showUnreadOnly": "Mostrar solo no leídos",
     "deleteNotification": "Eliminar notificación",
+    "filterGroup": "Filtros de notificación",
+    "listLabel": "Lista de notificaciones",
     "deleted": "Notificación eliminada",
     "levelUp": "¡Has alcanzado el Nivel {{level}}!",
     "filterLevel": "Subida de Nivel"

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -462,6 +462,8 @@
     "filterBadge": "Badge",
     "showUnreadOnly": "Afficher uniquement non lus",
     "deleteNotification": "Supprimer la notification",
+    "filterGroup": "Filtres de notification",
+    "listLabel": "Liste des notifications",
     "deleted": "Notification supprimée",
     "levelUp": "Vous avez atteint le Niveau {{level}} !",
     "filterLevel": "Niveau Supérieur"

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -455,6 +455,8 @@
     "filterBadge": "バッジ",
     "showUnreadOnly": "未読のみ表示",
     "deleteNotification": "通知を削除",
+    "filterGroup": "通知フィルター",
+    "listLabel": "通知一覧",
     "deleted": "通知を削除しました",
     "levelUp": "レベル {{level}} に到達しました！",
     "filterLevel": "レベルアップ"

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -462,6 +462,8 @@
     "filterBadge": "배지",
     "showUnreadOnly": "읽지 않은 항목만 표시",
     "deleteNotification": "알림 삭제",
+    "filterGroup": "알림 필터",
+    "listLabel": "알림 목록",
     "deleted": "알림이 삭제되었습니다",
     "levelUp": "레벨 {{level}}에 도달했습니다!",
     "filterLevel": "레벨 업"

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -462,6 +462,8 @@
     "filterBadge": "Emblema",
     "showUnreadOnly": "Mostrar apenas não lidos",
     "deleteNotification": "Excluir notificação",
+    "filterGroup": "Filtros de notificação",
+    "listLabel": "Lista de notificações",
     "deleted": "Notificação excluída",
     "levelUp": "Você alcançou o Nível {{level}}!",
     "filterLevel": "Subida de Nível"

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -462,6 +462,8 @@
     "filterBadge": "Значок",
     "showUnreadOnly": "Показать только непрочитанные",
     "deleteNotification": "Удалить уведомление",
+    "filterGroup": "Фильтры уведомлений",
+    "listLabel": "Список уведомлений",
     "deleted": "Уведомление удалено",
     "levelUp": "Вы достигли уровня {{level}}!",
     "filterLevel": "Повышение уровня"

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -462,6 +462,8 @@
     "filterBadge": "徽章",
     "showUnreadOnly": "仅显示未读",
     "deleteNotification": "删除通知",
+    "filterGroup": "通知筛选",
+    "listLabel": "通知列表",
     "deleted": "通知已删除",
     "levelUp": "已达到等级 {{level}}！",
     "filterLevel": "升级"

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -462,6 +462,8 @@
     "filterBadge": "徽章",
     "showUnreadOnly": "僅顯示未讀",
     "deleteNotification": "刪除通知",
+    "filterGroup": "通知篩選",
+    "listLabel": "通知列表",
     "deleted": "通知已刪除",
     "levelUp": "已達到等級 {{level}}！",
     "filterLevel": "升級"

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -103,7 +103,7 @@ export default function NotificationsPage() {
             onClick={markAllAsRead}
             className={`flex items-center gap-2 ${buttonSecondaryClass}`}
           >
-            <CheckCheck className="w-5 h-5" />
+            <CheckCheck className="w-5 h-5" aria-hidden="true" />
             {t('notifications.markAllRead')}
           </button>
         )}
@@ -111,11 +111,12 @@ export default function NotificationsPage() {
 
       {/* Filter Tabs */}
       <div className="flex flex-col gap-4 mb-6">
-        <div className="flex flex-wrap gap-2">
+        <div className="flex flex-wrap gap-2" role="group" aria-label={t('notifications.filterGroup')}>
           {FILTER_TYPES.map(({ key, labelKey }) => (
             <button
               key={key}
               onClick={() => setFilterType(key)}
+              aria-pressed={filterType === key}
               className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                 filterType === key
                   ? 'bg-gray-700 text-white'
@@ -130,13 +131,14 @@ export default function NotificationsPage() {
         {/* Unread Only Toggle */}
         <button
           onClick={() => setShowUnreadOnly(!showUnreadOnly)}
+          aria-pressed={showUnreadOnly}
           className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm font-medium transition-colors self-start ${
             showUnreadOnly
               ? 'bg-blue-600 text-white'
               : 'bg-gray-800 text-gray-400 hover:text-white'
           }`}
         >
-          <Filter className="w-4 h-4" />
+          <Filter className="w-4 h-4" aria-hidden="true" />
           {t('notifications.showUnreadOnly')}
         </button>
       </div>
@@ -153,9 +155,9 @@ export default function NotificationsPage() {
         />
       ) : (
         <>
-          <div className="space-y-2">
+          <ul className="space-y-2" role="list" aria-label={t('notifications.listLabel')}>
             {filteredNotifications.map((notification) => (
-              <div
+              <li
                 key={notification.id}
                 className={`flex items-start gap-3 p-4 rounded-lg border transition-colors ${
                   !notification.read
@@ -194,19 +196,19 @@ export default function NotificationsPage() {
                     </p>
                   </div>
                   {!notification.read && (
-                    <span className="w-2 h-2 bg-blue-500 rounded-full mt-2 shrink-0" />
+                    <span className="w-2 h-2 bg-blue-500 rounded-full mt-2 shrink-0" aria-hidden="true" />
                   )}
                 </Link>
                 <button
                   onClick={() => deleteNotification(notification.id)}
                   className="p-1.5 text-gray-500 hover:text-red-400 transition-colors rounded-md shrink-0"
-                  title={t('notifications.deleteNotification')}
+                  aria-label={t('notifications.deleteNotification')}
                 >
-                  <Trash2 className="w-4 h-4" />
+                  <Trash2 className="w-4 h-4" aria-hidden="true" />
                 </button>
-              </div>
+              </li>
             ))}
-          </div>
+          </ul>
 
           {/* Pagination */}
           {total > limit && (


### PR DESCRIPTION
## 概要
- フィルターボタングループにrole="group"・aria-label追加
- 各フィルターボタン・未読トグルにaria-pressed属性追加
- 通知リストをdiv→ul/liのセマンティック構造に変更
- 削除ボタンにaria-label追加
- 装飾アイコン・未読ドットにaria-hidden="true"追加
- 全10言語にfilterGroup・listLabelキー追加

## 変更ファイル
- `frontend/src/pages/NotificationsPage.tsx`
- `frontend/src/i18n/locales/*.json`（10ファイル）

Closes #609