### PR TITLE
fix: CodeSnippetInput/Viewerのa11y改善

### DIFF
--- a/frontend/src/components/posts/CodeSnippetInput.tsx
+++ b/frontend/src/components/posts/CodeSnippetInput.tsx
@@ -38,9 +38,9 @@ export default function CodeSnippetInput({ value, onChange, onRemove, index }: C
           type="button"
           onClick={onRemove}
           className="p-1.5 text-gray-400 hover:text-red-400 hover:bg-gray-700 rounded transition-colors"
-          title={t('post.removeSnippet')}
+          aria-label={t('post.removeSnippet')}
         >
-          <X className="w-4 h-4" />
+          <X className="w-4 h-4" aria-hidden="true" />
         </button>
       </div>
 

--- a/frontend/src/components/posts/CodeSnippetViewer.tsx
+++ b/frontend/src/components/posts/CodeSnippetViewer.tsx
@@ -68,12 +68,12 @@ export default function CodeSnippetViewer({ snippet, showComments = true }: Code
         >
           {copied ? (
             <>
-              <Check className="w-3.5 h-3.5 text-green-400" />
+              <Check className="w-3.5 h-3.5 text-green-400" aria-hidden="true" />
               <span className="text-green-400">{t('post.codeCopied')}</span>
             </>
           ) : (
             <>
-              <Copy className="w-3.5 h-3.5" />
+              <Copy className="w-3.5 h-3.5" aria-hidden="true" />
               {t('post.copyCode')}
             </>
           )}
@@ -96,9 +96,9 @@ export default function CodeSnippetViewer({ snippet, showComments = true }: Code
                         <button
                           onClick={() => setCommentLine(commentLine === lineNum ? null : lineNum)}
                           className="w-5 h-full flex items-center justify-center text-transparent group-hover:text-blue-400 hover:bg-gray-800 transition-colors"
-                          title={t('post.addLineComment')}
+                          aria-label={t('post.addLineComment')}
                         >
-                          <MessageSquarePlus className="w-3 h-3" />
+                          <MessageSquarePlus className="w-3 h-3" aria-hidden="true" />
                         </button>
                         {/* Line number */}
                         <span className="px-2 text-xs text-gray-600 select-none font-mono text-right min-w-[2.5rem] inline-block">
@@ -182,6 +182,7 @@ export default function CodeSnippetViewer({ snippet, showComments = true }: Code
                               <button
                                 onClick={() => removeComment(comment.id)}
                                 className="text-xs text-gray-600 hover:text-red-400 transition-colors"
+                                aria-label={t('post.deleteComment')}
                               >
                                 ×
                               </button>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -158,6 +158,7 @@
     "codeCopied": "Kopiert!",
     "lineComment": "Zeilenkommentar",
     "addLineComment": "Kommentar hinzufügen",
+    "deleteComment": "Kommentar löschen",
     "lineCommentPlaceholder": "Kommentar zu dieser Zeile...",
     "snippetComments": "{{count}} Kommentare",
     "codeSnippets": "Code-Snippets",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -158,6 +158,7 @@
     "codeCopied": "Copied!",
     "lineComment": "Line comment",
     "addLineComment": "Add comment",
+    "deleteComment": "Delete comment",
     "lineCommentPlaceholder": "Comment on this line...",
     "snippetComments": "{{count}} comments",
     "codeSnippets": "Code Snippets",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -158,6 +158,7 @@
     "codeCopied": "¡Copiado!",
     "lineComment": "Comentario de línea",
     "addLineComment": "Agregar comentario",
+    "deleteComment": "Eliminar comentario",
     "lineCommentPlaceholder": "Comentar en esta línea...",
     "snippetComments": "{{count}} comentarios",
     "codeSnippets": "Fragmentos de Código",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -158,6 +158,7 @@
     "codeCopied": "Copié !",
     "lineComment": "Commentaire de ligne",
     "addLineComment": "Ajouter un commentaire",
+    "deleteComment": "Supprimer le commentaire",
     "lineCommentPlaceholder": "Commenter cette ligne...",
     "snippetComments": "{{count}} commentaires",
     "codeSnippets": "Extraits de Code",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -159,6 +159,7 @@
     "codeCopied": "コピーしました",
     "lineComment": "行コメント",
     "addLineComment": "コメントを追加",
+    "deleteComment": "コメントを削除",
     "lineCommentPlaceholder": "この行へのコメント...",
     "snippetComments": "{{count}}件のコメント",
     "codeSnippets": "コードスニペット",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -158,6 +158,7 @@
     "codeCopied": "복사되었습니다",
     "lineComment": "라인 코멘트",
     "addLineComment": "코멘트 추가",
+    "deleteComment": "코멘트 삭제",
     "lineCommentPlaceholder": "이 줄에 코멘트...",
     "snippetComments": "{{count}}개의 코멘트",
     "codeSnippets": "코드 스니펫",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -158,6 +158,7 @@
     "codeCopied": "Copiado!",
     "lineComment": "Comentário de linha",
     "addLineComment": "Adicionar comentário",
+    "deleteComment": "Excluir comentário",
     "lineCommentPlaceholder": "Comentar nesta linha...",
     "snippetComments": "{{count}} comentários",
     "codeSnippets": "Trechos de Código",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -158,6 +158,7 @@
     "codeCopied": "Скопировано!",
     "lineComment": "Комментарий к строке",
     "addLineComment": "Добавить комментарий",
+    "deleteComment": "Удалить комментарий",
     "lineCommentPlaceholder": "Комментарий к этой строке...",
     "snippetComments": "{{count}} комментариев",
     "codeSnippets": "Фрагменты Кода",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -158,6 +158,7 @@
     "codeCopied": "已复制",
     "lineComment": "行注释",
     "addLineComment": "添加评论",
+    "deleteComment": "删除评论",
     "lineCommentPlaceholder": "对这行进行评论...",
     "snippetComments": "{{count}}条评论",
     "codeSnippets": "代码片段",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -158,6 +158,7 @@
     "codeCopied": "已複製",
     "lineComment": "行註解",
     "addLineComment": "新增留言",
+    "deleteComment": "刪除留言",
     "lineCommentPlaceholder": "對這行進行留言...",
     "snippetComments": "{{count}}則留言",
     "codeSnippets": "程式碼片段",


### PR DESCRIPTION
## 概要
CodeSnippetInputとCodeSnippetViewerのアクセシビリティを改善。

## 変更内容
- **CodeSnippetInput**: 削除ボタンの`title`→`aria-label`、Xアイコンに`aria-hidden="true"`
- **CodeSnippetViewer**: 
  - Copy/Checkアイコンに`aria-hidden="true"`
  - コメント追加ボタンの`title`→`aria-label`、MessageSquarePlusアイコンに`aria-hidden="true"`
  - コメント削除ボタン（×）に`aria-label`追加
- `post.deleteComment`キーを全10言語に追加

closes #667