### PR TITLE
fix: PostPinService.Reorderに所有権検証を追加

### DIFF
--- a/backend/internal/service/post_pin.go
+++ b/backend/internal/service/post_pin.go
@@ -64,10 +64,27 @@ func (s *PostPinService) GetByUserID(userID uint) ([]model.PostPin, error) {
 }
 
 // Reorder はピン留め投稿の表示順序を変更する。
+// 渡されたpostIDsが全てuserIDのピン留め済み投稿であることを検証する。
 func (s *PostPinService) Reorder(userID uint, postIDs []uint) error {
 	if len(postIDs) > maxPinsPerUser {
 		return domain.NewError(domain.ErrCodeBadRequest, "ピン留めは最大3件までです", nil)
 	}
+
+	// 現在のピン留め投稿を取得して所有権を検証
+	pins, err := s.pinRepo.GetByUserID(userID)
+	if err != nil {
+		return err
+	}
+	pinnedSet := make(map[uint]bool, len(pins))
+	for _, pin := range pins {
+		pinnedSet[pin.PostID] = true
+	}
+	for _, postID := range postIDs {
+		if !pinnedSet[postID] {
+			return domain.NewError(domain.ErrCodeForbidden, "自分のピン留め投稿のみ順序変更できます", nil)
+		}
+	}
+
 	return s.pinRepo.UpdateOrder(userID, postIDs)
 }
 

--- a/backend/internal/service/post_pin_test.go
+++ b/backend/internal/service/post_pin_test.go
@@ -133,6 +133,9 @@ func TestPostPinService_GetByUserID_Empty(t *testing.T) {
 
 func TestPostPinService_Reorder_Success(t *testing.T) {
 	svc, pinRepo, _ := newPostPinTestService()
+
+	pins := []model.PostPin{{PostID: 20}, {PostID: 10}}
+	pinRepo.On("GetByUserID", uint(1)).Return(pins, nil)
 	pinRepo.On("UpdateOrder", uint(1), []uint{20, 10}).Return(nil)
 
 	err := svc.Reorder(1, []uint{20, 10})
@@ -147,8 +150,34 @@ func TestPostPinService_Reorder_TooMany(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestPostPinService_Reorder_Forbidden(t *testing.T) {
+	svc, pinRepo, _ := newPostPinTestService()
+
+	// userID=1のピン留めはpostID=10のみ。postID=99は他ユーザーの投稿
+	pins := []model.PostPin{{PostID: 10}}
+	pinRepo.On("GetByUserID", uint(1)).Return(pins, nil)
+
+	err := svc.Reorder(1, []uint{10, 99})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "自分のピン留め投稿のみ")
+	pinRepo.AssertNotCalled(t, "UpdateOrder")
+}
+
+func TestPostPinService_Reorder_GetByUserIDError(t *testing.T) {
+	svc, pinRepo, _ := newPostPinTestService()
+
+	pinRepo.On("GetByUserID", uint(1)).Return([]model.PostPin{}, errors.New("db error"))
+
+	err := svc.Reorder(1, []uint{10})
+	assert.Error(t, err)
+	pinRepo.AssertNotCalled(t, "UpdateOrder")
+}
+
 func TestPostPinService_Reorder_RepoError(t *testing.T) {
 	svc, pinRepo, _ := newPostPinTestService()
+
+	pins := []model.PostPin{{PostID: 10}}
+	pinRepo.On("GetByUserID", uint(1)).Return(pins, nil)
 	pinRepo.On("UpdateOrder", uint(1), []uint{10}).Return(errors.New("db error"))
 
 	err := svc.Reorder(1, []uint{10})


### PR DESCRIPTION
## 問題
\`PostPinService.Reorder(userID, postIDs)\` が \`postIDs\` の内容を検証していなかった。
\`UpdateOrder\` リポジトリはWHERE句に \`user_id\` フィルタがあるが、service層での検証がなく、ユーザーが自分のピン留め済みでないpostIDを渡してもサイレントに処理されていた。

## 修正内容
- \`Reorder\` 実行前に \`GetByUserID(userID)\` でユーザーの全ピン留めを取得
- 渡された \`postIDs\` に未ピン留め投稿が含まれる場合は \`ErrCodeForbidden\` を返す
- \`Pin\` メソッドの「自分の投稿のみ操作できる」チェックパターンに倣う

## テスト追加（2件）
- \`TestPostPinService_Reorder_Forbidden\`: 未ピンのpostIDが含まれる場合に403を返すことを確認
- \`TestPostPinService_Reorder_GetByUserIDError\`: GetByUserIDがエラーの場合のエラーハンドリング

## テスト結果
全テストPASS

Closes #745