### PR TITLE
feat: ノート集計統計API（TDD実装）

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -61,6 +61,7 @@ type Container struct {
 	CommentLikeHandler       *handler.CommentLikeHandler
 	MentionHandler           *handler.MentionHandler
 	UserDashboardHandler     *handler.UserDashboardHandler
+	NoteStatsHandler         *handler.NoteStatsHandler
 	YouTubeHandler           *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -254,6 +255,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	userDashboardRepo := repository.NewUserDashboardRepository(db)
 	userDashboardService := service.NewUserDashboardService(userDashboardRepo)
 	c.UserDashboardHandler = handler.NewUserDashboardHandler(userDashboardService)
+
+	noteStatsRepo := repository.NewNoteStatsRepository(db)
+	noteStatsService := service.NewNoteStatsService(noteStatsRepo)
+	c.NoteStatsHandler = handler.NewNoteStatsHandler(noteStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/note_stats.go
+++ b/backend/internal/handler/note_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// NoteStatsServiceInterface はNoteStatsHandlerが依存するサービスメソッドを定義する。
+type NoteStatsServiceInterface interface {
+	GetNoteStats(userID uint) (*model.NoteStats, error)
+}
+
+// NoteStatsHandler はノート統計関連のHTTPハンドラ。
+type NoteStatsHandler struct {
+	service NoteStatsServiceInterface
+}
+
+// NewNoteStatsHandler は新しいNoteStatsHandlerインスタンスを生成する。
+func NewNoteStatsHandler(s NoteStatsServiceInterface) *NoteStatsHandler {
+	return &NoteStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのノート集計統計を返す。
+func (h *NoteStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetNoteStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/note_stats.go
+++ b/backend/internal/model/note_stats.go
@@ -1,0 +1,10 @@
+package model
+
+// NoteStats はユーザーのノートに関する集計統計を表す。
+type NoteStats struct {
+	TotalNotes     int64 `json:"total_notes"`
+	ArchivedNotes  int64 `json:"archived_notes"`
+	FavoriteNotes  int64 `json:"favorite_notes"`
+	TotalFolders   int64 `json:"total_folders"`
+	NotesThisWeek  int64 `json:"notes_this_week"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -13,6 +13,11 @@ type UserDashboardRepositoryInterface interface {
 	GetDashboardStats(userID uint) (*model.UserDashboardStats, error)
 }
 
+// NoteStatsRepositoryInterface はユーザーのノート集計統計の取得契約を定義する。
+type NoteStatsRepositoryInterface interface {
+	GetNoteStats(userID uint) (*model.NoteStats, error)
+}
+
 // PostAdvancedSearchRepositoryInterface は投稿の高度な検索フィルター機能の契約を定義する。
 // タグ・日付範囲・ソート順による絞り込みを提供する。
 type PostAdvancedSearchRepositoryInterface interface {

--- a/backend/internal/repository/note_stats.go
+++ b/backend/internal/repository/note_stats.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// NoteStatsRepository はノート集計統計の取得を担当するリポジトリ実装。
+type NoteStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewNoteStatsRepository は新しいNoteStatsRepositoryインスタンスを生成する。
+func NewNoteStatsRepository(db *gorm.DB) *NoteStatsRepository {
+	return &NoteStatsRepository{db: db}
+}
+
+// GetNoteStats は指定ユーザーのノート集計統計を返す。
+func (r *NoteStatsRepository) GetNoteStats(userID uint) (*model.NoteStats, error) {
+	var stats model.NoteStats
+
+	// 総ノート数
+	if err := r.db.Model(&model.Note{}).Where("user_id = ?", userID).Count(&stats.TotalNotes).Error; err != nil {
+		return nil, err
+	}
+
+	// アーカイブ済みノート数
+	if err := r.db.Model(&model.Note{}).Where("user_id = ? AND is_archived = ?", userID, true).Count(&stats.ArchivedNotes).Error; err != nil {
+		return nil, err
+	}
+
+	// お気に入りノート数
+	if err := r.db.Model(&model.Note{}).Where("user_id = ? AND is_favorite = ?", userID, true).Count(&stats.FavoriteNotes).Error; err != nil {
+		return nil, err
+	}
+
+	// フォルダ数
+	if err := r.db.Model(&model.NoteFolder{}).Where("user_id = ?", userID).Count(&stats.TotalFolders).Error; err != nil {
+		return nil, err
+	}
+
+	// 今週作成したノート数（過去7日間）
+	weekAgo := time.Now().AddDate(0, 0, -7)
+	if err := r.db.Model(&model.Note{}).Where("user_id = ? AND created_at >= ?", userID, weekAgo).Count(&stats.NotesThisWeek).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -97,6 +97,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerSpotifyRoutes(protected, c)
 		registerCommentLikeRoutes(protected, c)
 		registerUserDashboardRoutes(protected, c)
+		registerNoteStatsRoutes(protected, c)
 	}
 
 	return r
@@ -598,5 +599,12 @@ func registerUserDashboardRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/dashboard-stats", c.UserDashboardHandler.GetStats)
+	}
+}
+
+func registerNoteStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/note-stats", c.NoteStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1855,3 +1855,19 @@ func (m *MockUserDashboardRepository) GetDashboardStats(userID uint) (*model.Use
 	}
 	return args.Get(0).(*model.UserDashboardStats), args.Error(1)
 }
+
+// ============================================================
+// MockNoteStatsRepository は repository.NoteStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockNoteStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockNoteStatsRepository) GetNoteStats(userID uint) (*model.NoteStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.NoteStats), args.Error(1)
+}

--- a/backend/internal/service/note_stats.go
+++ b/backend/internal/service/note_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// NoteStatsService はユーザーのノート集計統計のビジネスロジックを提供する。
+type NoteStatsService struct {
+	repo repository.NoteStatsRepositoryInterface
+}
+
+// NewNoteStatsService は新しいNoteStatsServiceインスタンスを生成する。
+func NewNoteStatsService(repo repository.NoteStatsRepositoryInterface) *NoteStatsService {
+	return &NoteStatsService{repo: repo}
+}
+
+// GetNoteStats は指定ユーザーのノート集計統計を返す。
+func (s *NoteStatsService) GetNoteStats(userID uint) (*model.NoteStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetNoteStats(userID)
+}

--- a/backend/internal/service/note_stats_test.go
+++ b/backend/internal/service/note_stats_test.go
@@ -1,0 +1,75 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestNoteStatsService はテスト用のNoteStatsServiceを生成する。
+func newTestNoteStatsService() (*NoteStatsService, *MockNoteStatsRepository) {
+	repo := new(MockNoteStatsRepository)
+	svc := NewNoteStatsService(repo)
+	return svc, repo
+}
+
+// ============================================================
+// GetNoteStats テスト
+// ============================================================
+
+func TestNoteStatsService_GetNoteStats_Success(t *testing.T) {
+	svc, repo := newTestNoteStatsService()
+
+	expected := &model.NoteStats{
+		TotalNotes:    20,
+		ArchivedNotes: 3,
+		FavoriteNotes: 5,
+		TotalFolders:  4,
+		NotesThisWeek: 2,
+	}
+	repo.On("GetNoteStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetNoteStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(20), result.TotalNotes)
+	assert.Equal(t, int64(3), result.ArchivedNotes)
+	assert.Equal(t, int64(5), result.FavoriteNotes)
+	assert.Equal(t, int64(4), result.TotalFolders)
+	assert.Equal(t, int64(2), result.NotesThisWeek)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteStatsService_GetNoteStats_NewUser(t *testing.T) {
+	svc, repo := newTestNoteStatsService()
+
+	empty := &model.NoteStats{}
+	repo.On("GetNoteStats", uint(2)).Return(empty, nil)
+
+	result, err := svc.GetNoteStats(2)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalNotes)
+	assert.Equal(t, int64(0), result.TotalFolders)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteStatsService_GetNoteStats_InvalidUserID(t *testing.T) {
+	svc, _ := newTestNoteStatsService()
+
+	result, err := svc.GetNoteStats(0)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestNoteStatsService_GetNoteStats_RepoError(t *testing.T) {
+	svc, repo := newTestNoteStatsService()
+
+	repo.On("GetNoteStats", uint(1)).Return((*model.NoteStats)(nil), errors.New("db error"))
+
+	result, err := svc.GetNoteStats(1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
ユーザーのノートに関する集計統計を返すAPIを追加。TDDアプローチで実装。

## 追加したAPI
`GET /api/v1/users/:id/note-stats`

## レスポンス（model.NoteStats）
- `total_notes` — 総ノート数
- `archived_notes` — アーカイブ済みノート数
- `favorite_notes` — お気に入りノート数
- `total_folders` — フォルダ数
- `notes_this_week` — 今週（過去7日間）作成したノート数

## 変更ファイル
- `model/note_stats.go`: 新モデル定義
- `repository/interfaces.go`: `NoteStatsRepositoryInterface` 追加
- `repository/note_stats.go`: GORM実装（5つの集計クエリ）
- `service/note_stats.go`: `NoteStatsService`（userID=0バリデーション付き）
- `service/note_stats_test.go`: 4テスト追加（TDD先行作成）
- `service/mock_test.go`: `MockNoteStatsRepository` 追加
- `handler/note_stats.go`: HTTPハンドラ
- `di/container.go` + `router/router.go`: DI・ルーター登録

## テスト
4テスト全PASS、カバレッジ **83.3% → 83.4%**（+0.1%）

Closes #731