### PR TITLE
fix: AnswerService.Voteに自己投票防止チェックを追加

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -83,10 +83,18 @@ func (s *AnswerService) SetBestAnswer(questionID, answerID, userID uint) error {
 
 // Vote は投票値を検証した後、回答に投票する。
 // valueは1（賛成）または-1（反対）のみ許可される。
+// 自分の回答への自己投票は禁止する。
 func (s *AnswerService) Vote(userID, answerID uint, value int) error {
 	v := validator.NewQuestionValidator()
 	if err := v.ValidateVote(value); err != nil {
 		return err
+	}
+	answer, err := s.answerRepo.FindByID(answerID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if answer.UserID == userID {
+		return ErrForbidden
 	}
 	return s.answerRepo.Vote(userID, answerID, value)
 }

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -264,11 +264,38 @@ func TestSetBestAnswer_RepoError(t *testing.T) {
 func TestAnswerVote_Success(t *testing.T) {
 	svc, answerRepo, _ := newTestAnswerService()
 
+	// 回答者はuserID=99（投票者のuserID=1とは異なる）
+	answer := &model.Answer{UserID: 99}
+	answer.ID = 5
+	answerRepo.On("FindByID", uint(5)).Return(answer, nil)
 	answerRepo.On("Vote", uint(1), uint(5), 1).Return(nil)
 
 	err := svc.Vote(1, 5, 1)
 	assert.NoError(t, err)
 	answerRepo.AssertExpectations(t)
+}
+
+func TestAnswerVote_SelfVote_Forbidden(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	// 自分の回答に投票しようとする（userID=1の回答にuserID=1が投票）
+	answer := &model.Answer{UserID: 1}
+	answer.ID = 5
+	answerRepo.On("FindByID", uint(5)).Return(answer, nil)
+
+	err := svc.Vote(1, 5, 1)
+	assert.ErrorIs(t, err, ErrForbidden)
+	answerRepo.AssertNotCalled(t, "Vote")
+}
+
+func TestAnswerVote_AnswerNotFound(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answerRepo.On("FindByID", uint(99)).Return(nil, ErrNotFound)
+
+	err := svc.Vote(1, 99, 1)
+	assert.ErrorIs(t, err, ErrNotFound)
+	answerRepo.AssertNotCalled(t, "Vote")
 }
 
 func TestAnswerRemoveVote_Success(t *testing.T) {
@@ -365,6 +392,10 @@ func TestAnswerVote_OutOfRangeValue(t *testing.T) {
 func TestAnswerVote_ValidUpvote(t *testing.T) {
 	svc, answerRepo, _ := newTestAnswerService()
 
+	// 回答者はuserID=99（投票者のuserID=1とは異なる）
+	answer := &model.Answer{UserID: 99}
+	answer.ID = 1
+	answerRepo.On("FindByID", uint(1)).Return(answer, nil)
 	answerRepo.On("Vote", uint(1), uint(1), 1).Return(nil)
 
 	err := svc.Vote(1, 1, 1)
@@ -375,6 +406,10 @@ func TestAnswerVote_ValidUpvote(t *testing.T) {
 func TestAnswerVote_ValidDownvote(t *testing.T) {
 	svc, answerRepo, _ := newTestAnswerService()
 
+	// 回答者はuserID=99（投票者のuserID=1とは異なる）
+	answer := &model.Answer{UserID: 99}
+	answer.ID = 1
+	answerRepo.On("FindByID", uint(1)).Return(answer, nil)
 	answerRepo.On("Vote", uint(1), uint(1), -1).Return(nil)
 
 	err := svc.Vote(1, 1, -1)


### PR DESCRIPTION
## 脆弱性

`AnswerService.Vote` が投票値バリデーションのみ行っており、**自分の回答に自己投票できてしまう**セキュリティ上の問題がありました。

## 修正内容

- `Vote()` 内で `answerRepo.FindByID` を呼び出し、回答の所有者を確認
- `answer.UserID == userID` の場合は `ErrForbidden` を返して自己投票を拒否
- 回答が存在しない場合は `ErrNotFound` を返す

## テスト

- `TestAnswerVote_SelfVote_Forbidden`: 自己投票 → 403 Forbidden
- `TestAnswerVote_AnswerNotFound`: 回答なし → 404 Not Found
- 既存テスト（ValidUpvote/ValidDownvote/Success）に `FindByID` モックを追加