### PR TITLE
refactor: NoteFolderServiceの所有権チェックをfindAndCheckOwnershipヘルパーに統一

### DIFF
--- a/backend/internal/service/note_folder.go
+++ b/backend/internal/service/note_folder.go
@@ -47,14 +47,23 @@ func (s *NoteFolderService) GetRootFolders(userID uint) ([]model.NoteFolder, err
 	return s.repo.GetRootFolders(userID)
 }
 
-// Update は所有権を検証した後、フォルダを更新する。
-func (s *NoteFolderService) Update(id, userID uint, name string, parentID *uint) (*model.NoteFolder, error) {
+// findAndCheckOwnership はフォルダを取得し、指定ユーザーが所有者かを検証する。
+func (s *NoteFolderService) findAndCheckOwnership(id, userID uint) (*model.NoteFolder, error) {
 	folder, err := s.repo.FindByID(id)
 	if err != nil {
 		return nil, err
 	}
 	if folder.UserID != userID {
 		return nil, ErrForbidden
+	}
+	return folder, nil
+}
+
+// Update は所有権を検証した後、フォルダを更新する。
+func (s *NoteFolderService) Update(id, userID uint, name string, parentID *uint) (*model.NoteFolder, error) {
+	folder, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
 	}
 
 	if name != "" {
@@ -77,12 +86,8 @@ func (s *NoteFolderService) Update(id, userID uint, name string, parentID *uint)
 
 // Delete は所有権を検証した後、フォルダを削除する。
 func (s *NoteFolderService) Delete(id, userID uint) error {
-	folder, err := s.repo.FindByID(id)
-	if err != nil {
+	if _, err := s.findAndCheckOwnership(id, userID); err != nil {
 		return err
-	}
-	if folder.UserID != userID {
-		return ErrForbidden
 	}
 	return s.repo.Delete(id)
 }


### PR DESCRIPTION
## 概要
\`note_folder.go\` の Update/Delete メソッドで繰り返されていた「FindByID + 所有権チェック」パターンを共通プライベートヘルパーに抽出。

## 変更内容
- \`findAndCheckOwnership(id, userID uint) (*model.NoteFolder, error)\` プライベートヘルパーを追加
- \`Update\` / \`Delete\` メソッドをヘルパーを使用するよう簡潔化
- 重複コード: FindByID+所有権チェック（4行）×2箇所 → ヘルパー1箇所 に集約

## テスト
- 全21テストPASS
- 外部インターフェースの変更なし

Closes #741