### PR TITLE
refactor: AnswerServiceに所有権チェックヘルパーを抽出

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -31,14 +31,23 @@ func (s *AnswerService) Create(answer *model.Answer) error {
 	return s.answerRepo.Create(answer)
 }
 
-// Update は所有権を検証した後、回答を更新する。
-func (s *AnswerService) Update(answerID, userID uint, body string) (*model.Answer, error) {
+// findAndCheckOwnership は回答を取得し、指定ユーザーが所有者かを検証する。
+func (s *AnswerService) findAndCheckOwnership(answerID, userID uint) (*model.Answer, error) {
 	answer, err := s.answerRepo.FindByID(answerID)
 	if err != nil {
 		return nil, err
 	}
 	if answer.UserID != userID {
 		return nil, ErrForbidden
+	}
+	return answer, nil
+}
+
+// Update は所有権を検証した後、回答を更新する。
+func (s *AnswerService) Update(answerID, userID uint, body string) (*model.Answer, error) {
+	answer, err := s.findAndCheckOwnership(answerID, userID)
+	if err != nil {
+		return nil, err
 	}
 	answer.Body = body
 	if err := s.answerRepo.Update(answer); err != nil {
@@ -49,12 +58,9 @@ func (s *AnswerService) Update(answerID, userID uint, body string) (*model.Answe
 
 // Delete は所有権を検証した後、回答を削除する。
 func (s *AnswerService) Delete(answerID, userID uint) error {
-	answer, err := s.answerRepo.FindByID(answerID)
+	answer, err := s.findAndCheckOwnership(answerID, userID)
 	if err != nil {
 		return err
-	}
-	if answer.UserID != userID {
-		return ErrForbidden
 	}
 	return s.answerRepo.Delete(answer)
 }


### PR DESCRIPTION
## 概要
- AnswerService.Update/Deleteで重複していたFindByID + UserIDチェックを`findAndCheckOwnership`ヘルパーに統合
- コード重複の削減

## テスト
- 既存22テスト全PASS（変更なし）

closes #774