### PR TITLE
refactor: BookReviewServiceにfindAndCheckOwnershipヘルパーを抽出

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -35,14 +35,23 @@ func (s *BookReviewService) GetAll(limit, offset int) ([]model.BookReview, int64
 	return s.repo.FindAll(limit, offset)
 }
 
-// Update は所有権を検証した後、書籍レビューを更新する。
-func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (*model.BookReview, error) {
+// findAndCheckOwnership は書籍レビューを取得し、指定ユーザーが所有者かを検証する。
+func (s *BookReviewService) findAndCheckOwnership(id, userID uint) (*model.BookReview, error) {
 	review, err := s.repo.FindByID(id)
 	if err != nil {
 		return nil, err
 	}
 	if review.UserID != userID {
 		return nil, ErrForbidden
+	}
+	return review, nil
+}
+
+// Update は所有権を検証した後、書籍レビューを更新する。
+func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (*model.BookReview, error) {
+	review, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
 	}
 
 	if updates.Title != "" {
@@ -72,12 +81,8 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 
 // Delete は所有権を検証した後、書籍レビューを削除する。
 func (s *BookReviewService) Delete(id, userID uint) error {
-	review, err := s.repo.FindByID(id)
-	if err != nil {
+	if _, err := s.findAndCheckOwnership(id, userID); err != nil {
 		return err
-	}
-	if review.UserID != userID {
-		return ErrForbidden
 	}
 	return s.repo.Delete(id)
 }


### PR DESCRIPTION
## 概要

`BookReviewService` の `Update` / `Delete` メソッドに存在した所有権チェックの重複コード（FindByID → UserID検証 → ErrForbidden）を `findAndCheckOwnership` 共通ヘルパーに統一しました。

## 変更内容

- `findAndCheckOwnership(id, userID uint)` プライベートヘルパーを追加
- `Update` / `Delete` でヘルパーを利用するようリファクタリング
- 振る舞いは変えず、重複コードのみ解消

## テスト

既存14件が全PASS（振る舞い変更なし）

## 参考

- `note_folder.go` にて同様のリファクタリング実施済み（PR #742）