### PR TITLE
feat: ユーザーQ&A集計統計API（QAStats）を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -65,6 +65,7 @@ type Container struct {
 	StudyCircleStatsHandler       *handler.StudyCircleStatsHandler
 	PostStatsHandler              *handler.PostStatsHandler
 	BookReviewStatsHandler        *handler.BookReviewStatsHandler
+	QAStatsHandler                *handler.QAStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -274,6 +275,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	bookReviewStatsRepo := repository.NewBookReviewStatsRepository(db)
 	bookReviewStatsService := service.NewBookReviewStatsService(bookReviewStatsRepo)
 	c.BookReviewStatsHandler = handler.NewBookReviewStatsHandler(bookReviewStatsService)
+
+	qaStatsRepo := repository.NewQAStatsRepository(db)
+	qaStatsService := service.NewQAStatsService(qaStatsRepo)
+	c.QAStatsHandler = handler.NewQAStatsHandler(qaStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/qa_stats.go
+++ b/backend/internal/handler/qa_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// QAStatsServiceInterface はQAStatsHandlerが依存するサービスメソッドを定義する。
+type QAStatsServiceInterface interface {
+	GetQAStats(userID uint) (*model.QAStats, error)
+}
+
+// QAStatsHandler はユーザーQ&A統計関連のHTTPハンドラ。
+type QAStatsHandler struct {
+	service QAStatsServiceInterface
+}
+
+// NewQAStatsHandler は新しいQAStatsHandlerインスタンスを生成する。
+func NewQAStatsHandler(s QAStatsServiceInterface) *QAStatsHandler {
+	return &QAStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのQ&A活動集計統計を返す。
+func (h *QAStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetQAStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/qa_stats.go
+++ b/backend/internal/model/qa_stats.go
@@ -1,0 +1,9 @@
+package model
+
+// QAStats はユーザーのQ&A活動集計統計を表す。
+type QAStats struct {
+	TotalQuestions     int64 `json:"total_questions"`
+	TotalAnswers       int64 `json:"total_answers"`
+	BestAnswerCount    int64 `json:"best_answer_count"`
+	TotalVotesReceived int64 `json:"total_votes_received"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -536,3 +536,8 @@ type PostStatsRepositoryInterface interface {
 type BookReviewStatsRepositoryInterface interface {
 	GetBookReviewStats(userID uint) (*model.BookReviewStats, error)
 }
+
+// QAStatsRepositoryInterface はユーザーQ&A活動集計統計データ操作の契約を定義する。
+type QAStatsRepositoryInterface interface {
+	GetQAStats(userID uint) (*model.QAStats, error)
+}

--- a/backend/internal/repository/qa_stats.go
+++ b/backend/internal/repository/qa_stats.go
@@ -1,0 +1,54 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// QAStatsRepository はユーザーQ&A活動集計統計の取得を担当するリポジトリ実装。
+type QAStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewQAStatsRepository は新しいQAStatsRepositoryインスタンスを生成する。
+func NewQAStatsRepository(db *gorm.DB) *QAStatsRepository {
+	return &QAStatsRepository{db: db}
+}
+
+// GetQAStats は指定ユーザーのQ&A活動集計統計を返す。
+func (r *QAStatsRepository) GetQAStats(userID uint) (*model.QAStats, error) {
+	var stats model.QAStats
+
+	// 質問数
+	if err := r.db.Model(&model.Question{}).Where("user_id = ?", userID).Count(&stats.TotalQuestions).Error; err != nil {
+		return nil, err
+	}
+
+	// 回答数
+	if err := r.db.Model(&model.Answer{}).Where("user_id = ?", userID).Count(&stats.TotalAnswers).Error; err != nil {
+		return nil, err
+	}
+
+	// ベストアンサー数
+	if err := r.db.Model(&model.Answer{}).Where("user_id = ? AND is_best = ?", userID, true).Count(&stats.BestAnswerCount).Error; err != nil {
+		return nil, err
+	}
+
+	// 受け取った投票総数（質問のvote_count + 回答のvote_countの合計）
+	var questionVotes *int64
+	if err := r.db.Model(&model.Question{}).Where("user_id = ?", userID).Select("SUM(vote_count)").Scan(&questionVotes).Error; err != nil {
+		return nil, err
+	}
+	var answerVotes *int64
+	if err := r.db.Model(&model.Answer{}).Where("user_id = ?", userID).Select("SUM(vote_count)").Scan(&answerVotes).Error; err != nil {
+		return nil, err
+	}
+	if questionVotes != nil {
+		stats.TotalVotesReceived += *questionVotes
+	}
+	if answerVotes != nil {
+		stats.TotalVotesReceived += *answerVotes
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -101,6 +101,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerStudyCircleStatsRoutes(protected, c)
 		registerPostStatsRoutes(protected, c)
 		registerBookReviewStatsRoutes(protected, c)
+		registerQAStatsRoutes(protected, c)
 	}
 
 	return r
@@ -630,5 +631,12 @@ func registerBookReviewStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/book-review-stats", c.BookReviewStatsHandler.GetStats)
+	}
+}
+
+func registerQAStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/qa-stats", c.QAStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1919,3 +1919,19 @@ func (m *MockBookReviewStatsRepository) GetBookReviewStats(userID uint) (*model.
 	}
 	return args.Get(0).(*model.BookReviewStats), args.Error(1)
 }
+
+// ============================================================
+// MockQAStatsRepository は repository.QAStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockQAStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockQAStatsRepository) GetQAStats(userID uint) (*model.QAStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.QAStats), args.Error(1)
+}

--- a/backend/internal/service/qa_stats.go
+++ b/backend/internal/service/qa_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// QAStatsService はユーザーQ&A活動集計統計のビジネスロジックを提供する。
+type QAStatsService struct {
+	repo repository.QAStatsRepositoryInterface
+}
+
+// NewQAStatsService は新しいQAStatsServiceインスタンスを生成する。
+func NewQAStatsService(repo repository.QAStatsRepositoryInterface) *QAStatsService {
+	return &QAStatsService{repo: repo}
+}
+
+// GetQAStats は指定ユーザーのQ&A活動集計統計を取得する。
+func (s *QAStatsService) GetQAStats(userID uint) (*model.QAStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetQAStats(userID)
+}

--- a/backend/internal/service/qa_stats_test.go
+++ b/backend/internal/service/qa_stats_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newQAStatsTestService() (*QAStatsService, *MockQAStatsRepository) {
+	repo := new(MockQAStatsRepository)
+	svc := NewQAStatsService(repo)
+	return svc, repo
+}
+
+func TestQAStatsService_GetQAStats_Success(t *testing.T) {
+	svc, repo := newQAStatsTestService()
+	expected := &model.QAStats{
+		TotalQuestions:     5,
+		TotalAnswers:       12,
+		BestAnswerCount:    3,
+		TotalVotesReceived: 28,
+	}
+	repo.On("GetQAStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetQAStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestQAStatsService_GetQAStats_InvalidUserID(t *testing.T) {
+	svc, _ := newQAStatsTestService()
+
+	_, err := svc.GetQAStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestQAStatsService_GetQAStats_RepoError(t *testing.T) {
+	svc, repo := newQAStatsTestService()
+	repo.On("GetQAStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetQAStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestQAStatsService_GetQAStats_NoActivity(t *testing.T) {
+	svc, repo := newQAStatsTestService()
+	expected := &model.QAStats{}
+	repo.On("GetQAStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetQAStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalQuestions)
+	assert.Equal(t, int64(0), result.TotalAnswers)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要

ユーザーのQ&A活動に関する集計統計を取得するAPIを新設しました。

## 変更内容

- `GET /api/v1/users/:id/qa-stats` エンドポイントを追加
- `model.QAStats` 構造体（質問数・回答数・ベストアンサー数・受取投票総数）
- TDDアプローチ：serviceテスト4件を先行作成してから実装
- `QAStatsRepositoryInterface` → `QAStatsRepository`（GORMによるSUM/COUNT集計クエリ）
- DI・ルーターへの登録完了

## テスト

```
PASS: TestQAStatsService_GetQAStats_Success
PASS: TestQAStatsService_GetQAStats_InvalidUserID
PASS: TestQAStatsService_GetQAStats_RepoError
PASS: TestQAStatsService_GetQAStats_NoActivity
```