### PR TITLE
fix: AnswerService.Voteに投票値バリデーションを追加

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -80,8 +81,13 @@ func (s *AnswerService) SetBestAnswer(questionID, answerID, userID uint) error {
 	return s.answerRepo.SetBestAnswer(questionID, answerID)
 }
 
-// Vote は回答に投票する。
+// Vote は投票値を検証した後、回答に投票する。
+// valueは1（賛成）または-1（反対）のみ許可される。
 func (s *AnswerService) Vote(userID, answerID uint, value int) error {
+	v := validator.NewQuestionValidator()
+	if err := v.ValidateVote(value); err != nil {
+		return err
+	}
 	return s.answerRepo.Vote(userID, answerID, value)
 }
 

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -339,3 +339,45 @@ func TestAnswerGetUserVotes_Empty(t *testing.T) {
 	assert.Empty(t, result)
 	answerRepo.AssertExpectations(t)
 }
+
+// ============================================================
+// Vote バリデーションテスト
+// ============================================================
+
+func TestAnswerVote_InvalidValue(t *testing.T) {
+	svc, _, _ := newTestAnswerService()
+
+	// 0は無効な投票値
+	err := svc.Vote(1, 1, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "投票値は1または-1")
+}
+
+func TestAnswerVote_OutOfRangeValue(t *testing.T) {
+	svc, _, _ := newTestAnswerService()
+
+	// 99は無効な投票値
+	err := svc.Vote(1, 1, 99)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "投票値は1または-1")
+}
+
+func TestAnswerVote_ValidUpvote(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answerRepo.On("Vote", uint(1), uint(1), 1).Return(nil)
+
+	err := svc.Vote(1, 1, 1)
+	assert.NoError(t, err)
+	answerRepo.AssertExpectations(t)
+}
+
+func TestAnswerVote_ValidDownvote(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answerRepo.On("Vote", uint(1), uint(1), -1).Return(nil)
+
+	err := svc.Vote(1, 1, -1)
+	assert.NoError(t, err)
+	answerRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 問題
`QuestionService.Vote` は `validator.ValidateVote(value)` で投票値（1または-1のみ）を検証しているが、`AnswerService.Vote` には同じバリデーションが未実装だった。

## 修正
`AnswerService.Vote` に `validator.NewQuestionValidator().ValidateVote(value)` を追加。1または-1以外の値を ValidationError として拒否する。

## テスト
- `TestAnswerVote_InvalidValue` — 0（無効値）を拒否
- `TestAnswerVote_OutOfRangeValue` — 99（範囲外）を拒否
- `TestAnswerVote_ValidUpvote` — +1（賛成票）を許可
- `TestAnswerVote_ValidDownvote` — -1（反対票）を許可

Closes #737