### PR TITLE
test: NoteTemplateService.Updateの未カバーバリデーションテストを追加

### DIFF
--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -324,6 +324,47 @@ func TestNoteTemplateService_Update_ValidationNameError(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestNoteTemplateService_Update_ValidationContentTemplateError(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	existing := &model.NoteTemplate{ID: 1, UserID: 1, Name: "テンプレ"}
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// 空白のみのcontentTemplate → TrimSpace後に空 → バリデーションエラー
+	result, err := svc.Update(1, 1, "", "", "", "   ", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestNoteTemplateService_Update_ValidationDescriptionError(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	existing := &model.NoteTemplate{ID: 1, UserID: 1, Name: "テンプレ"}
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// 501文字の説明 → バリデーションエラー
+	longDesc := strings.Repeat("a", 501)
+	result, err := svc.Update(1, 1, "", longDesc, "", "", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestNoteTemplateService_Update_ValidationDefaultTitleError(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	existing := &model.NoteTemplate{ID: 1, UserID: 1, Name: "テンプレ"}
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// 201文字のデフォルトタイトル → バリデーションエラー
+	longTitle := strings.Repeat("a", 201)
+	result, err := svc.Update(1, 1, "", "", longTitle, "", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
 // ============================================================
 // Delete テスト
 // ============================================================


### PR DESCRIPTION
## 概要
Issue #727 の対応。NoteTemplateService.Update の3つの未カバーバリデーションエラーブランチにテストを追加。

## 変更内容
`service/note_template_test.go` に3テストを追加:
- `TestNoteTemplateService_Update_ValidationContentTemplateError`: contentTemplateが空白のみ（TrimSpace後空）の場合のエラー
- `TestNoteTemplateService_Update_ValidationDescriptionError`: descriptionが501文字超の場合のエラー
- `TestNoteTemplateService_Update_ValidationDefaultTitleError`: defaultTitleが201文字超の場合のエラー

## カバレッジ
**83.2% → 83.3%**（+0.1%）