### PR TITLE
fix: PostService.AddReactionに自己リアクション防止チェックを追加

### DIFF
--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -243,10 +243,17 @@ func (s *PostService) GetBookmarks(userID uint, page, limit int) ([]model.Post, 
 }
 
 // AddReaction は投稿にリアクション（絵文字）を追加する。
-// 許可された絵文字のみ使用可能。
+// 許可された絵文字のみ使用可能。自分の投稿への自己リアクションは禁止する。
 func (s *PostService) AddReaction(userID, postID uint, emoji string) error {
 	if !allowedEmojis[emoji] {
 		return domain.NewError(domain.ErrCodeBadRequest, "許可されていない絵文字です: "+emoji, nil)
+	}
+	post, err := s.repo.FindByID(postID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if post.UserID == userID {
+		return ErrForbidden
 	}
 	return s.repo.AddReaction(userID, postID, emoji)
 }

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -667,6 +667,7 @@ func TestPostGetBookmarks_Empty(t *testing.T) {
 func TestPostAddReaction_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	postRepo.On("FindByID", uint(10)).Return(&model.Post{UserID: 2}, nil)
 	postRepo.On("AddReaction", uint(1), uint(10), "👍").Return(nil)
 
 	err := svc.AddReaction(1, 10, "👍")
@@ -684,11 +685,32 @@ func TestPostAddReaction_InvalidEmoji(t *testing.T) {
 func TestPostAddReaction_Error(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	postRepo.On("FindByID", uint(10)).Return(&model.Post{UserID: 2}, nil)
 	postRepo.On("AddReaction", uint(1), uint(10), "🎉").Return(errors.New("duplicate"))
 
 	err := svc.AddReaction(1, 10, "🎉")
 	assert.Error(t, err)
 	postRepo.AssertExpectations(t)
+}
+
+func TestPostAddReaction_SelfReaction_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(10)).Return(&model.Post{UserID: 1}, nil)
+
+	err := svc.AddReaction(1, 10, "👍")
+	assert.ErrorIs(t, err, ErrForbidden)
+	postRepo.AssertNotCalled(t, "AddReaction")
+}
+
+func TestPostAddReaction_PostNotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.AddReaction(1, 99, "👍")
+	assert.ErrorIs(t, err, ErrNotFound)
+	postRepo.AssertNotCalled(t, "AddReaction")
 }
 
 func TestPostRemoveReaction_Success(t *testing.T) {


### PR DESCRIPTION
## 概要
- PostService.AddReactionで自分の投稿へのリアクション追加を防止するチェックを追加
- Like/Unlikeと同様にFindByID→所有者確認→ErrForbiddenのパターンを適用

## 変更内容
- `AddReaction`にFindByIDによる投稿取得と自己リアクション防止チェックを追加
- 既存テスト（Success/Error）にFindByIDモックを追加
- 新規テスト2件追加（SelfReaction_Forbidden, PostNotFound）

## テスト
- 全5件のAddReactionテストPASS確認済み

Closes #795