### PR TITLE
refactor: LearningLogServiceにfindAndCheckOwnershipヘルパーを抽出

### DIFF
--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -49,14 +49,23 @@ func (s *LearningLogService) GetByUserID(userID uint) ([]model.LearningLog, erro
 	return s.repo.GetByUserID(userID)
 }
 
-// Update は所有権を検証した後、学習ログを更新する。
-func (s *LearningLogService) Update(id, userID uint, updates *model.LearningLog) (*model.LearningLog, error) {
+// findAndCheckOwnership は学習ログを取得し、指定ユーザーが所有者かを検証する。
+func (s *LearningLogService) findAndCheckOwnership(id, userID uint) (*model.LearningLog, error) {
 	log, err := s.repo.FindByID(id)
 	if err != nil {
 		return nil, err
 	}
 	if log.UserID != userID {
 		return nil, ErrForbidden
+	}
+	return log, nil
+}
+
+// Update は所有権を検証した後、学習ログを更新する。
+func (s *LearningLogService) Update(id, userID uint, updates *model.LearningLog) (*model.LearningLog, error) {
+	log, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
 	}
 
 	if updates.Title != "" {
@@ -80,12 +89,8 @@ func (s *LearningLogService) Update(id, userID uint, updates *model.LearningLog)
 
 // Delete は所有権を検証した後、学習ログを削除する。
 func (s *LearningLogService) Delete(id, userID uint) error {
-	log, err := s.repo.FindByID(id)
-	if err != nil {
+	if _, err := s.findAndCheckOwnership(id, userID); err != nil {
 		return err
-	}
-	if log.UserID != userID {
-		return ErrForbidden
 	}
 	return s.repo.Delete(id, userID)
 }


### PR DESCRIPTION
## 概要

`LearningLogService` の `Update` / `Delete` メソッドの所有権チェック重複コードを `findAndCheckOwnership` 共通ヘルパーに統一しました。

## 変更内容

- `findAndCheckOwnership(id, userID uint)` プライベートヘルパーを追加
- `Update` / `Delete` でヘルパーを利用するようリファクタリング
- 振る舞いは変えず、重複コードのみ解消

## テスト

既存24件全PASS（振る舞い変更なし）