### PR TITLE
fix: CommentLikeService.Like/Unlikeに自己いいね防止チェックを追加

### DIFF
--- a/backend/internal/service/comment_like.go
+++ b/backend/internal/service/comment_like.go
@@ -20,10 +20,14 @@ func NewCommentLikeService(
 }
 
 // Like はコメントにいいねする。
-// コメントが存在しない場合やすでにいいね済みの場合はエラーを返す。
+// コメントが存在しない場合、自分のコメントの場合、すでにいいね済みの場合はエラーを返す。
 func (s *CommentLikeService) Like(userID, commentID uint) error {
-	if _, err := s.postRepo.FindCommentByID(commentID); err != nil {
+	comment, err := s.postRepo.FindCommentByID(commentID)
+	if err != nil {
 		return ErrNotFound
+	}
+	if comment.UserID == userID {
+		return ErrForbidden
 	}
 
 	liked, err := s.likeRepo.HasLiked(userID, commentID)
@@ -38,10 +42,14 @@ func (s *CommentLikeService) Like(userID, commentID uint) error {
 }
 
 // Unlike はコメントのいいねを取り消す。
-// コメントが存在しない場合やいいねしていない場合はエラーを返す。
+// コメントが存在しない場合、自分のコメントの場合、いいねしていない場合はエラーを返す。
 func (s *CommentLikeService) Unlike(userID, commentID uint) error {
-	if _, err := s.postRepo.FindCommentByID(commentID); err != nil {
+	comment, err := s.postRepo.FindCommentByID(commentID)
+	if err != nil {
 		return ErrNotFound
+	}
+	if comment.UserID == userID {
+		return ErrForbidden
 	}
 
 	liked, err := s.likeRepo.HasLiked(userID, commentID)

--- a/backend/internal/service/comment_like_test.go
+++ b/backend/internal/service/comment_like_test.go
@@ -56,6 +56,15 @@ func TestCommentLikeService_Like_AlreadyLiked(t *testing.T) {
 	likeRepo.AssertExpectations(t)
 }
 
+func TestCommentLikeService_Like_SelfLike_Forbidden(t *testing.T) {
+	svc, _, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 10), nil)
+
+	err := svc.Like(10, 1)
+	assert.ErrorIs(t, err, ErrForbidden)
+	postRepo.AssertExpectations(t)
+}
+
 func TestCommentLikeService_Like_HasLikedError(t *testing.T) {
 	svc, likeRepo, postRepo := newTestCommentLikeService()
 	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 2), nil)
@@ -68,6 +77,15 @@ func TestCommentLikeService_Like_HasLikedError(t *testing.T) {
 }
 
 // --- Unlike ---
+
+func TestCommentLikeService_Unlike_SelfUnlike_Forbidden(t *testing.T) {
+	svc, _, postRepo := newTestCommentLikeService()
+	postRepo.On("FindCommentByID", uint(1)).Return(makeComment(1, 10), nil)
+
+	err := svc.Unlike(10, 1)
+	assert.ErrorIs(t, err, ErrForbidden)
+	postRepo.AssertExpectations(t)
+}
 
 func TestCommentLikeService_Unlike_Success(t *testing.T) {
 	svc, likeRepo, postRepo := newTestCommentLikeService()


### PR DESCRIPTION
## 概要
- CommentLikeService.Like/Unlikeに自己いいね防止チェックを追加
- FindCommentByIDで取得したコメントのUserIDを確認し、所有者の場合はErrForbiddenを返す

## テスト
- `TestCommentLikeService_Like_SelfLike_Forbidden` — 自己いいね → Forbidden
- `TestCommentLikeService_Unlike_SelfUnlike_Forbidden` — 自己いいね取消 → Forbidden

closes #786