### PR TITLE
perf: StudyCirclesPage/PostDetailPageのuseCallback最適化

### DIFF
--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { usePostDetail, useConfirm } from '../hooks';
@@ -28,14 +28,14 @@ export default function PostDetailPage() {
   const [replyContent, setReplyContent] = useState('');
   const { confirm, dialogProps } = useConfirm();
 
-  const handleSubmitComment = async (e: React.FormEvent) => {
+  const handleSubmitComment = useCallback(async (e: React.FormEvent) => {
     e.preventDefault();
     if (!newComment.trim()) return;
     const success = await submitComment(newComment);
     if (success) setNewComment('');
-  };
+  }, [newComment, submitComment]);
 
-  const handleSubmitReply = async (e: React.FormEvent, parentId: number) => {
+  const handleSubmitReply = useCallback(async (e: React.FormEvent, parentId: number) => {
     e.preventDefault();
     if (!replyContent.trim()) return;
     const success = await submitComment(replyContent, parentId);
@@ -43,9 +43,9 @@ export default function PostDetailPage() {
       setReplyContent('');
       setReplyingTo(null);
     }
-  };
+  }, [replyContent, submitComment]);
 
-  const handleDeletePost = async () => {
+  const handleDeletePost = useCallback(async () => {
     if (!post) return;
     const confirmed = await confirm({
       title: t('common.delete'),
@@ -62,7 +62,15 @@ export default function PostDetailPage() {
     } catch {
       toast.error(t('post.deleteFailed'));
     }
-  };
+  }, [post, confirm, t, navigate]);
+
+  const handleOpenEdit = useCallback(() => setEditingPost(true), []);
+  const handleCloseEdit = useCallback(() => setEditingPost(false), []);
+
+  const handleEditSubmit = useCallback(async (title: string, content: string, imageUrls: string[]) => {
+    const result = await updatePost(title, content, imageUrls);
+    if (result) setEditingPost(false);
+  }, [updatePost]);
 
   if (loading) return <PageLoader />;
   if (!post) return <div className="text-center text-gray-400 py-12">{t('post.notFound')}</div>;
@@ -72,7 +80,7 @@ export default function PostDetailPage() {
       <PostCard
         post={post}
         isOwner={user?.id === post.user_id}
-        onEdit={() => setEditingPost(true)}
+        onEdit={handleOpenEdit}
         onDelete={handleDeletePost}
         onUpdate={refetch}
       />
@@ -220,14 +228,11 @@ export default function PostDetailPage() {
       <ConfirmDialog {...dialogProps} />
 
       {/* Edit Modal */}
-      <Modal isOpen={editingPost} onClose={() => setEditingPost(false)} title={t('dashboard.editPost')}>
+      <Modal isOpen={editingPost} onClose={handleCloseEdit} title={t('dashboard.editPost')}>
         <PostForm
           post={post}
-          onSubmit={async (title, content, imageUrls) => {
-            const result = await updatePost(title, content, imageUrls);
-            if (result) setEditingPost(false);
-          }}
-          onCancel={() => setEditingPost(false)}
+          onSubmit={handleEditSubmit}
+          onCancel={handleCloseEdit}
         />
       </Modal>
     </div>

--- a/frontend/src/pages/StudyCirclesPage.tsx
+++ b/frontend/src/pages/StudyCirclesPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Users, Plus, Crown } from 'lucide-react';
@@ -14,13 +14,29 @@ export default function StudyCirclesPage() {
   const [showModal, setShowModal] = useState(false);
   const [form, setForm] = useState({ name: '', topic: '', description: '', max_members: 5 });
 
-  const handleCreate = async () => {
+  const handleOpenModal = useCallback(() => setShowModal(true), []);
+  const handleCloseModal = useCallback(() => setShowModal(false), []);
+
+  const handleCreate = useCallback(async () => {
     const result = await createCircle(form);
     if (result) {
       setShowModal(false);
       setForm({ name: '', topic: '', description: '', max_members: 5 });
     }
-  };
+  }, [form, createCircle]);
+
+  const handleNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm((prev) => ({ ...prev, name: e.target.value }));
+  }, []);
+  const handleTopicChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm((prev) => ({ ...prev, topic: e.target.value }));
+  }, []);
+  const handleDescriptionChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setForm((prev) => ({ ...prev, description: e.target.value }));
+  }, []);
+  const handleMaxMembersChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setForm((prev) => ({ ...prev, max_members: parseInt(e.target.value) || 5 }));
+  }, []);
 
   return (
     <div className="space-y-6">
@@ -31,7 +47,7 @@ export default function StudyCirclesPage() {
           {t('studyCircle.title')}
         </h1>
         <button
-          onClick={() => setShowModal(true)}
+          onClick={handleOpenModal}
           className="flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-500 text-white rounded-lg text-sm font-medium transition-colors"
         >
           <Plus className="w-4 h-4" />
@@ -55,7 +71,7 @@ export default function StudyCirclesPage() {
           <Users className="w-16 h-16 mx-auto mb-4 text-gray-700" />
           <p className="text-gray-400 mb-4">{t('studyCircle.noCircles')}</p>
           <button
-            onClick={() => setShowModal(true)}
+            onClick={handleOpenModal}
             className="inline-flex items-center gap-2 px-4 py-2 bg-purple-600 hover:bg-purple-500 text-white rounded-lg text-sm font-medium transition-colors"
           >
             <Plus className="w-4 h-4" />
@@ -121,7 +137,7 @@ export default function StudyCirclesPage() {
       {/* Create Modal */}
       <Modal
         isOpen={showModal}
-        onClose={() => setShowModal(false)}
+        onClose={handleCloseModal}
         title={t('studyCircle.create')}
         maxWidth="max-w-md"
       >
@@ -131,7 +147,7 @@ export default function StudyCirclesPage() {
             <input
               type="text"
               value={form.name}
-              onChange={(e) => setForm({ ...form, name: e.target.value })}
+              onChange={handleNameChange}
               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
               placeholder="React学習会"
             />
@@ -141,7 +157,7 @@ export default function StudyCirclesPage() {
             <input
               type="text"
               value={form.topic}
-              onChange={(e) => setForm({ ...form, topic: e.target.value })}
+              onChange={handleTopicChange}
               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
               placeholder="React入門を1ヶ月で"
             />
@@ -150,7 +166,7 @@ export default function StudyCirclesPage() {
             <label className="text-xs text-gray-400 block mb-1">{t('studyCircle.description')}</label>
             <textarea
               value={form.description}
-              onChange={(e) => setForm({ ...form, description: e.target.value })}
+              onChange={handleDescriptionChange}
               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500 h-20 resize-none"
             />
           </div>
@@ -161,14 +177,14 @@ export default function StudyCirclesPage() {
               min={3}
               max={10}
               value={form.max_members}
-              onChange={(e) => setForm({ ...form, max_members: parseInt(e.target.value) || 5 })}
+              onChange={handleMaxMembersChange}
               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
             />
           </div>
         </div>
         <div className="flex justify-end gap-2 mt-5">
           <button
-            onClick={() => setShowModal(false)}
+            onClick={handleCloseModal}
             className="px-4 py-2 text-sm text-gray-400 hover:text-white transition-colors"
           >
             {t('common.cancel')}


### PR DESCRIPTION
## 概要
- StudyCirclesPage: `handleCreate`・モーダル開閉・フォームonChangeをuseCallbackでメモ化、関数的更新パターン（`setForm(prev => ...)`）に変更
- PostDetailPage: `handleSubmitComment`・`handleSubmitReply`・`handleDeletePost`・`handleEditSubmit`をuseCallbackでメモ化、インラインコールバックを名前付き関数に抽出

## 変更ファイル
- `frontend/src/pages/StudyCirclesPage.tsx` — useCallback追加（8箇所）
- `frontend/src/pages/PostDetailPage.tsx` — useCallback追加（6箇所）

Closes #619