### PR TITLE
feat: ユーザー書籍レビュー集計統計API（BookReviewStats）を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -64,6 +64,7 @@ type Container struct {
 	NoteStatsHandler              *handler.NoteStatsHandler
 	StudyCircleStatsHandler       *handler.StudyCircleStatsHandler
 	PostStatsHandler              *handler.PostStatsHandler
+	BookReviewStatsHandler        *handler.BookReviewStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -269,6 +270,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	postStatsRepo := repository.NewPostStatsRepository(db)
 	postStatsService := service.NewPostStatsService(postStatsRepo)
 	c.PostStatsHandler = handler.NewPostStatsHandler(postStatsService)
+
+	bookReviewStatsRepo := repository.NewBookReviewStatsRepository(db)
+	bookReviewStatsService := service.NewBookReviewStatsService(bookReviewStatsRepo)
+	c.BookReviewStatsHandler = handler.NewBookReviewStatsHandler(bookReviewStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/book_review_stats.go
+++ b/backend/internal/handler/book_review_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// BookReviewStatsServiceInterface はBookReviewStatsHandlerが依存するサービスメソッドを定義する。
+type BookReviewStatsServiceInterface interface {
+	GetBookReviewStats(userID uint) (*model.BookReviewStats, error)
+}
+
+// BookReviewStatsHandler はユーザー書籍レビュー統計関連のHTTPハンドラ。
+type BookReviewStatsHandler struct {
+	service BookReviewStatsServiceInterface
+}
+
+// NewBookReviewStatsHandler は新しいBookReviewStatsHandlerインスタンスを生成する。
+func NewBookReviewStatsHandler(s BookReviewStatsServiceInterface) *BookReviewStatsHandler {
+	return &BookReviewStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーの書籍レビュー集計統計を返す。
+func (h *BookReviewStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetBookReviewStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/book_review_stats.go
+++ b/backend/internal/model/book_review_stats.go
@@ -1,0 +1,10 @@
+package model
+
+// BookReviewStats はユーザーの書籍レビュー集計統計を表す。
+type BookReviewStats struct {
+	TotalReviews   int64   `json:"total_reviews"`
+	AverageRating  float64 `json:"average_rating"`
+	MaxRating      int     `json:"max_rating"`
+	MinRating      int     `json:"min_rating"`
+	FiveStarCount  int64   `json:"five_star_count"`
+}

--- a/backend/internal/repository/book_review_stats.go
+++ b/backend/internal/repository/book_review_stats.go
@@ -1,0 +1,64 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// BookReviewStatsRepository はユーザー書籍レビュー集計統計の取得を担当するリポジトリ実装。
+type BookReviewStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewBookReviewStatsRepository は新しいBookReviewStatsRepositoryインスタンスを生成する。
+func NewBookReviewStatsRepository(db *gorm.DB) *BookReviewStatsRepository {
+	return &BookReviewStatsRepository{db: db}
+}
+
+// GetBookReviewStats は指定ユーザーの書籍レビュー集計統計を返す。
+func (r *BookReviewStatsRepository) GetBookReviewStats(userID uint) (*model.BookReviewStats, error) {
+	var stats model.BookReviewStats
+
+	// 総レビュー数
+	if err := r.db.Model(&model.BookReview{}).Where("user_id = ?", userID).Count(&stats.TotalReviews).Error; err != nil {
+		return nil, err
+	}
+
+	if stats.TotalReviews == 0 {
+		return &stats, nil
+	}
+
+	// 平均評価
+	var avgRating *float64
+	if err := r.db.Model(&model.BookReview{}).Where("user_id = ?", userID).Select("AVG(rating)").Scan(&avgRating).Error; err != nil {
+		return nil, err
+	}
+	if avgRating != nil {
+		stats.AverageRating = *avgRating
+	}
+
+	// 最高評価
+	var maxRating *int
+	if err := r.db.Model(&model.BookReview{}).Where("user_id = ?", userID).Select("MAX(rating)").Scan(&maxRating).Error; err != nil {
+		return nil, err
+	}
+	if maxRating != nil {
+		stats.MaxRating = *maxRating
+	}
+
+	// 最低評価
+	var minRating *int
+	if err := r.db.Model(&model.BookReview{}).Where("user_id = ?", userID).Select("MIN(rating)").Scan(&minRating).Error; err != nil {
+		return nil, err
+	}
+	if minRating != nil {
+		stats.MinRating = *minRating
+	}
+
+	// 5つ星レビュー数
+	if err := r.db.Model(&model.BookReview{}).Where("user_id = ? AND rating = ?", userID, 5).Count(&stats.FiveStarCount).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -531,3 +531,8 @@ type PostViewRepositoryInterface interface {
 type PostStatsRepositoryInterface interface {
 	GetPostStats(userID uint) (*model.PostStats, error)
 }
+
+// BookReviewStatsRepositoryInterface はユーザー書籍レビュー集計統計データ操作の契約を定義する。
+type BookReviewStatsRepositoryInterface interface {
+	GetBookReviewStats(userID uint) (*model.BookReviewStats, error)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -100,6 +100,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerNoteStatsRoutes(protected, c)
 		registerStudyCircleStatsRoutes(protected, c)
 		registerPostStatsRoutes(protected, c)
+		registerBookReviewStatsRoutes(protected, c)
 	}
 
 	return r
@@ -622,5 +623,12 @@ func registerPostStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/post-stats", c.PostStatsHandler.GetStats)
+	}
+}
+
+func registerBookReviewStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/book-review-stats", c.BookReviewStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/book_review_stats.go
+++ b/backend/internal/service/book_review_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// BookReviewStatsService はユーザー書籍レビュー集計統計のビジネスロジックを提供する。
+type BookReviewStatsService struct {
+	repo repository.BookReviewStatsRepositoryInterface
+}
+
+// NewBookReviewStatsService は新しいBookReviewStatsServiceインスタンスを生成する。
+func NewBookReviewStatsService(repo repository.BookReviewStatsRepositoryInterface) *BookReviewStatsService {
+	return &BookReviewStatsService{repo: repo}
+}
+
+// GetBookReviewStats は指定ユーザーの書籍レビュー集計統計を取得する。
+func (s *BookReviewStatsService) GetBookReviewStats(userID uint) (*model.BookReviewStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetBookReviewStats(userID)
+}

--- a/backend/internal/service/book_review_stats_test.go
+++ b/backend/internal/service/book_review_stats_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newBookReviewStatsTestService() (*BookReviewStatsService, *MockBookReviewStatsRepository) {
+	repo := new(MockBookReviewStatsRepository)
+	svc := NewBookReviewStatsService(repo)
+	return svc, repo
+}
+
+func TestBookReviewStatsService_GetBookReviewStats_Success(t *testing.T) {
+	svc, repo := newBookReviewStatsTestService()
+	expected := &model.BookReviewStats{
+		TotalReviews:  5,
+		AverageRating: 3.8,
+		MaxRating:     5,
+		MinRating:     2,
+		FiveStarCount: 2,
+	}
+	repo.On("GetBookReviewStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetBookReviewStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewStatsService_GetBookReviewStats_InvalidUserID(t *testing.T) {
+	svc, _ := newBookReviewStatsTestService()
+
+	_, err := svc.GetBookReviewStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestBookReviewStatsService_GetBookReviewStats_RepoError(t *testing.T) {
+	svc, repo := newBookReviewStatsTestService()
+	repo.On("GetBookReviewStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetBookReviewStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewStatsService_GetBookReviewStats_NoReviews(t *testing.T) {
+	svc, repo := newBookReviewStatsTestService()
+	expected := &model.BookReviewStats{}
+	repo.On("GetBookReviewStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetBookReviewStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalReviews)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1903,3 +1903,19 @@ func (m *MockPostStatsRepository) GetPostStats(userID uint) (*model.PostStats, e
 	}
 	return args.Get(0).(*model.PostStats), args.Error(1)
 }
+
+// ============================================================
+// MockBookReviewStatsRepository は repository.BookReviewStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockBookReviewStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockBookReviewStatsRepository) GetBookReviewStats(userID uint) (*model.BookReviewStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.BookReviewStats), args.Error(1)
+}


### PR DESCRIPTION
## 概要

ユーザーの書籍レビューに関する集計統計を取得するAPIを新設しました。

## 変更内容

- `GET /api/v1/users/:id/book-review-stats` エンドポイントを追加
- `model.BookReviewStats` 構造体（総レビュー数・平均評価・最高評価・最低評価・5つ星数）
- TDDアプローチ：serviceテスト4件を先行作成してから実装
- `BookReviewStatsRepositoryInterface` → `BookReviewStatsRepository`（GORMによるAVG/MAX/MIN/COUNT集計クエリ）
- DI・ルーターへの登録完了

## テスト

```
PASS: TestBookReviewStatsService_GetBookReviewStats_Success
PASS: TestBookReviewStatsService_GetBookReviewStats_InvalidUserID
PASS: TestBookReviewStatsService_GetBookReviewStats_RepoError
PASS: TestBookReviewStatsService_GetBookReviewStats_NoReviews
```