### PR TITLE
test: RankingServiceの空リスト・境界値テスト追加

### DIFF
--- a/backend/internal/service/ranking_test.go
+++ b/backend/internal/service/ranking_test.go
@@ -123,3 +123,69 @@ func TestRankingService_AvailableLanguages(t *testing.T) {
 		repo.AssertExpectations(t)
 	})
 }
+
+func TestRankingService_ContributionRanking_EmptyList(t *testing.T) {
+	repo := new(MockRankingRepository)
+	svc := NewRankingService(repo)
+
+	repo.On("ContributionRanking", "weekly").Return([]repository.RankingEntry{}, nil)
+
+	result, err := svc.ContributionRanking("weekly")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestRankingService_LanguageRanking_EmptyList(t *testing.T) {
+	repo := new(MockRankingRepository)
+	svc := NewRankingService(repo)
+
+	repo.On("LanguageRanking", "Rust", "weekly").Return([]repository.RankingEntry{}, nil)
+
+	result, err := svc.LanguageRanking("Rust", "weekly")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestRankingService_LevelRanking_EmptyList(t *testing.T) {
+	repo := new(MockRankingRepository)
+	svc := NewRankingService(repo)
+
+	repo.On("LevelRanking").Return([]repository.RankingEntry{}, nil)
+
+	result, err := svc.LevelRanking()
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestRankingService_AvailableLanguages_EmptyList(t *testing.T) {
+	repo := new(MockRankingRepository)
+	svc := NewRankingService(repo)
+
+	repo.On("AvailableLanguages").Return([]string{}, nil)
+
+	result, err := svc.AvailableLanguages()
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestRankingService_ContributionRanking_LargeScores(t *testing.T) {
+	repo := new(MockRankingRepository)
+	svc := NewRankingService(repo)
+
+	expected := []repository.RankingEntry{
+		{UserID: 1, Name: "top-user", Score: 999999},
+		{UserID: 2, Name: "second-user", Score: 0},
+	}
+	repo.On("ContributionRanking", "monthly").Return(expected, nil)
+
+	result, err := svc.ContributionRanking("monthly")
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(999999), result[0].Score)
+	assert.Equal(t, int64(0), result[1].Score)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- RankingServiceの4メソッド全てに空リスト返却テストを追加
- コントリビューションランキングにスコア境界値テスト（999999, 0）を追加

## 追加テスト
- `TestRankingService_ContributionRanking_EmptyList`
- `TestRankingService_LanguageRanking_EmptyList`
- `TestRankingService_LevelRanking_EmptyList`
- `TestRankingService_AvailableLanguages_EmptyList`
- `TestRankingService_ContributionRanking_LargeScores`

## テスト
- [x] `go test ./internal/service/... -run TestRanking -v` 全13テスト通過

Closes #632