### PR TITLE
fix: セキュリティ強化（SQLインジェクション・バリデーション・セキュリティヘッダー）

### DIFF
--- a/backend/internal/handler/search.go
+++ b/backend/internal/handler/search.go
@@ -33,6 +33,9 @@ func NewSearchHandler(searchService PostSearchService, circleService CircleSearc
 	}
 }
 
+// maxSearchQueryLength は検索クエリの最大文字数。
+const maxSearchQueryLength = 500
+
 // SearchPosts handles post search requests with advanced filtering
 func (h *SearchHandler) SearchPosts(c *gin.Context) {
 	query := c.Query("q")
@@ -40,6 +43,11 @@ func (h *SearchHandler) SearchPosts(c *gin.Context) {
 		respondBadRequest(c, "query parameter 'q' is required")
 		return
 	}
+	if len([]rune(query)) > maxSearchQueryLength {
+		respondBadRequest(c, "検索クエリは500文字以下である必要があります")
+		return
+	}
+	query = strings.TrimSpace(query)
 
 	limit, offset := parseLimitOffset(c)
 
@@ -96,6 +104,11 @@ func (h *SearchHandler) SearchCircles(c *gin.Context) {
 		respondBadRequest(c, "query parameter 'q' is required")
 		return
 	}
+	if len([]rune(query)) > maxSearchQueryLength {
+		respondBadRequest(c, "検索クエリは500文字以下である必要があります")
+		return
+	}
+	query = strings.TrimSpace(query)
 
 	limit, offset := parseLimitOffset(c)
 

--- a/backend/internal/repository/ranking.go
+++ b/backend/internal/repository/ranking.go
@@ -1,6 +1,10 @@
 package repository
 
-import "gorm.io/gorm"
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
 
 // RankingRepository はユーザーランキングデータの集計・取得を提供するリポジトリ実装。
 type RankingRepository struct {
@@ -24,22 +28,23 @@ type RankingEntry struct {
 // ContributionRanking は指定期間（weekly/monthly）のGitHubコントリビューションランキングを取得する。
 // コントリビューション数の合計で降順ソートし、上位50件を返す。
 func (r *RankingRepository) ContributionRanking(period string) ([]RankingEntry, error) {
-	interval := "7 days"
+	days := 7
 	if period == "monthly" {
-		interval = "30 days"
+		days = 30
 	}
+	since := time.Now().AddDate(0, 0, -days)
 
 	var entries []RankingEntry
 	err := r.db.Raw(`
 		SELECT u.id as user_id, u.username, u.name, u.avatar_url, COALESCE(SUM(gc.count), 0) as score
 		FROM users u
 		JOIN git_hub_contributions gc ON gc.user_id = u.id
-		WHERE gc.date >= NOW() - INTERVAL '`+interval+`'
+		WHERE gc.date >= ?
 		GROUP BY u.id
 		HAVING SUM(gc.count) > 0
 		ORDER BY score DESC
 		LIMIT 50
-	`).Scan(&entries).Error
+	`, since).Scan(&entries).Error
 	return entries, err
 }
 

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -32,10 +32,13 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		AllowCredentials: true,
 	}))
 
-	// アップロードファイルの静的配信（セキュリティヘッダー付き）
+	// セキュリティヘッダー（全エンドポイント）
 	r.Use(func(ctx *gin.Context) {
+		ctx.Header("X-Content-Type-Options", "nosniff")
+		ctx.Header("X-Frame-Options", "DENY")
+		ctx.Header("X-XSS-Protection", "1; mode=block")
+		ctx.Header("Referrer-Policy", "strict-origin-when-cross-origin")
 		if strings.HasPrefix(ctx.Request.URL.Path, "/uploads/") {
-			ctx.Header("X-Content-Type-Options", "nosniff")
 			ctx.Header("Content-Security-Policy", "default-src 'none'; img-src 'self'; style-src 'none'; script-src 'none'")
 		}
 		ctx.Next()

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -361,6 +361,10 @@ func (s *AuthService) ResetPassword(token string, newPassword string) error {
 		return ErrBadRequest
 	}
 
+	if err := domain.ValidatePassword(newPassword); err != nil {
+		return err
+	}
+
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
 	if err != nil {
 		return err


### PR DESCRIPTION
## 概要
セキュリティ監査で発見された4つの問題を修正。

## 修正内容

### 1. SQLインジェクションリスク修正（CRITICAL）
`ranking.go` の `ContributionRanking` でSQL文字列結合を使用していた部分を、`time.Time` 型のパラメータ化クエリに変更。

**変更前**: `WHERE gc.date >= NOW() - INTERVAL '` + interval + `'`
**変更後**: `WHERE gc.date >= ?` パラメータに `time.Now().AddDate(0, 0, -days)` を渡す

### 2. パスワードリセット時のバリデーション欠如修正（HIGH）
`auth.go` の `ResetPassword` でパスワードバリデーションが欠如していた問題を修正。`domain.ValidatePassword()` を適用し、登録・変更フローと一貫性を確保。

### 3. セキュリティヘッダー拡充（MEDIUM）
`router.go` のセキュリティヘッダーが `/uploads/` パスのみに限定されていた問題を修正。全エンドポイントに以下を適用：
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `X-XSS-Protection: 1; mode=block`
- `Referrer-Policy: strict-origin-when-cross-origin`

### 4. 検索クエリ長バリデーション追加（MEDIUM）
`search.go` で検索クエリに上限がなかった問題を修正。500文字を超えるクエリは400エラーを返す。

## テスト
全テスト PASS（service/handler層）

## 関連
- Closes #697