### PR TITLE
feat: ProjectStats APIの追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -68,6 +68,7 @@ type Container struct {
 	QAStatsHandler                *handler.QAStatsHandler
 	CodeSnippetStatsHandler       *handler.CodeSnippetStatsHandler
 	LearningResourceStatsHandler  *handler.LearningResourceStatsHandler
+	ProjectStatsHandler           *handler.ProjectStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -289,6 +290,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	learningResourceStatsRepo := repository.NewLearningResourceStatsRepository(db)
 	learningResourceStatsService := service.NewLearningResourceStatsService(learningResourceStatsRepo)
 	c.LearningResourceStatsHandler = handler.NewLearningResourceStatsHandler(learningResourceStatsService)
+
+	projectStatsRepo := repository.NewProjectStatsRepository(db)
+	projectStatsService := service.NewProjectStatsService(projectStatsRepo)
+	c.ProjectStatsHandler = handler.NewProjectStatsHandler(projectStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/project_stats.go
+++ b/backend/internal/handler/project_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// ProjectStatsServiceInterface はProjectStatsHandlerが依存するサービスメソッドを定義する。
+type ProjectStatsServiceInterface interface {
+	GetProjectStats(userID uint) (*model.ProjectStats, error)
+}
+
+// ProjectStatsHandler はユーザープロジェクト統計関連のHTTPハンドラ。
+type ProjectStatsHandler struct {
+	service ProjectStatsServiceInterface
+}
+
+// NewProjectStatsHandler は新しいProjectStatsHandlerインスタンスを生成する。
+func NewProjectStatsHandler(s ProjectStatsServiceInterface) *ProjectStatsHandler {
+	return &ProjectStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのプロジェクト活動集計統計を返す。
+func (h *ProjectStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetProjectStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/project_stats.go
+++ b/backend/internal/model/project_stats.go
@@ -1,0 +1,9 @@
+package model
+
+// ProjectStats はユーザーのプロジェクト活動集計統計を表す。
+type ProjectStats struct {
+	TotalProjects     int64 `json:"total_projects"`
+	FeaturedProjects  int64 `json:"featured_projects"`
+	OngoingProjects   int64 `json:"ongoing_projects"`
+	CompletedProjects int64 `json:"completed_projects"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -551,3 +551,8 @@ type CodeSnippetStatsRepositoryInterface interface {
 type LearningResourceStatsRepositoryInterface interface {
 	GetLearningResourceStats(userID uint) (*model.LearningResourceStats, error)
 }
+
+// ProjectStatsRepositoryInterface はユーザープロジェクト活動集計統計データ操作の契約を定義する。
+type ProjectStatsRepositoryInterface interface {
+	GetProjectStats(userID uint) (*model.ProjectStats, error)
+}

--- a/backend/internal/repository/project_stats.go
+++ b/backend/internal/repository/project_stats.go
@@ -1,0 +1,43 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// ProjectStatsRepository はユーザープロジェクト活動集計統計の取得を担当するリポジトリ実装。
+type ProjectStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewProjectStatsRepository は新しいProjectStatsRepositoryインスタンスを生成する。
+func NewProjectStatsRepository(db *gorm.DB) *ProjectStatsRepository {
+	return &ProjectStatsRepository{db: db}
+}
+
+// GetProjectStats は指定ユーザーのプロジェクト活動集計統計を返す。
+func (r *ProjectStatsRepository) GetProjectStats(userID uint) (*model.ProjectStats, error) {
+	var stats model.ProjectStats
+
+	// 総プロジェクト数
+	if err := r.db.Model(&model.Project{}).Where("user_id = ?", userID).Count(&stats.TotalProjects).Error; err != nil {
+		return nil, err
+	}
+
+	// 注目プロジェクト数
+	if err := r.db.Model(&model.Project{}).Where("user_id = ? AND featured = ?", userID, true).Count(&stats.FeaturedProjects).Error; err != nil {
+		return nil, err
+	}
+
+	// 進行中プロジェクト数（end_dateがNULL）
+	if err := r.db.Model(&model.Project{}).Where("user_id = ? AND end_date IS NULL", userID).Count(&stats.OngoingProjects).Error; err != nil {
+		return nil, err
+	}
+
+	// 完了プロジェクト数（end_dateがNOT NULL）
+	if err := r.db.Model(&model.Project{}).Where("user_id = ? AND end_date IS NOT NULL", userID).Count(&stats.CompletedProjects).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -104,6 +104,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerQAStatsRoutes(protected, c)
 		registerCodeSnippetStatsRoutes(protected, c)
 		registerLearningResourceStatsRoutes(protected, c)
+		registerProjectStatsRoutes(protected, c)
 	}
 
 	return r
@@ -654,5 +655,12 @@ func registerLearningResourceStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/learning-resource-stats", c.LearningResourceStatsHandler.GetStats)
+	}
+}
+
+func registerProjectStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/project-stats", c.ProjectStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1965,3 +1965,18 @@ func (m *MockLearningResourceStatsRepository) GetLearningResourceStats(userID ui
 	}
 	return args.Get(0).(*model.LearningResourceStats), args.Error(1)
 }
+
+// MockProjectStatsRepository は repository.ProjectStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockProjectStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockProjectStatsRepository) GetProjectStats(userID uint) (*model.ProjectStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.ProjectStats), args.Error(1)
+}

--- a/backend/internal/service/project_stats.go
+++ b/backend/internal/service/project_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// ProjectStatsService はユーザープロジェクト活動集計統計のビジネスロジックを提供する。
+type ProjectStatsService struct {
+	repo repository.ProjectStatsRepositoryInterface
+}
+
+// NewProjectStatsService は新しいProjectStatsServiceインスタンスを生成する。
+func NewProjectStatsService(repo repository.ProjectStatsRepositoryInterface) *ProjectStatsService {
+	return &ProjectStatsService{repo: repo}
+}
+
+// GetProjectStats は指定ユーザーのプロジェクト活動集計統計を取得する。
+func (s *ProjectStatsService) GetProjectStats(userID uint) (*model.ProjectStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetProjectStats(userID)
+}

--- a/backend/internal/service/project_stats_test.go
+++ b/backend/internal/service/project_stats_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newProjectStatsTestService() (*ProjectStatsService, *MockProjectStatsRepository) {
+	repo := new(MockProjectStatsRepository)
+	svc := NewProjectStatsService(repo)
+	return svc, repo
+}
+
+func TestProjectStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newProjectStatsTestService()
+	expected := &model.ProjectStats{
+		TotalProjects:     8,
+		FeaturedProjects:  2,
+		OngoingProjects:   5,
+		CompletedProjects: 3,
+	}
+	repo.On("GetProjectStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetProjectStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newProjectStatsTestService()
+
+	_, err := svc.GetProjectStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestProjectStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newProjectStatsTestService()
+	repo.On("GetProjectStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetProjectStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newProjectStatsTestService()
+	expected := &model.ProjectStats{}
+	repo.On("GetProjectStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetProjectStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalProjects)
+	assert.Equal(t, int64(0), result.FeaturedProjects)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- ユーザーのプロジェクト活動集計統計エンドポイントを追加
- GET `/api/v1/users/:id/project-stats`
- 統計フィールド: TotalProjects, FeaturedProjects, OngoingProjects, CompletedProjects

## 実装
- model/project_stats.go — 統計構造体
- repository/project_stats.go — COUNTクエリ（featured/end_date条件）
- service/project_stats.go — userID検証 + リポジトリ委譲
- handler/project_stats.go — HTTPハンドラ
- DI・ルーター登録

## テスト
- Success / InvalidUserID / RepoError / NoActivity の4件

closes #789