### PR TITLE
a11y: GoalsPageのボタンaria-label追加

### DIFF
--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -359,9 +359,9 @@ const GoalCard = memo(function GoalCard({
             <button
               onClick={() => onStatusChange(goal, 'paused')}
               className="p-2 text-gray-400 hover:text-yellow-400 transition-colors"
-              title={t('goals.pause')}
+              aria-label={t('goals.pause')}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 5.25v13.5m-7.5-13.5v13.5" />
               </svg>
             </button>
@@ -370,9 +370,9 @@ const GoalCard = memo(function GoalCard({
             <button
               onClick={() => onStatusChange(goal, 'active')}
               className="p-2 text-gray-400 hover:text-blue-400 transition-colors"
-              title={t('goals.resume')}
+              aria-label={t('goals.resume')}
             >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
                 <path strokeLinecap="round" strokeLinejoin="round" d="M5.25 5.653c0-.856.917-1.398 1.667-.986l11.54 6.347a1.125 1.125 0 0 1 0 1.972l-11.54 6.347a1.125 1.125 0 0 1-1.667-.986V5.653Z" />
               </svg>
             </button>
@@ -380,18 +380,18 @@ const GoalCard = memo(function GoalCard({
           <button
             onClick={() => onEdit(goal)}
             className="p-2 text-gray-400 hover:text-blue-400 transition-colors"
-            title={t('common.edit')}
+            aria-label={t('common.edit')}
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
             </svg>
           </button>
           <button
             onClick={() => onDelete(goal.id)}
             className="p-2 text-gray-400 hover:text-red-400 transition-colors"
-            title={t('common.delete')}
+            aria-label={t('common.delete')}
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
             </svg>
           </button>


### PR DESCRIPTION
## 概要
- GoalCardの4つのアクションボタン（一時停止・再開・編集・削除）の`title`を`aria-label`に変更
- 装飾SVGアイコン4箇所に`aria-hidden="true"`を追加
- スクリーンリーダーでのアクセシビリティを改善

## テスト
- [x] `npx tsc --noEmit` 型チェック通過

Closes #645