### PR TITLE
feat: レベル称号をフロントエンドでi18n対応

### DIFF
--- a/frontend/src/components/dashboard/LevelWidget.tsx
+++ b/frontend/src/components/dashboard/LevelWidget.tsx
@@ -3,6 +3,16 @@ import { Star } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useMyLevel } from '../../hooks';
 
+function getLevelTitleKey(level: number): { key: string; params?: Record<string, unknown> } {
+  if (level === 0) return { key: 'level.titleNewcomer' };
+  if (level <= 5) return { key: 'level.titleBeginner' };
+  if (level <= 10) return { key: 'level.titleIntermediate' };
+  if (level <= 20) return { key: 'level.titleAdvanced' };
+  if (level <= 30) return { key: 'level.titleExpert' };
+  if (level <= 40) return { key: 'level.titleMaster' };
+  return { key: 'level.titleLegend', params: { level } };
+}
+
 export default function LevelWidget() {
   const { t } = useTranslation();
   const user = useAuthStore((s) => s.user);
@@ -40,6 +50,9 @@ export default function LevelWidget() {
           <span className="text-sm text-gray-400">{t('level.level')}</span>
           <span className="text-4xl font-bold text-white">{level}</span>
         </div>
+        <p className="text-xs text-yellow-400 mt-0.5">
+          {t(getLevelTitleKey(level).key, getLevelTitleKey(level).params)}
+        </p>
         <p className="text-xs text-gray-400 mt-1">
           {t('level.xpProgress', { current: totalXP.toLocaleString(), next: nextLevelXP.toLocaleString() })}
         </p>

--- a/frontend/src/components/profile/LevelDisplay.tsx
+++ b/frontend/src/components/profile/LevelDisplay.tsx
@@ -3,6 +3,16 @@ import { Star } from 'lucide-react';
 import { useLevel, useLevelBreakdown } from '../../hooks';
 import type { XPBreakdown } from '../../types/level';
 
+function getLevelTitleKey(level: number): { key: string; params?: Record<string, unknown> } {
+  if (level === 0) return { key: 'level.titleNewcomer' };
+  if (level <= 5) return { key: 'level.titleBeginner' };
+  if (level <= 10) return { key: 'level.titleIntermediate' };
+  if (level <= 20) return { key: 'level.titleAdvanced' };
+  if (level <= 30) return { key: 'level.titleExpert' };
+  if (level <= 40) return { key: 'level.titleMaster' };
+  return { key: 'level.titleLegend', params: { level } };
+}
+
 interface LevelDisplayProps {
   userId: number;
 }
@@ -67,6 +77,9 @@ export default function LevelDisplay({ userId }: LevelDisplayProps) {
         <div className="text-center">
           <span className="text-xs text-gray-500">{t('level.level')}</span>
           <div className="text-3xl font-bold text-yellow-400">{level}</div>
+          <p className="text-xs text-yellow-400/70 mt-0.5">
+            {t(getLevelTitleKey(level).key, getLevelTitleKey(level).params)}
+          </p>
         </div>
         <div className="flex-1">
           <div className="flex justify-between text-xs text-gray-400 mb-1">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1067,7 +1067,14 @@
     "breakdownStreakBonus": "Serie-Bonus",
     "xpUnit": "XP",
     "noActivity": "Noch keine Aktivität",
-    "rankingByLevel": "Nach Stufe"
+    "rankingByLevel": "Nach Stufe",
+    "titleNewcomer": "Neuling",
+    "titleBeginner": "Anfänger",
+    "titleIntermediate": "Fortgeschritten",
+    "titleAdvanced": "Erfahren",
+    "titleExpert": "Experte",
+    "titleMaster": "Meister",
+    "titleLegend": "Legende Lv.{{level}}"
   },
   "analytics": {
     "pageTitle": "Lernanalyse-Dashboard",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1067,7 +1067,14 @@
     "breakdownStreakBonus": "Streak Bonus",
     "xpUnit": "XP",
     "noActivity": "No activity yet",
-    "rankingByLevel": "By Level"
+    "rankingByLevel": "By Level",
+    "titleNewcomer": "Newcomer",
+    "titleBeginner": "Beginner",
+    "titleIntermediate": "Intermediate",
+    "titleAdvanced": "Advanced",
+    "titleExpert": "Expert",
+    "titleMaster": "Master",
+    "titleLegend": "Legend Lv.{{level}}"
   },
   "analytics": {
     "pageTitle": "Learning Analytics",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1067,7 +1067,14 @@
     "breakdownStreakBonus": "Bonus de Racha",
     "xpUnit": "XP",
     "noActivity": "Sin actividad aún",
-    "rankingByLevel": "Por Nivel"
+    "rankingByLevel": "Por Nivel",
+    "titleNewcomer": "Novato",
+    "titleBeginner": "Principiante",
+    "titleIntermediate": "Intermedio",
+    "titleAdvanced": "Avanzado",
+    "titleExpert": "Experto",
+    "titleMaster": "Maestro",
+    "titleLegend": "Leyenda Nv.{{level}}"
   },
   "analytics": {
     "pageTitle": "Panel de Análisis de Aprendizaje",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1067,7 +1067,14 @@
     "breakdownStreakBonus": "Bonus de Série",
     "xpUnit": "XP",
     "noActivity": "Aucune activité",
-    "rankingByLevel": "Par Niveau"
+    "rankingByLevel": "Par Niveau",
+    "titleNewcomer": "Nouveau",
+    "titleBeginner": "Débutant",
+    "titleIntermediate": "Intermédiaire",
+    "titleAdvanced": "Avancé",
+    "titleExpert": "Expert",
+    "titleMaster": "Maître",
+    "titleLegend": "Légende Nv.{{level}}"
   },
   "analytics": {
     "pageTitle": "Tableau de Bord Analytique",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -997,7 +997,14 @@
     "breakdownStreakBonus": "ストリークボーナス",
     "xpUnit": "XP",
     "noActivity": "アクティビティがありません",
-    "rankingByLevel": "レベル別"
+    "rankingByLevel": "レベル別",
+    "titleNewcomer": "ニューカマー",
+    "titleBeginner": "ビギナー",
+    "titleIntermediate": "中級者",
+    "titleAdvanced": "上級者",
+    "titleExpert": "エキスパート",
+    "titleMaster": "マスター",
+    "titleLegend": "レジェンド Lv.{{level}}"
   },
   "analytics": {
     "pageTitle": "学習分析ダッシュボード",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1067,7 +1067,14 @@
     "breakdownStreakBonus": "연속 보너스",
     "xpUnit": "XP",
     "noActivity": "아직 활동이 없습니다",
-    "rankingByLevel": "레벨별"
+    "rankingByLevel": "레벨별",
+    "titleNewcomer": "신입",
+    "titleBeginner": "초보자",
+    "titleIntermediate": "중급자",
+    "titleAdvanced": "상급자",
+    "titleExpert": "전문가",
+    "titleMaster": "마스터",
+    "titleLegend": "레전드 Lv.{{level}}"
   },
   "analytics": {
     "pageTitle": "학습 분석 대시보드",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1067,7 +1067,14 @@
     "breakdownStreakBonus": "Bônus de Sequência",
     "xpUnit": "XP",
     "noActivity": "Nenhuma atividade ainda",
-    "rankingByLevel": "Por Nível"
+    "rankingByLevel": "Por Nível",
+    "titleNewcomer": "Novato",
+    "titleBeginner": "Iniciante",
+    "titleIntermediate": "Intermediário",
+    "titleAdvanced": "Avançado",
+    "titleExpert": "Especialista",
+    "titleMaster": "Mestre",
+    "titleLegend": "Lenda Nv.{{level}}"
   },
   "analytics": {
     "pageTitle": "Painel de Análise de Aprendizado",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1067,7 +1067,14 @@
     "breakdownStreakBonus": "Бонус за серию",
     "xpUnit": "XP",
     "noActivity": "Пока нет активности",
-    "rankingByLevel": "По уровню"
+    "rankingByLevel": "По уровню",
+    "titleNewcomer": "Новичок",
+    "titleBeginner": "Начинающий",
+    "titleIntermediate": "Средний",
+    "titleAdvanced": "Продвинутый",
+    "titleExpert": "Эксперт",
+    "titleMaster": "Мастер",
+    "titleLegend": "Легенда Ур.{{level}}"
   },
   "analytics": {
     "pageTitle": "Панель Аналитики Обучения",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1067,7 +1067,14 @@
     "breakdownStreakBonus": "连续奖励",
     "xpUnit": "XP",
     "noActivity": "暂无活动",
-    "rankingByLevel": "按等级"
+    "rankingByLevel": "按等级",
+    "titleNewcomer": "新手",
+    "titleBeginner": "初学者",
+    "titleIntermediate": "中级",
+    "titleAdvanced": "高级",
+    "titleExpert": "专家",
+    "titleMaster": "大师",
+    "titleLegend": "传奇 Lv.{{level}}"
   },
   "analytics": {
     "pageTitle": "学习分析仪表盘",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1067,7 +1067,14 @@
     "breakdownStreakBonus": "連續獎勵",
     "xpUnit": "XP",
     "noActivity": "尚無活動",
-    "rankingByLevel": "依等級"
+    "rankingByLevel": "依等級",
+    "titleNewcomer": "新手",
+    "titleBeginner": "初學者",
+    "titleIntermediate": "中級",
+    "titleAdvanced": "高級",
+    "titleExpert": "專家",
+    "titleMaster": "大師",
+    "titleLegend": "傳奇 Lv.{{level}}"
   },
   "analytics": {
     "pageTitle": "學習分析儀表板",


### PR DESCRIPTION
## 概要
- LevelWidgetとLevelDisplayにレベル称号の表示を追加
- `getLevelTitleKey()`ヘルパーでレベル範囲に応じた称号を返す
- 7つの称号（ニューカマー/ビギナー/中級者/上級者/エキスパート/マスター/レジェンド）を10言語に翻訳

## 変更ファイル
- `frontend/src/components/dashboard/LevelWidget.tsx` — 称号表示追加
- `frontend/src/components/profile/LevelDisplay.tsx` — 称号表示追加
- `frontend/src/i18n/locales/*.json` — 全10言語に7キー追加

Closes #615