### PR TITLE
refactor: inputClassスタイルを共通定義に統一

### DIFF
--- a/frontend/src/components/common/SearchInput.tsx
+++ b/frontend/src/components/common/SearchInput.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Search } from 'lucide-react';
-import { buttonSecondaryClass } from '../../constants/styles';
+import { buttonSecondaryClass, searchInputClass } from '../../constants/styles';
 
 interface SearchInputProps {
   value: string;
@@ -29,7 +29,7 @@ export default function SearchInput({ value, onChange, onSearch, placeholder, sh
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
-          className="w-full pl-10 pr-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-400 focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+          className={searchInputClass}
         />
       </div>
       {showButton && onSearch && (

--- a/frontend/src/components/posts/PostForm.tsx
+++ b/frontend/src/components/posts/PostForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { Plus } from 'lucide-react';
+import { inputClass } from '../../constants/styles';
 import MarkdownEditor from './MarkdownEditor';
 import CodeSnippetInput, { type SnippetInputData } from './CodeSnippetInput';
 
@@ -80,7 +81,7 @@ export default function PostForm({ post, onSubmit, onCancel, loading: externalLo
         onChange={(e) => setTitle(e.target.value)}
         onFocus={() => setExpanded(true)}
         placeholder={t('post.createTitle')}
-        className="w-full px-3 py-2.5 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+        className={inputClass}
       />
       {expanded && (
         <>

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Search } from 'lucide-react';
+import { searchInputClass } from '../../constants/styles';
 
 interface SearchBarProps {
   value: string;
@@ -25,7 +26,7 @@ export default function SearchBar({ value, onChange, onSearch, placeholder }: Se
           value={value}
           onChange={(e) => onChange(e.target.value)}
           placeholder={placeholder || t('search.placeholder')}
-          className="w-full pl-10 pr-3 py-2.5 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+          className={searchInputClass}
         />
       </div>
       <button

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -1,6 +1,12 @@
 export const inputClass =
   'w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow';
 
+export const messageInputClass =
+  'flex-1 px-4 py-2.5 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow';
+
+export const searchInputClass =
+  'w-full pl-10 pr-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow';
+
 export const buttonPrimaryClass =
   'px-4 py-2 bg-blue-600 hover:bg-blue-500 text-white rounded-lg font-medium transition-colors';
 

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -2,6 +2,7 @@ import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { MessageSquare, Users, Plus, Settings, Send } from 'lucide-react';
 import { useChat } from '../hooks/useChat';
+import { messageInputClass } from '../constants/styles';
 import type { Message } from '../types/message';
 import type { ChatRoom } from '../types/chat';
 import Avatar from '../components/common/Avatar';
@@ -245,7 +246,7 @@ export default function ChatPage() {
                 value={c.newMessage}
                 onChange={(e) => c.setNewMessage(e.target.value)}
                 placeholder={t('chat.groupMessagePlaceholder')}
-                className="flex-1 px-4 py-2.5 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                className={messageInputClass}
               />
               <button
                 type="submit"
@@ -312,7 +313,7 @@ export default function ChatPage() {
                 value={c.newMessage}
                 onChange={(e) => c.setNewMessage(e.target.value)}
                 placeholder={t('chat.typeMessage')}
-                className="flex-1 px-4 py-2.5 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                className={messageInputClass}
               />
               <button
                 type="submit"

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { requestPasswordReset } from '../api/auth';
-import { labelClass } from '../constants/styles';
+import { inputClass, labelClass } from '../constants/styles';
 
 export default function ForgotPasswordPage() {
   const { t } = useTranslation();
@@ -77,7 +77,7 @@ export default function ForgotPasswordPage() {
                   type="email"
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                  className={inputClass}
                   placeholder={t('auth.emailPlaceholder')}
                   required
                 />

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../store/authStore';
 import { useToast } from '../hooks';
-import { labelClass } from '../constants/styles';
+import { inputClass, labelClass } from '../constants/styles';
 
 export default function LoginPage() {
   const { t } = useTranslation();
@@ -84,7 +84,7 @@ export default function LoginPage() {
                 value={email}
                 onChange={handleEmailChange}
                 required
-                className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                className={inputClass}
               />
             </div>
             <div>
@@ -97,7 +97,7 @@ export default function LoginPage() {
                 value={password}
                 onChange={handlePasswordChange}
                 required
-                className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                className={inputClass}
               />
             </div>
             <button

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { usePostDetail, useConfirm } from '../hooks';
-import { sectionContainerClass } from '../constants/styles';
+import { sectionContainerClass, messageInputClass } from '../constants/styles';
 import { deletePost } from '../api/posts';
 import { useAuthStore } from '../store/authStore';
 import PostCard from '../components/posts/PostCard';
@@ -116,7 +116,7 @@ export default function PostDetailPage() {
               value={newComment}
               onChange={setNewComment}
               placeholder={t('post.writeComment')}
-              className="flex-1 px-4 py-2.5 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+              className={messageInputClass}
               disabled={submitting}
             />
             <button
@@ -177,7 +177,7 @@ export default function PostDetailPage() {
                         value={replyContent}
                         onChange={setReplyContent}
                         placeholder={t('post.writeReply')}
-                        className="flex-1 px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                        className={messageInputClass}
                         disabled={submitting}
                       />
                       <button

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -3,7 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../store/authStore';
 import toast from 'react-hot-toast';
-import { labelClass } from '../constants/styles';
+import { inputClass, labelClass } from '../constants/styles';
 
 export default function RegisterPage() {
   const { t } = useTranslation();
@@ -91,7 +91,7 @@ export default function RegisterPage() {
                 value={name}
                 onChange={handleNameChange}
                 required
-                className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                className={inputClass}
               />
             </div>
             <div>
@@ -108,7 +108,7 @@ export default function RegisterPage() {
                 maxLength={30}
                 pattern="[a-zA-Z0-9_\-]+"
                 placeholder={t('auth.usernamePlaceholder')}
-                className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                className={inputClass}
               />
             </div>
             <div>
@@ -121,7 +121,7 @@ export default function RegisterPage() {
                 value={email}
                 onChange={handleEmailChange}
                 required
-                className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                className={inputClass}
               />
             </div>
             <div>
@@ -136,7 +136,7 @@ export default function RegisterPage() {
                 required
                 minLength={6}
                 placeholder={t('auth.passwordPlaceholder')}
-                className="w-full px-3 py-2 bg-gray-800/50 border border-gray-700 rounded-lg text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition-shadow"
+                className={inputClass}
               />
             </div>
             <button

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Link, useSearchParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { resetPassword } from '../api/auth';
-import { labelClass } from '../constants/styles';
+import { inputClass, labelClass } from '../constants/styles';
 
 export default function ResetPasswordPage() {
   const { t } = useTranslation();
@@ -108,7 +108,7 @@ export default function ResetPasswordPage() {
                   type="password"
                   value={password}
                   onChange={(e) => setPassword(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                  className={inputClass}
                   placeholder={t('auth.passwordPlaceholder')}
                   required
                   minLength={6}
@@ -123,7 +123,7 @@ export default function ResetPasswordPage() {
                   type="password"
                   value={confirmPassword}
                   onChange={(e) => setConfirmPassword(e.target.value)}
-                  className="w-full px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:border-blue-500"
+                  className={inputClass}
                   placeholder={t('auth.passwordPlaceholder')}
                   required
                   minLength={6}


### PR DESCRIPTION
## 概要
- `constants/styles.ts`に`messageInputClass`（チャット/コメント入力用）と`searchInputClass`（検索入力用）を新設
- 9ファイルのインラインinputスタイルを共通定数に置換
- `ForgotPasswordPage`/`ResetPasswordPage`のフォーカススタイルを他の認証ページと統一

## 変更ファイル（10ファイル）
| ファイル | 変更内容 |
|---------|---------|
| `constants/styles.ts` | `messageInputClass`, `searchInputClass` 追加 |
| `LoginPage.tsx` | `inputClass` に置換（2箇所） |
| `RegisterPage.tsx` | `inputClass` に置換（4箇所） |
| `PostForm.tsx` | `inputClass` に置換（1箇所） |
| `ForgotPasswordPage.tsx` | `inputClass` に置換（1箇所） |
| `ResetPasswordPage.tsx` | `inputClass` に置換（2箇所） |
| `ChatPage.tsx` | `messageInputClass` に置換（2箇所） |
| `PostDetailPage.tsx` | `messageInputClass` に置換（2箇所） |
| `SearchBar.tsx` | `searchInputClass` に置換（1箇所） |
| `SearchInput.tsx` | `searchInputClass` に置換（1箇所） |

## テスト
- `npx tsc --noEmit` 通過

Closes #314