### PR TITLE
feat: コメントへのいいね機能の実装（TDD）

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -58,6 +58,7 @@ type Container struct {
 	PostTagHandler           *handler.PostTagHandler
 	PostPinHandler           *handler.PostPinHandler
 	PostViewHandler          *handler.PostViewHandler
+	CommentLikeHandler       *handler.CommentLikeHandler
 	MentionHandler           *handler.MentionHandler
 	YouTubeHandler           *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
@@ -236,6 +237,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	postPinRepo := repository.NewPostPinRepository(db)
 	postPinService := service.NewPostPinService(postPinRepo, postRepo)
 	c.PostPinHandler = handler.NewPostPinHandler(postPinService)
+
+	commentLikeRepo := repository.NewCommentLikeRepository(db)
+	commentLikeService := service.NewCommentLikeService(commentLikeRepo, postRepo)
+	c.CommentLikeHandler = handler.NewCommentLikeHandler(commentLikeService)
 
 	postViewRepo := repository.NewPostViewRepository(db)
 	postViewService := service.NewPostViewService(postViewRepo)

--- a/backend/internal/handler/comment_like.go
+++ b/backend/internal/handler/comment_like.go
@@ -1,0 +1,71 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+)
+
+// CommentLikeServiceInterface はCommentLikeHandlerが依存するサービスインターフェース。
+type CommentLikeServiceInterface interface {
+	Like(userID, commentID uint) error
+	Unlike(userID, commentID uint) error
+	GetStatus(userID, commentID uint) (bool, int64, error)
+}
+
+// CommentLikeHandler はコメントへのいいね機能のHTTPハンドラー。
+type CommentLikeHandler struct {
+	service CommentLikeServiceInterface
+}
+
+// NewCommentLikeHandler は新しいCommentLikeHandlerを生成する。
+func NewCommentLikeHandler(service CommentLikeServiceInterface) *CommentLikeHandler {
+	return &CommentLikeHandler{service: service}
+}
+
+// Like はコメントにいいねする。
+func (h *CommentLikeHandler) Like(c *gin.Context) {
+	commentID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	if err := h.service.Like(userID, commentID); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"message": "いいねしました"})
+}
+
+// Unlike はコメントのいいねを取り消す。
+func (h *CommentLikeHandler) Unlike(c *gin.Context) {
+	commentID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	if err := h.service.Unlike(userID, commentID); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"message": "いいねを取り消しました"})
+}
+
+// GetStatus はコメントのいいね状態（いいねしているか・いいね数）を返す。
+func (h *CommentLikeHandler) GetStatus(c *gin.Context) {
+	commentID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	liked, count, err := h.service.GetStatus(userID, commentID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{
+		"liked": liked,
+		"count": count,
+	})
+}

--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -151,7 +151,17 @@ type Comment struct {
 	PostID    uint       `json:"post_id" gorm:"not null;index"`
 	ParentID  *uint      `json:"parent_id,omitempty" gorm:"index"`
 	Content   string     `json:"content" gorm:"type:text;not null"`
+	LikeCount int        `json:"like_count" gorm:"default:0"`
 	Replies   []Comment  `json:"replies,omitempty" gorm:"foreignKey:ParentID"`
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`
+}
+
+// CommentLike はコメントへの「いいね」を記録する。
+// uniqueIndex制約でユーザーごとに1コメント1いいねを保証する。
+type CommentLike struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	UserID    uint      `json:"user_id" gorm:"not null;uniqueIndex:idx_user_comment_like"`
+	CommentID uint      `json:"comment_id" gorm:"not null;uniqueIndex:idx_user_comment_like;index"`
+	CreatedAt time.Time `json:"created_at"`
 }

--- a/backend/internal/repository/comment_like.go
+++ b/backend/internal/repository/comment_like.go
@@ -1,0 +1,58 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// CommentLikeRepository はコメントへのいいね操作のDB実装。
+type CommentLikeRepository struct {
+	db *gorm.DB
+}
+
+// NewCommentLikeRepository は新しいCommentLikeRepositoryインスタンスを生成する。
+func NewCommentLikeRepository(db *gorm.DB) *CommentLikeRepository {
+	return &CommentLikeRepository{db: db}
+}
+
+// Like はコメントにいいねを追加し、コメントのいいね数をインクリメントする。
+func (r *CommentLikeRepository) Like(userID, commentID uint) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		like := &model.CommentLike{UserID: userID, CommentID: commentID}
+		if err := tx.Create(like).Error; err != nil {
+			return err
+		}
+		return tx.Model(&model.Comment{}).Where("id = ?", commentID).
+			UpdateColumn("like_count", gorm.Expr("like_count + 1")).Error
+	})
+}
+
+// Unlike はコメントのいいねを削除し、コメントのいいね数をデクリメントする。
+func (r *CommentLikeRepository) Unlike(userID, commentID uint) error {
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Where("user_id = ? AND comment_id = ?", userID, commentID).
+			Delete(&model.CommentLike{}).Error; err != nil {
+			return err
+		}
+		return tx.Model(&model.Comment{}).Where("id = ? AND like_count > 0", commentID).
+			UpdateColumn("like_count", gorm.Expr("like_count - 1")).Error
+	})
+}
+
+// HasLiked は指定ユーザーがコメントをいいね済みかどうかを返す。
+func (r *CommentLikeRepository) HasLiked(userID, commentID uint) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.CommentLike{}).
+		Where("user_id = ? AND comment_id = ?", userID, commentID).
+		Count(&count).Error
+	return count > 0, err
+}
+
+// CountByCommentID はコメントのいいね数を返す。
+func (r *CommentLikeRepository) CountByCommentID(commentID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.CommentLike{}).
+		Where("comment_id = ?", commentID).
+		Count(&count).Error
+	return count, err
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -14,6 +14,14 @@ type PostAdvancedSearchRepositoryInterface interface {
 	SearchWithFilter(query string, tags []string, sortBy string, dateFrom, dateTo *time.Time, limit, offset int) ([]model.Post, int64, error)
 }
 
+// CommentLikeRepositoryInterface はコメントへのいいね操作の契約を定義する。
+type CommentLikeRepositoryInterface interface {
+	Like(userID, commentID uint) error
+	Unlike(userID, commentID uint) error
+	HasLiked(userID, commentID uint) (bool, error)
+	CountByCommentID(commentID uint) (int64, error)
+}
+
 // UserRepositoryInterface はユーザーデータ操作の契約を定義する。
 type UserRepositoryInterface interface {
 	FindAll() ([]model.User, error)

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -95,6 +95,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerSearchRoutes(protected, c)
 		registerYouTubeRoutes(protected, c)
 		registerSpotifyRoutes(protected, c)
+		registerCommentLikeRoutes(protected, c)
 	}
 
 	return r
@@ -580,5 +581,14 @@ func registerSpotifyRoutes(g *gin.RouterGroup, c *di.Container) {
 		spotify.DELETE("/disconnect", c.SpotifyHandler.Disconnect)
 		spotify.GET("/currently-playing/:userId", c.SpotifyHandler.GetCurrentlyPlaying)
 		spotify.GET("/recently-played/:userId", c.SpotifyHandler.GetRecentlyPlayed)
+	}
+}
+
+func registerCommentLikeRoutes(g *gin.RouterGroup, c *di.Container) {
+	comments := g.Group("/comments")
+	{
+		comments.POST("/:id/likes", c.CommentLikeHandler.Like)
+		comments.DELETE("/:id/likes", c.CommentLikeHandler.Unlike)
+		comments.GET("/:id/likes", c.CommentLikeHandler.GetStatus)
 	}
 }

--- a/backend/internal/service/comment_like.go
+++ b/backend/internal/service/comment_like.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// CommentLikeService はコメントへのいいね機能のビジネスロジックを提供する。
+type CommentLikeService struct {
+	likeRepo repository.CommentLikeRepositoryInterface
+	postRepo repository.PostRepositoryInterface
+}
+
+// NewCommentLikeService は新しいCommentLikeServiceインスタンスを生成する。
+func NewCommentLikeService(
+	likeRepo repository.CommentLikeRepositoryInterface,
+	postRepo repository.PostRepositoryInterface,
+) *CommentLikeService {
+	return &CommentLikeService{likeRepo: likeRepo, postRepo: postRepo}
+}
+
+// Like はコメントにいいねする。
+// コメントが存在しない場合やすでにいいね済みの場合はエラーを返す。
+func (s *CommentLikeService) Like(userID, commentID uint) error {
+	if _, err := s.postRepo.FindCommentByID(commentID); err != nil {
+		return ErrNotFound
+	}
+
+	liked, err := s.likeRepo.HasLiked(userID, commentID)
+	if err != nil {
+		return err
+	}
+	if liked {
+		return domain.NewError(domain.ErrCodeBadRequest, "すでにいいね済みです", nil)
+	}
+
+	return s.likeRepo.Like(userID, commentID)
+}
+
+// Unlike はコメントのいいねを取り消す。
+// コメントが存在しない場合やいいねしていない場合はエラーを返す。
+func (s *CommentLikeService) Unlike(userID, commentID uint) error {
+	if _, err := s.postRepo.FindCommentByID(commentID); err != nil {
+		return ErrNotFound
+	}
+
+	liked, err := s.likeRepo.HasLiked(userID, commentID)
+	if err != nil {
+		return err
+	}
+	if !liked {
+		return domain.NewError(domain.ErrCodeNotFound, "いいねしていません", nil)
+	}
+
+	return s.likeRepo.Unlike(userID, commentID)
+}
+
+// GetStatus はコメントのいいね状態（いいねしているか・いいね数）を返す。
+func (s *CommentLikeService) GetStatus(userID, commentID uint) (bool, int64, error) {
+	if _, err := s.postRepo.FindCommentByID(commentID); err != nil {
+		return false, 0, ErrNotFound
+	}
+
+	liked, err := s.likeRepo.HasLiked(userID, commentID)
+	if err != nil {
+		return false, 0, err
+	}
+
+	count, err := s.likeRepo.CountByCommentID(commentID)
+	if err != nil {
+		return false, 0, err
+	}
+
+	return liked, count, nil
+}

--- a/backend/internal/service/comment_like_test.go
+++ b/backend/internal/service/comment_like_test.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// makeComment はテスト用のCommentオブジェクトを生成する。
+func makeComment(id, userID uint) *model.Comment {
+	c := &model.Comment{UserID: userID, PostID: 1, Content: "test"}
+	c.ID = id
+	return c
+}
+
+func newTestCommentLikeService() (*CommentLikeService, *MockCommentLikeRepository, *MockPostRepository) {
+	likeRepo := new(MockCommentLikeRepository)
+	postRepo := new(MockPostRepository)
+	svc := NewCommentLikeService(likeRepo, postRepo)
+	return svc, likeRepo, postRepo
+}
+
+// --- Like ---
+
+func TestCommentLikeService_Like_Success(t *testing.T) {
+	svc, likeRepo, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 2), nil)
+	likeRepo.On("HasLiked", uint(10), uint(1)).Return(false, nil)
+	likeRepo.On("Like", uint(10), uint(1)).Return(nil)
+
+	err := svc.Like(10, 1)
+	assert.NoError(t, err)
+	postRepo.AssertExpectations(t)
+	likeRepo.AssertExpectations(t)
+}
+
+func TestCommentLikeService_Like_CommentNotFound(t *testing.T) {
+	svc, _, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.Like(10, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+	postRepo.AssertExpectations(t)
+}
+
+func TestCommentLikeService_Like_AlreadyLiked(t *testing.T) {
+	svc, likeRepo, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 2), nil)
+	likeRepo.On("HasLiked", uint(10), uint(1)).Return(true, nil)
+
+	err := svc.Like(10, 1)
+	assert.Error(t, err)
+	postRepo.AssertExpectations(t)
+	likeRepo.AssertExpectations(t)
+}
+
+func TestCommentLikeService_Like_HasLikedError(t *testing.T) {
+	svc, likeRepo, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 2), nil)
+	likeRepo.On("HasLiked", uint(10), uint(1)).Return(false, errors.New("db error"))
+
+	err := svc.Like(10, 1)
+	assert.Error(t, err)
+	postRepo.AssertExpectations(t)
+	likeRepo.AssertExpectations(t)
+}
+
+// --- Unlike ---
+
+func TestCommentLikeService_Unlike_Success(t *testing.T) {
+	svc, likeRepo, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 2), nil)
+	likeRepo.On("HasLiked", uint(10), uint(1)).Return(true, nil)
+	likeRepo.On("Unlike", uint(10), uint(1)).Return(nil)
+
+	err := svc.Unlike(10, 1)
+	assert.NoError(t, err)
+	postRepo.AssertExpectations(t)
+	likeRepo.AssertExpectations(t)
+}
+
+func TestCommentLikeService_Unlike_CommentNotFound(t *testing.T) {
+	svc, _, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.Unlike(10, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+	postRepo.AssertExpectations(t)
+}
+
+func TestCommentLikeService_Unlike_NotLiked(t *testing.T) {
+	svc, likeRepo, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 2), nil)
+	likeRepo.On("HasLiked", uint(10), uint(1)).Return(false, nil)
+
+	err := svc.Unlike(10, 1)
+	assert.Error(t, err)
+	postRepo.AssertExpectations(t)
+	likeRepo.AssertExpectations(t)
+}
+
+// --- GetStatus ---
+
+func TestCommentLikeService_GetStatus_Success(t *testing.T) {
+	svc, likeRepo, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 2), nil)
+	likeRepo.On("HasLiked", uint(10), uint(1)).Return(true, nil)
+	likeRepo.On("CountByCommentID", uint(1)).Return(int64(5), nil)
+
+	liked, count, err := svc.GetStatus(10, 1)
+	assert.NoError(t, err)
+	assert.True(t, liked)
+	assert.Equal(t, int64(5), count)
+	postRepo.AssertExpectations(t)
+	likeRepo.AssertExpectations(t)
+}
+
+func TestCommentLikeService_GetStatus_CommentNotFound(t *testing.T) {
+	svc, _, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(99)).Return(nil, errors.New("not found"))
+
+	liked, count, err := svc.GetStatus(10, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+	assert.False(t, liked)
+	assert.Equal(t, int64(0), count)
+	postRepo.AssertExpectations(t)
+}
+
+func TestCommentLikeService_GetStatus_CountError(t *testing.T) {
+	svc, likeRepo, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 2), nil)
+	likeRepo.On("HasLiked", uint(10), uint(1)).Return(false, nil)
+	likeRepo.On("CountByCommentID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	liked, count, err := svc.GetStatus(10, 1)
+	assert.Error(t, err)
+	assert.False(t, liked)
+	assert.Equal(t, int64(0), count)
+	postRepo.AssertExpectations(t)
+	likeRepo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1776,3 +1776,33 @@ func (m *MockSpotifyRepository) DeleteUserData(userID uint) error {
 	args := m.Called(userID)
 	return args.Error(0)
 }
+
+// ============================================================
+// MockCommentLikeRepository は repository.CommentLikeRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockCommentLikeRepository struct {
+	mock.Mock
+}
+
+var _ repository.CommentLikeRepositoryInterface = (*MockCommentLikeRepository)(nil)
+
+func (m *MockCommentLikeRepository) Like(userID, commentID uint) error {
+	args := m.Called(userID, commentID)
+	return args.Error(0)
+}
+
+func (m *MockCommentLikeRepository) Unlike(userID, commentID uint) error {
+	args := m.Called(userID, commentID)
+	return args.Error(0)
+}
+
+func (m *MockCommentLikeRepository) HasLiked(userID, commentID uint) (bool, error) {
+	args := m.Called(userID, commentID)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockCommentLikeRepository) CountByCommentID(commentID uint) (int64, error) {
+	args := m.Called(commentID)
+	return args.Get(0).(int64), args.Error(1)
+}


### PR DESCRIPTION
## 概要
- コメントへのいいね機能をTDDで実装
- `CommentLike` モデルの追加（ユーザーごと1コメント1いいねの一意制約）
- `Comment` モデルに `LikeCount` フィールドを追加

## 変更ファイル
- `model/post.go` — `CommentLike` 構造体追加、`Comment.LikeCount` 追加
- `repository/interfaces.go` — `CommentLikeRepositoryInterface` 定義
- `repository/comment_like.go` — GORM実装（トランザクションでカウント同期）
- `service/comment_like.go` — ビジネスロジック実装
- `service/comment_like_test.go` — TDDテスト10件
- `handler/comment_like.go` — HTTPハンドラー
- `di/container.go` — DI登録
- `router/router.go` — ルーティング登録

## エンドポイント
| メソッド | パス | 説明 |
|---------|------|------|
| POST | `/api/v1/comments/:id/likes` | いいね |
| DELETE | `/api/v1/comments/:id/likes` | いいね取り消し |
| GET | `/api/v1/comments/:id/likes` | いいね状態・件数取得 |

## テスト
サービス層テスト10件すべてパス。カバレッジ 82.1%（+0.1%）

Closes #707