### PR TITLE
feat: ユーザー投稿集計統計API（PostStats）を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -63,6 +63,7 @@ type Container struct {
 	UserDashboardHandler     *handler.UserDashboardHandler
 	NoteStatsHandler              *handler.NoteStatsHandler
 	StudyCircleStatsHandler       *handler.StudyCircleStatsHandler
+	PostStatsHandler              *handler.PostStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -264,6 +265,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	studyCircleStatsRepo := repository.NewStudyCircleStatsRepository(db)
 	studyCircleStatsService := service.NewStudyCircleStatsService(studyCircleStatsRepo)
 	c.StudyCircleStatsHandler = handler.NewStudyCircleStatsHandler(studyCircleStatsService)
+
+	postStatsRepo := repository.NewPostStatsRepository(db)
+	postStatsService := service.NewPostStatsService(postStatsRepo)
+	c.PostStatsHandler = handler.NewPostStatsHandler(postStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/post_stats.go
+++ b/backend/internal/handler/post_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// PostStatsServiceInterface はPostStatsHandlerが依存するサービスメソッドを定義する。
+type PostStatsServiceInterface interface {
+	GetPostStats(userID uint) (*model.PostStats, error)
+}
+
+// PostStatsHandler はユーザー投稿統計関連のHTTPハンドラ。
+type PostStatsHandler struct {
+	service PostStatsServiceInterface
+}
+
+// NewPostStatsHandler は新しいPostStatsHandlerインスタンスを生成する。
+func NewPostStatsHandler(s PostStatsServiceInterface) *PostStatsHandler {
+	return &PostStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーの投稿集計統計を返す。
+func (h *PostStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetPostStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/post_stats.go
+++ b/backend/internal/model/post_stats.go
@@ -1,0 +1,11 @@
+package model
+
+// PostStats はユーザーの投稿集計統計を表す。
+type PostStats struct {
+	TotalPosts         int64 `json:"total_posts"`
+	PublishedPosts     int64 `json:"published_posts"`
+	DraftPosts         int64 `json:"draft_posts"`
+	TotalLikesReceived int64 `json:"total_likes_received"`
+	TotalComments      int64 `json:"total_comments"`
+	PostsThisMonth     int64 `json:"posts_this_month"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -526,3 +526,8 @@ type PostViewRepositoryInterface interface {
 	HasViewed(userID, postID uint) (bool, error)
 	GetMostViewed(limit int) ([]model.ViewCount, error)
 }
+
+// PostStatsRepositoryInterface はユーザー投稿集計統計データ操作の契約を定義する。
+type PostStatsRepositoryInterface interface {
+	GetPostStats(userID uint) (*model.PostStats, error)
+}

--- a/backend/internal/repository/post_stats.go
+++ b/backend/internal/repository/post_stats.go
@@ -1,0 +1,65 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// PostStatsRepository はユーザー投稿集計統計の取得を担当するリポジトリ実装。
+type PostStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewPostStatsRepository は新しいPostStatsRepositoryインスタンスを生成する。
+func NewPostStatsRepository(db *gorm.DB) *PostStatsRepository {
+	return &PostStatsRepository{db: db}
+}
+
+// GetPostStats は指定ユーザーの投稿集計統計を返す。
+func (r *PostStatsRepository) GetPostStats(userID uint) (*model.PostStats, error) {
+	var stats model.PostStats
+
+	// 総投稿数
+	if err := r.db.Model(&model.Post{}).Where("user_id = ?", userID).Count(&stats.TotalPosts).Error; err != nil {
+		return nil, err
+	}
+
+	// 公開済み投稿数
+	if err := r.db.Model(&model.Post{}).Where("user_id = ? AND is_draft = ?", userID, false).Count(&stats.PublishedPosts).Error; err != nil {
+		return nil, err
+	}
+
+	// 下書き投稿数
+	if err := r.db.Model(&model.Post{}).Where("user_id = ? AND is_draft = ?", userID, true).Count(&stats.DraftPosts).Error; err != nil {
+		return nil, err
+	}
+
+	// 受け取ったいいね総数
+	var totalLikes *int64
+	if err := r.db.Model(&model.Post{}).Where("user_id = ?", userID).Select("SUM(like_count)").Scan(&totalLikes).Error; err != nil {
+		return nil, err
+	}
+	if totalLikes != nil {
+		stats.TotalLikesReceived = *totalLikes
+	}
+
+	// 受け取ったコメント総数
+	var totalComments *int64
+	if err := r.db.Model(&model.Post{}).Where("user_id = ?", userID).Select("SUM(comment_count)").Scan(&totalComments).Error; err != nil {
+		return nil, err
+	}
+	if totalComments != nil {
+		stats.TotalComments = *totalComments
+	}
+
+	// 今月の投稿数
+	now := time.Now()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	if err := r.db.Model(&model.Post{}).Where("user_id = ? AND created_at >= ?", userID, monthStart).Count(&stats.PostsThisMonth).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -99,6 +99,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerUserDashboardRoutes(protected, c)
 		registerNoteStatsRoutes(protected, c)
 		registerStudyCircleStatsRoutes(protected, c)
+		registerPostStatsRoutes(protected, c)
 	}
 
 	return r
@@ -614,5 +615,12 @@ func registerStudyCircleStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	circles := g.Group("/study-circles")
 	{
 		circles.GET("/:id/stats", c.StudyCircleStatsHandler.GetStats)
+	}
+}
+
+func registerPostStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/post-stats", c.PostStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1887,3 +1887,19 @@ func (m *MockStudyCircleStatsRepository) GetCircleStats(circleID uint) (*model.S
 	}
 	return args.Get(0).(*model.StudyCircleStats), args.Error(1)
 }
+
+// ============================================================
+// MockPostStatsRepository は repository.PostStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockPostStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockPostStatsRepository) GetPostStats(userID uint) (*model.PostStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.PostStats), args.Error(1)
+}

--- a/backend/internal/service/post_stats.go
+++ b/backend/internal/service/post_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// PostStatsService はユーザー投稿集計統計のビジネスロジックを提供する。
+type PostStatsService struct {
+	repo repository.PostStatsRepositoryInterface
+}
+
+// NewPostStatsService は新しいPostStatsServiceインスタンスを生成する。
+func NewPostStatsService(repo repository.PostStatsRepositoryInterface) *PostStatsService {
+	return &PostStatsService{repo: repo}
+}
+
+// GetPostStats は指定ユーザーの投稿集計統計を取得する。
+func (s *PostStatsService) GetPostStats(userID uint) (*model.PostStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetPostStats(userID)
+}

--- a/backend/internal/service/post_stats_test.go
+++ b/backend/internal/service/post_stats_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newPostStatsTestService() (*PostStatsService, *MockPostStatsRepository) {
+	repo := new(MockPostStatsRepository)
+	svc := NewPostStatsService(repo)
+	return svc, repo
+}
+
+func TestPostStatsService_GetPostStats_Success(t *testing.T) {
+	svc, repo := newPostStatsTestService()
+	expected := &model.PostStats{
+		TotalPosts:         10,
+		PublishedPosts:     7,
+		DraftPosts:         3,
+		TotalLikesReceived: 42,
+		TotalComments:      15,
+		PostsThisMonth:     2,
+	}
+	repo.On("GetPostStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetPostStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestPostStatsService_GetPostStats_InvalidUserID(t *testing.T) {
+	svc, _ := newPostStatsTestService()
+
+	_, err := svc.GetPostStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestPostStatsService_GetPostStats_RepoError(t *testing.T) {
+	svc, repo := newPostStatsTestService()
+	repo.On("GetPostStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetPostStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostStatsService_GetPostStats_NoPosts(t *testing.T) {
+	svc, repo := newPostStatsTestService()
+	expected := &model.PostStats{}
+	repo.On("GetPostStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetPostStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalPosts)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要

ユーザーの投稿に関する集計統計を取得するAPIを新設しました。

## 変更内容

- `GET /api/v1/users/:id/post-stats` エンドポイントを追加
- `model.PostStats` 構造体（総投稿数・公開数・下書き数・いいね総数・コメント総数・今月の投稿数）
- TDDアプローチ：serviceテスト4件を先行作成してから実装
- `PostStatsRepositoryInterface` → `PostStatsRepository`（GORMによるSUM/COUNT集計クエリ）
- DI（`container.go`）・ルーター（`router.go`）への登録完了

## テスト

```
PASS: TestPostStatsService_GetPostStats_Success
PASS: TestPostStatsService_GetPostStats_InvalidUserID
PASS: TestPostStatsService_GetPostStats_RepoError
PASS: TestPostStatsService_GetPostStats_NoPosts
```