### PR TITLE
test: ZennServiceのエッジケーステスト追加

### DIFF
--- a/backend/internal/service/zenn_test.go
+++ b/backend/internal/service/zenn_test.go
@@ -176,3 +176,112 @@ func TestZennValidateUsername_NetworkError(t *testing.T) {
 	assert.Error(t, err)
 	assert.False(t, valid)
 }
+
+func TestZennFetchArticles_RequestURL(t *testing.T) {
+	svc := newTestZennService(func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "zenn.dev", req.URL.Host)
+		assert.Equal(t, "/api/articles", req.URL.Path)
+		assert.Equal(t, "myuser", req.URL.Query().Get("username"))
+		assert.Equal(t, "1", req.URL.Query().Get("page"))
+		assert.Equal(t, "latest", req.URL.Query().Get("order"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"articles":[],"next_page":null}`)),
+		}, nil
+	})
+
+	_, err := svc.FetchArticles("myuser")
+	assert.NoError(t, err)
+}
+
+func TestZennFetchArticles_MultipleArticles(t *testing.T) {
+	svc := newTestZennService(func(req *http.Request) (*http.Response, error) {
+		body := `{"articles":[
+			{"id":1,"title":"記事A","slug":"a","emoji":"📝","article_type":"tech","liked_count":10,"comments_count":2,"published_at":"2025-01-01T00:00:00Z"},
+			{"id":2,"title":"記事B","slug":"b","emoji":"📖","article_type":"idea","liked_count":20,"comments_count":4,"published_at":"2025-01-02T00:00:00Z"},
+			{"id":3,"title":"記事C","slug":"c","emoji":"🔧","article_type":"tech","liked_count":30,"comments_count":6,"published_at":"2025-01-03T00:00:00Z"}
+		],"next_page":null}`
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	})
+
+	articles, err := svc.FetchArticles("testuser")
+	assert.NoError(t, err)
+	assert.Len(t, articles, 3)
+	assert.Equal(t, "記事A", articles[0].Title)
+	assert.Equal(t, "記事B", articles[1].Title)
+	assert.Equal(t, "記事C", articles[2].Title)
+	assert.Equal(t, 30, articles[2].LikedCount)
+}
+
+func TestZennFetchArticles_NotFound(t *testing.T) {
+	svc := newTestZennService(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	articles, err := svc.FetchArticles("nonexistent")
+	assert.Nil(t, articles)
+	assert.Error(t, err)
+
+	var domainErr *domain.DomainError
+	assert.True(t, errors.As(err, &domainErr))
+	assert.Contains(t, domainErr.Message, "404")
+}
+
+func TestZennValidateUsername_ServerError(t *testing.T) {
+	svc := newTestZennService(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusInternalServerError,
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	valid, err := svc.ValidateUsername("testuser")
+	assert.NoError(t, err)
+	assert.False(t, valid)
+}
+
+func TestZennFetchArticles_PaginationURL(t *testing.T) {
+	callCount := 0
+	svc := newTestZennService(func(req *http.Request) (*http.Response, error) {
+		callCount++
+		if callCount == 1 {
+			assert.Equal(t, "1", req.URL.Query().Get("page"))
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(`{"articles":[],"next_page":3}`)),
+			}, nil
+		}
+		assert.Equal(t, "3", req.URL.Query().Get("page"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"articles":[],"next_page":null}`)),
+		}, nil
+	})
+
+	_, err := svc.FetchArticles("testuser")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, callCount)
+}
+
+func TestZennValidateUsername_RequestURL(t *testing.T) {
+	svc := newTestZennService(func(req *http.Request) (*http.Response, error) {
+		assert.Equal(t, "zenn.dev", req.URL.Host)
+		assert.Equal(t, "/api/articles", req.URL.Path)
+		assert.Equal(t, "zennuser", req.URL.Query().Get("username"))
+		assert.Equal(t, "1", req.URL.Query().Get("page"))
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader(`{"articles":[]}`)),
+		}, nil
+	})
+
+	valid, err := svc.ValidateUsername("zennuser")
+	assert.NoError(t, err)
+	assert.True(t, valid)
+}


### PR DESCRIPTION
## 概要
ZennServiceのFetchArticlesとValidateUsernameに対してエッジケーステスト6件を追加し、10→16テストに拡充。

## 追加テスト
- `TestZennFetchArticles_RequestURL` — リクエストURLパラメータ検証
- `TestZennFetchArticles_MultipleArticles` — 複数記事の正しい変換
- `TestZennFetchArticles_NotFound` — 404ステータスのエラーハンドリング
- `TestZennFetchArticles_PaginationURL` — ページネーション時のURLパラメータ遷移
- `TestZennValidateUsername_ServerError` — 500ステータスでfalse返却
- `TestZennValidateUsername_RequestURL` — リクエストURL検証

## テスト結果
16テスト全通過

closes #666