### PR TITLE
fix: QuestionService.Voteに自己投票防止チェックを追加

### DIFF
--- a/backend/internal/service/question.go
+++ b/backend/internal/service/question.go
@@ -95,10 +95,18 @@ func (s *QuestionService) Delete(id, userID uint) error {
 }
 
 // Vote は質問に投票する。
+// 自分の質問への自己投票は禁止する。
 func (s *QuestionService) Vote(userID, questionID uint, value int) error {
 	v := validator.NewQuestionValidator()
 	if err := v.ValidateVote(value); err != nil {
 		return err
+	}
+	question, err := s.repo.FindByID(questionID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if question.UserID == userID {
+		return ErrForbidden
 	}
 	return s.repo.Vote(userID, questionID, value)
 }

--- a/backend/internal/service/question_test.go
+++ b/backend/internal/service/question_test.go
@@ -118,11 +118,38 @@ func TestQuestionDelete_Forbidden(t *testing.T) {
 func TestQuestionVote_Success(t *testing.T) {
 	svc, repo := newTestQuestionService()
 
+	// 質問者はuserID=99（投票者のuserID=1とは異なる）
+	question := &model.Question{UserID: 99}
+	question.ID = 10
+	repo.On("FindByID", uint(10)).Return(question, nil)
 	repo.On("Vote", uint(1), uint(10), 1).Return(nil)
 
 	err := svc.Vote(1, 10, 1)
 	assert.NoError(t, err)
 	repo.AssertExpectations(t)
+}
+
+func TestQuestionVote_SelfVote_Forbidden(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	// 自分の質問に投票しようとする（userID=1の質問にuserID=1が投票）
+	question := &model.Question{UserID: 1}
+	question.ID = 10
+	repo.On("FindByID", uint(10)).Return(question, nil)
+
+	err := svc.Vote(1, 10, 1)
+	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertNotCalled(t, "Vote")
+}
+
+func TestQuestionVote_QuestionNotFound(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindByID", uint(99)).Return(nil, ErrNotFound)
+
+	err := svc.Vote(1, 99, 1)
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertNotCalled(t, "Vote")
 }
 
 func TestQuestionRemoveVote_Success(t *testing.T) {


### PR DESCRIPTION
## 脆弱性

`QuestionService.Vote` が投票値バリデーションのみ行っており、**自分の質問への自己投票が可能**な状態でした。

## 修正内容

- `Vote()` 内で `repo.FindByID` を呼び出し、質問の所有者を確認
- `question.UserID == userID` の場合は `ErrForbidden` を返して自己投票を拒否

## テスト

- `TestQuestionVote_SelfVote_Forbidden`: 自己投票 → 403 Forbidden
- `TestQuestionVote_QuestionNotFound`: 質問なし → 404 Not Found
- 既存テスト（Success）に `FindByID` モックを追加

## 参考

- `AnswerService.Vote` 同様の修正: PR #754