### PR TITLE
feat: ユーザーダッシュボード統計APIの実装（TDD）

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -60,6 +60,7 @@ type Container struct {
 	PostViewHandler          *handler.PostViewHandler
 	CommentLikeHandler       *handler.CommentLikeHandler
 	MentionHandler           *handler.MentionHandler
+	UserDashboardHandler     *handler.UserDashboardHandler
 	YouTubeHandler           *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -249,6 +250,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	mentionRepo := repository.NewMentionRepository(db)
 	mentionService := service.NewMentionService(mentionRepo, userRepo, notificationService)
 	c.MentionHandler = handler.NewMentionHandler(mentionService)
+
+	userDashboardRepo := repository.NewUserDashboardRepository(db)
+	userDashboardService := service.NewUserDashboardService(userDashboardRepo)
+	c.UserDashboardHandler = handler.NewUserDashboardHandler(userDashboardService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/user_dashboard.go
+++ b/backend/internal/handler/user_dashboard.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// UserDashboardServiceInterface はUserDashboardHandlerが依存するサービスインターフェース。
+type UserDashboardServiceInterface interface {
+	GetStats(userID uint) (*model.UserDashboardStats, error)
+}
+
+// UserDashboardHandler はユーザーダッシュボード統計のHTTPハンドラー。
+type UserDashboardHandler struct {
+	service UserDashboardServiceInterface
+}
+
+// NewUserDashboardHandler は新しいUserDashboardHandlerを生成する。
+func NewUserDashboardHandler(service UserDashboardServiceInterface) *UserDashboardHandler {
+	return &UserDashboardHandler{service: service}
+}
+
+// GetStats は指定ユーザーのダッシュボード統計情報を返す。
+// GET /api/v1/users/:id/dashboard-stats
+func (h *UserDashboardHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, stats)
+}

--- a/backend/internal/model/dashboard.go
+++ b/backend/internal/model/dashboard.go
@@ -1,0 +1,12 @@
+package model
+
+// UserDashboardStats はユーザーダッシュボードの統計情報を表す。
+// プロフィールページや管理画面で表示する集計データ。
+type UserDashboardStats struct {
+	PostCount        int64 `json:"post_count"`
+	LikesReceived    int64 `json:"likes_received"`
+	CommentsReceived int64 `json:"comments_received"`
+	ViewsReceived    int64 `json:"views_received"`
+	FollowerCount    int64 `json:"follower_count"`
+	FollowingCount   int64 `json:"following_count"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -8,6 +8,11 @@ import (
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
+// UserDashboardRepositoryInterface はユーザーダッシュボード統計情報の取得契約を定義する。
+type UserDashboardRepositoryInterface interface {
+	GetDashboardStats(userID uint) (*model.UserDashboardStats, error)
+}
+
 // PostAdvancedSearchRepositoryInterface は投稿の高度な検索フィルター機能の契約を定義する。
 // タグ・日付範囲・ソート順による絞り込みを提供する。
 type PostAdvancedSearchRepositoryInterface interface {

--- a/backend/internal/repository/user_dashboard.go
+++ b/backend/internal/repository/user_dashboard.go
@@ -1,0 +1,69 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// UserDashboardRepository はユーザーダッシュボード統計データへのアクセスを提供する。
+type UserDashboardRepository struct {
+	db *gorm.DB
+}
+
+// NewUserDashboardRepository は新しいUserDashboardRepositoryインスタンスを生成する。
+func NewUserDashboardRepository(db *gorm.DB) *UserDashboardRepository {
+	return &UserDashboardRepository{db: db}
+}
+
+// GetDashboardStats は指定ユーザーのダッシュボード統計情報を集計して返す。
+// 投稿数・受信いいね数・受信コメント数・受信閲覧数・フォロワー数・フォロー数を返す。
+func (r *UserDashboardRepository) GetDashboardStats(userID uint) (*model.UserDashboardStats, error) {
+	stats := &model.UserDashboardStats{}
+
+	// 投稿数（下書き除外）
+	if err := r.db.Model(&model.Post{}).
+		Where("user_id = ? AND is_draft = ?", userID, false).
+		Count(&stats.PostCount).Error; err != nil {
+		return nil, err
+	}
+
+	// 受信いいね数
+	if err := r.db.Model(&model.Post{}).
+		Select("COALESCE(SUM(like_count), 0)").
+		Where("user_id = ?", userID).
+		Scan(&stats.LikesReceived).Error; err != nil {
+		return nil, err
+	}
+
+	// 受信コメント数
+	if err := r.db.Model(&model.Post{}).
+		Select("COALESCE(SUM(comment_count), 0)").
+		Where("user_id = ?", userID).
+		Scan(&stats.CommentsReceived).Error; err != nil {
+		return nil, err
+	}
+
+	// 受信閲覧数
+	if err := r.db.Model(&model.PostView{}).
+		Joins("JOIN posts ON posts.id = post_views.post_id").
+		Where("posts.user_id = ?", userID).
+		Count(&stats.ViewsReceived).Error; err != nil {
+		return nil, err
+	}
+
+	// フォロワー数
+	if err := r.db.Model(&model.Follow{}).
+		Where("followee_id = ?", userID).
+		Count(&stats.FollowerCount).Error; err != nil {
+		return nil, err
+	}
+
+	// フォロー数
+	if err := r.db.Model(&model.Follow{}).
+		Where("follower_id = ?", userID).
+		Count(&stats.FollowingCount).Error; err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -96,6 +96,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerYouTubeRoutes(protected, c)
 		registerSpotifyRoutes(protected, c)
 		registerCommentLikeRoutes(protected, c)
+		registerUserDashboardRoutes(protected, c)
 	}
 
 	return r
@@ -590,5 +591,12 @@ func registerCommentLikeRoutes(g *gin.RouterGroup, c *di.Container) {
 		comments.POST("/:id/likes", c.CommentLikeHandler.Like)
 		comments.DELETE("/:id/likes", c.CommentLikeHandler.Unlike)
 		comments.GET("/:id/likes", c.CommentLikeHandler.GetStatus)
+	}
+}
+
+func registerUserDashboardRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/dashboard-stats", c.UserDashboardHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1839,3 +1839,19 @@ func (m *MockCommentLikeRepository) CountByCommentID(commentID uint) (int64, err
 	args := m.Called(commentID)
 	return args.Get(0).(int64), args.Error(1)
 }
+
+// ============================================================
+// MockUserDashboardRepository は repository.UserDashboardRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockUserDashboardRepository struct {
+	mock.Mock
+}
+
+func (m *MockUserDashboardRepository) GetDashboardStats(userID uint) (*model.UserDashboardStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.UserDashboardStats), args.Error(1)
+}

--- a/backend/internal/service/user_dashboard.go
+++ b/backend/internal/service/user_dashboard.go
@@ -1,0 +1,26 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// UserDashboardService はユーザーダッシュボード統計のビジネスロジックを提供する。
+type UserDashboardService struct {
+	repo repository.UserDashboardRepositoryInterface
+}
+
+// NewUserDashboardService は新しいUserDashboardServiceインスタンスを生成する。
+func NewUserDashboardService(repo repository.UserDashboardRepositoryInterface) *UserDashboardService {
+	return &UserDashboardService{repo: repo}
+}
+
+// GetStats は指定ユーザーのダッシュボード統計情報を取得する。
+// userID=0 の場合はBadRequestエラーを返す。
+func (s *UserDashboardService) GetStats(userID uint) (*model.UserDashboardStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetDashboardStats(userID)
+}

--- a/backend/internal/service/user_dashboard_test.go
+++ b/backend/internal/service/user_dashboard_test.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestUserDashboardGetStats_Success は正常にダッシュボード統計が取得できることを確認する。
+func TestUserDashboardGetStats_Success(t *testing.T) {
+	mockRepo := &MockUserDashboardRepository{}
+	svc := NewUserDashboardService(mockRepo)
+
+	expected := &model.UserDashboardStats{
+		PostCount:        10,
+		LikesReceived:    50,
+		CommentsReceived: 20,
+		ViewsReceived:    300,
+		FollowerCount:    15,
+		FollowingCount:   8,
+	}
+	mockRepo.On("GetDashboardStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetStats(1)
+
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	mockRepo.AssertExpectations(t)
+}
+
+// TestUserDashboardGetStats_ZeroValues は全カウントが0のユーザーでも正常に取得できることを確認する。
+func TestUserDashboardGetStats_ZeroValues(t *testing.T) {
+	mockRepo := &MockUserDashboardRepository{}
+	svc := NewUserDashboardService(mockRepo)
+
+	expected := &model.UserDashboardStats{}
+	mockRepo.On("GetDashboardStats", uint(2)).Return(expected, nil)
+
+	result, err := svc.GetStats(2)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.PostCount)
+	assert.Equal(t, int64(0), result.LikesReceived)
+	mockRepo.AssertExpectations(t)
+}
+
+// TestUserDashboardGetStats_InvalidUserID はuserID=0のときBadRequestエラーを返すことを確認する。
+func TestUserDashboardGetStats_InvalidUserID(t *testing.T) {
+	mockRepo := &MockUserDashboardRepository{}
+	svc := NewUserDashboardService(mockRepo)
+
+	result, err := svc.GetStats(0)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	var domainErr *domain.DomainError
+	assert.ErrorAs(t, err, &domainErr)
+	assert.Equal(t, domain.ErrCodeBadRequest, domainErr.Code)
+	mockRepo.AssertNotCalled(t, "GetDashboardStats")
+}
+
+// TestUserDashboardGetStats_RepoError はリポジトリエラーが正しく伝播することを確認する。
+func TestUserDashboardGetStats_RepoError(t *testing.T) {
+	mockRepo := &MockUserDashboardRepository{}
+	svc := NewUserDashboardService(mockRepo)
+
+	mockRepo.On("GetDashboardStats", uint(999)).Return(nil, errors.New("DB error"))
+
+	result, err := svc.GetStats(999)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.EqualError(t, err, "DB error")
+	mockRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
Issue #723 の対応。ユーザーのプロフィールページや管理画面向けにダッシュボード統計情報を返すAPIエンドポイントを追加。TDDで実装。

## 変更内容
- `model/dashboard.go`: `UserDashboardStats` 型定義（投稿数・受信いいね数・受信コメント数・受信閲覧数・フォロワー数・フォロー数）
- `repository/interfaces.go`: `UserDashboardRepositoryInterface` 追加
- `repository/user_dashboard.go`: GORM実装（各統計を集計クエリで取得）
- `service/user_dashboard.go`: `UserDashboardService.GetStats` 実装（userID=0バリデーション）
- `handler/user_dashboard.go`: `GET /api/v1/users/:id/dashboard-stats` エンドポイント
- DI・ルーター登録

## テスト
- TDD: テストを先行作成してからサービスを実装
- 4テスト追加（Success/ZeroValues/InvalidUserID/RepoError）
- カバレッジ: **83.1% → 83.2%**（+0.1%）