### PR TITLE
a11y: ShareModalのaria-label i18n対応

### DIFF
--- a/frontend/src/components/profile/ShareModal.tsx
+++ b/frontend/src/components/profile/ShareModal.tsx
@@ -189,7 +189,7 @@ export default function ShareModal({
             {/* Twitter */}
             <button
               onClick={handleShareTwitter}
-              aria-label="Twitter"
+              aria-label={t('sharing.shareOnTwitter')}
               className="flex flex-col items-center gap-2 p-4 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors"
             >
               <div className="w-10 h-10 flex items-center justify-center bg-sky-500/20 text-sky-400 rounded-full">
@@ -203,7 +203,7 @@ export default function ShareModal({
             {/* LinkedIn */}
             <button
               onClick={handleShareLinkedIn}
-              aria-label="LinkedIn"
+              aria-label={t('sharing.shareOnLinkedIn')}
               className="flex flex-col items-center gap-2 p-4 bg-gray-800 hover:bg-gray-700 rounded-md transition-colors"
             >
               <div className="w-10 h-10 flex items-center justify-center bg-blue-600/20 text-blue-500 rounded-full">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -646,7 +646,9 @@
     "linkCopied": "Link kopiert!",
     "downloaded": "Bild heruntergeladen!",
     "downloadFailed": "Bild konnte nicht heruntergeladen werden",
-    "twitterText": "Schau dir das Entwicklerprofil von {{name}} auf DevSync an!"
+    "twitterText": "Schau dir das Entwicklerprofil von {{name}} auf DevSync an!",
+    "shareOnTwitter": "Auf Twitter teilen",
+    "shareOnLinkedIn": "Auf LinkedIn teilen"
   },
   "projects": {
     "title": "Projekt-Showcase",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -646,7 +646,9 @@
     "linkCopied": "Link copied to clipboard!",
     "downloaded": "Image downloaded!",
     "downloadFailed": "Failed to download image",
-    "twitterText": "Check out {{name}}'s developer profile on DevSync!"
+    "twitterText": "Check out {{name}}'s developer profile on DevSync!",
+    "shareOnTwitter": "Share on Twitter",
+    "shareOnLinkedIn": "Share on LinkedIn"
   },
   "projects": {
     "title": "Project Showcase",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -646,7 +646,9 @@
     "linkCopied": "¡Enlace copiado!",
     "downloaded": "¡Imagen descargada!",
     "downloadFailed": "Error al descargar la imagen",
-    "twitterText": "¡Mira el perfil de desarrollador de {{name}} en DevSync!"
+    "twitterText": "¡Mira el perfil de desarrollador de {{name}} en DevSync!",
+    "shareOnTwitter": "Compartir en Twitter",
+    "shareOnLinkedIn": "Compartir en LinkedIn"
   },
   "projects": {
     "title": "Portafolio de Proyectos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -646,7 +646,9 @@
     "linkCopied": "Lien copié !",
     "downloaded": "Image téléchargée !",
     "downloadFailed": "Échec du téléchargement de l'image",
-    "twitterText": "Découvrez le profil développeur de {{name}} sur DevSync !"
+    "twitterText": "Découvrez le profil développeur de {{name}} sur DevSync !",
+    "shareOnTwitter": "Partager sur Twitter",
+    "shareOnLinkedIn": "Partager sur LinkedIn"
   },
   "projects": {
     "title": "Vitrine de Projets",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -620,7 +620,9 @@
     "linkCopied": "リンクをコピーしました！",
     "downloaded": "画像をダウンロードしました！",
     "downloadFailed": "画像のダウンロードに失敗しました",
-    "twitterText": "{{name}}さんの開発者プロフィールをDevSyncでチェック！"
+    "twitterText": "{{name}}さんの開発者プロフィールをDevSyncでチェック！",
+    "shareOnTwitter": "Twitterで共有",
+    "shareOnLinkedIn": "LinkedInで共有"
   },
   "projects": {
     "title": "プロジェクトショーケース",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -646,7 +646,9 @@
     "linkCopied": "링크가 복사되었습니다!",
     "downloaded": "이미지가 다운로드되었습니다!",
     "downloadFailed": "이미지 다운로드에 실패했습니다",
-    "twitterText": "DevSync에서 {{name}}님의 개발자 프로필을 확인하세요!"
+    "twitterText": "DevSync에서 {{name}}님의 개발자 프로필을 확인하세요!",
+    "shareOnTwitter": "Twitter에서 공유",
+    "shareOnLinkedIn": "LinkedIn에서 공유"
   },
   "projects": {
     "title": "프로젝트 쇼케이스",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -646,7 +646,9 @@
     "linkCopied": "Link copiado!",
     "downloaded": "Imagem baixada!",
     "downloadFailed": "Falha ao baixar imagem",
-    "twitterText": "Confira o perfil de desenvolvedor de {{name}} no DevSync!"
+    "twitterText": "Confira o perfil de desenvolvedor de {{name}} no DevSync!",
+    "shareOnTwitter": "Compartilhar no Twitter",
+    "shareOnLinkedIn": "Compartilhar no LinkedIn"
   },
   "projects": {
     "title": "Portfólio de Projetos",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -646,7 +646,9 @@
     "linkCopied": "Ссылка скопирована!",
     "downloaded": "Изображение скачано!",
     "downloadFailed": "Не удалось скачать изображение",
-    "twitterText": "Посмотрите профиль разработчика {{name}} на DevSync!"
+    "twitterText": "Посмотрите профиль разработчика {{name}} на DevSync!",
+    "shareOnTwitter": "Поделиться в Twitter",
+    "shareOnLinkedIn": "Поделиться в LinkedIn"
   },
   "projects": {
     "title": "Витрина Проектов",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -646,7 +646,9 @@
     "linkCopied": "链接已复制！",
     "downloaded": "图片已下载！",
     "downloadFailed": "下载图片失败",
-    "twitterText": "在DevSync上查看{{name}}的开发者资料！"
+    "twitterText": "在DevSync上查看{{name}}的开发者资料！",
+    "shareOnTwitter": "在Twitter上分享",
+    "shareOnLinkedIn": "在LinkedIn上分享"
   },
   "projects": {
     "title": "项目展示",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -646,7 +646,9 @@
     "linkCopied": "連結已複製！",
     "downloaded": "圖片已下載！",
     "downloadFailed": "下載圖片失敗",
-    "twitterText": "在DevSync上查看{{name}}的開發者資料！"
+    "twitterText": "在DevSync上查看{{name}}的開發者資料！",
+    "shareOnTwitter": "在Twitter上分享",
+    "shareOnLinkedIn": "在LinkedIn上分享"
   },
   "projects": {
     "title": "專案展示",


### PR DESCRIPTION
## 概要
- ShareModalのTwitter/LinkedInボタンのハードコードされた`aria-label`をi18nキーに置換
- 10言語のlocaleファイルに`sharing.shareOnTwitter`と`sharing.shareOnLinkedIn`を追加

## テスト
- [x] `npx tsc --noEmit` 型チェック通過

Closes #639