### PR TITLE
fix: DeleteCommentの所有権チェックをservice層に移動

### DIFF
--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -55,7 +55,7 @@ type PostRepositoryInterface interface {
 	FindCommentByID(id uint) (*model.Comment, error)
 	GetComments(postID uint) ([]model.Comment, error)
 	GetReplies(parentID uint) ([]model.Comment, error)
-	DeleteComment(id, userID uint) error
+	DeleteComment(id uint) error
 	Bookmark(userID, postID uint) error
 	Unbookmark(userID, postID uint) error
 	HasBookmarked(userID, postID uint) bool

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -130,14 +130,11 @@ func (r *PostRepository) GetReplies(parentID uint) ([]model.Comment, error) {
 }
 
 // DeleteComment はコメントを削除し、投稿のcomment_countをデクリメントする。
-// userIDによる所有権チェックを行う。
-func (r *PostRepository) DeleteComment(id, userID uint) error {
+// 所有権チェックはservice層で実施済みであること。
+func (r *PostRepository) DeleteComment(id uint) error {
 	var comment model.Comment
 	if err := r.db.First(&comment, id).Error; err != nil {
 		return err
-	}
-	if comment.UserID != userID {
-		return gorm.ErrRecordNotFound
 	}
 	r.db.Model(&model.Post{}).Where("id = ?", comment.PostID).UpdateColumn("comment_count", gorm.Expr("GREATEST(comment_count - 1, 0)"))
 	return r.db.Delete(&comment).Error

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -174,8 +174,8 @@ func (m *MockPostRepository) GetReplies(parentID uint) ([]model.Comment, error) 
 	return args.Get(0).([]model.Comment), args.Error(1)
 }
 
-func (m *MockPostRepository) DeleteComment(id, userID uint) error {
-	args := m.Called(id, userID)
+func (m *MockPostRepository) DeleteComment(id uint) error {
+	args := m.Called(id)
 	return args.Error(0)
 }
 

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -192,9 +192,18 @@ func (s *PostService) GetReplies(parentID uint) ([]model.Comment, error) {
 	return s.repo.GetReplies(parentID)
 }
 
-// DeleteComment はコメントを削除する。
+// DeleteComment は所有権を検証した後、コメントを削除する。
 func (s *PostService) DeleteComment(id, userID uint) error {
-	return s.repo.DeleteComment(id, userID)
+	comment, err := s.repo.FindCommentByID(id)
+	if err != nil {
+		return err
+	}
+
+	if comment.UserID != userID {
+		return domain.NewError(domain.ErrCodeForbidden, "この操作を行う権限がありません", nil)
+	}
+
+	return s.repo.DeleteComment(id)
 }
 
 // Bookmark は投稿をブックマークする。

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -282,10 +283,40 @@ func TestPostGetComments_Success(t *testing.T) {
 func TestPostDeleteComment_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
-	postRepo.On("DeleteComment", uint(5), uint(1)).Return(nil)
+	comment := &model.Comment{PostID: 10}
+	comment.ID = 5
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(5)).Return(comment, nil)
+	postRepo.On("DeleteComment", uint(5)).Return(nil)
 
 	err := svc.DeleteComment(5, 1)
 	assert.NoError(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostDeleteComment_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	comment := &model.Comment{PostID: 10}
+	comment.ID = 5
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(5)).Return(comment, nil)
+
+	err := svc.DeleteComment(5, 999)
+	assert.Error(t, err)
+	var domainErr *domain.DomainError
+	assert.ErrorAs(t, err, &domainErr)
+	assert.Equal(t, domain.ErrCodeForbidden, domainErr.Code)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostDeleteComment_NotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindCommentByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.DeleteComment(99, 1)
+	assert.Error(t, err)
 	postRepo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
Issue #721 の対応。`DeleteComment` の所有権チェックをrepository層からservice層に移動し、クリーンアーキテクチャの原則に準拠。

## 変更内容
- `PostRepositoryInterface.DeleteComment(id, userID uint)` → `DeleteComment(id uint)` に変更
- `repository/post.go`: userIDパラメータ・所有権チェックを削除
- `service/post.go`: `FindCommentByID` → 所有権チェック（`domain.ErrCodeForbidden`）→ `DeleteComment(id)` の順で処理
- `mock_test.go`: モックのシグネチャを更新
- `post_test.go`: `TestPostDeleteComment_Forbidden` / `_NotFound` テストを追加

## テスト
- 全サービス層テストPASS
- Forbidden・NotFoundケースのテストを追加