### PR TITLE
test: サービス層テストカバレッジ 79.2% → 82.0% に向上

### DIFF
--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -620,3 +620,98 @@ func TestGenerateUsername_AlreadyExists(t *testing.T) {
 	username := svc.generateUsername("testuser")
 	assert.Equal(t, "testuser2", username)
 }
+
+// ============================================================
+// Login 追加テスト
+// ============================================================
+
+func TestLogin_InvalidEmail(t *testing.T) {
+	svc, _, _ := newTestAuthService()
+
+	// 無効なメールアドレス
+	_, err := svc.Login(LoginInput{Email: "not-an-email", Password: "password123"})
+	assert.Error(t, err)
+}
+
+// ============================================================
+// RequestPasswordReset 追加テスト
+// ============================================================
+
+func TestRequestPasswordReset_CreateError(t *testing.T) {
+	svc, userRepo, passwordResetRepo := newTestAuthService()
+
+	user := &model.User{Email: "test@example.com"}
+	user.ID = 1
+
+	userRepo.On("FindByEmail", "test@example.com").Return(user, nil)
+	passwordResetRepo.On("InvalidateUserTokens", uint(1)).Return(nil)
+	passwordResetRepo.On("Create", mock.AnythingOfType("*model.PasswordResetToken")).Return(errors.New("db error"))
+
+	token, err := svc.RequestPasswordReset("test@example.com")
+	assert.Error(t, err)
+	assert.Empty(t, token)
+}
+
+// ============================================================
+// ValidateToken 追加テスト
+// ============================================================
+
+func TestValidateToken_EmptyString(t *testing.T) {
+	svc, _, _ := newTestAuthService()
+
+	// 空文字列トークンは無効
+	_, err := svc.ValidateToken("")
+	assert.Error(t, err)
+}
+
+func TestValidateToken_GeneratedToken(t *testing.T) {
+	svc, _, _ := newTestAuthService()
+
+	// generateTokenで生成したトークンが正しく検証できる
+	token, err := svc.generateToken(99)
+	assert.NoError(t, err)
+
+	userID, err := svc.ValidateToken(token)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(99), userID)
+}
+
+// ============================================================
+// ResetPassword 追加テスト
+// ============================================================
+
+func TestResetPassword_WeakPassword(t *testing.T) {
+	svc, _, passwordResetRepo := newTestAuthService()
+
+	validToken := &model.PasswordResetToken{
+		Token:     "valid-token-for-weak-pw",
+		UserID:    1,
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+		Used:      false,
+	}
+	validToken.ID = 1
+
+	passwordResetRepo.On("FindByToken", "valid-token-for-weak-pw").Return(validToken, nil)
+
+	// 弱いパスワード（短すぎる）
+	err := svc.ResetPassword("valid-token-for-weak-pw", "weak")
+	assert.Error(t, err)
+}
+
+func TestResetPassword_UpdatePasswordError(t *testing.T) {
+	svc, userRepo, passwordResetRepo := newTestAuthService()
+
+	validToken := &model.PasswordResetToken{
+		Token:     "valid-token-update-err",
+		UserID:    1,
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+		Used:      false,
+	}
+	validToken.ID = 1
+
+	passwordResetRepo.On("FindByToken", "valid-token-update-err").Return(validToken, nil)
+	userRepo.On("UpdatePassword", uint(1), mock.AnythingOfType("string")).Return(errors.New("db error"))
+
+	err := svc.ResetPassword("valid-token-update-err", "ValidPassword123!")
+	assert.Error(t, err)
+}

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -212,3 +212,32 @@ func TestBookReviewDelete_NotFound(t *testing.T) {
 	err := svc.Delete(99, 1)
 	assert.Error(t, err)
 }
+
+func TestBookReviewUpdate_AllFields(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Old", Author: "Old Author"}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	// 全フィールドを更新
+	updates := &model.BookReview{
+		Title:    "New Title",
+		Author:   "New Author",
+		ISBN:     "978-1234567890",
+		Rating:   5,
+		Review:   "Great book!",
+		ImageURL: "https://example.com/image.jpg",
+	}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "New Title", result.Title)
+	assert.Equal(t, "New Author", result.Author)
+	assert.Equal(t, "978-1234567890", result.ISBN)
+	assert.Equal(t, 5, result.Rating)
+	assert.Equal(t, "Great book!", result.Review)
+	assert.Equal(t, "https://example.com/image.jpg", result.ImageURL)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/email_test.go
+++ b/backend/internal/service/email_test.go
@@ -234,3 +234,22 @@ func TestRenderWeeklyReportHTML_UnsupportedLanguageFallback(t *testing.T) {
 	// 日本語テキストが含まれることを確認
 	assert.True(t, strings.Contains(html, "コントリビューション"))
 }
+
+func TestSendAllWeeklyReports_GetWeeklyReportError(t *testing.T) {
+	svc, _, userRepo, reportRepo := newTestWeeklyReportEmailService()
+
+	users := []model.User{
+		{Name: "ユーザー1", Email: "user1@example.com", EmailWeeklyReport: true, EmailLanguage: "ja"},
+	}
+	users[0].ID = 1
+
+	userRepo.On("FindAll").Return(users, nil)
+	// GetWeeklyReport がエラーを返す → continue でスキップ
+	reportRepo.On("GetWeeklyReport", uint(1)).Return((*model.ActivityReport)(nil), errors.New("report error"))
+
+	err := svc.SendAllWeeklyReports()
+	// 一部エラーでもnilを返す
+	assert.NoError(t, err)
+	userRepo.AssertExpectations(t)
+	reportRepo.AssertExpectations(t)
+}

--- a/backend/internal/service/github_test.go
+++ b/backend/internal/service/github_test.go
@@ -200,3 +200,16 @@ func TestGitHubService_GetRepos_Empty(t *testing.T) {
 	assert.Empty(t, result)
 	githubRepo.AssertExpectations(t)
 }
+
+// SyncUserData_Success は FindByID が成功して SyncData を呼び出すパスをカバーする
+func TestGitHubService_SyncUserData_UserFound_NoToken(t *testing.T) {
+	svc, userRepo, _ := newGitHubTestService()
+	user := &model.User{GitHubToken: ""}
+	user.ID = 1
+	userRepo.On("FindByID", uint(1)).Return(user, nil)
+
+	// SyncData は GitHubToken なしでエラーを返すが、SyncUserData の return s.SyncData(user) は実行される
+	err := svc.SyncUserData(1)
+	assert.Error(t, err)
+	userRepo.AssertExpectations(t)
+}

--- a/backend/internal/service/learning_analytics_test.go
+++ b/backend/internal/service/learning_analytics_test.go
@@ -424,3 +424,281 @@ func TestGetInsights_RepoError(t *testing.T) {
 	assert.Nil(t, insights)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// analyzeWeeklyGrowth テスト（GetInsights経由）
+// ============================================================
+
+func TestGetInsights_WeeklyGrowthUp(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	// 直近2週間で成長あり（prev=100, current=150 → +50%成長）
+	trends := []model.WeeklyTrend{
+		{TotalMinutes: 100},
+		{TotalMinutes: 150},
+	}
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown{}, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return(trends, nil)
+	repo.On("GetProductivityStats", uint(1)).Return(&model.ProductivityStats{}, nil)
+
+	insights, err := svc.GetInsights(1)
+	assert.NoError(t, err)
+	// weekly_growth_upのインサイトが含まれているはず
+	found := false
+	for _, ins := range insights {
+		if ins.Type == "weekly_growth_up" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "weekly_growth_up インサイトが含まれていること")
+	repo.AssertExpectations(t)
+}
+
+func TestGetInsights_WeeklyGrowthDown(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	// 直近2週間で大きく下落（prev=200, current=100 → -50%下落）
+	trends := []model.WeeklyTrend{
+		{TotalMinutes: 200},
+		{TotalMinutes: 100},
+	}
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown{}, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return(trends, nil)
+	repo.On("GetProductivityStats", uint(1)).Return(&model.ProductivityStats{}, nil)
+
+	insights, err := svc.GetInsights(1)
+	assert.NoError(t, err)
+	// weekly_growth_downのインサイトが含まれているはず
+	found := false
+	for _, ins := range insights {
+		if ins.Type == "weekly_growth_down" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "weekly_growth_down インサイトが含まれていること")
+	repo.AssertExpectations(t)
+}
+
+func TestGetInsights_WeeklyGrowthNoChange(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	// 変化なし（-20%以内の微小下落はnilを返す）
+	trends := []model.WeeklyTrend{
+		{TotalMinutes: 100},
+		{TotalMinutes: 90}, // -10%（-20%以内なのでweekly_growth_downなし）
+	}
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown{}, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return(trends, nil)
+	repo.On("GetProductivityStats", uint(1)).Return(&model.ProductivityStats{}, nil)
+
+	insights, err := svc.GetInsights(1)
+	assert.NoError(t, err)
+	// weekly_growth系インサイトは含まれないはず
+	for _, ins := range insights {
+		assert.NotEqual(t, "weekly_growth_up", ins.Type)
+		assert.NotEqual(t, "weekly_growth_down", ins.Type)
+	}
+	repo.AssertExpectations(t)
+}
+
+func TestGetInsights_WeeklyGrowthPrevZero(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	// prev=0の場合は除算を避けてnilを返す
+	trends := []model.WeeklyTrend{
+		{TotalMinutes: 0},
+		{TotalMinutes: 100},
+	}
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown{}, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return(trends, nil)
+	repo.On("GetProductivityStats", uint(1)).Return(&model.ProductivityStats{}, nil)
+
+	insights, err := svc.GetInsights(1)
+	assert.NoError(t, err)
+	// weekly_growth系インサイトは含まれないはず（prev=0で除算スキップ）
+	for _, ins := range insights {
+		assert.NotEqual(t, "weekly_growth_up", ins.Type)
+		assert.NotEqual(t, "weekly_growth_down", ins.Type)
+	}
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// analyzeStreak 追加テスト
+// ============================================================
+
+func TestGetInsights_StreakRecord(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	// CurrentStreak < 7 かつ LongestStreak > CurrentStreak → streak_record
+	stats := &model.ProductivityStats{
+		CurrentStreak: 3,
+		LongestStreak: 10,
+	}
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown{}, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return([]model.WeeklyTrend{}, nil)
+	repo.On("GetProductivityStats", uint(1)).Return(stats, nil)
+
+	insights, err := svc.GetInsights(1)
+	assert.NoError(t, err)
+
+	hasStreakRecord := false
+	for _, ins := range insights {
+		if ins.Type == "streak_record" {
+			hasStreakRecord = true
+		}
+	}
+	assert.True(t, hasStreakRecord)
+	repo.AssertExpectations(t)
+}
+
+func TestGetInsights_StreakNil(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	// CurrentStreak < 7 かつ LongestStreak == 0 → analyzeStreak nil
+	stats := &model.ProductivityStats{
+		CurrentStreak: 2,
+		LongestStreak: 0,
+	}
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown{}, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return([]model.WeeklyTrend{}, nil)
+	repo.On("GetProductivityStats", uint(1)).Return(stats, nil)
+
+	insights, err := svc.GetInsights(1)
+	assert.NoError(t, err)
+	for _, ins := range insights {
+		assert.NotEqual(t, "streak_active", ins.Type)
+		assert.NotEqual(t, "streak_record", ins.Type)
+	}
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// analyzeCategoryFocus 追加テスト
+// ============================================================
+
+func TestGetInsights_CategoryFocusBelow70(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	// 最大カテゴリが全体の50%（70%未満）→ nil
+	categories := []model.CategoryBreakdown{
+		{Category: "coding", TotalMinutes: 100},
+		{Category: "reading", TotalMinutes: 100},
+	}
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return(categories, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return([]model.WeeklyTrend{}, nil)
+	repo.On("GetProductivityStats", uint(1)).Return(&model.ProductivityStats{}, nil)
+
+	insights, err := svc.GetInsights(1)
+	assert.NoError(t, err)
+	for _, ins := range insights {
+		assert.NotEqual(t, "category_focus", ins.Type)
+	}
+	repo.AssertExpectations(t)
+}
+
+func TestGetInsights_CategoryFocusZeroMinutes(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	// 全カテゴリのTotalMinutes=0 → totalMinutes==0でnil
+	categories := []model.CategoryBreakdown{
+		{Category: "coding", TotalMinutes: 0},
+	}
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return(categories, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return([]model.WeeklyTrend{}, nil)
+	repo.On("GetProductivityStats", uint(1)).Return(&model.ProductivityStats{}, nil)
+
+	insights, err := svc.GetInsights(1)
+	assert.NoError(t, err)
+	for _, ins := range insights {
+		assert.NotEqual(t, "category_focus", ins.Type)
+	}
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// GetInsights エラーパス 追加テスト
+// ============================================================
+
+func TestGetInsights_CategoryBreakdownError(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown(nil), assert.AnError)
+
+	insights, err := svc.GetInsights(1)
+	assert.Error(t, err)
+	assert.Nil(t, insights)
+	repo.AssertExpectations(t)
+}
+
+func TestGetInsights_WeeklyTrendsError(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown{}, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return([]model.WeeklyTrend(nil), assert.AnError)
+
+	insights, err := svc.GetInsights(1)
+	assert.Error(t, err)
+	assert.Nil(t, insights)
+	repo.AssertExpectations(t)
+}
+
+func TestGetInsights_ProductivityStatsError(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	repo.On("GetHeatmapData", uint(1)).Return([]model.HeatmapEntry{}, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown{}, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return([]model.WeeklyTrend{}, nil)
+	repo.On("GetProductivityStats", uint(1)).Return((*model.ProductivityStats)(nil), assert.AnError)
+
+	insights, err := svc.GetInsights(1)
+	assert.Error(t, err)
+	assert.Nil(t, insights)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// analyzePeakTime 追加テスト
+// ============================================================
+
+func TestGetInsights_PeakTimeAllZeroMinutes(t *testing.T) {
+	svc, repo := newTestAnalyticsService()
+
+	// 全エントリのTotalMinutes=0 → maxEntry.TotalMinutes==0でnil
+	heatmap := []model.HeatmapEntry{
+		{DayOfWeek: 1, Hour: 10, TotalMinutes: 0},
+		{DayOfWeek: 2, Hour: 20, TotalMinutes: 0},
+	}
+
+	repo.On("GetHeatmapData", uint(1)).Return(heatmap, nil)
+	repo.On("GetCategoryBreakdown", uint(1)).Return([]model.CategoryBreakdown{}, nil)
+	repo.On("GetWeeklyTrends", uint(1), 12).Return([]model.WeeklyTrend{}, nil)
+	repo.On("GetProductivityStats", uint(1)).Return(&model.ProductivityStats{}, nil)
+
+	insights, err := svc.GetInsights(1)
+	assert.NoError(t, err)
+	for _, ins := range insights {
+		assert.NotEqual(t, "peak_time", ins.Type)
+	}
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -287,3 +287,28 @@ func TestLearningLogDelete_NotFound(t *testing.T) {
 	err := svc.Delete(99, 1)
 	assert.Error(t, err)
 }
+
+func TestLearningLogUpdate_AllFields(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	existing := &model.LearningLog{Title: "Old", Content: "Old Content", UserID: 1, Duration: 30}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	// 全フィールドを更新
+	updates := &model.LearningLog{
+		Title:    "New Title",
+		Content:  "New Content",
+		Category: model.LogCategoryCoding,
+		Duration: 90,
+	}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "New Title", result.Title)
+	assert.Equal(t, "New Content", result.Content)
+	assert.Equal(t, model.LogCategoryCoding, result.Category)
+	assert.Equal(t, 90, result.Duration)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -563,3 +563,47 @@ func TestLearningResourceGetSavedByUserID_Empty(t *testing.T) {
 	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// UpdateVisibility 追加テスト
+// ============================================================
+
+func TestLearningResourceUpdateVisibility_NotFound(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	result, err := svc.UpdateVisibility(99, 1, true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceUpdateVisibility_UpdateError(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	existing := &model.LearningResource{UserID: 1, IsPublic: false}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+
+	result, err := svc.UpdateVisibility(1, 1, true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// Delete 追加テスト
+// ============================================================
+
+func TestLearningResourceDelete_NotFound(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.Delete(99, 1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/note_folder_test.go
+++ b/backend/internal/service/note_folder_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -338,4 +339,18 @@ func TestNoteFolderService_Delete_RepoError(t *testing.T) {
 	err := service.Delete(1, 1)
 	assert.Error(t, err)
 	mockRepo.AssertExpectations(t)
+}
+
+func TestNoteFolderService_Update_ValidateLongNameError(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	existing := &model.NoteFolder{ID: 1, UserID: 1, Name: "元の名前"}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// 101文字のフォルダ名 → ValidateUpdate でバリデーションエラー
+	longName := strings.Repeat("あ", 101)
+	result, err := service.Update(1, 1, longName, nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }

--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -309,6 +310,20 @@ func TestNoteTemplateService_Update_ClearDefaultFlagError(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestNoteTemplateService_Update_ValidationNameError(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	existing := &model.NoteTemplate{ID: 1, UserID: 1, Name: "テンプレ"}
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// 101文字の名前 → バリデーションエラー
+	longName := strings.Repeat("あ", 101)
+	result, err := svc.Update(1, 1, longName, "", "", "", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
 // ============================================================
 // Delete テスト
 // ============================================================
@@ -456,4 +471,30 @@ func TestNoteTemplateService_GetDefaultByUserID_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_Delete_NotFound(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.Delete(99, 1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_Create_DefaultTitleValidationError(t *testing.T) {
+	svc, _, _ := newTestNoteTemplateService()
+
+	// 101文字のデフォルトタイトル → バリデーションエラー
+	longTitle := strings.Repeat("あ", 101)
+	template := &model.NoteTemplate{
+		UserID:          1,
+		Name:            "テンプレート",
+		ContentTemplate: "本文",
+		DefaultTitle:    longTitle,
+	}
+
+	err := svc.Create(template)
+	assert.Error(t, err)
 }

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -467,4 +468,30 @@ func TestNoteService_Update_WithAllFields(t *testing.T) {
 	assert.Equal(t, "新内容", result.Content)
 	assert.Equal(t, "React,Go", result.Tags)
 	assert.Equal(t, &folderID, result.FolderID)
+}
+
+func TestNoteService_Update_ValidationError(t *testing.T) {
+	svc, repo := newTestNoteService()
+	existing := &model.Note{ID: 1, UserID: 1, Title: "元"}
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// 201文字のタイトル → ValidateUpdateNote でバリデーションエラー
+	longTitle := strings.Repeat("あ", 201)
+	result, err := svc.Update(1, 1, longTitle, "", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestNoteService_Duplicate_ValidationError(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	// 198文字のタイトル → " (コピー)" (12バイト) 付加後 210バイト > 200 → バリデーションエラー
+	longTitle := strings.Repeat("a", 198)
+	existing := &model.Note{ID: 1, UserID: 1, Title: longTitle}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	result, err := svc.Duplicate(1, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }

--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -342,5 +343,15 @@ func TestPostCollectionGetPosts_Empty(t *testing.T) {
 	result, err := svc.GetPosts(10)
 	assert.NoError(t, err)
 	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestPostCollectionRemovePost_NotFound(t *testing.T) {
+	svc, repo := newTestPostCollectionService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.RemovePost(99, 1, 5)
+	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }

--- a/backend/internal/service/post_pin_test.go
+++ b/backend/internal/service/post_pin_test.go
@@ -174,3 +174,25 @@ func TestPostPinService_IsPinned_False(t *testing.T) {
 	assert.NoError(t, err)
 	assert.False(t, result)
 }
+
+func TestPostPinService_Unpin_IsPinnedError(t *testing.T) {
+	svc, pinRepo, _ := newPostPinTestService()
+	pinRepo.On("IsPinned", uint(1), uint(10)).Return(false, errors.New("db error"))
+
+	err := svc.Unpin(1, 10)
+	assert.Error(t, err)
+	pinRepo.AssertExpectations(t)
+}
+
+func TestPostPinService_Pin_CountError(t *testing.T) {
+	svc, pinRepo, postRepo := newPostPinTestService()
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+	pinRepo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	err := svc.Pin(1, 10)
+	assert.Error(t, err)
+	pinRepo.AssertExpectations(t)
+	postRepo.AssertExpectations(t)
+}

--- a/backend/internal/service/post_series_test.go
+++ b/backend/internal/service/post_series_test.go
@@ -327,3 +327,30 @@ func TestPostSeriesGetPosts_Empty(t *testing.T) {
 	assert.Empty(t, result)
 	repo.AssertExpectations(t)
 }
+
+func TestPostSeriesRemovePost_NotFound(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.RemovePost(99, 5, 1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostSeriesUpdate_Description(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	existing := &model.PostSeries{Title: "Title", Description: "Old Desc", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	updates := &model.PostSeries{Description: "New Desc"}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "Title", result.Title)
+	assert.Equal(t, "New Desc", result.Description)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -434,6 +434,32 @@ func TestPostPublish_AlreadyPublished(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestPostPublish_NotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	result, err := svc.Publish(99, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostPublish_UpdateError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	draft := &model.Post{Title: "Draft", UserID: 1, IsDraft: true}
+	draft.ID = 1
+
+	postRepo.On("FindByID", uint(1)).Return(draft, nil)
+	postRepo.On("Update", draft).Return(errors.New("db error"))
+
+	result, err := svc.Publish(1, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	postRepo.AssertExpectations(t)
+}
+
 // ============================================================
 // 投稿作成 追加テスト
 // ============================================================
@@ -691,6 +717,28 @@ func TestEstimateReadTime_MixedContent(t *testing.T) {
 	assert.Equal(t, 2, result)
 }
 
+func TestPostCreate_FindByIDErrorAfterCreate(t *testing.T) {
+	svc, postRepo, notifRepo := newTestPostService()
+
+	post := &model.Post{Title: "Test", Content: "Content", UserID: 1}
+
+	postRepo.On("Create", post).Run(func(args mock.Arguments) {
+		p := args.Get(0).(*model.Post)
+		p.ID = 10
+	}).Return(nil)
+	// Createは成功するがFindByIDが失敗 → return post, nil
+	postRepo.On("FindByID", uint(10)).Return(nil, errors.New("not found"))
+
+	notifRepo.On("GetFollowerIDs", uint(1)).Return([]uint{}, nil).Maybe()
+	notifRepo.On("CreateBatch", mock.Anything).Return(nil).Maybe()
+
+	result, err := svc.Create(post)
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.Equal(t, post, result) // FindByIDが失敗した場合は元のpostを返す
+	postRepo.AssertExpectations(t)
+}
+
 func TestPostCreate_SetsEstimatedReadTime(t *testing.T) {
 	svc, postRepo, notifRepo := newTestPostService()
 
@@ -713,4 +761,48 @@ func TestPostCreate_SetsEstimatedReadTime(t *testing.T) {
 	result, err := svc.Create(post)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, result.EstimatedReadTime)
+}
+
+// ============================================================
+// Update 追加テスト
+// ============================================================
+
+func TestPostUpdate_WithImageURLs(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	existing := &model.Post{Title: "Old Title", Content: "Old Content", UserID: 1}
+	existing.ID = 1
+
+	postRepo.On("FindByID", uint(1)).Return(existing, nil)
+	postRepo.On("Update", existing).Return(nil)
+
+	// imageUrlsをJSON配列形式で指定してアップデート
+	result, err := svc.Update(1, 1, "New Title", "New Content", `["https://example.com/img.jpg"]`)
+	assert.NoError(t, err)
+	assert.Equal(t, `["https://example.com/img.jpg"]`, result.ImageURLs)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostUpdate_RepoError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	existing := &model.Post{Title: "Old Title", Content: "Old Content", UserID: 1}
+	existing.ID = 1
+
+	postRepo.On("FindByID", uint(1)).Return(existing, nil)
+	postRepo.On("Update", existing).Return(errors.New("db error"))
+
+	_, err := svc.Update(1, 1, "New Title", "New Content", "")
+	assert.Error(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostUpdate_NotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	_, err := svc.Update(99, 1, "Title", "Content", "")
+	assert.Error(t, err)
+	postRepo.AssertExpectations(t)
 }

--- a/backend/internal/service/project_test.go
+++ b/backend/internal/service/project_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -313,6 +314,56 @@ func TestProjectUpdateFeatured_NotFound(t *testing.T) {
 	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
 
 	result, err := svc.UpdateFeatured(999, 1, true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectUpdate_AllFields(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	now := time.Now()
+	repoID := uint(42)
+	existing := &model.Project{Title: "Old", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	updates := &model.Project{
+		Title:        "New Title",
+		Description:  "New Description",
+		TechStack:    "Go, React, PostgreSQL",
+		DemoURL:      "https://demo.example.com",
+		GithubURL:    "https://github.com/example/repo",
+		ImageURL:     "https://example.com/image.jpg",
+		Role:         "Backend Developer",
+		StartDate:    &now,
+		EndDate:      &now,
+		GithubRepoID: &repoID,
+	}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "New Title", result.Title)
+	assert.Equal(t, "New Description", result.Description)
+	assert.Equal(t, "Go, React, PostgreSQL", result.TechStack)
+	assert.Equal(t, "https://demo.example.com", result.DemoURL)
+	assert.Equal(t, "https://github.com/example/repo", result.GithubURL)
+	assert.Equal(t, "https://example.com/image.jpg", result.ImageURL)
+	assert.Equal(t, "Backend Developer", result.Role)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectUpdateFeatured_UpdateError(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	existing := &model.Project{UserID: 1, Featured: false}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+
+	result, err := svc.UpdateFeatured(1, 1, true)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)

--- a/backend/internal/service/question_test.go
+++ b/backend/internal/service/question_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -278,4 +279,52 @@ func TestQuestionVote_InvalidValueTwo(t *testing.T) {
 	// 2は無効な投票値
 	err := svc.Vote(1, 10, 2)
 	assert.Error(t, err)
+}
+
+// ============================================================
+// Delete 追加テスト
+// ============================================================
+
+func TestQuestionDelete_NotFound(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.Delete(99, 1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// Update 追加テスト
+// ============================================================
+
+func TestQuestionUpdate_RepoError(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	existing := &model.Question{UserID: 1, Title: "Old", Body: "Body"}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(errors.New("db error"))
+
+	_, err := svc.Update(1, 1, "New Title", "New Body", "go")
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionUpdate_ValidationError(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	existing := &model.Question{UserID: 1, Title: "Old"}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// 501文字のタイトルでバリデーションエラーを発生させる
+	longTitle := strings.Repeat("a", 501)
+	result, err := svc.Update(1, 1, longTitle, "", "")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
 }

--- a/backend/internal/service/reminder_settings_test.go
+++ b/backend/internal/service/reminder_settings_test.go
@@ -243,3 +243,29 @@ func TestReminderSettingsService_SendReminder_Error(t *testing.T) {
 	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }
+
+func TestReminderSettingsService_UpdateSettings_WithNotificationTimeAndInactiveDays(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	existingSettings := &model.ReminderSettings{
+		ID:     1,
+		UserID: 1,
+	}
+
+	updates := &model.ReminderSettings{
+		NotificationTime: "20:00",
+		InactiveDays:     7,
+		Enabled:          true,
+	}
+
+	repo.On("GetByUserID", uint(1)).Return(existingSettings, nil)
+	repo.On("CreateOrUpdate", mock.MatchedBy(func(s *model.ReminderSettings) bool {
+		return s.NotificationTime == "20:00" && s.InactiveDays == 7
+	})).Return(nil)
+
+	result, err := svc.UpdateSettings(1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "20:00", result.NotificationTime)
+	assert.Equal(t, 7, result.InactiveDays)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/roadmap_test.go
+++ b/backend/internal/service/roadmap_test.go
@@ -859,3 +859,161 @@ func TestRoadmapUpdate_WithAllFields(t *testing.T) {
 	assert.Equal(t, "Desc", result.Description)
 	assert.Equal(t, model.RoadmapCategorySkill, result.Category)
 }
+
+// ============================================================
+// UpdateStep 追加テスト
+// ============================================================
+
+func TestUpdateStep_StepBelongsToDifferentRoadmap(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 1
+
+	// ステップが別ロードマップ（ID=2）に属している
+	step := &model.RoadmapStep{Title: "Step", RoadmapID: 2}
+	step.ID = 10
+
+	repo.On("FindByID", uint(1)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(10)).Return(step, nil)
+
+	updates := &model.RoadmapStep{Title: "Updated"}
+	_, err := svc.UpdateStep(1, 10, 1, updates)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestUpdateStep_UpdateStepRepoError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 1
+
+	step := &model.RoadmapStep{Title: "Step", RoadmapID: 1}
+	step.ID = 10
+
+	repo.On("FindByID", uint(1)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(10)).Return(step, nil)
+	repo.On("UpdateStep", step).Return(errors.New("db error"))
+
+	updates := &model.RoadmapStep{Title: "Updated"}
+	_, err := svc.UpdateStep(1, 10, 1, updates)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestUpdateStep_FindStepError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(10)).Return(nil, errors.New("step not found"))
+
+	updates := &model.RoadmapStep{Title: "Updated"}
+	_, err := svc.UpdateStep(1, 10, 1, updates)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// ReorderSteps 追加テスト
+// ============================================================
+
+func TestRoadmapReorderSteps_NotFound(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.ReorderSteps(99, 1, []model.StepOrder{})
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// CopyRoadmap 追加テスト
+// ============================================================
+
+func TestCopyRoadmap_NotFound(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	_, err := svc.CopyRoadmap(99, 1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapDeleteStep_FindStepByIDError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.DeleteStep(10, 99, 1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapDeleteStep_FindByIDError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.DeleteStep(99, 5, 1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapUpdateStep_AllFields(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+
+	step := &model.RoadmapStep{RoadmapID: 10, Title: "Old", Description: "Old Desc", ResourceURL: "https://old.example.com"}
+	step.ID = 5
+
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+	repo.On("UpdateStep", step).Return(nil)
+
+	updates := &model.RoadmapStep{
+		Title:       "New Step",
+		Description: "New Description",
+		ResourceURL: "https://new.example.com",
+	}
+	result, err := svc.UpdateStep(10, 5, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "New Step", result.Title)
+	assert.Equal(t, "New Description", result.Description)
+	assert.Equal(t, "https://new.example.com", result.ResourceURL)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapUpdateStep_FindByIDError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	updates := &model.RoadmapStep{Title: "New"}
+	result, err := svc.UpdateStep(99, 5, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapUpdateStepCompletion_FindByIDError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	result, err := svc.UpdateStepCompletion(99, 5, 1, true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -57,6 +57,17 @@ func TestStudyCircleCreate_NormalizesMaxMembers(t *testing.T) {
 	assert.Equal(t, 5, circle.MaxMembers) // 3〜10の範囲外 → 5にリセット
 }
 
+func TestStudyCircleCreate_CreateError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	circle := &model.StudyCircle{Name: "Test", Topic: "Test", OwnerID: 1, MaxMembers: 5}
+	repo.On("Create", circle).Return(errors.New("db error"))
+
+	err := svc.Create(circle, nil)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
 // --- GetByID ---
 
 func TestStudyCircleGetByID_Success(t *testing.T) {
@@ -612,6 +623,14 @@ func TestStudyCircleDeleteStep_StepNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 }
 
+func TestStudyCircleDeleteStep_CircleNotFound(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	err := svc.DeleteStep(99, 1, 5)
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertExpectations(t)
+}
+
 func TestStudyCircleDeleteStep_StepBelongsToDifferentCircle(t *testing.T) {
 	svc, repo := newTestStudyCircleService()
 	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
@@ -792,4 +811,84 @@ func TestSearchCircles_RepoError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.Nil(t, result)
+}
+
+func TestStudyCircleUpdateStep_WithDescription(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	circle := &model.StudyCircle{OwnerID: 1}
+	circle.ID = 1
+	step := &model.StudyCircleStep{CircleID: 1, Title: "Title", Description: "Old Desc"}
+	step.ID = 5
+
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+	repo.On("UpdateStep", step).Return(nil)
+
+	newDesc := "New Description"
+	result, err := svc.UpdateStep(1, 1, 5, nil, &newDesc)
+	assert.NoError(t, err)
+	assert.Equal(t, "New Description", result.Description)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleReorderSteps_NotFound(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.ReorderSteps(99, 1, []model.StepOrder{})
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleUpdate_FindByIDError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	newName := "変更"
+	result, err := svc.Update(99, 1, &newName, nil, nil)
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleUpdate_TopicAndDescription(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("Update", circle).Return(nil)
+
+	newTopic := "新トピック"
+	newDesc := "新説明"
+	result, err := svc.Update(1, 1, nil, &newTopic, &newDesc)
+	assert.NoError(t, err)
+	assert.Equal(t, "新トピック", result.Topic)
+	assert.Equal(t, "新説明", result.Description)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleUpdateStep_CircleNotFound(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	newTitle := "Title"
+	result, err := svc.UpdateStep(99, 1, 5, &newTitle, nil)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleCreateCheckin_IsMemberError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("IsMember", uint(1), uint(1)).Return(false, errors.New("db error"))
+
+	result, err := svc.CreateCheckin(1, 1, "content")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
- サービス層のユニットテストを大幅に追加し、カバレッジを **79.2% → 82.0%** に改善

## 変更内容
- 未カバーブランチを中心に20ファイルへテストを追加（合計1,121行）
- 主なカバレッジ向上ポイント：
  - `FindByID` エラーパス（→ NotFound/エラー返却）
  - フィールドの一部更新テスト（nil/空文字をスキップする分岐）
  - バリデーションエラーパス（長すぎる文字列でトリガー）
  - DB操作エラーパス（repo.Update、repo.Create等）
  - IsMember/CountByUserID等の補助リポジトリエラーパス

## テスト実行結果
```
ok  github.com/norman6464/devsync/backend/internal/service  coverage: 82.0% of statements
```