### PR TITLE
fix: PostService.Like/Unlikeに自己いいね防止チェックを追加

### DIFF
--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -141,12 +141,28 @@ func (s *PostService) Delete(id, userID uint) error {
 }
 
 // Like は投稿にいいねを追加する。
+// 自分の投稿にはいいねできない。
 func (s *PostService) Like(userID, postID uint) error {
+	post, err := s.repo.FindByID(postID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if post.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.Like(userID, postID)
 }
 
 // Unlike は投稿のいいねを取り消す。
+// 自分の投稿のいいねは取り消せない（そもそもいいねできないため）。
 func (s *PostService) Unlike(userID, postID uint) error {
+	post, err := s.repo.FindByID(postID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if post.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.Unlike(userID, postID)
 }
 

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -219,6 +219,9 @@ func TestPostTimeline_Success(t *testing.T) {
 func TestPostLike_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	post := &model.Post{UserID: 2, Title: "Other's post"}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
 	postRepo.On("Like", uint(1), uint(10)).Return(nil)
 
 	err := svc.Like(1, 10)
@@ -226,14 +229,50 @@ func TestPostLike_Success(t *testing.T) {
 	postRepo.AssertExpectations(t)
 }
 
+func TestPostLike_SelfLike_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	post := &model.Post{UserID: 1, Title: "My post"}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	err := svc.Like(1, 10)
+	assert.ErrorIs(t, err, ErrForbidden)
+	postRepo.AssertNotCalled(t, "Like")
+}
+
+func TestPostLike_PostNotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.Like(1, 999)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestPostUnlike_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	post := &model.Post{UserID: 2, Title: "Other's post"}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
 	postRepo.On("Unlike", uint(1), uint(10)).Return(nil)
 
 	err := svc.Unlike(1, 10)
 	assert.NoError(t, err)
 	postRepo.AssertExpectations(t)
+}
+
+func TestPostUnlike_SelfUnlike_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	post := &model.Post{UserID: 1, Title: "My post"}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	err := svc.Unlike(1, 10)
+	assert.ErrorIs(t, err, ErrForbidden)
+	postRepo.AssertNotCalled(t, "Unlike")
 }
 
 func TestPostHasLiked(t *testing.T) {


### PR DESCRIPTION
## 概要
- PostService.Like/Unlikeに自己いいね防止チェックを追加
- FindByIDで投稿を取得し、所有者の場合はErrForbiddenを返す

## テスト
- `TestPostLike_SelfLike_Forbidden` — 自己いいね → Forbidden
- `TestPostLike_PostNotFound` — 存在しない投稿 → NotFound
- `TestPostUnlike_SelfUnlike_Forbidden` — 自己いいね取消 → Forbidden
- 既存の`TestPostLike_Success`/`TestPostUnlike_Success`もFindByIDモック追加で更新

closes #770