### PR TITLE
refactor: SearchService の型定義を model 層に移動

### DIFF
--- a/backend/internal/handler/search.go
+++ b/backend/internal/handler/search.go
@@ -5,12 +5,12 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/norman6464/devsync/backend/internal/model"
 )
 
 // PostSearchService は投稿の高度な検索サービスのインターフェース。
 type PostSearchService interface {
-	SearchPosts(params service.PostSearchParams) (*service.PostSearchResult, error)
+	SearchPosts(params model.PostSearchParams) (*model.PostSearchResult, error)
 }
 
 // CircleSearchService はスタディサークル検索のサービスインターフェース。
@@ -63,7 +63,7 @@ func (h *SearchHandler) SearchPosts(c *gin.Context) {
 	}
 
 	// ソート順
-	sortBy := service.SearchSortBy(c.DefaultQuery("sort_by", string(service.SearchSortByLatest)))
+	sortBy := model.SearchSortBy(c.DefaultQuery("sort_by", string(model.SearchSortByLatest)))
 
 	// 日付範囲フィルター
 	var dateFrom, dateTo *time.Time
@@ -78,7 +78,7 @@ func (h *SearchHandler) SearchPosts(c *gin.Context) {
 		}
 	}
 
-	params := service.PostSearchParams{
+	params := model.PostSearchParams{
 		Query:    query,
 		Tags:     tags,
 		SortBy:   sortBy,

--- a/backend/internal/handler/search_test.go
+++ b/backend/internal/handler/search_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
-	"github.com/norman6464/devsync/backend/internal/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -18,12 +17,12 @@ type MockPostSearchService struct {
 	mock.Mock
 }
 
-func (m *MockPostSearchService) SearchPosts(params service.PostSearchParams) (*service.PostSearchResult, error) {
+func (m *MockPostSearchService) SearchPosts(params model.PostSearchParams) (*model.PostSearchResult, error) {
 	args := m.Called(params)
 	if args.Get(0) == nil {
 		return nil, args.Error(1)
 	}
-	return args.Get(0).(*service.PostSearchResult), args.Error(1)
+	return args.Get(0).(*model.PostSearchResult), args.Error(1)
 }
 
 // MockCircleSearchService は CircleSearchService のテスト用モック。
@@ -40,10 +39,10 @@ func TestSearchPosts_Success(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	mockSvc := new(MockPostSearchService)
-	mockSvc.On("SearchPosts", mock.MatchedBy(func(p service.PostSearchParams) bool {
+	mockSvc.On("SearchPosts", mock.MatchedBy(func(p model.PostSearchParams) bool {
 		return p.Query == "test" && p.Limit == 20 && p.Offset == 0
 	})).Return(
-		&service.PostSearchResult{
+		&model.PostSearchResult{
 			Posts: []model.Post{{ID: 1, Title: "Test Post", Content: "Test content"}},
 			Total: 1,
 			Limit: 20,
@@ -61,7 +60,7 @@ func TestSearchPosts_Success(t *testing.T) {
 	h.SearchPosts(c)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var response service.PostSearchResult
+	var response model.PostSearchResult
 	err := json.Unmarshal(w.Body.Bytes(), &response)
 	assert.NoError(t, err)
 	assert.Equal(t, int64(1), response.Total)
@@ -88,11 +87,11 @@ func TestSearchPosts_WithTagFilter(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	mockSvc := new(MockPostSearchService)
-	mockSvc.On("SearchPosts", mock.MatchedBy(func(p service.PostSearchParams) bool {
+	mockSvc.On("SearchPosts", mock.MatchedBy(func(p model.PostSearchParams) bool {
 		return p.Query == "Go" && len(p.Tags) == 2 &&
 			p.Tags[0] == "golang" && p.Tags[1] == "beginner"
 	})).Return(
-		&service.PostSearchResult{
+		&model.PostSearchResult{
 			Posts: []model.Post{{Title: "Go入門"}},
 			Total: 1,
 			Limit: 20,
@@ -117,10 +116,10 @@ func TestSearchPosts_WithSortBy(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	mockSvc := new(MockPostSearchService)
-	mockSvc.On("SearchPosts", mock.MatchedBy(func(p service.PostSearchParams) bool {
-		return p.Query == "記事" && p.SortBy == service.SearchSortByPopular
+	mockSvc.On("SearchPosts", mock.MatchedBy(func(p model.PostSearchParams) bool {
+		return p.Query == "記事" && p.SortBy == model.SearchSortByPopular
 	})).Return(
-		&service.PostSearchResult{
+		&model.PostSearchResult{
 			Posts: []model.Post{{Title: "人気記事", LikeCount: 100}},
 			Total: 1,
 			Limit: 20,

--- a/backend/internal/model/search.go
+++ b/backend/internal/model/search.go
@@ -1,0 +1,31 @@
+package model
+
+import "time"
+
+// SearchSortBy は検索結果のソート順を表す。
+type SearchSortBy string
+
+const (
+	SearchSortByLatest  SearchSortBy = "latest"  // 最新順
+	SearchSortByPopular SearchSortBy = "popular" // 人気順（いいね数）
+	SearchSortByViews   SearchSortBy = "views"   // 閲覧数順
+)
+
+// PostSearchParams は投稿検索のパラメータ。
+type PostSearchParams struct {
+	Query    string
+	Tags     []string
+	SortBy   SearchSortBy
+	DateFrom *time.Time
+	DateTo   *time.Time
+	Limit    int
+	Offset   int
+}
+
+// PostSearchResult は投稿検索結果のレスポンス。
+type PostSearchResult struct {
+	Posts  []Post `json:"posts"`
+	Total  int64  `json:"total"`
+	Limit  int    `json:"limit"`
+	Offset int    `json:"offset"`
+}

--- a/backend/internal/service/search_service.go
+++ b/backend/internal/service/search_service.go
@@ -12,34 +12,6 @@ const (
 	maxSearchLimit     = 100
 )
 
-// SearchSortBy は検索結果のソート順を表す。
-type SearchSortBy string
-
-const (
-	SearchSortByLatest  SearchSortBy = "latest"  // 最新順
-	SearchSortByPopular SearchSortBy = "popular" // 人気順（いいね数）
-	SearchSortByViews   SearchSortBy = "views"   // 閲覧数順
-)
-
-// PostSearchParams は投稿検索のパラメータ。
-type PostSearchParams struct {
-	Query    string
-	Tags     []string
-	SortBy   SearchSortBy
-	DateFrom *time.Time
-	DateTo   *time.Time
-	Limit    int
-	Offset   int
-}
-
-// PostSearchResult は投稿検索結果のレスポンス。
-type PostSearchResult struct {
-	Posts  []model.Post `json:"posts"`
-	Total  int64        `json:"total"`
-	Limit  int          `json:"limit"`
-	Offset int          `json:"offset"`
-}
-
 // PostAdvancedSearchRepo は投稿の高度な検索リポジトリのインターフェース。
 type PostAdvancedSearchRepo interface {
 	SearchWithFilter(query string, tags []string, sortBy string, dateFrom, dateTo *time.Time, limit, offset int) ([]model.Post, int64, error)
@@ -57,7 +29,7 @@ func NewSearchService(postSearchRepo PostAdvancedSearchRepo) *SearchService {
 
 // SearchPosts は投稿の高度な検索を実行する。
 // タグフィルター・日付範囲・ソート順に対応する。
-func (s *SearchService) SearchPosts(params PostSearchParams) (*PostSearchResult, error) {
+func (s *SearchService) SearchPosts(params model.PostSearchParams) (*model.PostSearchResult, error) {
 	if params.Query == "" {
 		return nil, domain.NewError(domain.ErrCodeBadRequest, "検索クエリは必須です", nil)
 	}
@@ -73,7 +45,7 @@ func (s *SearchService) SearchPosts(params PostSearchParams) (*PostSearchResult,
 	// ソート順の正規化
 	sortBy := string(params.SortBy)
 	if sortBy == "" {
-		sortBy = string(SearchSortByLatest)
+		sortBy = string(model.SearchSortByLatest)
 	}
 
 	posts, total, err := s.postSearchRepo.SearchWithFilter(
@@ -89,7 +61,7 @@ func (s *SearchService) SearchPosts(params PostSearchParams) (*PostSearchResult,
 		return nil, err
 	}
 
-	return &PostSearchResult{
+	return &model.PostSearchResult{
 		Posts:  posts,
 		Total:  total,
 		Limit:  limit,

--- a/backend/internal/service/search_service_test.go
+++ b/backend/internal/service/search_service_test.go
@@ -50,7 +50,7 @@ func TestSearchPosts_NoFilter_Success(t *testing.T) {
 	repo.On("SearchWithFilter", "Go", []string(nil), "latest", (*time.Time)(nil), (*time.Time)(nil), 20, 0).
 		Return(expected, int64(2), nil)
 
-	params := PostSearchParams{Query: "Go", Limit: 20, Offset: 0}
+	params := model.PostSearchParams{Query: "Go", Limit: 20, Offset: 0}
 	result, err := svc.SearchPosts(params)
 
 	assert.NoError(t, err)
@@ -71,7 +71,7 @@ func TestSearchPosts_WithTagFilter_Success(t *testing.T) {
 	repo.On("SearchWithFilter", "Go", tags, "latest", (*time.Time)(nil), (*time.Time)(nil), 20, 0).
 		Return(expected, int64(1), nil)
 
-	params := PostSearchParams{
+	params := model.PostSearchParams{
 		Query:  "Go",
 		Tags:   tags,
 		Limit:  20,
@@ -96,9 +96,9 @@ func TestSearchPosts_WithSortPopular_Success(t *testing.T) {
 	repo.On("SearchWithFilter", "記事", []string(nil), "popular", (*time.Time)(nil), (*time.Time)(nil), 20, 0).
 		Return(expected, int64(2), nil)
 
-	params := PostSearchParams{
+	params := model.PostSearchParams{
 		Query:  "記事",
-		SortBy: SearchSortByPopular,
+		SortBy: model.SearchSortByPopular,
 		Limit:  20,
 		Offset: 0,
 	}
@@ -123,7 +123,7 @@ func TestSearchPosts_WithDateRange_Success(t *testing.T) {
 	repo.On("SearchWithFilter", "記事", []string(nil), "latest", &from, &to, 20, 0).
 		Return(expected, int64(1), nil)
 
-	params := PostSearchParams{
+	params := model.PostSearchParams{
 		Query:    "記事",
 		DateFrom: &from,
 		DateTo:   &to,
@@ -141,7 +141,7 @@ func TestSearchPosts_WithDateRange_Success(t *testing.T) {
 func TestSearchPosts_EmptyQuery_Error(t *testing.T) {
 	svc, _ := newTestSearchService()
 
-	params := PostSearchParams{Query: "", Limit: 20}
+	params := model.PostSearchParams{Query: "", Limit: 20}
 	result, err := svc.SearchPosts(params)
 
 	assert.Error(t, err)
@@ -155,7 +155,7 @@ func TestSearchPosts_LimitCapped_Success(t *testing.T) {
 	repo.On("SearchWithFilter", "Go", []string(nil), "latest", (*time.Time)(nil), (*time.Time)(nil), 100, 0).
 		Return([]model.Post{}, int64(0), nil)
 
-	params := PostSearchParams{Query: "Go", Limit: 200, Offset: 0}
+	params := model.PostSearchParams{Query: "Go", Limit: 200, Offset: 0}
 	_, err := svc.SearchPosts(params)
 
 	assert.NoError(t, err)
@@ -169,7 +169,7 @@ func TestSearchPosts_DefaultLimit_Success(t *testing.T) {
 	repo.On("SearchWithFilter", "Go", []string(nil), "latest", (*time.Time)(nil), (*time.Time)(nil), 20, 0).
 		Return([]model.Post{}, int64(0), nil)
 
-	params := PostSearchParams{Query: "Go"}
+	params := model.PostSearchParams{Query: "Go"}
 	_, err := svc.SearchPosts(params)
 
 	assert.NoError(t, err)
@@ -183,7 +183,7 @@ func TestSearchPosts_RepositoryError(t *testing.T) {
 	repo.On("SearchWithFilter", "Go", []string(nil), "latest", (*time.Time)(nil), (*time.Time)(nil), 20, 0).
 		Return(nil, int64(0), errors.New("db error"))
 
-	params := PostSearchParams{Query: "Go", Limit: 20}
+	params := model.PostSearchParams{Query: "Go", Limit: 20}
 	result, err := svc.SearchPosts(params)
 
 	assert.Error(t, err)


### PR DESCRIPTION
## 概要
handler/search.go が service パッケージを直接インポートしていたクリーンアーキテクチャ違反を解消する。

## 問題
handler 層が service 層の型を直接参照することは、handler → service の型依存を生み、
「handler はインターフェース経由のみで service 層と通信する」という原則に違反する。

## 変更内容
- `model/search.go` を新規作成
  - `PostSearchParams`・`PostSearchResult`・`SearchSortBy` を model 層に移動
- `service/search_service.go` — service 独自の型定義を削除し model 型を使用
- `handler/search.go` — `service` パッケージのインポートを削除し `model` のみを参照
- テスト更新（`search_service_test.go`・`search_test.go`）

## 効果
- handler 層が service 型に直接依存しなくなり疎結合を実現
- model 層（最下位依存パッケージ）に共有型を置くことで循環インポートを回避
- 全テスト通過

Closes #709