### PR TITLE
feat: コメントいいね機能のフロントエンド対応

### DIFF
--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -113,3 +113,12 @@ export const addReaction = (postId: number, emoji: string) =>
 
 export const removeReaction = (postId: number, emoji: string) =>
   client.delete(`/posts/${postId}/reactions`, { data: { emoji } });
+
+export const likeComment = (commentId: number) =>
+  client.post(`/comments/${commentId}/likes`);
+
+export const unlikeComment = (commentId: number) =>
+  client.delete(`/comments/${commentId}/likes`);
+
+export const getCommentLikeStatus = (commentId: number) =>
+  client.get<{ liked: boolean; like_count: number }>(`/comments/${commentId}/likes`);

--- a/frontend/src/components/posts/CommentLikeButton.tsx
+++ b/frontend/src/components/posts/CommentLikeButton.tsx
@@ -1,0 +1,51 @@
+import { useTranslation } from 'react-i18next';
+import { useCommentLike } from '../../hooks/useCommentLike';
+
+interface CommentLikeButtonProps {
+  commentId: number;
+  initialLiked: boolean;
+  initialCount: number;
+}
+
+export default function CommentLikeButton({
+  commentId,
+  initialLiked,
+  initialCount,
+}: CommentLikeButtonProps) {
+  const { t } = useTranslation();
+  const { liked, likeCount, toggleLike, loading } = useCommentLike(
+    commentId,
+    initialLiked,
+    initialCount,
+  );
+
+  return (
+    <button
+      onClick={toggleLike}
+      disabled={loading}
+      aria-pressed={liked}
+      aria-label={liked ? t('post.unlike') : t('post.like')}
+      className={`flex items-center gap-1 text-xs transition-colors disabled:opacity-50 ${
+        liked
+          ? 'text-pink-400 hover:text-pink-300'
+          : 'text-gray-500 hover:text-pink-400'
+      }`}
+    >
+      <svg
+        aria-hidden="true"
+        className="w-3.5 h-3.5"
+        fill={liked ? 'currentColor' : 'none'}
+        stroke="currentColor"
+        strokeWidth="2"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M21 8.25c0-2.485-2.099-4.5-4.688-4.5-1.935 0-3.597 1.126-4.312 2.733-.715-1.607-2.377-2.733-4.313-2.733C5.1 3.75 3 5.765 3 8.25c0 7.22 9 12 9 12s9-4.78 9-12Z"
+        />
+      </svg>
+      {likeCount > 0 && <span>{likeCount}</span>}
+    </button>
+  );
+}

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -50,3 +50,4 @@ export { useAutoSave } from './useAutoSave';
 export { useConfirm } from './useConfirm';
 export { useOnboarding } from './useOnboarding';
 export { useYoutube } from './useYoutube';
+export { useCommentLike } from './useCommentLike';

--- a/frontend/src/hooks/useCommentLike.ts
+++ b/frontend/src/hooks/useCommentLike.ts
@@ -1,0 +1,41 @@
+import { useState, useCallback } from 'react';
+import { likeComment, unlikeComment } from '../api/posts';
+import toast from 'react-hot-toast';
+
+export function useCommentLike(
+  commentId: number,
+  initialLiked: boolean,
+  initialCount: number,
+) {
+  const [liked, setLiked] = useState(initialLiked);
+  const [likeCount, setLikeCount] = useState(initialCount);
+  const [loading, setLoading] = useState(false);
+
+  const toggleLike = useCallback(async () => {
+    if (loading) return;
+    setLoading(true);
+    const prevLiked = liked;
+    const prevCount = likeCount;
+
+    // 楽観的UI更新
+    setLiked(!prevLiked);
+    setLikeCount(prevLiked ? prevCount - 1 : prevCount + 1);
+
+    try {
+      if (prevLiked) {
+        await unlikeComment(commentId);
+      } else {
+        await likeComment(commentId);
+      }
+    } catch {
+      // 失敗時はロールバック
+      setLiked(prevLiked);
+      setLikeCount(prevCount);
+      toast.error('操作に失敗しました');
+    } finally {
+      setLoading(false);
+    }
+  }, [commentId, liked, likeCount, loading]);
+
+  return { liked, likeCount, toggleLike, loading };
+}

--- a/frontend/src/pages/PostDetailPage.tsx
+++ b/frontend/src/pages/PostDetailPage.tsx
@@ -12,6 +12,7 @@ import Avatar from '../components/common/Avatar';
 import MentionInput from '../components/common/MentionInput';
 import MentionText from '../components/common/MentionText';
 import { PageLoader, Modal } from '../components/common';
+import CommentLikeButton from '../components/posts/CommentLikeButton';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 import { format } from 'date-fns';
 import toast from 'react-hot-toast';
@@ -157,15 +158,22 @@ export default function PostDetailPage() {
                     <p className="text-sm text-gray-300 mt-1 leading-relaxed">
                       <MentionText text={comment.content} />
                     </p>
-                    <button
-                      onClick={() => {
-                        setReplyingTo(replyingTo === comment.id ? null : comment.id);
-                        setReplyContent('');
-                      }}
-                      className="mt-1.5 text-xs text-gray-500 hover:text-blue-400 transition-colors"
-                    >
-                      {t('post.reply')}
-                    </button>
+                    <div className="flex items-center gap-3 mt-1.5">
+                      <CommentLikeButton
+                        commentId={comment.id}
+                        initialLiked={comment.liked ?? false}
+                        initialCount={comment.like_count ?? 0}
+                      />
+                      <button
+                        onClick={() => {
+                          setReplyingTo(replyingTo === comment.id ? null : comment.id);
+                          setReplyContent('');
+                        }}
+                        className="text-xs text-gray-500 hover:text-blue-400 transition-colors"
+                      >
+                        {t('post.reply')}
+                      </button>
+                    </div>
                   </div>
                 </div>
 
@@ -214,6 +222,13 @@ export default function PostDetailPage() {
                           <p className="text-sm text-gray-300 mt-0.5 leading-relaxed">
                             <MentionText text={reply.content} />
                           </p>
+                          <div className="mt-1">
+                            <CommentLikeButton
+                              commentId={reply.id}
+                              initialLiked={reply.liked ?? false}
+                              initialCount={reply.like_count ?? 0}
+                            />
+                          </div>
                         </div>
                       </div>
                     ))}

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -33,6 +33,8 @@ export interface Comment {
   post_id: number;
   parent_id?: number;
   content: string;
+  like_count: number;
+  liked?: boolean;
   replies?: Comment[];
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## 概要

バックエンド（PR #708）で実装済みのコメントいいね機能をフロントエンドに表示・操作できるようにする。

## 変更内容

### 型定義（`types/post.ts`）
- `Comment` 型に `like_count: number`・`liked?: boolean` フィールドを追加

### API（`api/posts.ts`）
- `likeComment(commentId)` - コメントにいいね
- `unlikeComment(commentId)` - いいね解除
- `getCommentLikeStatus(commentId)` - いいね状態取得

### カスタムフック（`hooks/useCommentLike.ts`）
- 楽観的UI更新（即時反映・エラー時ロールバック）
- `hooks/index.ts` にエクスポート追加

### UIコンポーネント（`components/posts/CommentLikeButton.tsx`）
- ハートアイコン＋いいね数表示
- aria-pressed/aria-label でアクセシビリティ対応

### ページ（`pages/PostDetailPage.tsx`）
- コメント・返信の両方に `CommentLikeButton` を統合

Closes #715