### PR TITLE
feat: CodeSnippetStats APIの追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -66,6 +66,7 @@ type Container struct {
 	PostStatsHandler              *handler.PostStatsHandler
 	BookReviewStatsHandler        *handler.BookReviewStatsHandler
 	QAStatsHandler                *handler.QAStatsHandler
+	CodeSnippetStatsHandler       *handler.CodeSnippetStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -279,6 +280,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	qaStatsRepo := repository.NewQAStatsRepository(db)
 	qaStatsService := service.NewQAStatsService(qaStatsRepo)
 	c.QAStatsHandler = handler.NewQAStatsHandler(qaStatsService)
+
+	codeSnippetStatsRepo := repository.NewCodeSnippetStatsRepository(db)
+	codeSnippetStatsService := service.NewCodeSnippetStatsService(codeSnippetStatsRepo)
+	c.CodeSnippetStatsHandler = handler.NewCodeSnippetStatsHandler(codeSnippetStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/code_snippet_stats.go
+++ b/backend/internal/handler/code_snippet_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// CodeSnippetStatsServiceInterface はCodeSnippetStatsHandlerが依存するサービスメソッドを定義する。
+type CodeSnippetStatsServiceInterface interface {
+	GetCodeSnippetStats(userID uint) (*model.CodeSnippetStats, error)
+}
+
+// CodeSnippetStatsHandler はユーザーコードスニペット統計関連のHTTPハンドラ。
+type CodeSnippetStatsHandler struct {
+	service CodeSnippetStatsServiceInterface
+}
+
+// NewCodeSnippetStatsHandler は新しいCodeSnippetStatsHandlerインスタンスを生成する。
+func NewCodeSnippetStatsHandler(s CodeSnippetStatsServiceInterface) *CodeSnippetStatsHandler {
+	return &CodeSnippetStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのコードスニペット活動集計統計を返す。
+func (h *CodeSnippetStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetCodeSnippetStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/code_snippet_stats.go
+++ b/backend/internal/model/code_snippet_stats.go
@@ -1,0 +1,8 @@
+package model
+
+// CodeSnippetStats はユーザーのコードスニペット活動集計統計を表す。
+type CodeSnippetStats struct {
+	TotalSnippets int64 `json:"total_snippets"`
+	TotalComments int64 `json:"total_comments"`
+	LanguageCount int64 `json:"language_count"`
+}

--- a/backend/internal/repository/code_snippet_stats.go
+++ b/backend/internal/repository/code_snippet_stats.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// CodeSnippetStatsRepository はユーザーコードスニペット活動集計統計の取得を担当するリポジトリ実装。
+type CodeSnippetStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewCodeSnippetStatsRepository は新しいCodeSnippetStatsRepositoryインスタンスを生成する。
+func NewCodeSnippetStatsRepository(db *gorm.DB) *CodeSnippetStatsRepository {
+	return &CodeSnippetStatsRepository{db: db}
+}
+
+// GetCodeSnippetStats は指定ユーザーのコードスニペット活動集計統計を返す。
+func (r *CodeSnippetStatsRepository) GetCodeSnippetStats(userID uint) (*model.CodeSnippetStats, error) {
+	var stats model.CodeSnippetStats
+
+	// 総スニペット数
+	if err := r.db.Model(&model.CodeSnippet{}).Where("user_id = ?", userID).Count(&stats.TotalSnippets).Error; err != nil {
+		return nil, err
+	}
+
+	// コメント総数（SUM of comment_count）
+	var totalComments *int64
+	if err := r.db.Model(&model.CodeSnippet{}).Where("user_id = ?", userID).Select("SUM(comment_count)").Scan(&totalComments).Error; err != nil {
+		return nil, err
+	}
+	if totalComments != nil {
+		stats.TotalComments = *totalComments
+	}
+
+	// 使用言語数（DISTINCT language）
+	if err := r.db.Model(&model.CodeSnippet{}).Where("user_id = ?", userID).Distinct("language").Count(&stats.LanguageCount).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -541,3 +541,8 @@ type BookReviewStatsRepositoryInterface interface {
 type QAStatsRepositoryInterface interface {
 	GetQAStats(userID uint) (*model.QAStats, error)
 }
+
+// CodeSnippetStatsRepositoryInterface はユーザーコードスニペット活動集計統計データ操作の契約を定義する。
+type CodeSnippetStatsRepositoryInterface interface {
+	GetCodeSnippetStats(userID uint) (*model.CodeSnippetStats, error)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -102,6 +102,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerPostStatsRoutes(protected, c)
 		registerBookReviewStatsRoutes(protected, c)
 		registerQAStatsRoutes(protected, c)
+		registerCodeSnippetStatsRoutes(protected, c)
 	}
 
 	return r
@@ -638,5 +639,12 @@ func registerQAStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/qa-stats", c.QAStatsHandler.GetStats)
+	}
+}
+
+func registerCodeSnippetStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/code-snippet-stats", c.CodeSnippetStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/code_snippet_stats.go
+++ b/backend/internal/service/code_snippet_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// CodeSnippetStatsService はユーザーコードスニペット活動集計統計のビジネスロジックを提供する。
+type CodeSnippetStatsService struct {
+	repo repository.CodeSnippetStatsRepositoryInterface
+}
+
+// NewCodeSnippetStatsService は新しいCodeSnippetStatsServiceインスタンスを生成する。
+func NewCodeSnippetStatsService(repo repository.CodeSnippetStatsRepositoryInterface) *CodeSnippetStatsService {
+	return &CodeSnippetStatsService{repo: repo}
+}
+
+// GetCodeSnippetStats は指定ユーザーのコードスニペット活動集計統計を取得する。
+func (s *CodeSnippetStatsService) GetCodeSnippetStats(userID uint) (*model.CodeSnippetStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetCodeSnippetStats(userID)
+}

--- a/backend/internal/service/code_snippet_stats_test.go
+++ b/backend/internal/service/code_snippet_stats_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newCodeSnippetStatsTestService() (*CodeSnippetStatsService, *MockCodeSnippetStatsRepository) {
+	repo := new(MockCodeSnippetStatsRepository)
+	svc := NewCodeSnippetStatsService(repo)
+	return svc, repo
+}
+
+func TestCodeSnippetStatsService_GetCodeSnippetStats_Success(t *testing.T) {
+	svc, repo := newCodeSnippetStatsTestService()
+	expected := &model.CodeSnippetStats{
+		TotalSnippets: 15,
+		TotalComments: 42,
+		LanguageCount: 5,
+	}
+	repo.On("GetCodeSnippetStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetCodeSnippetStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestCodeSnippetStatsService_GetCodeSnippetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newCodeSnippetStatsTestService()
+
+	_, err := svc.GetCodeSnippetStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestCodeSnippetStatsService_GetCodeSnippetStats_RepoError(t *testing.T) {
+	svc, repo := newCodeSnippetStatsTestService()
+	repo.On("GetCodeSnippetStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetCodeSnippetStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestCodeSnippetStatsService_GetCodeSnippetStats_NoActivity(t *testing.T) {
+	svc, repo := newCodeSnippetStatsTestService()
+	expected := &model.CodeSnippetStats{}
+	repo.On("GetCodeSnippetStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetCodeSnippetStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalSnippets)
+	assert.Equal(t, int64(0), result.TotalComments)
+	assert.Equal(t, int64(0), result.LanguageCount)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1935,3 +1935,18 @@ func (m *MockQAStatsRepository) GetQAStats(userID uint) (*model.QAStats, error) 
 	}
 	return args.Get(0).(*model.QAStats), args.Error(1)
 }
+
+// MockCodeSnippetStatsRepository は repository.CodeSnippetStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockCodeSnippetStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockCodeSnippetStatsRepository) GetCodeSnippetStats(userID uint) (*model.CodeSnippetStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.CodeSnippetStats), args.Error(1)
+}


### PR DESCRIPTION
## 概要
- ユーザーのコードスニペット活動集計統計エンドポイントを追加
- GET `/api/v1/users/:id/code-snippet-stats`
- 統計フィールド: TotalSnippets, TotalComments, LanguageCount

## 実装
- model/code_snippet_stats.go — 統計構造体
- repository/code_snippet_stats.go — COUNT/SUM/DISTINCTクエリ
- service/code_snippet_stats.go — userID検証 + リポジトリ委譲
- handler/code_snippet_stats.go — HTTPハンドラ
- DI・ルーター登録

## テスト
- Success / InvalidUserID / RepoError / NoActivity の4件

closes #772