### PR TITLE
feat: スレッド型コメント（コメント返信）の実装

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -26,8 +26,10 @@ type UpdatePostRequest struct {
 }
 
 // CreateCommentRequest はコメント作成リクエスト。
+// ParentIDが指定された場合は返信コメントとして作成する。
 type CreateCommentRequest struct {
-	Content string `json:"content" binding:"required,max=5000"`
+	Content  string `json:"content" binding:"required,max=5000"`
+	ParentID *uint  `json:"parent_id,omitempty"`
 }
 
 // PostDetailResponse は投稿詳細レスポンス（いいね済み・ブックマーク済みフラグ付き）。

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -251,7 +251,7 @@ func (h *PostHandler) CreateComment(c *gin.Context) {
 		return
 	}
 
-	comment := &model.Comment{UserID: userID, PostID: id, Content: input.Content}
+	comment := &model.Comment{UserID: userID, PostID: id, Content: input.Content, ParentID: input.ParentID}
 	if err := h.service.CreateComment(comment); err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/post_test.go
+++ b/backend/internal/handler/post_test.go
@@ -289,6 +289,23 @@ func TestPostCreateComment_ValidationError(t *testing.T) {
 	assertStatus(t, w, http.StatusBadRequest)
 }
 
+func TestPostCreateReply_Success(t *testing.T) {
+	h, postRepo, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/:id/comments", h.CreateComment)
+
+	parentComment := &model.Comment{PostID: 5, ParentID: nil}
+	parentComment.ID = 10
+	postRepo.On("FindCommentByID", uint(10)).Return(parentComment, nil)
+	postRepo.On("CreateComment", mock.AnythingOfType("*model.Comment")).Return(nil)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/comments", map[string]interface{}{
+		"content":   "Reply to comment!",
+		"parent_id": 10,
+	})
+	assertStatus(t, w, http.StatusCreated)
+}
+
 func TestPostDeleteComment_Success(t *testing.T) {
 	h, postRepo, _, _ := setupPostHandler()
 	r := newRouter(1)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -97,6 +97,13 @@ func (m *MockPostRepository) HasLiked(userID, postID uint) bool {
 func (m *MockPostRepository) CreateComment(comment *model.Comment) error {
 	return m.Called(comment).Error(0)
 }
+func (m *MockPostRepository) FindCommentByID(id uint) (*model.Comment, error) {
+	args := m.Called(id)
+	if p := args.Get(0); p != nil {
+		return p.(*model.Comment), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
 func (m *MockPostRepository) GetComments(postID uint) ([]model.Comment, error) {
 	args := m.Called(postID)
 	return args.Get(0).([]model.Comment), args.Error(1)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -34,6 +34,7 @@ type PostRepositoryInterface interface {
 	Unlike(userID, postID uint) error
 	HasLiked(userID, postID uint) bool
 	CreateComment(comment *model.Comment) error
+	FindCommentByID(id uint) (*model.Comment, error)
 	GetComments(postID uint) ([]model.Comment, error)
 	GetReplies(parentID uint) ([]model.Comment, error)
 	DeleteComment(id, userID uint) error

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -103,6 +103,15 @@ func (r *PostRepository) CreateComment(comment *model.Comment) error {
 	return r.db.Model(&model.Post{}).Where("id = ?", comment.PostID).UpdateColumn("comment_count", gorm.Expr("comment_count + 1")).Error
 }
 
+// FindCommentByID はコメントをIDで取得する。
+func (r *PostRepository) FindCommentByID(id uint) (*model.Comment, error) {
+	var comment model.Comment
+	if err := r.db.First(&comment, id).Error; err != nil {
+		return nil, err
+	}
+	return &comment, nil
+}
+
 // GetComments は指定投稿の全コメントをユーザー情報付きで取得する（古い順）。
 func (r *PostRepository) GetComments(postID uint) ([]model.Comment, error) {
 	var comments []model.Comment

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -156,6 +156,14 @@ func (m *MockPostRepository) CreateComment(comment *model.Comment) error {
 	return args.Error(0)
 }
 
+func (m *MockPostRepository) FindCommentByID(id uint) (*model.Comment, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.Comment), args.Error(1)
+}
+
 func (m *MockPostRepository) GetComments(postID uint) ([]model.Comment, error) {
 	args := m.Called(postID)
 	return args.Get(0).([]model.Comment), args.Error(1)

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -156,11 +156,27 @@ func (s *PostService) HasLiked(userID, postID uint) bool {
 }
 
 // CreateComment は投稿にコメントを作成する。
+// ParentIDが指定された場合は親コメントの存在確認と深さ制限（1階層）を行う。
 func (s *PostService) CreateComment(comment *model.Comment) error {
 	// バリデーション
 	v := validator.NewPostValidator()
 	if err := v.ValidateComment(comment.Content); err != nil {
 		return err
+	}
+
+	// 返信の場合: 親コメントの存在確認と深さ制限
+	if comment.ParentID != nil {
+		parent, err := s.repo.FindCommentByID(*comment.ParentID)
+		if err != nil {
+			return domain.NewError(domain.ErrCodeNotFound, "親コメントが見つかりません", err)
+		}
+		if parent.PostID != comment.PostID {
+			return domain.NewError(domain.ErrCodeBadRequest, "親コメントが別の投稿に属しています", nil)
+		}
+		// 深さ制限: 返信への返信は不可（1階層のみ）
+		if parent.ParentID != nil {
+			return domain.NewError(domain.ErrCodeBadRequest, "返信への返信はできません", nil)
+		}
 	}
 
 	return s.repo.CreateComment(comment)

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -297,12 +297,59 @@ func TestPostCreateReply_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
 	parentID := uint(5)
+	parentComment := &model.Comment{PostID: 10, ParentID: nil}
+	parentComment.ID = 5
+	postRepo.On("FindCommentByID", uint(5)).Return(parentComment, nil)
+
 	reply := &model.Comment{Content: "Great reply!", UserID: 2, PostID: 10, ParentID: &parentID}
 	postRepo.On("CreateComment", reply).Return(nil)
 
 	err := svc.CreateComment(reply)
 	assert.NoError(t, err)
 	postRepo.AssertExpectations(t)
+}
+
+func TestPostCreateReply_ParentNotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	parentID := uint(999)
+	reply := &model.Comment{Content: "Reply", UserID: 2, PostID: 10, ParentID: &parentID}
+	postRepo.On("FindCommentByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.CreateComment(reply)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "親コメントが見つかりません")
+}
+
+func TestPostCreateReply_ParentOnDifferentPost(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	parentID := uint(5)
+	parentComment := &model.Comment{PostID: 20, ParentID: nil}
+	parentComment.ID = 5
+	postRepo.On("FindCommentByID", uint(5)).Return(parentComment, nil)
+
+	reply := &model.Comment{Content: "Reply", UserID: 2, PostID: 10, ParentID: &parentID}
+
+	err := svc.CreateComment(reply)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "別の投稿に属しています")
+}
+
+func TestPostCreateReply_NestedReplyNotAllowed(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	grandParentID := uint(3)
+	parentID := uint(5)
+	parentComment := &model.Comment{PostID: 10, ParentID: &grandParentID}
+	parentComment.ID = 5
+	postRepo.On("FindCommentByID", uint(5)).Return(parentComment, nil)
+
+	reply := &model.Comment{Content: "Nested reply", UserID: 2, PostID: 10, ParentID: &parentID}
+
+	err := svc.CreateComment(reply)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "返信への返信はできません")
 }
 
 func TestPostGetReplies_Success(t *testing.T) {


### PR DESCRIPTION
## 概要
コメントへの返信機能（スレッド型コメント）のバックエンド対応。
フロントエンドは既に返信UI・API・フック全てが実装済みだったため、バックエンドのDTO/ハンドラー/サービスの修正のみで機能が完成。

## 変更内容

### バックエンド
- `dto/post_dto.go`: `CreateCommentRequest` に `ParentID *uint` フィールド追加
- `handler/post.go`: `CreateComment` で `ParentID` をコメントモデルにセット
- `repository/interfaces.go`: `FindCommentByID` メソッド追加
- `repository/post.go`: `FindCommentByID` 実装
- `service/post.go`: 親コメントのバリデーション追加
  - 親コメントの存在確認
  - 同一投稿に属することの確認
  - 深さ制限（返信への返信は不可、1階層のみ）

### テスト
- `TestPostCreateReply_Success` — 返信作成成功
- `TestPostCreateReply_ParentNotFound` — 存在しない親コメント
- `TestPostCreateReply_ParentOnDifferentPost` — 別投稿への返信
- `TestPostCreateReply_NestedReplyNotAllowed` — 深さ制限

## テスト結果
- `go test ./internal/service/... -v` — 全テスト通過
- `go test ./internal/handler/... -v` — 全テスト通過

Closes #529