### PR TITLE
feat: LearningResourceStats APIの追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -67,6 +67,7 @@ type Container struct {
 	BookReviewStatsHandler        *handler.BookReviewStatsHandler
 	QAStatsHandler                *handler.QAStatsHandler
 	CodeSnippetStatsHandler       *handler.CodeSnippetStatsHandler
+	LearningResourceStatsHandler  *handler.LearningResourceStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -284,6 +285,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	codeSnippetStatsRepo := repository.NewCodeSnippetStatsRepository(db)
 	codeSnippetStatsService := service.NewCodeSnippetStatsService(codeSnippetStatsRepo)
 	c.CodeSnippetStatsHandler = handler.NewCodeSnippetStatsHandler(codeSnippetStatsService)
+
+	learningResourceStatsRepo := repository.NewLearningResourceStatsRepository(db)
+	learningResourceStatsService := service.NewLearningResourceStatsService(learningResourceStatsRepo)
+	c.LearningResourceStatsHandler = handler.NewLearningResourceStatsHandler(learningResourceStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/learning_resource_stats.go
+++ b/backend/internal/handler/learning_resource_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// LearningResourceStatsServiceInterface はLearningResourceStatsHandlerが依存するサービスメソッドを定義する。
+type LearningResourceStatsServiceInterface interface {
+	GetLearningResourceStats(userID uint) (*model.LearningResourceStats, error)
+}
+
+// LearningResourceStatsHandler はユーザー学習リソース統計関連のHTTPハンドラ。
+type LearningResourceStatsHandler struct {
+	service LearningResourceStatsServiceInterface
+}
+
+// NewLearningResourceStatsHandler は新しいLearningResourceStatsHandlerインスタンスを生成する。
+func NewLearningResourceStatsHandler(s LearningResourceStatsServiceInterface) *LearningResourceStatsHandler {
+	return &LearningResourceStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーの学習リソース活動集計統計を返す。
+func (h *LearningResourceStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetLearningResourceStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/learning_resource_stats.go
+++ b/backend/internal/model/learning_resource_stats.go
@@ -1,0 +1,9 @@
+package model
+
+// LearningResourceStats はユーザーの学習リソース活動集計統計を表す。
+type LearningResourceStats struct {
+	TotalResources int64 `json:"total_resources"`
+	TotalLikes     int64 `json:"total_likes"`
+	TotalSaves     int64 `json:"total_saves"`
+	CategoryCount  int64 `json:"category_count"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -546,3 +546,8 @@ type QAStatsRepositoryInterface interface {
 type CodeSnippetStatsRepositoryInterface interface {
 	GetCodeSnippetStats(userID uint) (*model.CodeSnippetStats, error)
 }
+
+// LearningResourceStatsRepositoryInterface はユーザー学習リソース活動集計統計データ操作の契約を定義する。
+type LearningResourceStatsRepositoryInterface interface {
+	GetLearningResourceStats(userID uint) (*model.LearningResourceStats, error)
+}

--- a/backend/internal/repository/learning_resource_stats.go
+++ b/backend/internal/repository/learning_resource_stats.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// LearningResourceStatsRepository はユーザー学習リソース活動集計統計の取得を担当するリポジトリ実装。
+type LearningResourceStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewLearningResourceStatsRepository は新しいLearningResourceStatsRepositoryインスタンスを生成する。
+func NewLearningResourceStatsRepository(db *gorm.DB) *LearningResourceStatsRepository {
+	return &LearningResourceStatsRepository{db: db}
+}
+
+// GetLearningResourceStats は指定ユーザーの学習リソース活動集計統計を返す。
+func (r *LearningResourceStatsRepository) GetLearningResourceStats(userID uint) (*model.LearningResourceStats, error) {
+	var stats model.LearningResourceStats
+
+	// 総リソース数
+	if err := r.db.Model(&model.LearningResource{}).Where("user_id = ?", userID).Count(&stats.TotalResources).Error; err != nil {
+		return nil, err
+	}
+
+	// いいね総数（SUM of like_count）
+	var totalLikes *int64
+	if err := r.db.Model(&model.LearningResource{}).Where("user_id = ?", userID).Select("SUM(like_count)").Scan(&totalLikes).Error; err != nil {
+		return nil, err
+	}
+	if totalLikes != nil {
+		stats.TotalLikes = *totalLikes
+	}
+
+	// 保存総数（SUM of save_count）
+	var totalSaves *int64
+	if err := r.db.Model(&model.LearningResource{}).Where("user_id = ?", userID).Select("SUM(save_count)").Scan(&totalSaves).Error; err != nil {
+		return nil, err
+	}
+	if totalSaves != nil {
+		stats.TotalSaves = *totalSaves
+	}
+
+	// 使用カテゴリ数（DISTINCT category）
+	if err := r.db.Model(&model.LearningResource{}).Where("user_id = ?", userID).Distinct("category").Count(&stats.CategoryCount).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -103,6 +103,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerBookReviewStatsRoutes(protected, c)
 		registerQAStatsRoutes(protected, c)
 		registerCodeSnippetStatsRoutes(protected, c)
+		registerLearningResourceStatsRoutes(protected, c)
 	}
 
 	return r
@@ -646,5 +647,12 @@ func registerCodeSnippetStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/code-snippet-stats", c.CodeSnippetStatsHandler.GetStats)
+	}
+}
+
+func registerLearningResourceStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/learning-resource-stats", c.LearningResourceStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/learning_resource_stats.go
+++ b/backend/internal/service/learning_resource_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// LearningResourceStatsService はユーザー学習リソース活動集計統計のビジネスロジックを提供する。
+type LearningResourceStatsService struct {
+	repo repository.LearningResourceStatsRepositoryInterface
+}
+
+// NewLearningResourceStatsService は新しいLearningResourceStatsServiceインスタンスを生成する。
+func NewLearningResourceStatsService(repo repository.LearningResourceStatsRepositoryInterface) *LearningResourceStatsService {
+	return &LearningResourceStatsService{repo: repo}
+}
+
+// GetLearningResourceStats は指定ユーザーの学習リソース活動集計統計を取得する。
+func (s *LearningResourceStatsService) GetLearningResourceStats(userID uint) (*model.LearningResourceStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetLearningResourceStats(userID)
+}

--- a/backend/internal/service/learning_resource_stats_test.go
+++ b/backend/internal/service/learning_resource_stats_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newLearningResourceStatsTestService() (*LearningResourceStatsService, *MockLearningResourceStatsRepository) {
+	repo := new(MockLearningResourceStatsRepository)
+	svc := NewLearningResourceStatsService(repo)
+	return svc, repo
+}
+
+func TestLearningResourceStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newLearningResourceStatsTestService()
+	expected := &model.LearningResourceStats{
+		TotalResources: 20,
+		TotalLikes:     85,
+		TotalSaves:     30,
+		CategoryCount:  4,
+	}
+	repo.On("GetLearningResourceStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetLearningResourceStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newLearningResourceStatsTestService()
+
+	_, err := svc.GetLearningResourceStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestLearningResourceStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newLearningResourceStatsTestService()
+	repo.On("GetLearningResourceStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetLearningResourceStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newLearningResourceStatsTestService()
+	expected := &model.LearningResourceStats{}
+	repo.On("GetLearningResourceStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetLearningResourceStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalResources)
+	assert.Equal(t, int64(0), result.TotalLikes)
+	assert.Equal(t, int64(0), result.TotalSaves)
+	assert.Equal(t, int64(0), result.CategoryCount)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1950,3 +1950,18 @@ func (m *MockCodeSnippetStatsRepository) GetCodeSnippetStats(userID uint) (*mode
 	}
 	return args.Get(0).(*model.CodeSnippetStats), args.Error(1)
 }
+
+// MockLearningResourceStatsRepository は repository.LearningResourceStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockLearningResourceStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockLearningResourceStatsRepository) GetLearningResourceStats(userID uint) (*model.LearningResourceStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.LearningResourceStats), args.Error(1)
+}


### PR DESCRIPTION
## 概要
- ユーザーの学習リソース活動集計統計エンドポイントを追加
- GET `/api/v1/users/:id/learning-resource-stats`
- 統計フィールド: TotalResources, TotalLikes, TotalSaves, CategoryCount

## 実装
- model/learning_resource_stats.go — 統計構造体
- repository/learning_resource_stats.go — COUNT/SUM/DISTINCTクエリ
- service/learning_resource_stats.go — userID検証 + リポジトリ委譲
- handler/learning_resource_stats.go — HTTPハンドラ
- DI・ルーター登録

## テスト
- Success / InvalidUserID / RepoError / NoActivity の4件

closes #780