### PR TITLE
fix: NoteLinkServiceのCreateLink/DeleteLinkに所有権チェックを追加

### DIFF
--- a/backend/internal/handler/note_link.go
+++ b/backend/internal/handler/note_link.go
@@ -8,10 +8,10 @@ import (
 
 // NoteLinkServiceInterface はNoteLinkServiceのインターフェース。
 type NoteLinkServiceInterface interface {
-	CreateLink(sourceNoteID, targetNoteID uint) error
+	CreateLink(sourceNoteID, targetNoteID, userID uint) error
 	GetLinks(sourceNoteID uint) ([]model.NoteLink, error)
 	GetBacklinks(targetNoteID uint) ([]model.NoteLink, error)
-	DeleteLink(sourceNoteID, targetNoteID uint) error
+	DeleteLink(sourceNoteID, targetNoteID, userID uint) error
 }
 
 // NoteLinkHandler はノート間リンク関連のHTTPハンドラ。
@@ -36,12 +36,14 @@ func (h *NoteLinkHandler) CreateLink(c *gin.Context) {
 		return
 	}
 
+	userID := c.GetUint("userID")
+
 	input := bindJSON[CreateLinkInput](c)
 	if input == nil {
 		return
 	}
 
-	if err := h.service.CreateLink(sourceNoteID, input.TargetNoteID); err != nil {
+	if err := h.service.CreateLink(sourceNoteID, input.TargetNoteID, userID); err != nil {
 		respondError(c, err)
 		return
 	}
@@ -92,7 +94,9 @@ func (h *NoteLinkHandler) DeleteLink(c *gin.Context) {
 		return
 	}
 
-	if err := h.service.DeleteLink(sourceNoteID, targetNoteID); err != nil {
+	userID := c.GetUint("userID")
+
+	if err := h.service.DeleteLink(sourceNoteID, targetNoteID, userID); err != nil {
 		respondError(c, err)
 		return
 	}

--- a/backend/internal/service/note_link.go
+++ b/backend/internal/service/note_link.go
@@ -30,14 +30,24 @@ func NewNoteLinkService(repo NoteLinkRepositoryInterface, noteRepo repository.No
 }
 
 // CreateLink は新しいリンクを作成する。
-func (s *NoteLinkService) CreateLink(sourceNoteID, targetNoteID uint) error {
+// ソースノートの所有権を検証した後、リンクを作成する。
+func (s *NoteLinkService) CreateLink(sourceNoteID, targetNoteID, userID uint) error {
 	// 同じノートへのリンクは作成できない
 	if sourceNoteID == targetNoteID {
 		return domain.NewError(domain.ErrCodeValidation, "同じノートへのリンクは作成できません", nil)
 	}
 
+	// ソースノートの所有権を確認
+	sourceNote, err := s.noteRepo.FindByID(sourceNoteID)
+	if err != nil {
+		return domain.NewError(domain.ErrCodeNotFound, "ソースノートが見つかりません", err)
+	}
+	if sourceNote.UserID != userID {
+		return domain.NewError(domain.ErrCodeForbidden, "この操作を行う権限がありません", nil)
+	}
+
 	// ターゲットノートが存在するかチェック
-	_, err := s.noteRepo.FindByID(targetNoteID)
+	_, err = s.noteRepo.FindByID(targetNoteID)
 	if err != nil {
 		return domain.NewError(domain.ErrCodeNotFound, "リンク先のノートが見つかりません", err)
 	}
@@ -69,7 +79,14 @@ func (s *NoteLinkService) GetBacklinks(targetNoteID uint) ([]model.NoteLink, err
 	return s.repo.FindByTargetNoteID(targetNoteID)
 }
 
-// DeleteLink はリンクを削除する。
-func (s *NoteLinkService) DeleteLink(sourceNoteID, targetNoteID uint) error {
+// DeleteLink はソースノートの所有権を検証した後、リンクを削除する。
+func (s *NoteLinkService) DeleteLink(sourceNoteID, targetNoteID, userID uint) error {
+	sourceNote, err := s.noteRepo.FindByID(sourceNoteID)
+	if err != nil {
+		return domain.NewError(domain.ErrCodeNotFound, "ソースノートが見つかりません", err)
+	}
+	if sourceNote.UserID != userID {
+		return domain.NewError(domain.ErrCodeForbidden, "この操作を行う権限がありません", nil)
+	}
 	return s.repo.Delete(sourceNoteID, targetNoteID)
 }

--- a/backend/internal/service/note_link_test.go
+++ b/backend/internal/service/note_link_test.go
@@ -52,15 +52,17 @@ func newTestNoteLinkService() (*NoteLinkService, *MockNoteLinkRepository, *MockN
 func TestNoteLinkService_CreateLink(t *testing.T) {
 	svc, linkRepo, noteRepo := newTestNoteLinkService()
 
+	sourceNote := &model.Note{ID: 1, UserID: 1, Title: "ソースノート"}
 	targetNote := &model.Note{ID: 2, UserID: 1, Title: "リンク先ノート"}
 
+	noteRepo.On("FindByID", uint(1)).Return(sourceNote, nil)
 	noteRepo.On("FindByID", uint(2)).Return(targetNote, nil)
 	linkRepo.On("Exists", uint(1), uint(2)).Return(false, nil)
 	linkRepo.On("Create", mock.MatchedBy(func(l *model.NoteLink) bool {
 		return l.SourceNoteID == 1 && l.TargetNoteID == 2
 	})).Return(nil)
 
-	err := svc.CreateLink(1, 2)
+	err := svc.CreateLink(1, 2, 1)
 	assert.NoError(t, err)
 	linkRepo.AssertExpectations(t)
 	noteRepo.AssertExpectations(t)
@@ -69,20 +71,46 @@ func TestNoteLinkService_CreateLink(t *testing.T) {
 func TestNoteLinkService_CreateLink_SelfLink(t *testing.T) {
 	svc, _, _ := newTestNoteLinkService()
 
-	err := svc.CreateLink(1, 1)
+	err := svc.CreateLink(1, 1, 1)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "同じノートへのリンクは作成できません")
+}
+
+func TestNoteLinkService_CreateLink_SourceNotFound(t *testing.T) {
+	svc, _, noteRepo := newTestNoteLinkService()
+
+	noteRepo.On("FindByID", uint(1)).Return((*model.Note)(nil), errors.New("not found"))
+
+	err := svc.CreateLink(1, 2, 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ソースノートが見つかりません")
+	noteRepo.AssertExpectations(t)
+}
+
+func TestNoteLinkService_CreateLink_Forbidden(t *testing.T) {
+	svc, _, noteRepo := newTestNoteLinkService()
+
+	// ソースノートは別ユーザーが所有
+	sourceNote := &model.Note{ID: 1, UserID: 99, Title: "他ユーザーのノート"}
+	noteRepo.On("FindByID", uint(1)).Return(sourceNote, nil)
+
+	err := svc.CreateLink(1, 2, 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "この操作を行う権限がありません")
+	noteRepo.AssertExpectations(t)
 }
 
 func TestNoteLinkService_CreateLink_AlreadyExists(t *testing.T) {
 	svc, linkRepo, noteRepo := newTestNoteLinkService()
 
+	sourceNote := &model.Note{ID: 1, UserID: 1, Title: "ソースノート"}
 	targetNote := &model.Note{ID: 2, UserID: 1, Title: "リンク先ノート"}
 
+	noteRepo.On("FindByID", uint(1)).Return(sourceNote, nil)
 	noteRepo.On("FindByID", uint(2)).Return(targetNote, nil)
 	linkRepo.On("Exists", uint(1), uint(2)).Return(true, nil)
 
-	err := svc.CreateLink(1, 2)
+	err := svc.CreateLink(1, 2, 1)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "このリンクは既に存在します")
 	linkRepo.AssertExpectations(t)
@@ -134,13 +162,40 @@ func TestNoteLinkService_GetBacklinks(t *testing.T) {
 // ============================================================
 
 func TestNoteLinkService_DeleteLink(t *testing.T) {
-	svc, linkRepo, _ := newTestNoteLinkService()
+	svc, linkRepo, noteRepo := newTestNoteLinkService()
 
+	sourceNote := &model.Note{ID: 1, UserID: 1, Title: "ソースノート"}
+	noteRepo.On("FindByID", uint(1)).Return(sourceNote, nil)
 	linkRepo.On("Delete", uint(1), uint(2)).Return(nil)
 
-	err := svc.DeleteLink(1, 2)
+	err := svc.DeleteLink(1, 2, 1)
 	assert.NoError(t, err)
 	linkRepo.AssertExpectations(t)
+	noteRepo.AssertExpectations(t)
+}
+
+func TestNoteLinkService_DeleteLink_SourceNotFound(t *testing.T) {
+	svc, _, noteRepo := newTestNoteLinkService()
+
+	noteRepo.On("FindByID", uint(1)).Return((*model.Note)(nil), errors.New("not found"))
+
+	err := svc.DeleteLink(1, 2, 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ソースノートが見つかりません")
+	noteRepo.AssertExpectations(t)
+}
+
+func TestNoteLinkService_DeleteLink_Forbidden(t *testing.T) {
+	svc, _, noteRepo := newTestNoteLinkService()
+
+	// ソースノートは別ユーザーが所有
+	sourceNote := &model.Note{ID: 1, UserID: 99, Title: "他ユーザーのノート"}
+	noteRepo.On("FindByID", uint(1)).Return(sourceNote, nil)
+
+	err := svc.DeleteLink(1, 2, 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "この操作を行う権限がありません")
+	noteRepo.AssertExpectations(t)
 }
 
 // ============================================================
@@ -150,9 +205,11 @@ func TestNoteLinkService_DeleteLink(t *testing.T) {
 func TestNoteLinkService_CreateLink_TargetNotFound(t *testing.T) {
 	svc, _, noteRepo := newTestNoteLinkService()
 
+	sourceNote := &model.Note{ID: 1, UserID: 1, Title: "ソースノート"}
+	noteRepo.On("FindByID", uint(1)).Return(sourceNote, nil)
 	noteRepo.On("FindByID", uint(2)).Return((*model.Note)(nil), errors.New("not found"))
 
-	err := svc.CreateLink(1, 2)
+	err := svc.CreateLink(1, 2, 1)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "リンク先のノートが見つかりません")
 	noteRepo.AssertExpectations(t)
@@ -161,11 +218,13 @@ func TestNoteLinkService_CreateLink_TargetNotFound(t *testing.T) {
 func TestNoteLinkService_CreateLink_ExistsError(t *testing.T) {
 	svc, linkRepo, noteRepo := newTestNoteLinkService()
 
+	sourceNote := &model.Note{ID: 1, UserID: 1, Title: "ソースノート"}
 	targetNote := &model.Note{ID: 2, UserID: 1, Title: "ノート"}
+	noteRepo.On("FindByID", uint(1)).Return(sourceNote, nil)
 	noteRepo.On("FindByID", uint(2)).Return(targetNote, nil)
 	linkRepo.On("Exists", uint(1), uint(2)).Return(false, errors.New("db error"))
 
-	err := svc.CreateLink(1, 2)
+	err := svc.CreateLink(1, 2, 1)
 	assert.Error(t, err)
 	linkRepo.AssertExpectations(t)
 	noteRepo.AssertExpectations(t)
@@ -174,12 +233,14 @@ func TestNoteLinkService_CreateLink_ExistsError(t *testing.T) {
 func TestNoteLinkService_CreateLink_CreateError(t *testing.T) {
 	svc, linkRepo, noteRepo := newTestNoteLinkService()
 
+	sourceNote := &model.Note{ID: 1, UserID: 1, Title: "ソースノート"}
 	targetNote := &model.Note{ID: 2, UserID: 1, Title: "ノート"}
+	noteRepo.On("FindByID", uint(1)).Return(sourceNote, nil)
 	noteRepo.On("FindByID", uint(2)).Return(targetNote, nil)
 	linkRepo.On("Exists", uint(1), uint(2)).Return(false, nil)
 	linkRepo.On("Create", mock.AnythingOfType("*model.NoteLink")).Return(errors.New("db error"))
 
-	err := svc.CreateLink(1, 2)
+	err := svc.CreateLink(1, 2, 1)
 	assert.Error(t, err)
 	linkRepo.AssertExpectations(t)
 	noteRepo.AssertExpectations(t)
@@ -208,11 +269,14 @@ func TestNoteLinkService_GetBacklinks_Error(t *testing.T) {
 }
 
 func TestNoteLinkService_DeleteLink_Error(t *testing.T) {
-	svc, linkRepo, _ := newTestNoteLinkService()
+	svc, linkRepo, noteRepo := newTestNoteLinkService()
 
+	sourceNote := &model.Note{ID: 1, UserID: 1, Title: "ソースノート"}
+	noteRepo.On("FindByID", uint(1)).Return(sourceNote, nil)
 	linkRepo.On("Delete", uint(1), uint(2)).Return(errors.New("db error"))
 
-	err := svc.DeleteLink(1, 2)
+	err := svc.DeleteLink(1, 2, 1)
 	assert.Error(t, err)
 	linkRepo.AssertExpectations(t)
+	noteRepo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
- `NoteLinkService.CreateLink` と `DeleteLink` に `userID` パラメータを追加し、ソースノートの所有権チェックをservice層で実施
- ハンドラ側では `c.GetUint("userID")` でuserIDを取得してserviceに渡すよう修正

## 変更内容
- `service/note_link.go`: `CreateLink/DeleteLink` シグネチャに `userID uint` 追加、所有権チェックロジック実装
- `handler/note_link.go`: `NoteLinkServiceInterface` シグネチャ更新、ハンドラでuserID取得・渡し処理追加
- `service/note_link_test.go`: 既存テストのシグネチャ更新 + 所有権チェック・NotFound・Forbiddenテスト追加

## テスト
- 16テスト全PASS、カバレッジ 83.3% 維持

Closes #729