### PR TITLE
test: PostServiceの未カバーブランチにテストを追加

### DIFF
--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -834,6 +835,34 @@ func TestPostUpdate_NotFound(t *testing.T) {
 	postRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
 
 	_, err := svc.Update(99, 1, "Title", "Content", "")
+	assert.Error(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostCreate_CreateRepoError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	post := &model.Post{Title: "Test Post", Content: "Content", UserID: 1}
+
+	postRepo.On("Create", post).Return(errors.New("db error"))
+
+	result, err := svc.Create(post)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostUpdate_ValidationError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	existing := &model.Post{Title: "Old Title", Content: "Old Content", UserID: 1}
+	existing.ID = 1
+
+	postRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// タイトルが長すぎる場合 → バリデーションエラー
+	longTitle := strings.Repeat("a", 300)
+	_, err := svc.Update(1, 1, longTitle, "", "")
 	assert.Error(t, err)
 	postRepo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
`PostService.Create`（91.7%）と`PostService.Update`（94.4%）の未カバーブランチにテストを追加。

## 追加したテスト
- `TestPostCreate_CreateRepoError` — `repo.Create` がDBエラーを返すケース（Create内の `err != nil` ブランチ）
- `TestPostUpdate_ValidationError` — タイトルが300文字超でバリデーションエラーになるケース（Update内の `ValidateUpdatePost` エラーブランチ）

## 結果
カバレッジ: **83.3% → 83.4%**（+0.1%）

Closes #735