### PR TITLE
fix: LearningResourceService.Like/Unlikeに自己いいね防止チェックを追加

### DIFF
--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -143,12 +143,28 @@ func (s *LearningResourceService) Delete(id, userID uint) error {
 }
 
 // Like は学習リソースにいいねを追加する。
+// 自分のリソースにはいいねできない。
 func (s *LearningResourceService) Like(userID, resourceID uint) error {
+	resource, err := s.repo.FindByID(resourceID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if resource.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.Like(userID, resourceID)
 }
 
 // Unlike は学習リソースのいいねを取り消す。
+// 自分のリソースのいいねは取り消せない（そもそもいいねできないため）。
 func (s *LearningResourceService) Unlike(userID, resourceID uint) error {
+	resource, err := s.repo.FindByID(resourceID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if resource.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.Unlike(userID, resourceID)
 }
 

--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -477,6 +477,9 @@ func TestLearningResourceSearch_Empty(t *testing.T) {
 
 func TestLearningResourceLike_Success(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
+	resource := &model.LearningResource{UserID: 2, Title: "Other's resource"}
+	resource.ID = 10
+	repo.On("FindByID", uint(10)).Return(resource, nil)
 	repo.On("Like", uint(1), uint(10)).Return(nil)
 
 	err := svc.Like(1, 10)
@@ -484,8 +487,30 @@ func TestLearningResourceLike_Success(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestLearningResourceLike_SelfLike_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	resource := &model.LearningResource{UserID: 1, Title: "My resource"}
+	resource.ID = 10
+	repo.On("FindByID", uint(10)).Return(resource, nil)
+
+	err := svc.Like(1, 10)
+	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertNotCalled(t, "Like")
+}
+
+func TestLearningResourceLike_NotFound(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.Like(1, 999)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
 func TestLearningResourceLike_Error(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
+	resource := &model.LearningResource{UserID: 2, Title: "Other's resource"}
+	resource.ID = 10
+	repo.On("FindByID", uint(10)).Return(resource, nil)
 	repo.On("Like", uint(1), uint(10)).Return(errors.New("already liked"))
 
 	err := svc.Like(1, 10)
@@ -495,6 +520,9 @@ func TestLearningResourceLike_Error(t *testing.T) {
 
 func TestLearningResourceUnlike_Success(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
+	resource := &model.LearningResource{UserID: 2, Title: "Other's resource"}
+	resource.ID = 10
+	repo.On("FindByID", uint(10)).Return(resource, nil)
 	repo.On("Unlike", uint(1), uint(10)).Return(nil)
 
 	err := svc.Unlike(1, 10)
@@ -502,8 +530,22 @@ func TestLearningResourceUnlike_Success(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestLearningResourceUnlike_SelfUnlike_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	resource := &model.LearningResource{UserID: 1, Title: "My resource"}
+	resource.ID = 10
+	repo.On("FindByID", uint(10)).Return(resource, nil)
+
+	err := svc.Unlike(1, 10)
+	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertNotCalled(t, "Unlike")
+}
+
 func TestLearningResourceUnlike_Error(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
+	resource := &model.LearningResource{UserID: 2, Title: "Other's resource"}
+	resource.ID = 10
+	repo.On("FindByID", uint(10)).Return(resource, nil)
 	repo.On("Unlike", uint(1), uint(10)).Return(errors.New("not liked"))
 
 	err := svc.Unlike(1, 10)


### PR DESCRIPTION
## 概要
- LearningResourceService.Like/Unlikeに自己いいね防止チェックを追加
- FindByIDでリソースを取得し、所有者の場合はErrForbiddenを返す

## テスト
- `TestLearningResourceLike_SelfLike_Forbidden` — 自己いいね → Forbidden
- `TestLearningResourceLike_NotFound` — 存在しないリソース → NotFound
- `TestLearningResourceUnlike_SelfUnlike_Forbidden` — 自己いいね取消 → Forbidden
- 既存のSuccess/Errorテストも FindByIDモック追加で更新

closes #778