### PR TITLE
refactor: プロフィールURLをIDベースからユーザー名ベースに移行

### DIFF
--- a/backend/internal/repository/ranking.go
+++ b/backend/internal/repository/ranking.go
@@ -15,7 +15,8 @@ func NewRankingRepository(db *gorm.DB) *RankingRepository {
 // RankingEntry はランキング表示用の1エントリを表す。
 type RankingEntry struct {
 	UserID    uint   `json:"user_id"`    // ユーザーID
-	Name      string `json:"name"`       // ユーザー名
+	Username  string `json:"username"`   // ユーザー名（URLスラッグ用）
+	Name      string `json:"name"`       // 表示名
 	AvatarURL string `json:"avatar_url"` // アバター画像URL
 	Score     int64  `json:"score"`      // ランキングスコア
 }
@@ -30,7 +31,7 @@ func (r *RankingRepository) ContributionRanking(period string) ([]RankingEntry, 
 
 	var entries []RankingEntry
 	err := r.db.Raw(`
-		SELECT u.id as user_id, u.name, u.avatar_url, COALESCE(SUM(gc.count), 0) as score
+		SELECT u.id as user_id, u.username, u.name, u.avatar_url, COALESCE(SUM(gc.count), 0) as score
 		FROM users u
 		JOIN git_hub_contributions gc ON gc.user_id = u.id
 		WHERE gc.date >= NOW() - INTERVAL '`+interval+`'
@@ -47,7 +48,7 @@ func (r *RankingRepository) ContributionRanking(period string) ([]RankingEntry, 
 func (r *RankingRepository) LanguageRanking(language, period string) ([]RankingEntry, error) {
 	var entries []RankingEntry
 	err := r.db.Raw(`
-		SELECT u.id as user_id, u.name, u.avatar_url, gls.bytes as score
+		SELECT u.id as user_id, u.username, u.name, u.avatar_url, gls.bytes as score
 		FROM users u
 		JOIN git_hub_language_stats gls ON gls.user_id = u.id
 		WHERE gls.language = ?
@@ -62,7 +63,7 @@ func (r *RankingRepository) LanguageRanking(language, period string) ([]RankingE
 func (r *RankingRepository) LevelRanking() ([]RankingEntry, error) {
 	var entries []RankingEntry
 	err := r.db.Raw(`
-		SELECT u.id as user_id, u.name, u.avatar_url,
+		SELECT u.id as user_id, u.username, u.name, u.avatar_url,
 			COALESCE(ll.xp, 0) + COALESCE(p.xp, 0) + COALESCE(gh.xp, 0) +
 			COALESCE(g.xp, 0) + COALESCE(c.xp, 0) + COALESCE(lk.xp, 0) as score
 		FROM users u

--- a/frontend/src/components/bookReviews/BookReviewCard.tsx
+++ b/frontend/src/components/bookReviews/BookReviewCard.tsx
@@ -101,7 +101,7 @@ export default function BookReviewCard({
           <div className="flex items-center justify-between mt-3 pt-2 border-t border-gray-700">
             {showUser && review.user && (
               <Link
-                to={`/profile/${review.user_id}`}
+                to={`/profile/${review.user?.username || review.user_id}`}
                 className="flex items-center gap-2 hover:opacity-80 transition-opacity"
               >
                 <Avatar avatarUrl={review.user.avatar_url} name={review.user.name} size="sm" />

--- a/frontend/src/components/common/MentionText.tsx
+++ b/frontend/src/components/common/MentionText.tsx
@@ -22,7 +22,7 @@ export default function MentionText({ text, className = '' }: MentionTextProps) 
     parts.push(
       <Link
         key={`${start}-${username}`}
-        to={`/profile/by-username/${username}`}
+        to={`/profile/${username}`}
         className="text-blue-400 hover:text-blue-300 font-medium transition-colors"
       >
         @{username}

--- a/frontend/src/components/dashboard/RecommendedUsersWidget.tsx
+++ b/frontend/src/components/dashboard/RecommendedUsersWidget.tsx
@@ -64,12 +64,12 @@ export default function RecommendedUsersWidget() {
 
           return (
             <div key={rec.user.id} className="flex items-center gap-2.5 p-1.5 rounded-lg hover:bg-gray-800/50 transition-colors">
-              <Link to={`/profile/${rec.user.id}`}>
+              <Link to={`/profile/${rec.user.username}`}>
                 <Avatar name={rec.user.name} avatarUrl={rec.user.avatar_url} size="sm" />
               </Link>
               <div className="flex-1 min-w-0">
                 <Link
-                  to={`/profile/${rec.user.id}`}
+                  to={`/profile/${rec.user.username}`}
                   className="text-xs font-medium text-gray-200 hover:text-white block truncate"
                 >
                   {rec.user.name}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -190,7 +190,7 @@ export default function Header() {
 
           {user && (
             <Link
-              to={`/profile/${user.id}`}
+              to={`/profile/${user.username}`}
               className="flex items-center gap-2 ml-1"
               aria-label={t('nav.profile')}
             >

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -61,13 +61,13 @@ export default function NotificationDropdown() {
       case 'comment':
         return notification.post_id ? `/posts/${notification.post_id}` : '/';
       case 'follow':
-        return `/profile/${notification.actor_id}`;
+        return `/profile/${notification.actor.username}`;
       case 'message':
         return '/chat';
       case 'answer':
         return notification.question_id ? `/qa/${notification.question_id}` : '/';
       case 'badge':
-        return `/profile/${notification.actor_id}`;
+        return `/profile/${notification.actor.username}`;
       default:
         return '/';
     }

--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -109,11 +109,11 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
   return (
     <div className={cardDarkClass}>
       <div className="flex items-center gap-3 mb-3">
-        <Link to={`/profile/${post.user_id}`}>
+        <Link to={`/profile/${post.user?.username || post.user_id}`}>
           <Avatar name={post.user?.name || 'U'} avatarUrl={post.user?.avatar_url} size="sm" />
         </Link>
         <div className="min-w-0">
-          <Link to={`/profile/${post.user_id}`} className="font-medium text-sm hover:text-blue-400 transition-colors">
+          <Link to={`/profile/${post.user?.username || post.user_id}`} className="font-medium text-sm hover:text-blue-400 transition-colors">
             {post.user?.name}
           </Link>
           <p className="text-xs text-gray-500">

--- a/frontend/src/components/profile/ShareModal.tsx
+++ b/frontend/src/components/profile/ShareModal.tsx
@@ -33,7 +33,7 @@ export default function ShareModal({
 
   if (!isOpen) return null;
 
-  const profileUrl = `${window.location.origin}/profile/${user.id}`;
+  const profileUrl = `${window.location.origin}/profile/${user.username}`;
 
   const generateImage = async (): Promise<Blob | null> => {
     if (!cardRef.current) return null;

--- a/frontend/src/components/qa/AnswerCard.tsx
+++ b/frontend/src/components/qa/AnswerCard.tsx
@@ -90,7 +90,7 @@ export default function AnswerCard({
             <div className="flex items-center gap-3">
               {answer.user && (
                 <Link
-                  to={`/profile/${answer.user_id}`}
+                  to={`/profile/${answer.user?.username || answer.user_id}`}
                   className="flex items-center gap-2 hover:opacity-80 transition-opacity"
                 >
                   <Avatar avatarUrl={answer.user.avatar_url} name={answer.user.name} size="sm" />

--- a/frontend/src/components/qa/QuestionCard.tsx
+++ b/frontend/src/components/qa/QuestionCard.tsx
@@ -97,7 +97,7 @@ export default function QuestionCard({ question, isOwner = false, onEdit, onDele
           <div className="flex items-center justify-between mt-3 pt-2 border-t border-gray-700/50">
             {question.user && (
               <Link
-                to={`/profile/${question.user_id}`}
+                to={`/profile/${question.user?.username || question.user_id}`}
                 className="flex items-center gap-2 hover:opacity-80 transition-opacity"
               >
                 <Avatar avatarUrl={question.user.avatar_url} name={question.user.name} size="sm" />

--- a/frontend/src/components/resources/ResourceCard.tsx
+++ b/frontend/src/components/resources/ResourceCard.tsx
@@ -168,7 +168,7 @@ export default function ResourceCard({
         <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-700">
           {showUser && resource.user && (
             <Link
-              to={`/profile/${resource.user_id}`}
+              to={`/profile/${resource.user?.username || resource.user_id}`}
               className="flex items-center gap-2 hover:opacity-80 transition-opacity"
             >
               <Avatar avatarUrl={resource.user.avatar_url} name={resource.user.name} size="sm" />

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -198,7 +198,7 @@ export default function DashboardPage() {
             <div className="flex items-center gap-3 mb-3">
               <Avatar name={user.name} avatarUrl={user.avatar_url} size="md" />
               <div className="min-w-0">
-                <Link to={`/profile/${user.id}`} className="font-medium text-sm hover:text-blue-400 block truncate">
+                <Link to={`/profile/${user.username}`} className="font-medium text-sm hover:text-blue-400 block truncate">
                   {user.name}
                 </Link>
                 {user.github_username && (
@@ -207,7 +207,7 @@ export default function DashboardPage() {
               </div>
             </div>
             <div className="space-y-0.5">
-              <Link to={`/profile/${user.id}`} className="flex items-center gap-2 text-sm text-gray-400 hover:text-white hover:bg-gray-800 py-1.5 px-2 rounded-md transition-colors">
+              <Link to={`/profile/${user.username}`} className="flex items-center gap-2 text-sm text-gray-400 hover:text-white hover:bg-gray-800 py-1.5 px-2 rounded-md transition-colors">
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24" aria-hidden="true"><path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.9 17.9 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" /></svg>
                 {t('dashboard.yourProfile')}
               </Link>

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -27,13 +27,13 @@ function getNotificationLink(notification: Notification): string {
     case 'comment':
       return notification.post_id ? `/posts/${notification.post_id}` : '/';
     case 'follow':
-      return `/profile/${notification.actor_id}`;
+      return `/profile/${notification.actor.username}`;
     case 'message':
       return '/chat';
     case 'answer':
       return notification.question_id ? `/qa/${notification.question_id}` : '/';
     case 'badge':
-      return `/profile/${notification.actor_id}`;
+      return `/profile/${notification.actor.username}`;
     default:
       return '/';
   }

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -139,13 +139,13 @@ export default function PostDetailPage() {
             {comments.map((comment) => (
               <div key={comment.id} className="px-6 py-4">
                 <div className="flex gap-3">
-                  <Link to={`/profile/${comment.user_id}`} className="flex-shrink-0">
+                  <Link to={`/profile/${comment.user?.username || comment.user_id}`} className="flex-shrink-0">
                     <Avatar name={comment.user?.name || 'U'} avatarUrl={comment.user?.avatar_url} size="sm" />
                   </Link>
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2 flex-wrap">
                       <Link
-                        to={`/profile/${comment.user_id}`}
+                        to={`/profile/${comment.user?.username || comment.user_id}`}
                         className="font-medium text-sm hover:text-blue-400 transition-colors"
                       >
                         {comment.user?.name}
@@ -196,13 +196,13 @@ export default function PostDetailPage() {
                   <div className="ml-11 mt-3 space-y-3 border-l-2 border-gray-800 pl-4">
                     {comment.replies.map((reply) => (
                       <div key={reply.id} className="flex gap-2.5">
-                        <Link to={`/profile/${reply.user_id}`} className="flex-shrink-0">
+                        <Link to={`/profile/${reply.user?.username || reply.user_id}`} className="flex-shrink-0">
                           <Avatar name={reply.user?.name || 'U'} avatarUrl={reply.user?.avatar_url} size="xs" />
                         </Link>
                         <div className="min-w-0 flex-1">
                           <div className="flex items-center gap-2 flex-wrap">
                             <Link
-                              to={`/profile/${reply.user_id}`}
+                              to={`/profile/${reply.user?.username || reply.user_id}`}
                               className="font-medium text-xs hover:text-blue-400 transition-colors"
                             >
                               {reply.user?.name}

--- a/frontend/src/pages/QADetailPage.tsx
+++ b/frontend/src/pages/QADetailPage.tsx
@@ -129,7 +129,7 @@ export default function QADetailPage() {
             <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-700/50">
               {question.user && (
                 <Link
-                  to={`/profile/${question.user_id}`}
+                  to={`/profile/${question.user?.username || question.user_id}`}
                   className="flex items-center gap-2 hover:opacity-80 transition-opacity"
                 >
                   <Avatar avatarUrl={question.user.avatar_url} name={question.user.name} size="sm" />

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -139,7 +139,7 @@ export default function RankingsPage() {
           {rankings.map((entry, index) => (
             <Link
               key={entry.user_id}
-              to={`/profile/${entry.user_id}`}
+              to={`/profile/${entry.username}`}
               className="grid grid-cols-[3rem_1fr_auto] gap-4 items-center px-6 py-3 hover:bg-gray-800/50 transition-colors border-b border-gray-800/50 last:border-b-0"
             >
               <span className={`text-center font-bold text-lg ${medalColor(index)}`}>

--- a/frontend/src/pages/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage.tsx
@@ -159,11 +159,11 @@ function UserCard({ user, currentUserId, t }: { user: User; currentUserId?: numb
   return (
     <div className="bg-gray-900 border border-gray-800 rounded-md p-5 hover:border-gray-700 transition-colors">
       <div className="flex items-start gap-4">
-        <Link to={`/profile/${user.id}`}>
+        <Link to={`/profile/${user.username}`}>
           <Avatar name={user.name} avatarUrl={user.avatar_url} />
         </Link>
         <div className="flex-1 min-w-0">
-          <Link to={`/profile/${user.id}`} className="font-semibold text-sm hover:text-blue-400 transition-colors">
+          <Link to={`/profile/${user.username}`} className="font-semibold text-sm hover:text-blue-400 transition-colors">
             {user.name}
           </Link>
           {user.bio && <p className="text-xs text-gray-400 mt-1 line-clamp-2">{user.bio}</p>}
@@ -171,7 +171,7 @@ function UserCard({ user, currentUserId, t }: { user: User; currentUserId?: numb
       </div>
       <div className="flex items-center gap-2 mt-4 pt-3 border-t border-gray-800/50">
         <Link
-          to={`/profile/${user.id}`}
+          to={`/profile/${user.username}`}
           className="flex-1 px-3 py-1.5 rounded-lg bg-gray-800 hover:bg-gray-700 text-gray-300 text-xs font-medium text-center transition-colors"
         >
           {t('search.viewProfile')}

--- a/frontend/src/types/ranking.ts
+++ b/frontend/src/types/ranking.ts
@@ -1,5 +1,6 @@
 export interface RankingEntry {
   user_id: number;
+  username: string;
   name: string;
   avatar_url: string;
   score: number;

--- a/frontend/src/types/recommendation.ts
+++ b/frontend/src/types/recommendation.ts
@@ -2,6 +2,7 @@
 export interface RecommendedUser {
   user: {
     id: number;
+    username: string;
     name: string;
     avatar_url: string;
     github_username: string;


### PR DESCRIPTION
## 概要
プロフィールURLを `/profile/1`（数値ID）から `/profile/username`（ユーザー名）に変更。

## 変更内容
- **バックエンド**: `RankingEntry` に `Username` フィールド追加、SQL 3本に `u.username` 追加
- **フロントエンド型定義**: `ranking.ts`, `recommendation.ts` に `username` フィールド追加
- **フロントエンドリンク**: 15ファイル・約25箇所をusernameベースに更新
- **MentionText バグ修正**: `/profile/by-username/` → `/profile/` （ルート不一致修正）

## テスト
- Go ビルド: OK
- Go テスト: 全パス
- TypeScript 型チェック: エラーなし

Closes #686