### PR TITLE
feat: 学習ログCSVエクスポート機能の追加（TDD）

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -1,6 +1,10 @@
 package handler
 
 import (
+	"fmt"
+	"strconv"
+	"time"
+
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -15,6 +19,7 @@ type LearningLogServiceInterface interface {
 	Delete(id, userID uint) error
 	GetStreakInfo(userID uint) (*model.StreakInfo, error)
 	GetCalendarData(userID uint) ([]model.CalendarEntry, error)
+	ExportCSV(userID uint, days int) ([]byte, error)
 }
 
 // LearningLogHandler は学習ログ関連のHTTPハンドラ。
@@ -188,4 +193,38 @@ func (h *LearningLogHandler) GetCalendarData(c *gin.Context) {
 	}
 
 	respondOK(c, entries)
+}
+
+// ExportLogs は学習ログをCSV形式でダウンロードする。
+// クエリパラメータ: period=7|30|90|all（デフォルト30日）
+func (h *LearningLogHandler) ExportLogs(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	days := 30
+	if p := c.Query("period"); p != "" {
+		if p == "all" {
+			days = 0
+		} else {
+			n, err := strconv.Atoi(p)
+			if err != nil || n < 0 {
+				respondBadRequest(c, "periodは7/30/90/allのいずれかを指定してください")
+				return
+			}
+			days = n
+		}
+	}
+
+	csvBytes, err := h.service.ExportCSV(userID, days)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	filename := fmt.Sprintf("learning-logs-%ddays-%s.csv", days, time.Now().Format("20060102"))
+	if days == 0 {
+		filename = fmt.Sprintf("learning-logs-all-%s.csv", time.Now().Format("20060102"))
+	}
+
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
+	c.Data(200, "text/csv; charset=utf-8", csvBytes)
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1247,6 +1247,14 @@ func (m *MockLearningLogService) GetCalendarData(userID uint) ([]model.CalendarE
 	return args.Get(0).([]model.CalendarEntry), args.Error(1)
 }
 
+func (m *MockLearningLogService) ExportCSV(userID uint, days int) ([]byte, error) {
+	args := m.Called(userID, days)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]byte), args.Error(1)
+}
+
 // setupLearningLogHandler はLearningLogHandlerテスト用のセットアップを行う。
 func setupLearningLogHandler() (*LearningLogHandler, *MockLearningLogService) {
 	svc := new(MockLearningLogService)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -126,6 +126,7 @@ type LearningLogRepositoryInterface interface {
 	Delete(id, userID uint) error
 	FindByID(id uint) (*model.LearningLog, error)
 	GetByUserID(userID uint) ([]model.LearningLog, error)
+	GetByPeriod(userID uint, days int) ([]model.LearningLog, error)
 	GetStreakInfo(userID uint) (*model.StreakInfo, error)
 	GetCalendarData(userID uint) ([]model.CalendarEntry, error)
 }

--- a/backend/internal/repository/learning_log.go
+++ b/backend/internal/repository/learning_log.go
@@ -50,6 +50,19 @@ func (r *LearningLogRepository) GetByUserID(userID uint) ([]model.LearningLog, e
 	return logs, err
 }
 
+// GetByPeriod は指定ユーザーの指定期間分の学習ログを取得する。
+// days=0 の場合は全期間を取得する。
+func (r *LearningLogRepository) GetByPeriod(userID uint, days int) ([]model.LearningLog, error) {
+	var logs []model.LearningLog
+	query := r.db.Where("user_id = ?", userID)
+	if days > 0 {
+		since := time.Now().AddDate(0, 0, -days)
+		query = query.Where("created_at >= ?", since)
+	}
+	err := query.Order("created_at DESC").Find(&logs).Error
+	return logs, err
+}
+
 // GetStreakInfo は学習ログから連続学習情報を算出する。
 // 現在の連続日数、最長連続日数、合計学習日数、最終ログ日を返す。
 func (r *LearningLogRepository) GetStreakInfo(userID uint) (*model.StreakInfo, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -351,6 +351,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		learningLogs.POST("", c.LearningLogHandler.Create)
 		learningLogs.GET("", c.LearningLogHandler.GetMyLogs)
+		learningLogs.GET("/export", c.LearningLogHandler.ExportLogs)
 		learningLogs.GET("/user/:userId", c.LearningLogHandler.GetByUserID)
 		learningLogs.GET("/calendar/:userId", c.LearningLogHandler.GetCalendarData)
 		learningLogs.GET("/streak/:userId", c.LearningLogHandler.GetStreakInfo)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -1,6 +1,11 @@
 package service
 
 import (
+	"bytes"
+	"encoding/csv"
+	"fmt"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -93,4 +98,46 @@ func (s *LearningLogService) GetStreakInfo(userID uint) (*model.StreakInfo, erro
 // GetCalendarData はカレンダー表示用の日別学習ログ集計データを取得する。
 func (s *LearningLogService) GetCalendarData(userID uint) ([]model.CalendarEntry, error) {
 	return s.repo.GetCalendarData(userID)
+}
+
+// ExportCSV は指定ユーザーの学習ログをCSV形式でエクスポートする。
+// days: 取得する過去の日数（0は全期間）。負の値はバリデーションエラー。
+func (s *LearningLogService) ExportCSV(userID uint, days int) ([]byte, error) {
+	if days < 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "期間は0以上の値を指定してください", nil)
+	}
+
+	logs, err := s.repo.GetByPeriod(userID, days)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+
+	// ヘッダー行（BOM付きUTF-8でExcel互換）
+	buf.WriteString("\xef\xbb\xbf")
+	if err := w.Write([]string{"日付", "カテゴリ", "タイトル", "学習時間(分)", "メモ"}); err != nil {
+		return nil, err
+	}
+
+	for _, log := range logs {
+		row := []string{
+			log.CreatedAt.Format("2006-01-02"),
+			string(log.Category),
+			log.Title,
+			fmt.Sprintf("%d", log.Duration),
+			log.Content,
+		}
+		if err := w.Write(row); err != nil {
+			return nil, err
+		}
+	}
+
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }

--- a/backend/internal/service/learning_log_export_test.go
+++ b/backend/internal/service/learning_log_export_test.go
@@ -1,0 +1,101 @@
+package service
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// ============================================================
+// 学習ログCSVエクスポートテスト
+// ============================================================
+
+func TestExportCSV_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	now := time.Now()
+	logs := []model.LearningLog{
+		{
+			ID:        1,
+			UserID:    1,
+			Title:     "Goの基礎",
+			Content:   "変数と型を学んだ",
+			Category:  model.LogCategoryCoding,
+			Duration:  60,
+			CreatedAt: now,
+		},
+		{
+			ID:        2,
+			UserID:    1,
+			Title:     "クリーンアーキテクチャ",
+			Content:   "依存性逆転の原則",
+			Category:  model.LogCategoryReading,
+			Duration:  45,
+			CreatedAt: now.Add(-24 * time.Hour),
+		},
+	}
+
+	repo.On("GetByPeriod", uint(1), 30).Return(logs, nil)
+
+	csvBytes, err := svc.ExportCSV(1, 30)
+	assert.NoError(t, err)
+	assert.NotNil(t, csvBytes)
+
+	csvContent := string(csvBytes)
+	// ヘッダー行の確認
+	assert.Contains(t, csvContent, "日付")
+	assert.Contains(t, csvContent, "カテゴリ")
+	assert.Contains(t, csvContent, "タイトル")
+	assert.Contains(t, csvContent, "学習時間(分)")
+	// データ行の確認
+	assert.Contains(t, csvContent, "Goの基礎")
+	assert.Contains(t, csvContent, "クリーンアーキテクチャ")
+	assert.Contains(t, csvContent, "60")
+	assert.Contains(t, csvContent, "45")
+}
+
+func TestExportCSV_EmptyLogs(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetByPeriod", uint(1), 7).Return([]model.LearningLog{}, nil)
+
+	csvBytes, err := svc.ExportCSV(1, 7)
+	assert.NoError(t, err)
+	// ヘッダー行のみが含まれる
+	lines := strings.Split(strings.TrimSpace(string(csvBytes)), "\n")
+	assert.Equal(t, 1, len(lines)) // ヘッダー行のみ
+}
+
+func TestExportCSV_InvalidPeriod(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	_, err := svc.ExportCSV(1, -1)
+	assert.Error(t, err)
+}
+
+func TestExportCSV_AllPeriod(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	logs := []model.LearningLog{
+		{Title: "過去ログ", Category: model.LogCategoryCourse, Duration: 30},
+	}
+	// period=0 は全期間
+	repo.On("GetByPeriod", uint(1), 0).Return(logs, nil)
+
+	csvBytes, err := svc.ExportCSV(1, 0)
+	assert.NoError(t, err)
+	assert.Contains(t, string(csvBytes), "過去ログ")
+}
+
+func TestExportCSV_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetByPeriod", uint(1), 30).Return([]model.LearningLog{}, errors.New("db error"))
+
+	_, err := svc.ExportCSV(1, 30)
+	assert.Error(t, err)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -484,6 +484,11 @@ func (m *MockLearningLogRepository) GetByUserID(userID uint) ([]model.LearningLo
 	return args.Get(0).([]model.LearningLog), args.Error(1)
 }
 
+func (m *MockLearningLogRepository) GetByPeriod(userID uint, days int) ([]model.LearningLog, error) {
+	args := m.Called(userID, days)
+	return args.Get(0).([]model.LearningLog), args.Error(1)
+}
+
 func (m *MockLearningLogRepository) GetStreakInfo(userID uint) (*model.StreakInfo, error) {
 	args := m.Called(userID)
 	if args.Get(0) == nil {

--- a/frontend/src/api/learningLogs.ts
+++ b/frontend/src/api/learningLogs.ts
@@ -24,3 +24,8 @@ export const getCalendarData = (userId: number) =>
 
 export const getStreakInfo = (userId: number) =>
   client.get<StreakInfo>(`/learning-logs/streak/${userId}`);
+
+export type ExportPeriod = '7' | '30' | '90' | 'all';
+
+export const exportLogsCSV = (period: ExportPeriod = '30') =>
+  client.get<Blob>(`/learning-logs/export?period=${period}`, { responseType: 'blob' });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -640,7 +640,10 @@
     "deleted": "Eintrag gelöscht",
     "confirmDelete": "Möchten Sie diesen Eintrag wirklich löschen?",
     "totalLogs": "{{count}} Einträge im letzten Jahr",
-    "logsOnDate": "Einträge am {{date}}"
+    "logsOnDate": "Einträge am {{date}}",
+    "exportCSV": "CSV exportieren",
+    "exportDays": "Letzte {{days}} Tage",
+    "exportAll": "Gesamter Zeitraum"
   },
   "reports": {
     "title": "Aktivitätsberichte",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -640,7 +640,10 @@
     "deleted": "Log deleted",
     "confirmDelete": "Are you sure you want to delete this log?",
     "totalLogs": "{{count}} logs in the past year",
-    "logsOnDate": "Logs on {{date}}"
+    "logsOnDate": "Logs on {{date}}",
+    "exportCSV": "Export CSV",
+    "exportDays": "Last {{days}} days",
+    "exportAll": "All time"
   },
   "reports": {
     "title": "Activity Reports",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -640,7 +640,10 @@
     "deleted": "Registro eliminado",
     "confirmDelete": "¿Estás seguro de que deseas eliminar este registro?",
     "totalLogs": "{{count}} registros en el último año",
-    "logsOnDate": "Registros del {{date}}"
+    "logsOnDate": "Registros del {{date}}",
+    "exportCSV": "Exportar CSV",
+    "exportDays": "Últimos {{days}} días",
+    "exportAll": "Todo el tiempo"
   },
   "reports": {
     "title": "Informes de Actividad",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -640,7 +640,10 @@
     "deleted": "Entrée supprimée",
     "confirmDelete": "Êtes-vous sûr de vouloir supprimer cette entrée ?",
     "totalLogs": "{{count}} entrées au cours de l'année écoulée",
-    "logsOnDate": "Entrées du {{date}}"
+    "logsOnDate": "Entrées du {{date}}",
+    "exportCSV": "Exporter CSV",
+    "exportDays": "Derniers {{days}} jours",
+    "exportAll": "Toute la période"
   },
   "reports": {
     "title": "Rapports d'Activité",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -624,7 +624,10 @@
     "deleted": "ログを削除しました",
     "confirmDelete": "このログを削除してもよろしいですか？",
     "totalLogs": "過去1年で{{count}}件のログ",
-    "logsOnDate": "{{date}}のログ"
+    "logsOnDate": "{{date}}のログ",
+    "exportCSV": "CSVエクスポート",
+    "exportDays": "過去{{days}}日",
+    "exportAll": "全期間"
   },
   "reports": {
     "title": "アクティビティレポート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -640,7 +640,10 @@
     "deleted": "로그가 삭제되었습니다",
     "confirmDelete": "이 로그를 삭제하시겠습니까?",
     "totalLogs": "지난 1년간 {{count}}건의 로그",
-    "logsOnDate": "{{date}}의 로그"
+    "logsOnDate": "{{date}}의 로그",
+    "exportCSV": "CSV 내보내기",
+    "exportDays": "최근 {{days}}일",
+    "exportAll": "전체 기간"
   },
   "reports": {
     "title": "활동 리포트",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -640,7 +640,10 @@
     "deleted": "Registro excluído",
     "confirmDelete": "Tem certeza de que deseja excluir este registro?",
     "totalLogs": "{{count}} registros no último ano",
-    "logsOnDate": "Registros em {{date}}"
+    "logsOnDate": "Registros em {{date}}",
+    "exportCSV": "Exportar CSV",
+    "exportDays": "Últimos {{days}} dias",
+    "exportAll": "Todo o período"
   },
   "reports": {
     "title": "Relatórios de Atividade",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -640,7 +640,10 @@
     "deleted": "Запись удалена",
     "confirmDelete": "Вы уверены, что хотите удалить эту запись?",
     "totalLogs": "{{count}} записей за последний год",
-    "logsOnDate": "Записи за {{date}}"
+    "logsOnDate": "Записи за {{date}}",
+    "exportCSV": "Экспорт CSV",
+    "exportDays": "Последние {{days}} дней",
+    "exportAll": "Весь период"
   },
   "reports": {
     "title": "Отчёты об Активности",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -640,7 +640,10 @@
     "deleted": "日志已删除",
     "confirmDelete": "确定要删除这条日志吗？",
     "totalLogs": "过去一年{{count}}条日志",
-    "logsOnDate": "{{date}}的日志"
+    "logsOnDate": "{{date}}的日志",
+    "exportCSV": "导出CSV",
+    "exportDays": "最近{{days}}天",
+    "exportAll": "全部"
   },
   "reports": {
     "title": "活动报告",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -640,7 +640,10 @@
     "deleted": "日誌已刪除",
     "confirmDelete": "確定要刪除這條日誌嗎？",
     "totalLogs": "過去一年{{count}}條日誌",
-    "logsOnDate": "{{date}}的日誌"
+    "logsOnDate": "{{date}}的日誌",
+    "exportCSV": "匯出CSV",
+    "exportDays": "最近{{days}}天",
+    "exportAll": "全部"
   },
   "reports": {
     "title": "活動報告",

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -1,7 +1,8 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Code, BookOpen, GraduationCap, Users, FileText, Calendar, List, type LucideIcon } from 'lucide-react';
+import { Code, BookOpen, GraduationCap, Users, FileText, Calendar, List, Download, type LucideIcon } from 'lucide-react';
 import { useLearningLogForm } from '../hooks/useLearningLogForm';
+import { exportLogsCSV, type ExportPeriod } from '../api/learningLogs';
 import type { LogCategory } from '../types/learningLog';
 import LogCalendar from '../components/learning-logs/LogCalendar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
@@ -31,6 +32,7 @@ const getCategoryColor = (cat: LogCategory) => {
 
 export default function LearningLogsPage() {
   const { t } = useTranslation();
+  const [exporting, setExporting] = useState(false);
   const {
     filteredLogs, calendarData, loading, saving,
     view, setView,
@@ -44,6 +46,21 @@ export default function LearningLogsPage() {
     duration, setDuration,
     resetForm, handleSubmit, handleEdit, handleDelete, handleDateClick,
   } = useLearningLogForm();
+
+  const handleExport = useCallback(async (period: ExportPeriod) => {
+    setExporting(true);
+    try {
+      const res = await exportLogsCSV(period);
+      const url = URL.createObjectURL(res.data);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `learning-logs-${period}-${new Date().toISOString().slice(0, 10)}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setExporting(false);
+    }
+  }, []);
 
   const handleShowForm = useCallback(() => setShowForm(true), [setShowForm]);
   const handleViewList = useCallback(() => { setView('list'); clearFilterDate(); }, [setView, clearFilterDate]);
@@ -63,12 +80,34 @@ export default function LearningLogsPage() {
           <h1 className="text-2xl font-bold">{t('learningLogs.title')}</h1>
           <p className="text-sm text-gray-400 mt-1">{t('learningLogs.subtitle')}</p>
         </div>
-        <button
-          onClick={handleShowForm}
-          className={`${buttonSecondaryClass} font-medium text-sm`}
-        >
-          {t('learningLogs.addLog')}
-        </button>
+        <div className="flex items-center gap-2">
+          <div className="relative group">
+            <button
+              disabled={exporting}
+              className={`${buttonSecondaryClass} font-medium text-sm flex items-center gap-1.5`}
+            >
+              <Download className="w-4 h-4" />
+              {exporting ? t('common.loading') : t('learningLogs.exportCSV')}
+            </button>
+            <div className="absolute right-0 top-full mt-1 w-40 bg-gray-800 border border-gray-700 rounded-lg shadow-lg opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-10">
+              {(['7', '30', '90', 'all'] as ExportPeriod[]).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => handleExport(p)}
+                  className="w-full text-left px-3 py-2 text-sm text-gray-300 hover:text-white hover:bg-gray-700 first:rounded-t-lg last:rounded-b-lg"
+                >
+                  {p === 'all' ? t('learningLogs.exportAll') : t('learningLogs.exportDays', { days: p })}
+                </button>
+              ))}
+            </div>
+          </div>
+          <button
+            onClick={handleShowForm}
+            className={`${buttonSecondaryClass} font-medium text-sm`}
+          >
+            {t('learningLogs.addLog')}
+          </button>
+        </div>
       </div>
 
       {/* View Toggle */}


### PR DESCRIPTION
## 概要
Issue #699「学習ログのCSVエクスポート機能」を TDD（テスト先行）で実装。

## 実装内容

### バックエンド
- `GET /api/v1/learning-logs/export?period=7|30|90|all` エンドポイント追加
- `GetByPeriod(userID, days)` リポジトリメソッドを追加（days=0は全期間）
- `ExportCSV(userID, days)` サービスメソッドを追加（BOM付きUTF-8・Excel互換）
- CSVフォーマット: `日付, カテゴリ, タイトル, 学習時間(分), メモ`

### フロントエンド
- `exportLogsCSV(period)` API関数を追加
- 学習ログページにホバードロップダウン式のエクスポートボタンを追加
- ファイル名: `learning-logs-{period}-{date}.csv`

### 多言語対応
全10言語（ja/en/ko/zh-CN/zh-TW/es/fr/de/pt/ru）に以下のキーを追加：
- `exportCSV` — ボタンラベル
- `exportDays` — 「過去N日」表示
- `exportAll` — 「全期間」表示

## テスト（TDD）
実装前にテストを作成し、5ケース全てPASS：
- `TestExportCSV_Success` — 正常系：CSV内容を検証
- `TestExportCSV_EmptyLogs` — 空ログ：ヘッダー行のみ
- `TestExportCSV_InvalidPeriod` — 負の値でエラー
- `TestExportCSV_AllPeriod` — period=0で全期間取得
- `TestExportCSV_RepoError` — リポジトリエラー時のハンドリング

## 関連
- Closes #699