### PR TITLE
feat: ユーザー登録・GitHubログイン時にUsernameを自動生成

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -322,6 +322,7 @@ func seedTemplateRoadmaps(db *gorm.DB, roadmapService *service.RoadmapService) {
 		user = model.User{
 			Name:           "DevSync System",
 			Email:          systemEmail,
+			Username:       "__system__",
 			GitHubID:       -1,
 			GitHubUsername: "__system__",
 		}

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -3,6 +3,8 @@ package service
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -72,10 +74,15 @@ func (s *AuthService) Register(input RegisterInput) (*AuthResponse, error) {
 		return nil, err
 	}
 
+	// メールアドレスの@より前をベースにユニークなユーザー名を生成
+	usernameBase := strings.Split(input.Email, "@")[0]
+	username := s.generateUsername(usernameBase)
+
 	user := &model.User{
 		Name:     input.Name,
 		Email:    input.Email,
 		Password: string(hashed),
+		Username: username,
 	}
 
 	if err := s.userRepo.Create(user); err != nil {
@@ -221,9 +228,13 @@ func (s *AuthService) GitHubLogin(ghUser *GitHubUserInfo, accessToken string) (*
 		email = ghUser.Login + "@github.local"
 	}
 
+	// GitHubのログイン名をベースにユニークなユーザー名を生成
+	username := s.generateUsername(ghUser.Login)
+
 	newUser := &model.User{
 		Name:            name,
 		Email:           email,
+		Username:        username,
 		GitHubID:        ghUser.ID,
 		GitHubUsername:  ghUser.Login,
 		GitHubToken:     accessToken,
@@ -360,6 +371,19 @@ func (s *AuthService) ResetPassword(token string, newPassword string) error {
 
 	s.passwordResetRepo.MarkAsUsed(resetToken.ID)
 	return nil
+}
+
+// generateUsername は候補のユーザー名からユニークなユーザー名を生成する。
+// 候補が既に使われている場合は末尾に連番を付与する（例: alice → alice2 → alice3）。
+func (s *AuthService) generateUsername(base string) string {
+	candidate := base
+	for i := 2; ; i++ {
+		existing, _ := s.userRepo.FindByUsername(candidate)
+		if existing == nil {
+			return candidate
+		}
+		candidate = fmt.Sprintf("%s%d", base, i)
+	}
 }
 
 // generateToken は指定ユーザーIDのJWTトークンを生成する（有効期限72時間）。

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -29,6 +29,7 @@ func TestRegister_Success(t *testing.T) {
 	svc, userRepo, _ := newTestAuthService()
 
 	userRepo.On("FindByEmail", "test@example.com").Return(nil, errors.New("not found"))
+	userRepo.On("FindByUsername", "test").Return(nil, errors.New("not found"))
 	userRepo.On("Create", mock.AnythingOfType("*model.User")).Return(nil)
 
 	resp, err := svc.Register(RegisterInput{
@@ -42,6 +43,7 @@ func TestRegister_Success(t *testing.T) {
 	assert.NotEmpty(t, resp.Token)
 	assert.Equal(t, "testuser", resp.User.Name)
 	assert.Equal(t, "test@example.com", resp.User.Email)
+	assert.Equal(t, "test", resp.User.Username)
 	userRepo.AssertExpectations(t)
 }
 
@@ -106,6 +108,7 @@ func TestRegister_CreateUserError(t *testing.T) {
 	svc, userRepo, _ := newTestAuthService()
 
 	userRepo.On("FindByEmail", "new@example.com").Return(nil, errors.New("not found"))
+	userRepo.On("FindByUsername", "new").Return(nil, errors.New("not found"))
 	userRepo.On("Create", mock.AnythingOfType("*model.User")).Return(errors.New("db error"))
 
 	resp, err := svc.Register(RegisterInput{
@@ -443,6 +446,7 @@ func TestGitHubLogin_CreateNewUser(t *testing.T) {
 	// GitHub IDもメールも見つからない
 	userRepo.On("FindByGitHubID", int64(12345)).Return(nil, errors.New("not found"))
 	userRepo.On("FindByEmail", "new@example.com").Return(nil, errors.New("not found"))
+	userRepo.On("FindByUsername", "newghuser").Return(nil, errors.New("not found"))
 	userRepo.On("Create", mock.AnythingOfType("*model.User")).Return(nil)
 
 	ghUser := &GitHubUserInfo{
@@ -464,11 +468,13 @@ func TestGitHubLogin_NoEmailFallback(t *testing.T) {
 
 	// GitHub IDが見つからず、メールも未提供
 	userRepo.On("FindByGitHubID", int64(12345)).Return(nil, errors.New("not found"))
+	userRepo.On("FindByUsername", "ghuser").Return(nil, errors.New("not found"))
 	userRepo.On("Create", mock.AnythingOfType("*model.User")).Run(func(args mock.Arguments) {
 		user := args.Get(0).(*model.User)
 		// メール無しの場合、login@github.local がフォールバック
 		assert.Equal(t, "ghuser@github.local", user.Email)
 		assert.Equal(t, "ghuser", user.Name) // Name空の場合、Loginがフォールバック
+		assert.Equal(t, "ghuser", user.Username)
 	}).Return(nil)
 
 	ghUser := &GitHubUserInfo{


### PR DESCRIPTION
## Summary
- Register時: メールアドレスの`@`前をベースにユニークなUsernameを自動生成
- GitHubLogin時: GitHubログイン名をベースにユニークなUsernameを自動生成
- シードユーザー（DevSync System）に`__system__`のUsernameを設定
- 重複時は末尾に連番を付与（例: alice → alice2 → alice3）

## Test plan
- [x] Go build 成功
- [x] 全サービステスト通過（`go test ./internal/service/...`）
- [x] TypeScript型チェック通過（`npx tsc --noEmit`）
- [ ] Docker再ビルド後、新規登録でUsernameが正しく設定されることを確認

Closes #688