### PR TITLE
i18n: StudyCirclesPageのハードコードプレースホルダーi18n対応

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1232,6 +1232,8 @@
       "todayCheckin": "Heutiger Check-in",
       "viewAll": "Alle anzeigen"
     },
+    "namePlaceholder": "React-Lerngruppe",
+    "topicPlaceholder": "React-Grundlagen in 1 Monat lernen",
     "searchUsers": "Benutzer suchen..."
   },
   "notes": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1232,6 +1232,8 @@
       "todayCheckin": "Today's Check-in",
       "viewAll": "View All"
     },
+    "namePlaceholder": "React Study Group",
+    "topicPlaceholder": "Learn React basics in 1 month",
     "searchUsers": "Search users..."
   },
   "notes": {

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1232,6 +1232,8 @@
       "todayCheckin": "Check-in de Hoy",
       "viewAll": "Ver Todo"
     },
+    "namePlaceholder": "Grupo de estudio React",
+    "topicPlaceholder": "Aprender React en 1 mes",
     "searchUsers": "Buscar usuarios..."
   },
   "notes": {

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1232,6 +1232,8 @@
       "todayCheckin": "Check-in du Jour",
       "viewAll": "Tout Voir"
     },
+    "namePlaceholder": "Groupe d'étude React",
+    "topicPlaceholder": "Apprendre React en 1 mois",
     "searchUsers": "Rechercher des utilisateurs..."
   },
   "notes": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1133,6 +1133,8 @@
       "todayCheckin": "今日のチェックイン",
       "viewAll": "すべて見る"
     },
+    "namePlaceholder": "React学習会",
+    "topicPlaceholder": "React入門を1ヶ月で",
     "searchUsers": "ユーザーを検索..."
   },
   "notes": {

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1232,6 +1232,8 @@
       "todayCheckin": "오늘의 체크인",
       "viewAll": "모두 보기"
     },
+    "namePlaceholder": "React 스터디",
+    "topicPlaceholder": "1개월 만에 React 입문",
     "searchUsers": "사용자 검색..."
   },
   "notes": {

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1232,6 +1232,8 @@
       "todayCheckin": "Check-in de Hoje",
       "viewAll": "Ver Tudo"
     },
+    "namePlaceholder": "Grupo de estudo React",
+    "topicPlaceholder": "Aprender React em 1 mês",
     "searchUsers": "Pesquisar usuários..."
   },
   "notes": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1232,6 +1232,8 @@
       "todayCheckin": "Сегодняшняя Отметка",
       "viewAll": "Показать Все"
     },
+    "namePlaceholder": "Группа изучения React",
+    "topicPlaceholder": "Изучить основы React за 1 месяц",
     "searchUsers": "Поиск пользователей..."
   },
   "notes": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1232,6 +1232,8 @@
       "todayCheckin": "今日签到",
       "viewAll": "查看全部"
     },
+    "namePlaceholder": "React学习会",
+    "topicPlaceholder": "一个月掌握React入门",
     "searchUsers": "搜索用户..."
   },
   "notes": {

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1232,6 +1232,8 @@
       "todayCheckin": "今日簽到",
       "viewAll": "查看全部"
     },
+    "namePlaceholder": "React學習會",
+    "topicPlaceholder": "一個月學會React入門",
     "searchUsers": "搜尋使用者..."
   },
   "notes": {

--- a/frontend/src/pages/StudyCirclesPage.tsx
+++ b/frontend/src/pages/StudyCirclesPage.tsx
@@ -149,7 +149,7 @@ export default function StudyCirclesPage() {
               value={form.name}
               onChange={handleNameChange}
               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
-              placeholder="React学習会"
+              placeholder={t('studyCircle.namePlaceholder')}
             />
           </div>
           <div>
@@ -159,7 +159,7 @@ export default function StudyCirclesPage() {
               value={form.topic}
               onChange={handleTopicChange}
               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
-              placeholder="React入門を1ヶ月で"
+              placeholder={t('studyCircle.topicPlaceholder')}
             />
           </div>
           <div>


### PR DESCRIPTION
## 概要
- StudyCirclesPageの日本語ハードコードプレースホルダー2箇所をi18nキーに置換
- `namePlaceholder`・`topicPlaceholder`を全10言語に翻訳追加

## 変更ファイル
- `frontend/src/pages/StudyCirclesPage.tsx` — placeholder 2箇所をt()に置換
- `frontend/src/i18n/locales/*.json` — 全10言語に2キー追加

Closes #621