### PR TITLE
fix: セキュリティ強化 - エラーメッセージ隠蔽・パスワード最小長引き上げ

### DIFF
--- a/backend/internal/domain/validators.go
+++ b/backend/internal/domain/validators.go
@@ -16,7 +16,7 @@ const (
 
 // Password validation constants
 const (
-	MinPasswordLength = 6
+	MinPasswordLength = 8
 	MaxPasswordLength = 128
 )
 

--- a/backend/internal/domain/validators_test.go
+++ b/backend/internal/domain/validators_test.go
@@ -44,8 +44,8 @@ func TestValidatePassword(t *testing.T) {
 	}{
 		{"有効なパスワード", "password123", false},
 		{"有効なパスワード（記号付き）", "pass@word!", false},
-		{"有効なパスワード（最小長）", "pass1!", false},
-		{"無効なパスワード（短すぎる）", "pass", true},
+		{"有効なパスワード（最小長）", "passw0rd!", false},
+		{"無効なパスワード（短すぎる）", "pass1!", true},
 		{"無効なパスワード（数字記号なし）", "password", true},
 		{"無効なパスワード（空）", "", true},
 		{"無効なパスワード（長すぎる）", strings.Repeat("a", 130), true},

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -54,7 +54,7 @@ func parseLimitOffset(c *gin.Context) (limit, offset int) {
 func bindJSON[T any](c *gin.Context) *T {
 	var req T
 	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+		respondBadRequest(c, "リクエストの形式が不正です")
 		return nil
 	}
 	return &req
@@ -70,8 +70,8 @@ func respondError(c *gin.Context, err error) {
 		return
 	}
 
-	// DomainError でない場合は内部エラーとして扱う
-	response := domain.NewErrorResponse(err.Error(), "", nil)
+	// DomainError でない場合は内部エラーとして扱う（内部エラーの詳細は隠蔽）
+	response := domain.NewErrorResponse("内部エラーが発生しました", string(domain.ErrCodeInternal), nil)
 	c.JSON(http.StatusInternalServerError, response)
 }
 


### PR DESCRIPTION
## 概要
Closes #705

セキュリティ調査で特定した3点の問題を修正。

## 変更内容

### 1. `bindJSON` バリデーションエラーの隠蔽
`handler/helpers.go` の `bindJSON` が `err.Error()` をクライアントに返却していた問題を修正。
内部構造体フィールド名（例: `Key: 'CreateStudyCircleRequest.Name' Error:Field validation for 'Name'`）が露出しないよう汎用メッセージに変更。

### 2. `respondError` 内部エラーメッセージの隠蔽
`handler/helpers.go` の `respondError` が DomainError 以外のエラーを `err.Error()` でそのまま返却していた問題を修正。
DBエラー等の詳細情報が漏洩しないよう `"内部エラーが発生しました"` に統一。

### 3. パスワード最小長の引き上げ（6 → 8文字）
`domain/validators.go` の `MinPasswordLength` を 6 から 8 に引き上げ。
NIST SP 800-63B ガイドラインに準拠し、ブルートフォース攻撃耐性を向上。

## テスト
- `validators_test.go` のテストケースを新しい最小長要件に更新
- 全テストパス確認済み