### PR TITLE
test: NotificationSettingsService/ReminderSettingsServiceのエラーケーステスト追加

### DIFF
--- a/backend/internal/service/notification_settings_test.go
+++ b/backend/internal/service/notification_settings_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -132,5 +133,70 @@ func TestNotificationSettingsService_ShouldNotify(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, should)
 
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// エラーケーステスト
+// ============================================================
+
+func TestNotificationSettingsService_GetSettings_Error(t *testing.T) {
+	svc, repo := setupNotificationSettingsService()
+
+	repo.On("GetOrCreateDefault", uint(1)).Return(nil, errors.New("db error"))
+
+	result, err := svc.GetSettings(1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestNotificationSettingsService_UpdateSettings_GetError(t *testing.T) {
+	svc, repo := setupNotificationSettingsService()
+
+	repo.On("GetOrCreateDefault", uint(1)).Return(nil, errors.New("db error"))
+
+	updates := &model.NotificationSettings{EnableLikes: true}
+	result, err := svc.UpdateSettings(1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestNotificationSettingsService_UpdateSettings_SaveError(t *testing.T) {
+	svc, repo := setupNotificationSettingsService()
+
+	existing := &model.NotificationSettings{ID: 1, UserID: 1, EnableLikes: true}
+	repo.On("GetOrCreateDefault", uint(1)).Return(existing, nil)
+	repo.On("CreateOrUpdate", mock.AnythingOfType("*model.NotificationSettings")).Return(errors.New("save error"))
+
+	updates := &model.NotificationSettings{EnableLikes: false}
+	result, err := svc.UpdateSettings(1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestNotificationSettingsService_ShouldNotify_Error(t *testing.T) {
+	svc, repo := setupNotificationSettingsService()
+
+	repo.On("GetOrCreateDefault", uint(1)).Return(nil, errors.New("db error"))
+
+	should, err := svc.ShouldNotify(1, model.NotificationTypeLike)
+	assert.Error(t, err)
+	assert.False(t, should)
+	repo.AssertExpectations(t)
+}
+
+func TestNotificationSettingsService_ShouldNotify_DefaultType(t *testing.T) {
+	svc, repo := setupNotificationSettingsService()
+
+	settings := &model.NotificationSettings{UserID: 1}
+	repo.On("GetOrCreateDefault", uint(1)).Return(settings, nil)
+
+	// 未定義の通知タイプはデフォルトでtrue
+	should, err := svc.ShouldNotify(1, model.NotificationType("unknown"))
+	assert.NoError(t, err)
+	assert.True(t, should)
 	repo.AssertExpectations(t)
 }

--- a/backend/internal/service/reminder_settings_test.go
+++ b/backend/internal/service/reminder_settings_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -161,5 +162,84 @@ func TestReminderSettingsService_ShouldRemind(t *testing.T) {
 		})
 	}
 
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// エラーケーステスト
+// ============================================================
+
+func TestReminderSettingsService_GetSettings_Error(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	repo.On("GetOrCreateDefault", uint(1)).Return(nil, errors.New("db error"))
+
+	result, err := svc.GetSettings(1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestReminderSettingsService_UpdateSettings_GetError(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	repo.On("GetByUserID", uint(1)).Return(nil, errors.New("db error"))
+
+	updates := &model.ReminderSettings{Frequency: model.ReminderFrequencyDaily}
+	result, err := svc.UpdateSettings(1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestReminderSettingsService_UpdateSettings_SaveError(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	existing := &model.ReminderSettings{
+		ID:               1,
+		UserID:           1,
+		Enabled:          true,
+		Frequency:        model.ReminderFrequencyDaily,
+		NotificationTime: "09:00",
+		InactiveDays:     3,
+	}
+
+	repo.On("GetByUserID", uint(1)).Return(existing, nil)
+	repo.On("CreateOrUpdate", mock.AnythingOfType("*model.ReminderSettings")).Return(errors.New("save error"))
+
+	updates := &model.ReminderSettings{Frequency: model.ReminderFrequencyWeekly}
+	result, err := svc.UpdateSettings(1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestReminderSettingsService_ShouldRemind_RepoError(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	repo.On("GetByUserID", uint(1)).Return(nil, errors.New("db error"))
+
+	result := svc.ShouldRemind(1, time.Now().Add(-5*24*time.Hour))
+	assert.False(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestReminderSettingsService_SendReminder_Success(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	repo.On("UpdateLastRemindedAt", uint(1)).Return(nil)
+
+	err := svc.SendReminder(1)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestReminderSettingsService_SendReminder_Error(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	repo.On("UpdateLastRemindedAt", uint(1)).Return(errors.New("db error"))
+
+	err := svc.SendReminder(1)
+	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
- NotificationSettingsService: GetSettings/UpdateSettings(Get・Save)/ShouldNotify(Error・DefaultType)の5テスト追加（3→8件）
- ReminderSettingsService: GetSettings/UpdateSettings(Get・Save)/ShouldRemind(RepoError)/SendReminder(Success・Error)の6テスト追加（3→9件）

## 変更ファイル
- `backend/internal/service/notification_settings_test.go` — 5テスト追加
- `backend/internal/service/reminder_settings_test.go` — 6テスト追加

Closes #620