### PR TITLE
test: ActivityReportServiceにエッジケーステスト6件追加

### DIFF
--- a/backend/internal/service/activity_report_test.go
+++ b/backend/internal/service/activity_report_test.go
@@ -117,3 +117,101 @@ func TestGetComparison_Error(t *testing.T) {
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// エッジケーステスト
+// ============================================================
+
+func TestNewActivityReportService(t *testing.T) {
+	repo := new(MockActivityReportRepository)
+	svc := NewActivityReportService(repo)
+	assert.NotNil(t, svc)
+}
+
+func TestGetWeeklyReport_EmptyReport(t *testing.T) {
+	repo := new(MockActivityReportRepository)
+	svc := NewActivityReportService(repo)
+
+	expected := &model.ActivityReport{
+		Period:             model.ReportPeriodWeekly,
+		UserID:             1,
+		TotalContributions: 0,
+		PostsCreated:       0,
+	}
+	repo.On("GetWeeklyReport", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetWeeklyReport(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, result.TotalContributions)
+	assert.Equal(t, 0, result.PostsCreated)
+	repo.AssertExpectations(t)
+}
+
+func TestGetMonthlyReport_LargeValues(t *testing.T) {
+	repo := new(MockActivityReportRepository)
+	svc := NewActivityReportService(repo)
+
+	expected := &model.ActivityReport{
+		Period:             model.ReportPeriodMonthly,
+		UserID:             1,
+		TotalContributions: 999999,
+		PostsCreated:       10000,
+	}
+	repo.On("GetMonthlyReport", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetMonthlyReport(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 999999, result.TotalContributions)
+	assert.Equal(t, 10000, result.PostsCreated)
+	repo.AssertExpectations(t)
+}
+
+func TestGetComparison_Monthly_Error(t *testing.T) {
+	repo := new(MockActivityReportRepository)
+	svc := NewActivityReportService(repo)
+
+	repo.On("GetComparison", uint(1), model.ReportPeriodMonthly).Return(nil, errors.New("db error"))
+
+	result, err := svc.GetComparison(1, model.ReportPeriodMonthly)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestGetComparison_ZeroDifferences(t *testing.T) {
+	repo := new(MockActivityReportRepository)
+	svc := NewActivityReportService(repo)
+
+	expected := &model.ReportComparison{
+		ContributionsDiff: 0,
+		PostsDiff:         0,
+		FollowersDiff:     0,
+		GoalsDiff:         0,
+		TrendPercentage:   0.0,
+	}
+	repo.On("GetComparison", uint(1), model.ReportPeriodWeekly).Return(expected, nil)
+
+	result, err := svc.GetComparison(1, model.ReportPeriodWeekly)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, result.ContributionsDiff)
+	assert.Equal(t, 0.0, result.TrendPercentage)
+	repo.AssertExpectations(t)
+}
+
+func TestGetComparison_LargeNegativeTrend(t *testing.T) {
+	repo := new(MockActivityReportRepository)
+	svc := NewActivityReportService(repo)
+
+	expected := &model.ReportComparison{
+		ContributionsDiff: -100,
+		PostsDiff:         -50,
+		TrendPercentage:   -99.9,
+	}
+	repo.On("GetComparison", uint(1), model.ReportPeriodMonthly).Return(expected, nil)
+
+	result, err := svc.GetComparison(1, model.ReportPeriodMonthly)
+	assert.NoError(t, err)
+	assert.Equal(t, -100, result.ContributionsDiff)
+	assert.Equal(t, -99.9, result.TrendPercentage)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
ActivityReportServiceのテストカバレッジを強化（7→13テスト）。

## 追加テスト
- `TestNewActivityReportService` — コンストラクタの正常生成確認
- `TestGetWeeklyReport_EmptyReport` — 全フィールドゼロの週次レポート
- `TestGetMonthlyReport_LargeValues` — 大きな値（999999件）の境界値テスト
- `TestGetComparison_Monthly_Error` — 月次比較のリポジトリエラー
- `TestGetComparison_ZeroDifferences` — 変化なし（差分ゼロ）の比較結果
- `TestGetComparison_LargeNegativeTrend` — 大幅な負のトレンド（-99.9%）

Closes #654