### PR TITLE
refactor: クリーンアーキテクチャに沿ったリファクタリング

### DIFF
--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/dto"
@@ -90,12 +89,7 @@ func (h *BookReviewHandler) GetByUserID(c *gin.Context) {
 
 // GetAll は書籍レビューの一覧をページネーション付きで取得する。
 func (h *BookReviewHandler) GetAll(c *gin.Context) {
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
-
-	if limit > 100 {
-		limit = 100
-	}
+	limit, offset := parseLimitOffset(c)
 
 	reviews, total, err := h.service.GetAll(limit, offset)
 	if err != nil {

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -40,6 +40,15 @@ func parsePagination(c *gin.Context) (page, limit int) {
 	return page, limit
 }
 
+// parseLimitOffset はクエリパラメータからlimit/offsetを取得し正規化する。
+// デフォルト: limit=20, offset=0。limitの上限は100（domain.ValidatePagination準拠）。
+func parseLimitOffset(c *gin.Context) (limit, offset int) {
+	limit, _ = strconv.Atoi(c.DefaultQuery("limit", "20"))
+	offset, _ = strconv.Atoi(c.DefaultQuery("offset", "0"))
+	limit, offset, _ = domain.ValidatePagination(limit, offset)
+	return limit, offset
+}
+
 // bindJSON はリクエストボディをJSON構造体にバインドする。
 // バインド失敗時は400レスポンスを返しnilを返す。
 func bindJSON[T any](c *gin.Context) *T {

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -144,14 +143,9 @@ func (h *LearningResourceHandler) GetByUserID(c *gin.Context) {
 
 // GetPublic は公開学習リソース一覧をページネーション・フィルター付きで取得する。
 func (h *LearningResourceHandler) GetPublic(c *gin.Context) {
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	limit, offset := parseLimitOffset(c)
 	category := c.Query("category")
 	difficulty := c.Query("difficulty")
-
-	if limit > 100 {
-		limit = 100
-	}
 
 	resources, total, err := h.service.GetPublic(limit, offset, category, difficulty)
 	if err != nil {
@@ -170,12 +164,7 @@ func (h *LearningResourceHandler) GetPublic(c *gin.Context) {
 // Search はキーワードで学習リソースを検索する。
 func (h *LearningResourceHandler) Search(c *gin.Context) {
 	query := c.Query("q")
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
-
-	if limit > 100 {
-		limit = 100
-	}
+	limit, offset := parseLimitOffset(c)
 
 	resources, total, err := h.service.Search(query, limit, offset)
 	if err != nil {
@@ -328,12 +317,7 @@ func (h *LearningResourceHandler) UnsaveResource(c *gin.Context) {
 // GetSaved は認証ユーザーの保存済み学習リソース一覧を取得する。
 func (h *LearningResourceHandler) GetSaved(c *gin.Context) {
 	userID := c.GetUint("userID")
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
-
-	if limit > 100 {
-		limit = 100
-	}
+	limit, offset := parseLimitOffset(c)
 
 	resources, total, err := h.service.GetSavedByUserID(userID, limit, offset)
 	if err != nil {

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -215,12 +214,7 @@ func (h *ProjectHandler) Delete(c *gin.Context) {
 
 // GetAll はプロジェクトの一覧をページネーション付きで取得する。
 func (h *ProjectHandler) GetAll(c *gin.Context) {
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
-
-	if limit > 100 {
-		limit = 100
-	}
+	limit, offset := parseLimitOffset(c)
 
 	projects, total, err := h.service.GetAll(limit, offset)
 	if err != nil {

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -1,7 +1,6 @@
 package handler
 
 import (
-	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -60,14 +59,9 @@ func (h *QuestionHandler) Create(c *gin.Context) {
 
 // GetAll は質問一覧をページネーション・タグ・ソート付きで取得する。
 func (h *QuestionHandler) GetAll(c *gin.Context) {
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	limit, offset := parseLimitOffset(c)
 	tag := c.Query("tag")
 	sort := c.DefaultQuery("sort", "newest")
-
-	if limit > 100 {
-		limit = 100
-	}
 
 	questions, total, err := h.service.GetAll(limit, offset, tag, sort)
 	if err != nil {
@@ -91,12 +85,7 @@ func (h *QuestionHandler) Search(c *gin.Context) {
 		return
 	}
 
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
-
-	if limit > 100 {
-		limit = 100
-	}
+	limit, offset := parseLimitOffset(c)
 
 	questions, total, err := h.service.Search(q, limit, offset)
 	if err != nil {

--- a/backend/internal/handler/search.go
+++ b/backend/internal/handler/search.go
@@ -1,12 +1,10 @@
 package handler
 
 import (
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
 
@@ -15,22 +13,23 @@ type PostSearchService interface {
 	SearchPosts(params service.PostSearchParams) (*service.PostSearchResult, error)
 }
 
-// StudyCircleSearchRepository はスタディサークル検索のリポジトリインターフェース
-type StudyCircleSearchRepository interface {
-	Search(query string, limit, offset int) (interface{}, int64, error)
+// CircleSearchService はスタディサークル検索のサービスインターフェース。
+// Service 層を経由することでクリーンアーキテクチャを維持する。
+type CircleSearchService interface {
+	SearchCircles(query string, limit, offset int) (interface{}, int64, error)
 }
 
 // SearchHandler is the handler for search operations
 type SearchHandler struct {
 	searchService PostSearchService
-	circleRepo    StudyCircleSearchRepository
+	circleService CircleSearchService
 }
 
 // NewSearchHandler creates a new search handler instance
-func NewSearchHandler(searchService PostSearchService, circleRepo StudyCircleSearchRepository) *SearchHandler {
+func NewSearchHandler(searchService PostSearchService, circleService CircleSearchService) *SearchHandler {
 	return &SearchHandler{
 		searchService: searchService,
-		circleRepo:    circleRepo,
+		circleService: circleService,
 	}
 }
 
@@ -42,10 +41,9 @@ func (h *SearchHandler) SearchPosts(c *gin.Context) {
 		return
 	}
 
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	limit, offset := parseLimitOffset(c)
 
-	// タグフィルター（カンマ区切り or 複数パラメータ対応）
+	// タグフィルター（カンマ区切り対応）
 	var tags []string
 	if rawTags := c.Query("tags"); rawTags != "" {
 		for _, t := range strings.Split(rawTags, ",") {
@@ -99,54 +97,13 @@ func (h *SearchHandler) SearchCircles(c *gin.Context) {
 		return
 	}
 
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	limit, offset := parseLimitOffset(c)
 
-	results, _, err := h.circleRepo.Search(query, limit, offset)
+	results, _, err := h.circleService.SearchCircles(query, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
 	respondOK(c, results)
-}
-
-// PostSearchRepository は handler/search_test.go で使われる後方互換インターフェース。
-// 既存のhandlerテストとの互換性のために残す。
-type PostSearchRepository interface {
-	Search(query string, limit, offset int) (interface{}, int64, error)
-}
-
-// legacyPostSearchService は旧インターフェース互換のラッパー。
-type legacyPostSearchService struct {
-	repo PostSearchRepository
-}
-
-func (s *legacyPostSearchService) SearchPosts(params service.PostSearchParams) (*service.PostSearchResult, error) {
-	results, total, err := s.repo.Search(params.Query, params.Limit, params.Offset)
-	if err != nil {
-		return nil, err
-	}
-
-	var posts []model.Post
-	if p, ok := results.([]model.Post); ok {
-		posts = p
-	}
-
-	return &service.PostSearchResult{
-		Posts:  posts,
-		Total:  total,
-		Limit:  params.Limit,
-		Offset: params.Offset,
-	}, nil
-}
-
-// NewSearchHandlerWithRepo は旧インターフェース（リポジトリ直接）からSearchHandlerを生成する。
-// di/container.goからの後方互換のために提供する。
-func NewSearchHandlerWithRepo(postRepo PostSearchRepository, circleRepo StudyCircleSearchRepository) *SearchHandler {
-	svc := &legacyPostSearchService{repo: postRepo}
-	return &SearchHandler{
-		searchService: svc,
-		circleRepo:    circleRepo,
-	}
 }

--- a/backend/internal/handler/search_test.go
+++ b/backend/internal/handler/search_test.go
@@ -26,6 +26,16 @@ func (m *MockPostSearchService) SearchPosts(params service.PostSearchParams) (*s
 	return args.Get(0).(*service.PostSearchResult), args.Error(1)
 }
 
+// MockCircleSearchService は CircleSearchService のテスト用モック。
+type MockCircleSearchService struct {
+	mock.Mock
+}
+
+func (m *MockCircleSearchService) SearchCircles(query string, limit, offset int) (interface{}, int64, error) {
+	args := m.Called(query, limit, offset)
+	return args.Get(0), args.Get(1).(int64), args.Error(2)
+}
+
 func TestSearchPosts_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -134,14 +144,14 @@ func TestSearchPosts_WithSortBy(t *testing.T) {
 func TestSearchCircles_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	mockRepo := new(MockStudyCircleRepository)
-	mockRepo.On("Search", "golang", 20, 0).Return(
+	mockCircleSvc := new(MockCircleSearchService)
+	mockCircleSvc.On("SearchCircles", "golang", 20, 0).Return(
 		[]model.StudyCircle{{ID: 1, Name: "Golang Study", Topic: "Programming"}},
 		int64(1),
 		nil,
 	)
 
-	h := &SearchHandler{circleRepo: mockRepo}
+	h := &SearchHandler{circleService: mockCircleSvc}
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)
@@ -161,8 +171,8 @@ func TestSearchCircles_Success(t *testing.T) {
 func TestSearchCircles_EmptyQuery(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
-	mockRepo := new(MockStudyCircleRepository)
-	h := &SearchHandler{circleRepo: mockRepo}
+	mockCircleSvc := new(MockCircleSearchService)
+	h := &SearchHandler{circleService: mockCircleSvc}
 
 	w := httptest.NewRecorder()
 	c, _ := gin.CreateTestContext(w)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -354,6 +354,9 @@ type StudyCircleRepositoryInterface interface {
 	Update(circle *model.StudyCircle) error
 	Delete(id uint) error
 
+	// 検索
+	Search(query string, limit, offset int) (interface{}, int64, error)
+
 	// メンバー管理
 	AddMember(circleID, userID uint, role model.StudyCircleMemberRole) error
 	RemoveMember(circleID, userID uint) error

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1388,6 +1388,11 @@ func (m *MockStudyCircleRepository) GetStreakRanking(circleID uint) ([]model.Cir
 	return args.Get(0).([]model.CircleMemberStreak), args.Error(1)
 }
 
+func (m *MockStudyCircleRepository) Search(query string, limit, offset int) (interface{}, int64, error) {
+	args := m.Called(query, limit, offset)
+	return args.Get(0), args.Get(1).(int64), args.Error(2)
+}
+
 // インターフェース適合チェック
 var _ EmailSenderInterface = (*MockEmailSender)(nil)
 var _ repository.ActivityReportRepositoryInterface = (*MockActivityReportRepository)(nil)

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -326,3 +326,8 @@ func (s *StudyCircleService) GetStreakRanking(circleID, userID uint) ([]model.Ci
 	}
 	return s.repo.GetStreakRanking(circleID)
 }
+
+// SearchCircles はキーワードでスタディサークルを検索する。
+func (s *StudyCircleService) SearchCircles(query string, limit, offset int) (interface{}, int64, error) {
+	return s.repo.Search(query, limit, offset)
+}


### PR DESCRIPTION
## 概要

Issue #236 の実装。クリーンアーキテクチャ違反の修正と共通コードの整理を行いました。

## 変更内容

### アーキテクチャ修正（Handler → Service → Repository）
- `SearchHandler` が `StudyCircleRepository` を直接参照していた問題を修正
  - `CircleSearchService` インターフェースを新規定義
  - `StudyCircleService.SearchCircles()` メソッドを追加
  - `StudyCircleRepositoryInterface` に `Search` メソッドを追加
  - DI コンテナを `studyCircleRepo` → `studyCircleService` に修正

### 共通化・重複排除
- `helpers.go` に `parseLimitOffset()` 関数を追加
  - `limit`/`offset` クエリパラメータの取得と正規化を一元化
  - `domain.ValidatePagination()` を活用（上限 100）
- 各ハンドラーの重複する `limit > 100` チェックを `parseLimitOffset()` に置換
  - 合計 7 箇所の重複コードを削減

### テスト
- `MockCircleSearchService` を追加（Service 層モック）
- `MockStudyCircleRepository.Search` メソッドを追加

## テスト結果

```
ok  github.com/norman6464/devsync/backend/internal/service
ok  github.com/norman6464/devsync/backend/internal/handler
```

## 関連 Issue

Closes #236

## マイルストーン

Phase 7: UX向上とエンゲージメント強化