### PR TITLE
refactor: 検索クエリバリデーションとページネーション処理を共通ヘルパーに統一

### DIFF
--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -47,6 +48,25 @@ func parseLimitOffset(c *gin.Context) (limit, offset int) {
 	offset, _ = strconv.Atoi(c.DefaultQuery("offset", "0"))
 	limit, offset, _ = domain.ValidatePagination(limit, offset)
 	return limit, offset
+}
+
+// maxSearchQueryLen は検索クエリの最大文字数（ルーン数）。
+const maxSearchQueryLen = 500
+
+// parseSearchQuery はクエリパラメータ "q" を取得・検証する共通ヘルパー。
+// 未指定・空文字列・500文字超の場合は400を返しfalseを返す。
+// 前後の空白はTrimSpaceで除去して返す。
+func parseSearchQuery(c *gin.Context) (string, bool) {
+	query := c.Query("q")
+	if query == "" {
+		respondBadRequest(c, "query parameter 'q' is required")
+		return "", false
+	}
+	if len([]rune(query)) > maxSearchQueryLen {
+		respondBadRequest(c, "検索クエリは500文字以下である必要があります")
+		return "", false
+	}
+	return strings.TrimSpace(query), true
 }
 
 // bindJSON はリクエストボディをJSON構造体にバインドする。

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
@@ -88,8 +86,7 @@ func (h *RoadmapHandler) GetMyRoadmaps(c *gin.Context) {
 
 // GetPublicRoadmaps は公開ロードマップの一覧をページネーション付きで取得する。
 func (h *RoadmapHandler) GetPublicRoadmaps(c *gin.Context) {
-	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "20"))
-	offset, _ := strconv.Atoi(c.DefaultQuery("offset", "0"))
+	limit, offset := parseLimitOffset(c)
 
 	roadmaps, total, err := h.service.GetPublicRoadmaps(limit, offset)
 	if err != nil {

--- a/backend/internal/handler/search.go
+++ b/backend/internal/handler/search.go
@@ -33,21 +33,12 @@ func NewSearchHandler(searchService PostSearchService, circleService CircleSearc
 	}
 }
 
-// maxSearchQueryLength は検索クエリの最大文字数。
-const maxSearchQueryLength = 500
-
 // SearchPosts handles post search requests with advanced filtering
 func (h *SearchHandler) SearchPosts(c *gin.Context) {
-	query := c.Query("q")
-	if query == "" {
-		respondBadRequest(c, "query parameter 'q' is required")
+	query, ok := parseSearchQuery(c)
+	if !ok {
 		return
 	}
-	if len([]rune(query)) > maxSearchQueryLength {
-		respondBadRequest(c, "検索クエリは500文字以下である必要があります")
-		return
-	}
-	query = strings.TrimSpace(query)
 
 	limit, offset := parseLimitOffset(c)
 
@@ -99,16 +90,10 @@ func (h *SearchHandler) SearchPosts(c *gin.Context) {
 
 // SearchCircles handles study circle search requests
 func (h *SearchHandler) SearchCircles(c *gin.Context) {
-	query := c.Query("q")
-	if query == "" {
-		respondBadRequest(c, "query parameter 'q' is required")
+	query, ok := parseSearchQuery(c)
+	if !ok {
 		return
 	}
-	if len([]rune(query)) > maxSearchQueryLength {
-		respondBadRequest(c, "検索クエリは500文字以下である必要があります")
-		return
-	}
-	query = strings.TrimSpace(query)
 
 	limit, offset := parseLimitOffset(c)
 


### PR DESCRIPTION
## 概要
Issue #725 の対応。ハンドラー層のコード重複を解消するリファクタリング。

## 変更内容
### 1. handler/helpers.go: parseSearchQuery ヘルパー追加
- `parseSearchQuery(c) (string, bool)` を追加
- 空チェック・500文字制限・TrimSpaceを一か所に集約

### 2. handler/search.go: DRY違反を修正
- `SearchPosts` と `SearchCircles` で9行重複していたクエリバリデーションを `parseSearchQuery(c)` に統一
- `maxSearchQueryLength` 定数（重複定義）を削除

### 3. handler/roadmap.go: parseLimitOffset ヘルパーに統一
- `GetPublicRoadmaps` の `strconv.Atoi(c.DefaultQuery(...))` を `parseLimitOffset(c)` に変更
- `domain.ValidatePagination` による入力バリデーションが自動適用される
- 不要な `"strconv"` インポートを削除