### PR TITLE
feat: 登録フォームにUsername入力フィールド追加・重複チェック

### DIFF
--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -11,6 +11,7 @@ type UserResponse struct {
 // RegisterRequest は新規ユーザー登録リクエスト
 type RegisterRequest struct {
 	Name            string `json:"name" binding:"required" validate:"required"`
+	Username        string `json:"username" binding:"required" validate:"required"`
 	Email           string `json:"email" binding:"required,email" validate:"required,email"`
 	Password        string `json:"password" binding:"required,min=6" validate:"required,min=6"`
 	ConfirmPassword string `json:"confirm_password" binding:"required" validate:"required"`

--- a/backend/internal/dto/auth_dto_test.go
+++ b/backend/internal/dto/auth_dto_test.go
@@ -24,6 +24,7 @@ func TestRegisterRequest_Validation(t *testing.T) {
 			name: "有効なリクエスト",
 			request: dto.RegisterRequest{
 				Name:            "Test User",
+				Username:        "testuser",
 				Email:           "test@example.com",
 				Password:        "password123",
 				ConfirmPassword: "password123",
@@ -34,6 +35,18 @@ func TestRegisterRequest_Validation(t *testing.T) {
 			name: "名前が空",
 			request: dto.RegisterRequest{
 				Name:            "",
+				Username:        "testuser",
+				Email:           "test@example.com",
+				Password:        "password123",
+				ConfirmPassword: "password123",
+			},
+			wantErr: true,
+		},
+		{
+			name: "ユーザー名が空",
+			request: dto.RegisterRequest{
+				Name:            "Test User",
+				Username:        "",
 				Email:           "test@example.com",
 				Password:        "password123",
 				ConfirmPassword: "password123",
@@ -44,6 +57,7 @@ func TestRegisterRequest_Validation(t *testing.T) {
 			name: "無効なメールアドレス",
 			request: dto.RegisterRequest{
 				Name:            "Test User",
+				Username:        "testuser",
 				Email:           "invalid-email",
 				Password:        "password123",
 				ConfirmPassword: "password123",
@@ -54,6 +68,7 @@ func TestRegisterRequest_Validation(t *testing.T) {
 			name: "パスワードが短すぎる",
 			request: dto.RegisterRequest{
 				Name:            "Test User",
+				Username:        "testuser",
 				Email:           "test@example.com",
 				Password:        "short",
 				ConfirmPassword: "short",
@@ -64,6 +79,7 @@ func TestRegisterRequest_Validation(t *testing.T) {
 			name: "確認パスワードが空",
 			request: dto.RegisterRequest{
 				Name:            "Test User",
+				Username:        "testuser",
 				Email:           "test@example.com",
 				Password:        "password123",
 				ConfirmPassword: "",

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -73,6 +73,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	// DTOをservice層の入力に変換
 	input := service.RegisterInput{
 		Name:     req.Name,
+		Username: req.Username,
 		Email:    req.Email,
 		Password: req.Password,
 	}

--- a/backend/internal/handler/auth_test.go
+++ b/backend/internal/handler/auth_test.go
@@ -237,10 +237,12 @@ func TestRegister_SetsCookie(t *testing.T) {
 	r, mockUserRepo := setupLoginTest()
 
 	mockUserRepo.On("FindByEmail", "new@example.com").Return(nil, assert.AnError)
+	mockUserRepo.On("FindByUsername", "newuser").Return(nil, assert.AnError)
 	mockUserRepo.On("Create", mock.AnythingOfType("*model.User")).Return(nil)
 
 	body, _ := json.Marshal(map[string]string{
 		"name":             "NewUser",
+		"username":         "newuser",
 		"email":            "new@example.com",
 		"password":         "password123",
 		"confirm_password": "password123",

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -4,7 +4,6 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -34,6 +33,7 @@ func NewAuthService(userRepo repository.UserRepositoryInterface, passwordResetRe
 // RegisterInput はユーザー登録リクエストの入力値を表す。
 type RegisterInput struct {
 	Name     string `json:"name" binding:"required"`
+	Username string `json:"username" binding:"required"`
 	Email    string `json:"email" binding:"required,email"`
 	Password string `json:"password" binding:"required,min=6"`
 }
@@ -60,7 +60,7 @@ func (s *AuthService) Register(input RegisterInput) (*AuthResponse, error) {
 	if err := domain.ValidatePassword(input.Password); err != nil {
 		return nil, err
 	}
-	if err := domain.ValidateUsername(input.Name); err != nil {
+	if err := domain.ValidateUsername(input.Username); err != nil {
 		return nil, err
 	}
 
@@ -69,20 +69,21 @@ func (s *AuthService) Register(input RegisterInput) (*AuthResponse, error) {
 		return nil, domain.NewError(domain.ErrCodeAlreadyExists, "このメールアドレスは既に登録されています", nil)
 	}
 
+	existingUsername, _ := s.userRepo.FindByUsername(input.Username)
+	if existingUsername != nil {
+		return nil, domain.NewError(domain.ErrCodeAlreadyExists, "このユーザー名は既に使用されています", nil)
+	}
+
 	hashed, err := bcrypt.GenerateFromPassword([]byte(input.Password), bcrypt.DefaultCost)
 	if err != nil {
 		return nil, err
 	}
 
-	// メールアドレスの@より前をベースにユニークなユーザー名を生成
-	usernameBase := strings.Split(input.Email, "@")[0]
-	username := s.generateUsername(usernameBase)
-
 	user := &model.User{
 		Name:     input.Name,
 		Email:    input.Email,
 		Password: string(hashed),
-		Username: username,
+		Username: input.Username,
 	}
 
 	if err := s.userRepo.Create(user); err != nil {

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -29,11 +29,12 @@ func TestRegister_Success(t *testing.T) {
 	svc, userRepo, _ := newTestAuthService()
 
 	userRepo.On("FindByEmail", "test@example.com").Return(nil, errors.New("not found"))
-	userRepo.On("FindByUsername", "test").Return(nil, errors.New("not found"))
+	userRepo.On("FindByUsername", "testuser").Return(nil, errors.New("not found"))
 	userRepo.On("Create", mock.AnythingOfType("*model.User")).Return(nil)
 
 	resp, err := svc.Register(RegisterInput{
-		Name:     "testuser",
+		Name:     "Test User",
+		Username: "testuser",
 		Email:    "test@example.com",
 		Password: "password123",
 	})
@@ -41,9 +42,9 @@ func TestRegister_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.NotEmpty(t, resp.Token)
-	assert.Equal(t, "testuser", resp.User.Name)
+	assert.Equal(t, "Test User", resp.User.Name)
 	assert.Equal(t, "test@example.com", resp.User.Email)
-	assert.Equal(t, "test", resp.User.Username)
+	assert.Equal(t, "testuser", resp.User.Username)
 	userRepo.AssertExpectations(t)
 }
 
@@ -55,6 +56,7 @@ func TestRegister_DuplicateEmail(t *testing.T) {
 
 	resp, err := svc.Register(RegisterInput{
 		Name:     "testuser",
+		Username: "testuser",
 		Email:    "test@example.com",
 		Password: "password123",
 	})
@@ -70,6 +72,7 @@ func TestRegister_InvalidEmail(t *testing.T) {
 
 	resp, err := svc.Register(RegisterInput{
 		Name:     "testuser",
+		Username: "testuser",
 		Email:    "invalid-email",
 		Password: "password123",
 	})
@@ -83,6 +86,7 @@ func TestRegister_InvalidPassword(t *testing.T) {
 
 	resp, err := svc.Register(RegisterInput{
 		Name:     "testuser",
+		Username: "testuser",
 		Email:    "test@example.com",
 		Password: "short",
 	})
@@ -95,7 +99,8 @@ func TestRegister_InvalidUsername(t *testing.T) {
 	svc, _, _ := newTestAuthService()
 
 	resp, err := svc.Register(RegisterInput{
-		Name:     "",
+		Name:     "testuser",
+		Username: "",
 		Email:    "test@example.com",
 		Password: "password123",
 	})
@@ -104,15 +109,36 @@ func TestRegister_InvalidUsername(t *testing.T) {
 	assert.Nil(t, resp)
 }
 
+func TestRegister_DuplicateUsername(t *testing.T) {
+	svc, userRepo, _ := newTestAuthService()
+
+	userRepo.On("FindByEmail", "new@example.com").Return(nil, errors.New("not found"))
+	existingUser := &model.User{Name: "Existing", Username: "taken"}
+	userRepo.On("FindByUsername", "taken").Return(existingUser, nil)
+
+	resp, err := svc.Register(RegisterInput{
+		Name:     "testuser",
+		Username: "taken",
+		Email:    "new@example.com",
+		Password: "password123",
+	})
+
+	assert.Error(t, err)
+	assert.Nil(t, resp)
+	assert.Contains(t, err.Error(), "このユーザー名は既に使用されています")
+	userRepo.AssertExpectations(t)
+}
+
 func TestRegister_CreateUserError(t *testing.T) {
 	svc, userRepo, _ := newTestAuthService()
 
 	userRepo.On("FindByEmail", "new@example.com").Return(nil, errors.New("not found"))
-	userRepo.On("FindByUsername", "new").Return(nil, errors.New("not found"))
+	userRepo.On("FindByUsername", "newuser").Return(nil, errors.New("not found"))
 	userRepo.On("Create", mock.AnythingOfType("*model.User")).Return(errors.New("db error"))
 
 	resp, err := svc.Register(RegisterInput{
 		Name:     "testuser",
+		Username: "newuser",
 		Email:    "new@example.com",
 		Password: "password123",
 	})

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,8 +1,8 @@
 import client from './client';
 import type { AuthResponse, User } from '../types/user';
 
-export const register = (name: string, email: string, password: string) =>
-  client.post<AuthResponse>('/auth/register', { name, email, password });
+export const register = (name: string, username: string, email: string, password: string) =>
+  client.post<AuthResponse>('/auth/register', { name, username, email, password });
 
 export const login = (email: string, password: string) =>
   client.post<AuthResponse>('/auth/login', { email, password });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -78,6 +78,8 @@
     "email": "E-Mail",
     "password": "Passwort",
     "name": "Name",
+    "username": "Benutzername",
+    "usernamePlaceholder": "Buchstaben, Zahlen, Unterstriche, Bindestriche",
     "confirmPassword": "Passwort bestätigen",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "Mindestens 6 Zeichen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -78,6 +78,8 @@
     "email": "Email",
     "password": "Password",
     "name": "Name",
+    "username": "Username",
+    "usernamePlaceholder": "Letters, numbers, underscores, hyphens",
     "confirmPassword": "Confirm Password",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6+ characters",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -78,6 +78,8 @@
     "email": "Correo electrónico",
     "password": "Contraseña",
     "name": "Nombre",
+    "username": "Nombre de usuario",
+    "usernamePlaceholder": "Letras, números, guiones bajos, guiones",
     "confirmPassword": "Confirmar contraseña",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6+ caracteres",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -78,6 +78,8 @@
     "email": "Email",
     "password": "Mot de passe",
     "name": "Nom",
+    "username": "Nom d'utilisateur",
+    "usernamePlaceholder": "Lettres, chiffres, tirets bas, tirets",
     "confirmPassword": "Confirmer le mot de passe",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6 caractères minimum",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -79,6 +79,8 @@
     "email": "メールアドレス",
     "password": "パスワード",
     "name": "名前",
+    "username": "ユーザー名",
+    "usernamePlaceholder": "英数字・アンダースコア・ハイフン",
     "confirmPassword": "パスワード確認",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6文字以上",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -78,6 +78,8 @@
     "email": "이메일",
     "password": "비밀번호",
     "name": "이름",
+    "username": "사용자 이름",
+    "usernamePlaceholder": "영문, 숫자, 밑줄, 하이픈",
     "confirmPassword": "비밀번호 확인",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6자 이상",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -78,6 +78,8 @@
     "email": "Email",
     "password": "Senha",
     "name": "Nome",
+    "username": "Nome de usuário",
+    "usernamePlaceholder": "Letras, números, sublinhados, hífens",
     "confirmPassword": "Confirmar senha",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6+ caracteres",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -78,6 +78,8 @@
     "email": "Email",
     "password": "Пароль",
     "name": "Имя",
+    "username": "Имя пользователя",
+    "usernamePlaceholder": "Буквы, цифры, подчёркивания, дефисы",
     "confirmPassword": "Подтвердите пароль",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "Минимум 6 символов",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -78,6 +78,8 @@
     "email": "邮箱",
     "password": "密码",
     "name": "姓名",
+    "username": "用户名",
+    "usernamePlaceholder": "字母、数字、下划线、连字符",
     "confirmPassword": "确认密码",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6个字符以上",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -78,6 +78,8 @@
     "email": "電子郵件",
     "password": "密碼",
     "name": "姓名",
+    "username": "使用者名稱",
+    "usernamePlaceholder": "字母、數字、底線、連字號",
     "confirmPassword": "確認密碼",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6個字元以上",

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -8,6 +8,7 @@ import { labelClass } from '../constants/styles';
 export default function RegisterPage() {
   const { t } = useTranslation();
   const [name, setName] = useState('');
+  const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -23,14 +24,14 @@ export default function RegisterPage() {
     }
     setLoading(true);
     try {
-      await register(name, email, password);
+      await register(name, username, email, password);
       navigate('/');
     } catch {
       toast.error(t('errors.somethingWrong'));
     } finally {
       setLoading(false);
     }
-  }, [password, name, email, register, navigate, t]);
+  }, [password, name, username, email, register, navigate, t]);
 
   const handleGitHubLogin = useCallback(async () => {
     setLoading(true);
@@ -43,6 +44,7 @@ export default function RegisterPage() {
   }, [loginWithGitHub, t]);
 
   const handleNameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setName(e.target.value), []);
+  const handleUsernameChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setUsername(e.target.value), []);
   const handleEmailChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setEmail(e.target.value), []);
   const handlePasswordChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setPassword(e.target.value), []);
 
@@ -89,6 +91,23 @@ export default function RegisterPage() {
                 value={name}
                 onChange={handleNameChange}
                 required
+                className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+              />
+            </div>
+            <div>
+              <label htmlFor="register-username" className={labelClass}>
+                {t('auth.username')}
+              </label>
+              <input
+                id="register-username"
+                type="text"
+                value={username}
+                onChange={handleUsernameChange}
+                required
+                minLength={2}
+                maxLength={30}
+                pattern="[a-zA-Z0-9_\-]+"
+                placeholder={t('auth.usernamePlaceholder')}
                 className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
               />
             </div>

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -7,7 +7,7 @@ interface AuthState {
   isAuthenticated: boolean;
   loading: boolean;
   login: (email: string, password: string) => Promise<void>;
-  register: (name: string, email: string, password: string) => Promise<void>;
+  register: (name: string, username: string, email: string, password: string) => Promise<void>;
   loginWithGitHub: () => Promise<void>;
   handleGitHubCallback: (code: string, state: string) => Promise<void>;
   logout: () => Promise<void>;
@@ -25,8 +25,8 @@ export const useAuthStore = create<AuthState>((set) => ({
     set({ user: data.user, isAuthenticated: true });
   },
 
-  register: async (name, email, password) => {
-    const { data } = await authApi.register(name, email, password);
+  register: async (name, username, email, password) => {
+    const { data } = await authApi.register(name, username, email, password);
     set({ user: data.user, isAuthenticated: true });
   },
 


### PR DESCRIPTION
## Summary
- Backend: `RegisterInput`・DTO・HandlerにUsernameフィールド追加
- Backend: Username重複チェック（既に使用されている場合はエラー返却）
- Backend: `ValidateUsername`でフォーマットチェック（2-30文字、英数字・_・-のみ）
- Frontend: 登録フォームにUsernameフィールド追加（パターン制約付き）
- i18n: 10言語に`auth.username`・`auth.usernamePlaceholder`キー追加
- テスト: DTOバリデーション・Service層・Handler層のテスト更新（重複テスト追加）

## Test plan
- [x] Go build 成功
- [x] Service層テスト通過
- [x] Handler層テスト通過
- [x] DTOテスト通過
- [x] TypeScript型チェック通過
- [ ] Docker再ビルド後、登録画面でUsernameフィールドが表示されること
- [ ] 重複Usernameで登録するとエラーになること

Closes #690