### PR TITLE
refactor: クリーンアーキテクチャ - Repository型定義をModelへ移動

### DIFF
--- a/backend/internal/dto/roadmap_dto.go
+++ b/backend/internal/dto/roadmap_dto.go
@@ -2,7 +2,6 @@ package dto
 
 import (
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
 
 // CreateRoadmapRequest はロードマップ作成リクエストのDTO。
@@ -40,7 +39,7 @@ type UpdateRoadmapStepRequest struct {
 
 // ReorderRoadmapStepsRequest はロードマップステップ並べ替えリクエストのDTO。
 type ReorderRoadmapStepsRequest struct {
-	Orders []service.StepOrder `json:"orders" binding:"required"`
+	Orders []model.StepOrder `json:"orders" binding:"required"`
 }
 
 // RoadmapListResponse はロードマップ一覧レスポンス。

--- a/backend/internal/dto/study_circle_dto.go
+++ b/backend/internal/dto/study_circle_dto.go
@@ -1,6 +1,6 @@
 package dto
 
-import "github.com/norman6464/devsync/backend/internal/repository"
+import "github.com/norman6464/devsync/backend/internal/model"
 
 // CreateStudyCircleRequest はスタディサークル作成リクエストのDTO。
 type CreateStudyCircleRequest struct {
@@ -39,7 +39,7 @@ type UpdateStudyCircleStepRequest struct {
 
 // ReorderStudyCircleStepsRequest はスタディサークルステップ並べ替えリクエストのDTO。
 type ReorderStudyCircleStepsRequest struct {
-	Orders []repository.StepOrder `json:"orders" binding:"required"`
+	Orders []model.StepOrder `json:"orders" binding:"required"`
 }
 
 // UpdateStudyCircleProgressRequest はスタディサークル進捗更新リクエストのDTO。

--- a/backend/internal/handler/message.go
+++ b/backend/internal/handler/message.go
@@ -6,12 +6,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/repository"
 )
 
 // MessageServiceInterface はMessageHandlerが依存するサービスのインターフェース。
 type MessageServiceInterface interface {
-	GetConversations(userID uint) ([]repository.ConversationSummary, error)
+	GetConversations(userID uint) ([]model.ConversationSummary, error)
 	GetConversation(userID, otherUserID uint, page, limit int) ([]model.Message, error)
 	SendMessage(msg *model.Message) error
 }

--- a/backend/internal/handler/message_test.go
+++ b/backend/internal/handler/message_test.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/repository"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestMessage_GetConversations_Success(t *testing.T) {
 	h, svc := setupMessageHandler()
-	svc.On("GetConversations", uint(1)).Return([]repository.ConversationSummary{
+	svc.On("GetConversations", uint(1)).Return([]model.ConversationSummary{
 		{UserID: 2, Name: "Alice", LastMessage: "Hello"},
 		{UserID: 3, Name: "Bob", LastMessage: "Hi"},
 	}, nil)
@@ -27,7 +26,7 @@ func TestMessage_GetConversations_Success(t *testing.T) {
 
 func TestMessage_GetConversations_ServiceError(t *testing.T) {
 	h, svc := setupMessageHandler()
-	svc.On("GetConversations", uint(1)).Return([]repository.ConversationSummary(nil), errors.New("db error"))
+	svc.On("GetConversations", uint(1)).Return([]model.ConversationSummary(nil), errors.New("db error"))
 
 	r := newRouter(1)
 	r.GET("/conversations", h.GetConversations)

--- a/backend/internal/handler/ranking.go
+++ b/backend/internal/handler/ranking.go
@@ -2,14 +2,14 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/repository"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
 
 // RankingServiceInterface はRankingHandlerが依存するサービスメソッドを定義する。
 type RankingServiceInterface interface {
-	ContributionRanking(period string) ([]repository.RankingEntry, error)
-	LanguageRanking(language, period string) ([]repository.RankingEntry, error)
-	LevelRanking() ([]repository.RankingEntry, error)
+	ContributionRanking(period string) ([]model.RankingEntry, error)
+	LanguageRanking(language, period string) ([]model.RankingEntry, error)
+	LevelRanking() ([]model.RankingEntry, error)
 	AvailableLanguages() ([]string, error)
 }
 

--- a/backend/internal/handler/ranking_test.go
+++ b/backend/internal/handler/ranking_test.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/norman6464/devsync/backend/internal/repository"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
 
 // ---------- ContributionRanking ----------
 
 func TestRankingContribution_Success(t *testing.T) {
 	h, svc := setupRankingHandler()
-	entries := []repository.RankingEntry{{UserID: 1, Score: 100}}
+	entries := []model.RankingEntry{{UserID: 1, Score: 100}}
 	svc.On("ContributionRanking", "weekly").Return(entries, nil)
 
 	r := newRouter(1)
@@ -24,7 +24,7 @@ func TestRankingContribution_Success(t *testing.T) {
 
 func TestRankingContribution_WithPeriod(t *testing.T) {
 	h, svc := setupRankingHandler()
-	entries := []repository.RankingEntry{{UserID: 1, Score: 50}}
+	entries := []model.RankingEntry{{UserID: 1, Score: 50}}
 	svc.On("ContributionRanking", "monthly").Return(entries, nil)
 
 	r := newRouter(1)
@@ -37,7 +37,7 @@ func TestRankingContribution_WithPeriod(t *testing.T) {
 
 func TestRankingContribution_ServiceError(t *testing.T) {
 	h, svc := setupRankingHandler()
-	svc.On("ContributionRanking", "weekly").Return([]repository.RankingEntry{}, fmt.Errorf("internal error"))
+	svc.On("ContributionRanking", "weekly").Return([]model.RankingEntry{}, fmt.Errorf("internal error"))
 
 	r := newRouter(1)
 	r.GET("/rankings/contributions", h.ContributionRanking)
@@ -51,7 +51,7 @@ func TestRankingContribution_ServiceError(t *testing.T) {
 
 func TestRankingLanguage_Success(t *testing.T) {
 	h, svc := setupRankingHandler()
-	entries := []repository.RankingEntry{{UserID: 1, Score: 80}}
+	entries := []model.RankingEntry{{UserID: 1, Score: 80}}
 	svc.On("LanguageRanking", "Go", "weekly").Return(entries, nil)
 
 	r := newRouter(1)
@@ -66,7 +66,7 @@ func TestRankingLanguage_Success(t *testing.T) {
 
 func TestRankingLevel_Success(t *testing.T) {
 	h, svc := setupRankingHandler()
-	entries := []repository.RankingEntry{{UserID: 1, Score: 500}}
+	entries := []model.RankingEntry{{UserID: 1, Score: 500}}
 	svc.On("LevelRanking").Return(entries, nil)
 
 	r := newRouter(1)

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -7,7 +7,6 @@ import (
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 )
 
 // RoadmapServiceInterface はRoadmapHandlerが依存するサービスメソッドを定義する。
@@ -26,7 +25,7 @@ type RoadmapServiceInterface interface {
 	UpdateStep(roadmapID, stepID, userID uint, updates *model.RoadmapStep) (*model.RoadmapStep, error)
 	UpdateStepCompletion(roadmapID, stepID, userID uint, isCompleted bool) (*model.RoadmapStep, error)
 	DeleteStep(roadmapID, stepID, userID uint) error
-	ReorderSteps(roadmapID, userID uint, orders []service.StepOrder) error
+	ReorderSteps(roadmapID, userID uint, orders []model.StepOrder) error
 }
 
 // RoadmapHandler はロードマップ関連のHTTPハンドラ。

--- a/backend/internal/handler/roadmap_test.go
+++ b/backend/internal/handler/roadmap_test.go
@@ -391,7 +391,7 @@ func TestRoadmapReorderSteps_Success(t *testing.T) {
 	rm.ID = 10
 	rm.UserID = 1
 	repo.On("FindByID", uint(10)).Return(rm, nil)
-	repo.On("ReorderSteps", uint(10), mock.AnythingOfType("[]repository.StepOrder")).Return(nil)
+	repo.On("ReorderSteps", uint(10), mock.AnythingOfType("[]model.StepOrder")).Return(nil)
 
 	w := doRequest(r, http.MethodPut, "/roadmaps/10/steps/reorder", map[string]interface{}{
 		"orders": []map[string]interface{}{

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -5,7 +5,6 @@ import (
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/repository"
 )
 
 // StudyCircleServiceInterface はStudyCircleHandlerが依存するサービスメソッドを定義する。
@@ -21,7 +20,7 @@ type StudyCircleServiceInterface interface {
 	CreateStep(circleID, userID uint, step *model.StudyCircleStep) error
 	UpdateStep(circleID, userID, stepID uint, title, description *string) (*model.StudyCircleStep, error)
 	DeleteStep(circleID, userID, stepID uint) error
-	ReorderSteps(circleID, userID uint, orders []repository.StepOrder) error
+	ReorderSteps(circleID, userID uint, orders []model.StepOrder) error
 	UpdateProgress(circleID, userID, stepID uint, isCompleted bool) error
 	GetProgress(circleID, userID uint) ([]model.StudyCircleMemberProgress, error)
 	CreateCheckin(circleID, userID uint, content string) (*model.StudyCircleCheckin, error)

--- a/backend/internal/handler/study_circle_test.go
+++ b/backend/internal/handler/study_circle_test.go
@@ -532,7 +532,7 @@ func TestStudyCircleReorderSteps_Success(t *testing.T) {
 	circle := &model.StudyCircle{OwnerID: 1}
 	circle.ID = 10
 	repo.On("FindByID", uint(10)).Return(circle, nil)
-	repo.On("ReorderSteps", uint(10), mock.AnythingOfType("[]repository.StepOrder")).Return(nil)
+	repo.On("ReorderSteps", uint(10), mock.AnythingOfType("[]model.StepOrder")).Return(nil)
 
 	w := doRequest(r, http.MethodPut, "/study-circles/10/steps/reorder", map[string]interface{}{
 		"orders": []map[string]interface{}{

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/repository"
 	"github.com/norman6464/devsync/backend/internal/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -375,7 +374,7 @@ func (m *MockRoadmapRepository) FindStepByID(stepID uint) (*model.RoadmapStep, e
 	}
 	return nil, args.Error(1)
 }
-func (m *MockRoadmapRepository) ReorderSteps(roadmapID uint, stepOrders []repository.StepOrder) error {
+func (m *MockRoadmapRepository) ReorderSteps(roadmapID uint, stepOrders []model.StepOrder) error {
 	return m.Called(roadmapID, stepOrders).Error(0)
 }
 func (m *MockRoadmapRepository) GetTemplates() ([]model.Roadmap, error) {
@@ -658,7 +657,7 @@ func (m *MockStudyCircleRepository) FindStepByID(stepID uint) (*model.StudyCircl
 	}
 	return nil, args.Error(1)
 }
-func (m *MockStudyCircleRepository) ReorderSteps(circleID uint, stepOrders []repository.StepOrder) error {
+func (m *MockStudyCircleRepository) ReorderSteps(circleID uint, stepOrders []model.StepOrder) error {
 	return m.Called(circleID, stepOrders).Error(0)
 }
 func (m *MockStudyCircleRepository) UpsertProgress(progress *model.StudyCircleMemberProgress) error {
@@ -955,7 +954,7 @@ func (m *MockRoadmapService) UpdateStepCompletion(roadmapID, stepID, userID uint
 func (m *MockRoadmapService) DeleteStep(roadmapID, stepID, userID uint) error {
 	return m.Called(roadmapID, stepID, userID).Error(0)
 }
-func (m *MockRoadmapService) ReorderSteps(roadmapID, userID uint, orders []service.StepOrder) error {
+func (m *MockRoadmapService) ReorderSteps(roadmapID, userID uint, orders []model.StepOrder) error {
 	return m.Called(roadmapID, userID, orders).Error(0)
 }
 
@@ -987,17 +986,17 @@ func setupBadgeHandler() (*BadgeHandler, *MockBadgeService) {
 // MockRankingService は RankingServiceInterface のモック実装。
 type MockRankingService struct{ mock.Mock }
 
-func (m *MockRankingService) ContributionRanking(period string) ([]repository.RankingEntry, error) {
+func (m *MockRankingService) ContributionRanking(period string) ([]model.RankingEntry, error) {
 	args := m.Called(period)
-	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+	return args.Get(0).([]model.RankingEntry), args.Error(1)
 }
-func (m *MockRankingService) LanguageRanking(language, period string) ([]repository.RankingEntry, error) {
+func (m *MockRankingService) LanguageRanking(language, period string) ([]model.RankingEntry, error) {
 	args := m.Called(language, period)
-	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+	return args.Get(0).([]model.RankingEntry), args.Error(1)
 }
-func (m *MockRankingService) LevelRanking() ([]repository.RankingEntry, error) {
+func (m *MockRankingService) LevelRanking() ([]model.RankingEntry, error) {
 	args := m.Called()
-	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+	return args.Get(0).([]model.RankingEntry), args.Error(1)
 }
 func (m *MockRankingService) AvailableLanguages() ([]string, error) {
 	args := m.Called()
@@ -1265,9 +1264,9 @@ func setupLearningLogHandler() (*LearningLogHandler, *MockLearningLogService) {
 // MockMessageService は MessageServiceInterface のモック実装。
 type MockMessageService struct{ mock.Mock }
 
-func (m *MockMessageService) GetConversations(userID uint) ([]repository.ConversationSummary, error) {
+func (m *MockMessageService) GetConversations(userID uint) ([]model.ConversationSummary, error) {
 	args := m.Called(userID)
-	return args.Get(0).([]repository.ConversationSummary), args.Error(1)
+	return args.Get(0).([]model.ConversationSummary), args.Error(1)
 }
 func (m *MockMessageService) GetConversation(userID, otherUserID uint, page, limit int) ([]model.Message, error) {
 	args := m.Called(userID, otherUserID, page, limit)

--- a/backend/internal/model/message.go
+++ b/backend/internal/model/message.go
@@ -2,6 +2,16 @@ package model
 
 import "time"
 
+// ConversationSummary は会話一覧表示用のサマリー情報を表す。
+type ConversationSummary struct {
+	UserID      uint   `json:"user_id"`      // 会話相手のユーザーID
+	Name        string `json:"name"`         // 会話相手の名前
+	AvatarURL   string `json:"avatar_url"`   // 会話相手のアバターURL
+	LastMessage string `json:"last_message"` // 最新メッセージの内容
+	LastTime    string `json:"last_time"`    // 最新メッセージの日時
+	UnreadCount int    `json:"unread_count"` // 未読メッセージ数
+}
+
 // Message はユーザー間のダイレクトメッセージを表す。
 type Message struct {
 	ID         uint      `json:"id" gorm:"primaryKey"`

--- a/backend/internal/model/ranking.go
+++ b/backend/internal/model/ranking.go
@@ -1,0 +1,10 @@
+package model
+
+// RankingEntry はランキング表示用の1エントリを表す。
+type RankingEntry struct {
+	UserID    uint   `json:"user_id"`    // ユーザーID
+	Username  string `json:"username"`   // ユーザー名（URLスラッグ用）
+	Name      string `json:"name"`       // 表示名
+	AvatarURL string `json:"avatar_url"` // アバター画像URL
+	Score     int64  `json:"score"`      // ランキングスコア
+}

--- a/backend/internal/model/roadmap.go
+++ b/backend/internal/model/roadmap.go
@@ -2,6 +2,13 @@ package model
 
 import "time"
 
+// StepOrder はステップの並び替え情報を表す。
+// ロードマップ・スタディサークルのステップ並び替えに使用する。
+type StepOrder struct {
+	StepID     uint `json:"step_id"`     // ステップID
+	OrderIndex int  `json:"order_index"` // 新しい表示順序
+}
+
 // RoadmapCategory は学習ロードマップのカテゴリを表す型。
 type RoadmapCategory string
 

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -85,7 +85,7 @@ type NotificationRepositoryInterface interface {
 type MessageRepositoryInterface interface {
 	Create(msg *model.Message) error
 	GetConversation(userID, otherUserID uint, page, limit int) ([]model.Message, error)
-	GetConversations(userID uint) ([]ConversationSummary, error)
+	GetConversations(userID uint) ([]model.ConversationSummary, error)
 	MarkAsRead(senderID, receiverID uint) error
 }
 
@@ -146,9 +146,9 @@ type LearningGoalRepositoryInterface interface {
 // RankingRepositoryInterface はランキングデータ操作の契約を定義する。
 // GitHubコントリビューションと言語別ランキングを提供する。
 type RankingRepositoryInterface interface {
-	ContributionRanking(period string) ([]RankingEntry, error)
-	LanguageRanking(language, period string) ([]RankingEntry, error)
-	LevelRanking() ([]RankingEntry, error)
+	ContributionRanking(period string) ([]model.RankingEntry, error)
+	LanguageRanking(language, period string) ([]model.RankingEntry, error)
+	LevelRanking() ([]model.RankingEntry, error)
 	AvailableLanguages() ([]string, error)
 }
 
@@ -207,7 +207,7 @@ type RoadmapRepositoryInterface interface {
 	UpdateStep(step *model.RoadmapStep) error
 	DeleteStep(stepID uint) error
 	FindStepByID(stepID uint) (*model.RoadmapStep, error)
-	ReorderSteps(roadmapID uint, stepOrders []StepOrder) error
+	ReorderSteps(roadmapID uint, stepOrders []model.StepOrder) error
 	GetTemplates() ([]model.Roadmap, error)
 }
 
@@ -370,7 +370,7 @@ type StudyCircleRepositoryInterface interface {
 	UpdateStep(step *model.StudyCircleStep) error
 	DeleteStep(stepID uint) error
 	FindStepByID(stepID uint) (*model.StudyCircleStep, error)
-	ReorderSteps(circleID uint, stepOrders []StepOrder) error
+	ReorderSteps(circleID uint, stepOrders []model.StepOrder) error
 
 	// 進捗管理
 	UpsertProgress(progress *model.StudyCircleMemberProgress) error

--- a/backend/internal/repository/message.go
+++ b/backend/internal/repository/message.go
@@ -33,20 +33,10 @@ func (r *MessageRepository) GetConversation(userID, otherUserID uint, page, limi
 	return messages, err
 }
 
-// ConversationSummary は会話一覧表示用のサマリー情報を表す。
-type ConversationSummary struct {
-	UserID      uint   `json:"user_id"`     // 会話相手のユーザーID
-	Name        string `json:"name"`        // 会話相手の名前
-	AvatarURL   string `json:"avatar_url"`  // 会話相手のアバターURL
-	LastMessage string `json:"last_message"` // 最新メッセージの内容
-	LastTime    string `json:"last_time"`   // 最新メッセージの日時
-	UnreadCount int    `json:"unread_count"` // 未読メッセージ数
-}
-
 // GetConversations はユーザーの全会話一覧をサマリー形式で取得する。
 // DISTINCT ON を使用して各会話相手との最新メッセージを1件ずつ取得する。
-func (r *MessageRepository) GetConversations(userID uint) ([]ConversationSummary, error) {
-	var conversations []ConversationSummary
+func (r *MessageRepository) GetConversations(userID uint) ([]model.ConversationSummary, error) {
+	var conversations []model.ConversationSummary
 	err := r.db.Raw(`
 		SELECT DISTINCT ON (other_id) other_id as user_id, u.name, u.avatar_url, m.content as last_message, m.created_at as last_time,
 			(SELECT COUNT(*) FROM messages WHERE sender_id = other_id AND receiver_id = ? AND read = false) as unread_count

--- a/backend/internal/repository/ranking.go
+++ b/backend/internal/repository/ranking.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
 
@@ -16,25 +17,16 @@ func NewRankingRepository(db *gorm.DB) *RankingRepository {
 	return &RankingRepository{db: db}
 }
 
-// RankingEntry はランキング表示用の1エントリを表す。
-type RankingEntry struct {
-	UserID    uint   `json:"user_id"`    // ユーザーID
-	Username  string `json:"username"`   // ユーザー名（URLスラッグ用）
-	Name      string `json:"name"`       // 表示名
-	AvatarURL string `json:"avatar_url"` // アバター画像URL
-	Score     int64  `json:"score"`      // ランキングスコア
-}
-
 // ContributionRanking は指定期間（weekly/monthly）のGitHubコントリビューションランキングを取得する。
 // コントリビューション数の合計で降順ソートし、上位50件を返す。
-func (r *RankingRepository) ContributionRanking(period string) ([]RankingEntry, error) {
+func (r *RankingRepository) ContributionRanking(period string) ([]model.RankingEntry, error) {
 	days := 7
 	if period == "monthly" {
 		days = 30
 	}
 	since := time.Now().AddDate(0, 0, -days)
 
-	var entries []RankingEntry
+	var entries []model.RankingEntry
 	err := r.db.Raw(`
 		SELECT u.id as user_id, u.username, u.name, u.avatar_url, COALESCE(SUM(gc.count), 0) as score
 		FROM users u
@@ -50,8 +42,8 @@ func (r *RankingRepository) ContributionRanking(period string) ([]RankingEntry, 
 
 // LanguageRanking は指定プログラミング言語のバイト数ランキングを取得する。
 // GitHubの言語統計データに基づき、上位50件を返す。
-func (r *RankingRepository) LanguageRanking(language, period string) ([]RankingEntry, error) {
-	var entries []RankingEntry
+func (r *RankingRepository) LanguageRanking(language, period string) ([]model.RankingEntry, error) {
+	var entries []model.RankingEntry
 	err := r.db.Raw(`
 		SELECT u.id as user_id, u.username, u.name, u.avatar_url, gls.bytes as score
 		FROM users u
@@ -65,8 +57,8 @@ func (r *RankingRepository) LanguageRanking(language, period string) ([]RankingE
 
 // LevelRanking はユーザーのXP合計に基づくレベルランキングを取得する。
 // 各種アクティビティから獲得したXPの合計で降順ソートし、上位50件を返す。
-func (r *RankingRepository) LevelRanking() ([]RankingEntry, error) {
-	var entries []RankingEntry
+func (r *RankingRepository) LevelRanking() ([]model.RankingEntry, error) {
+	var entries []model.RankingEntry
 	err := r.db.Raw(`
 		SELECT u.id as user_id, u.username, u.name, u.avatar_url,
 			COALESCE(ll.xp, 0) + COALESCE(p.xp, 0) + COALESCE(gh.xp, 0) +

--- a/backend/internal/repository/roadmap.go
+++ b/backend/internal/repository/roadmap.go
@@ -253,7 +253,7 @@ func (r *RoadmapRepository) FindStepByID(stepID uint) (*model.RoadmapStep, error
 }
 
 // ReorderSteps は複数ステップの表示順序を一括で更新する。
-func (r *RoadmapRepository) ReorderSteps(roadmapID uint, stepOrders []StepOrder) error {
+func (r *RoadmapRepository) ReorderSteps(roadmapID uint, stepOrders []model.StepOrder) error {
 	return r.db.Transaction(func(tx *gorm.DB) error {
 		for _, order := range stepOrders {
 			if err := tx.Model(&model.RoadmapStep{}).
@@ -278,8 +278,3 @@ func (r *RoadmapRepository) GetTemplates() ([]model.Roadmap, error) {
 	return templates, err
 }
 
-// StepOrder はステップの並び替え情報を表す。
-type StepOrder struct {
-	StepID     uint `json:"step_id"`     // ステップID
-	OrderIndex int  `json:"order_index"` // 新しい表示順序
-}

--- a/backend/internal/repository/study_circle.go
+++ b/backend/internal/repository/study_circle.go
@@ -144,7 +144,7 @@ func (r *StudyCircleRepository) FindStepByID(stepID uint) (*model.StudyCircleSte
 }
 
 // ReorderSteps はステップの表示順序を更新する。
-func (r *StudyCircleRepository) ReorderSteps(circleID uint, stepOrders []StepOrder) error {
+func (r *StudyCircleRepository) ReorderSteps(circleID uint, stepOrders []model.StepOrder) error {
 	return r.db.Transaction(func(tx *gorm.DB) error {
 		for _, o := range stepOrders {
 			if err := tx.Model(&model.StudyCircleStep{}).

--- a/backend/internal/service/message.go
+++ b/backend/internal/service/message.go
@@ -18,7 +18,7 @@ func NewMessageService(repo repository.MessageRepositoryInterface, notificationS
 }
 
 // GetConversations は指定ユーザーの全会話一覧を取得する。
-func (s *MessageService) GetConversations(userID uint) ([]repository.ConversationSummary, error) {
+func (s *MessageService) GetConversations(userID uint) ([]model.ConversationSummary, error) {
 	return s.repo.GetConversations(userID)
 }
 

--- a/backend/internal/service/message_test.go
+++ b/backend/internal/service/message_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -26,7 +25,7 @@ func newTestMessageService() (*MessageService, *MockMessageRepository, *MockNoti
 func TestMessageGetConversations_Success(t *testing.T) {
 	svc, msgRepo, _ := newTestMessageService()
 
-	summaries := []repository.ConversationSummary{
+	summaries := []model.ConversationSummary{
 		{UserID: 2, Name: "Alice", LastMessage: "Hello"},
 	}
 	msgRepo.On("GetConversations", uint(1)).Return(summaries, nil)
@@ -97,7 +96,7 @@ func TestMessageMarkAsRead_Success(t *testing.T) {
 func TestMessageGetConversations_RepoError(t *testing.T) {
 	svc, msgRepo, _ := newTestMessageService()
 
-	msgRepo.On("GetConversations", uint(1)).Return([]repository.ConversationSummary(nil), errors.New("db error"))
+	msgRepo.On("GetConversations", uint(1)).Return([]model.ConversationSummary(nil), errors.New("db error"))
 
 	result, err := svc.GetConversations(1)
 	assert.Error(t, err)
@@ -108,7 +107,7 @@ func TestMessageGetConversations_RepoError(t *testing.T) {
 func TestMessageGetConversations_Empty(t *testing.T) {
 	svc, msgRepo, _ := newTestMessageService()
 
-	msgRepo.On("GetConversations", uint(1)).Return([]repository.ConversationSummary{}, nil)
+	msgRepo.On("GetConversations", uint(1)).Return([]model.ConversationSummary{}, nil)
 
 	result, err := svc.GetConversations(1)
 	assert.NoError(t, err)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -321,9 +321,9 @@ func (m *MockMessageRepository) GetConversation(userID, otherUserID uint, page, 
 	return args.Get(0).([]model.Message), args.Error(1)
 }
 
-func (m *MockMessageRepository) GetConversations(userID uint) ([]repository.ConversationSummary, error) {
+func (m *MockMessageRepository) GetConversations(userID uint) ([]model.ConversationSummary, error) {
 	args := m.Called(userID)
-	return args.Get(0).([]repository.ConversationSummary), args.Error(1)
+	return args.Get(0).([]model.ConversationSummary), args.Error(1)
 }
 
 func (m *MockMessageRepository) MarkAsRead(senderID, receiverID uint) error {
@@ -835,7 +835,7 @@ func (m *MockRoadmapRepository) FindStepByID(stepID uint) (*model.RoadmapStep, e
 	return args.Get(0).(*model.RoadmapStep), args.Error(1)
 }
 
-func (m *MockRoadmapRepository) ReorderSteps(roadmapID uint, stepOrders []repository.StepOrder) error {
+func (m *MockRoadmapRepository) ReorderSteps(roadmapID uint, stepOrders []model.StepOrder) error {
 	args := m.Called(roadmapID, stepOrders)
 	return args.Error(0)
 }
@@ -1358,7 +1358,7 @@ func (m *MockStudyCircleRepository) FindStepByID(stepID uint) (*model.StudyCircl
 	return args.Get(0).(*model.StudyCircleStep), args.Error(1)
 }
 
-func (m *MockStudyCircleRepository) ReorderSteps(circleID uint, stepOrders []repository.StepOrder) error {
+func (m *MockStudyCircleRepository) ReorderSteps(circleID uint, stepOrders []model.StepOrder) error {
 	args := m.Called(circleID, stepOrders)
 	return args.Error(0)
 }
@@ -1450,19 +1450,19 @@ type MockRankingRepository struct {
 
 var _ repository.RankingRepositoryInterface = (*MockRankingRepository)(nil)
 
-func (m *MockRankingRepository) ContributionRanking(period string) ([]repository.RankingEntry, error) {
+func (m *MockRankingRepository) ContributionRanking(period string) ([]model.RankingEntry, error) {
 	args := m.Called(period)
-	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+	return args.Get(0).([]model.RankingEntry), args.Error(1)
 }
 
-func (m *MockRankingRepository) LanguageRanking(language, period string) ([]repository.RankingEntry, error) {
+func (m *MockRankingRepository) LanguageRanking(language, period string) ([]model.RankingEntry, error) {
 	args := m.Called(language, period)
-	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+	return args.Get(0).([]model.RankingEntry), args.Error(1)
 }
 
-func (m *MockRankingRepository) LevelRanking() ([]repository.RankingEntry, error) {
+func (m *MockRankingRepository) LevelRanking() ([]model.RankingEntry, error) {
 	args := m.Called()
-	return args.Get(0).([]repository.RankingEntry), args.Error(1)
+	return args.Get(0).([]model.RankingEntry), args.Error(1)
 }
 
 func (m *MockRankingRepository) AvailableLanguages() ([]string, error) {

--- a/backend/internal/service/ranking.go
+++ b/backend/internal/service/ranking.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
 
@@ -16,17 +17,17 @@ func NewRankingService(repo repository.RankingRepositoryInterface) *RankingServi
 }
 
 // ContributionRanking は指定期間のコントリビューションランキングを返す。
-func (s *RankingService) ContributionRanking(period string) ([]repository.RankingEntry, error) {
+func (s *RankingService) ContributionRanking(period string) ([]model.RankingEntry, error) {
 	return s.repo.ContributionRanking(period)
 }
 
 // LanguageRanking は指定言語・期間の言語別ランキングを返す。
-func (s *RankingService) LanguageRanking(language, period string) ([]repository.RankingEntry, error) {
+func (s *RankingService) LanguageRanking(language, period string) ([]model.RankingEntry, error) {
 	return s.repo.LanguageRanking(language, period)
 }
 
 // LevelRanking はXP合計に基づくレベルランキングを返す。
-func (s *RankingService) LevelRanking() ([]repository.RankingEntry, error) {
+func (s *RankingService) LevelRanking() ([]model.RankingEntry, error) {
 	return s.repo.LevelRanking()
 }
 

--- a/backend/internal/service/ranking_test.go
+++ b/backend/internal/service/ranking_test.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/norman6464/devsync/backend/internal/repository"
+	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -13,7 +13,7 @@ func TestRankingService_ContributionRanking(t *testing.T) {
 		repo := new(MockRankingRepository)
 		svc := NewRankingService(repo)
 
-		expected := []repository.RankingEntry{
+		expected := []model.RankingEntry{
 			{UserID: 1, Name: "alice", Score: 100},
 			{UserID: 2, Name: "bob", Score: 80},
 		}
@@ -29,7 +29,7 @@ func TestRankingService_ContributionRanking(t *testing.T) {
 		repo := new(MockRankingRepository)
 		svc := NewRankingService(repo)
 
-		repo.On("ContributionRanking", "monthly").Return([]repository.RankingEntry(nil), errors.New("db error"))
+		repo.On("ContributionRanking", "monthly").Return([]model.RankingEntry(nil), errors.New("db error"))
 
 		result, err := svc.ContributionRanking("monthly")
 		assert.Error(t, err)
@@ -43,7 +43,7 @@ func TestRankingService_LanguageRanking(t *testing.T) {
 		repo := new(MockRankingRepository)
 		svc := NewRankingService(repo)
 
-		expected := []repository.RankingEntry{
+		expected := []model.RankingEntry{
 			{UserID: 1, Name: "alice", Score: 50},
 		}
 		repo.On("LanguageRanking", "Go", "weekly").Return(expected, nil)
@@ -58,7 +58,7 @@ func TestRankingService_LanguageRanking(t *testing.T) {
 		repo := new(MockRankingRepository)
 		svc := NewRankingService(repo)
 
-		repo.On("LanguageRanking", "Python", "monthly").Return([]repository.RankingEntry(nil), errors.New("db error"))
+		repo.On("LanguageRanking", "Python", "monthly").Return([]model.RankingEntry(nil), errors.New("db error"))
 
 		result, err := svc.LanguageRanking("Python", "monthly")
 		assert.Error(t, err)
@@ -72,7 +72,7 @@ func TestRankingService_LevelRanking(t *testing.T) {
 		repo := new(MockRankingRepository)
 		svc := NewRankingService(repo)
 
-		expected := []repository.RankingEntry{
+		expected := []model.RankingEntry{
 			{UserID: 3, Name: "charlie", Score: 200},
 			{UserID: 1, Name: "alice", Score: 150},
 		}
@@ -88,7 +88,7 @@ func TestRankingService_LevelRanking(t *testing.T) {
 		repo := new(MockRankingRepository)
 		svc := NewRankingService(repo)
 
-		repo.On("LevelRanking").Return([]repository.RankingEntry(nil), errors.New("db error"))
+		repo.On("LevelRanking").Return([]model.RankingEntry(nil), errors.New("db error"))
 
 		result, err := svc.LevelRanking()
 		assert.Error(t, err)
@@ -128,7 +128,7 @@ func TestRankingService_ContributionRanking_EmptyList(t *testing.T) {
 	repo := new(MockRankingRepository)
 	svc := NewRankingService(repo)
 
-	repo.On("ContributionRanking", "weekly").Return([]repository.RankingEntry{}, nil)
+	repo.On("ContributionRanking", "weekly").Return([]model.RankingEntry{}, nil)
 
 	result, err := svc.ContributionRanking("weekly")
 	assert.NoError(t, err)
@@ -140,7 +140,7 @@ func TestRankingService_LanguageRanking_EmptyList(t *testing.T) {
 	repo := new(MockRankingRepository)
 	svc := NewRankingService(repo)
 
-	repo.On("LanguageRanking", "Rust", "weekly").Return([]repository.RankingEntry{}, nil)
+	repo.On("LanguageRanking", "Rust", "weekly").Return([]model.RankingEntry{}, nil)
 
 	result, err := svc.LanguageRanking("Rust", "weekly")
 	assert.NoError(t, err)
@@ -152,7 +152,7 @@ func TestRankingService_LevelRanking_EmptyList(t *testing.T) {
 	repo := new(MockRankingRepository)
 	svc := NewRankingService(repo)
 
-	repo.On("LevelRanking").Return([]repository.RankingEntry{}, nil)
+	repo.On("LevelRanking").Return([]model.RankingEntry{}, nil)
 
 	result, err := svc.LevelRanking()
 	assert.NoError(t, err)
@@ -176,7 +176,7 @@ func TestRankingService_ContributionRanking_LargeScores(t *testing.T) {
 	repo := new(MockRankingRepository)
 	svc := NewRankingService(repo)
 
-	expected := []repository.RankingEntry{
+	expected := []model.RankingEntry{
 		{UserID: 1, Name: "top-user", Score: 999999},
 		{UserID: 2, Name: "second-user", Score: 0},
 	}

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -7,8 +7,6 @@ import (
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
 
-// StepOrder はステップの並び替え情報を表す型エイリアス。
-type StepOrder = repository.StepOrder
 
 // RoadmapService は学習ロードマップのビジネスロジックを提供する。
 // ロードマップとステップのCRUD操作、可視性制御、コピー機能を担当する。
@@ -409,7 +407,7 @@ func (s *RoadmapService) SeedTemplates(userID uint) error {
 }
 
 // ReorderSteps は所有権を検証した後、ステップの表示順序を一括更新する。
-func (s *RoadmapService) ReorderSteps(roadmapID, userID uint, orders []repository.StepOrder) error {
+func (s *RoadmapService) ReorderSteps(roadmapID, userID uint, orders []model.StepOrder) error {
 	roadmap, err := s.repo.FindByID(roadmapID)
 	if err != nil {
 		return err

--- a/backend/internal/service/roadmap_test.go
+++ b/backend/internal/service/roadmap_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -698,7 +697,7 @@ func TestRoadmapReorderSteps_Success(t *testing.T) {
 	roadmap := &model.Roadmap{UserID: 1}
 	roadmap.ID = 10
 
-	orders := []repository.StepOrder{
+	orders := []model.StepOrder{
 		{StepID: 1, OrderIndex: 0},
 		{StepID: 2, OrderIndex: 1},
 	}
@@ -719,7 +718,7 @@ func TestRoadmapReorderSteps_Forbidden(t *testing.T) {
 
 	repo.On("FindByID", uint(10)).Return(roadmap, nil)
 
-	orders := []repository.StepOrder{{StepID: 1, OrderIndex: 0}}
+	orders := []model.StepOrder{{StepID: 1, OrderIndex: 0}}
 	err := svc.ReorderSteps(10, 999, orders)
 	assert.ErrorIs(t, err, ErrForbidden)
 	repo.AssertExpectations(t)

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -226,7 +226,7 @@ func (s *StudyCircleService) DeleteStep(circleID, userID, stepID uint) error {
 }
 
 // ReorderSteps はステップの順序を変更する。オーナーのみ。
-func (s *StudyCircleService) ReorderSteps(circleID, userID uint, orders []repository.StepOrder) error {
+func (s *StudyCircleService) ReorderSteps(circleID, userID uint, orders []model.StepOrder) error {
 	circle, err := s.repo.FindByID(circleID)
 	if err != nil {
 		return ErrNotFound

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/repository"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -465,7 +464,7 @@ func TestStudyCircleReorderSteps_Success(t *testing.T) {
 	svc, repo := newTestStudyCircleService()
 
 	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
-	orders := []repository.StepOrder{
+	orders := []model.StepOrder{
 		{StepID: 1, OrderIndex: 0},
 		{StepID: 2, OrderIndex: 1},
 	}
@@ -484,7 +483,7 @@ func TestStudyCircleReorderSteps_Forbidden(t *testing.T) {
 	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
 	repo.On("FindByID", uint(1)).Return(circle, nil)
 
-	orders := []repository.StepOrder{{StepID: 1, OrderIndex: 0}}
+	orders := []model.StepOrder{{StepID: 1, OrderIndex: 0}}
 	err := svc.ReorderSteps(1, 99, orders)
 	assert.ErrorIs(t, err, ErrForbidden)
 }


### PR DESCRIPTION
## 概要
- `RankingEntry`、`ConversationSummary`、`StepOrder` の各型をrepository/serviceパッケージからmodelパッケージへ移動
- handler層がrepositoryやservice層の型を直接参照するクリーンアーキテクチャ違反を解消
- handler→service→repositoryの依存方向を厳格化し、疎結合を実現

## 変更内容
- `model/ranking.go` 新規作成（RankingEntry型）
- `model/message.go`, `model/roadmap.go` にConversationSummary・StepOrder型を追加
- repository, service, handler, dto の全参照を `model.*` に統一
- 全テストファイル（service/handler）の型参照も更新

## 関連Issue
closes #701