### PR TITLE
test: PostService.UnlikeのPostNotFoundテスト追加

### DIFF
--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -275,6 +275,15 @@ func TestPostUnlike_SelfUnlike_Forbidden(t *testing.T) {
 	postRepo.AssertNotCalled(t, "Unlike")
 }
 
+func TestPostUnlike_PostNotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.Unlike(1, 999)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestPostHasLiked(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 


### PR DESCRIPTION
## 概要
- PostService.Unlikeの存在しない投稿に対するエラーパスのテストを追加
- FindByIDエラー時にErrNotFoundが返ることを検証

## テスト
- `TestPostUnlike_PostNotFound` — 存在しない投稿 → ErrNotFound

closes #776