### PR TITLE
feat: FollowStats API（フォロワー数・フォロー数統計）を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -69,6 +69,7 @@ type Container struct {
 	CodeSnippetStatsHandler       *handler.CodeSnippetStatsHandler
 	LearningResourceStatsHandler  *handler.LearningResourceStatsHandler
 	ProjectStatsHandler           *handler.ProjectStatsHandler
+	FollowStatsHandler            *handler.FollowStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -294,6 +295,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	projectStatsRepo := repository.NewProjectStatsRepository(db)
 	projectStatsService := service.NewProjectStatsService(projectStatsRepo)
 	c.ProjectStatsHandler = handler.NewProjectStatsHandler(projectStatsService)
+
+	followStatsRepo := repository.NewFollowStatsRepository(db)
+	followStatsService := service.NewFollowStatsService(followStatsRepo)
+	c.FollowStatsHandler = handler.NewFollowStatsHandler(followStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/follow_stats.go
+++ b/backend/internal/handler/follow_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// FollowStatsServiceInterface はFollowStatsHandlerが依存するサービスメソッドを定義する。
+type FollowStatsServiceInterface interface {
+	GetFollowStats(userID uint) (*model.FollowStats, error)
+}
+
+// FollowStatsHandler はユーザーフォロー統計関連のHTTPハンドラ。
+type FollowStatsHandler struct {
+	service FollowStatsServiceInterface
+}
+
+// NewFollowStatsHandler は新しいFollowStatsHandlerインスタンスを生成する。
+func NewFollowStatsHandler(s FollowStatsServiceInterface) *FollowStatsHandler {
+	return &FollowStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのフォロー関係集計統計を返す。
+func (h *FollowStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetFollowStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/follow_stats.go
+++ b/backend/internal/model/follow_stats.go
@@ -1,0 +1,7 @@
+package model
+
+// FollowStats はユーザーのフォロー関係集計統計を表す。
+type FollowStats struct {
+	FollowerCount  int64 `json:"follower_count"`
+	FollowingCount int64 `json:"following_count"`
+}

--- a/backend/internal/repository/follow_stats.go
+++ b/backend/internal/repository/follow_stats.go
@@ -1,0 +1,33 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// FollowStatsRepository はユーザーフォロー関係集計統計の取得を担当するリポジトリ実装。
+type FollowStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewFollowStatsRepository は新しいFollowStatsRepositoryインスタンスを生成する。
+func NewFollowStatsRepository(db *gorm.DB) *FollowStatsRepository {
+	return &FollowStatsRepository{db: db}
+}
+
+// GetFollowStats は指定ユーザーのフォロー関係集計統計を返す。
+func (r *FollowStatsRepository) GetFollowStats(userID uint) (*model.FollowStats, error) {
+	var stats model.FollowStats
+
+	// フォロワー数
+	if err := r.db.Model(&model.Follow{}).Where("followee_id = ?", userID).Count(&stats.FollowerCount).Error; err != nil {
+		return nil, err
+	}
+
+	// フォロー数
+	if err := r.db.Model(&model.Follow{}).Where("follower_id = ?", userID).Count(&stats.FollowingCount).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -556,3 +556,8 @@ type LearningResourceStatsRepositoryInterface interface {
 type ProjectStatsRepositoryInterface interface {
 	GetProjectStats(userID uint) (*model.ProjectStats, error)
 }
+
+// FollowStatsRepositoryInterface はユーザーフォロー関係集計統計データ操作の契約を定義する。
+type FollowStatsRepositoryInterface interface {
+	GetFollowStats(userID uint) (*model.FollowStats, error)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -105,6 +105,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerCodeSnippetStatsRoutes(protected, c)
 		registerLearningResourceStatsRoutes(protected, c)
 		registerProjectStatsRoutes(protected, c)
+		registerFollowStatsRoutes(protected, c)
 	}
 
 	return r
@@ -662,5 +663,12 @@ func registerProjectStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/project-stats", c.ProjectStatsHandler.GetStats)
+	}
+}
+
+func registerFollowStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/follow-stats", c.FollowStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/follow_stats.go
+++ b/backend/internal/service/follow_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// FollowStatsService はユーザーフォロー関係集計統計のビジネスロジックを提供する。
+type FollowStatsService struct {
+	repo repository.FollowStatsRepositoryInterface
+}
+
+// NewFollowStatsService は新しいFollowStatsServiceインスタンスを生成する。
+func NewFollowStatsService(repo repository.FollowStatsRepositoryInterface) *FollowStatsService {
+	return &FollowStatsService{repo: repo}
+}
+
+// GetFollowStats は指定ユーザーのフォロー関係集計統計を取得する。
+func (s *FollowStatsService) GetFollowStats(userID uint) (*model.FollowStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetFollowStats(userID)
+}

--- a/backend/internal/service/follow_stats_test.go
+++ b/backend/internal/service/follow_stats_test.go
@@ -1,0 +1,58 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newFollowStatsTestService() (*FollowStatsService, *MockFollowStatsRepository) {
+	repo := new(MockFollowStatsRepository)
+	svc := NewFollowStatsService(repo)
+	return svc, repo
+}
+
+func TestFollowStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newFollowStatsTestService()
+	expected := &model.FollowStats{
+		FollowerCount:  42,
+		FollowingCount: 15,
+	}
+	repo.On("GetFollowStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetFollowStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestFollowStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newFollowStatsTestService()
+
+	_, err := svc.GetFollowStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestFollowStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newFollowStatsTestService()
+	repo.On("GetFollowStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetFollowStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestFollowStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newFollowStatsTestService()
+	expected := &model.FollowStats{}
+	repo.On("GetFollowStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetFollowStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.FollowerCount)
+	assert.Equal(t, int64(0), result.FollowingCount)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1980,3 +1980,18 @@ func (m *MockProjectStatsRepository) GetProjectStats(userID uint) (*model.Projec
 	}
 	return args.Get(0).(*model.ProjectStats), args.Error(1)
 }
+
+// MockFollowStatsRepository は repository.FollowStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockFollowStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockFollowStatsRepository) GetFollowStats(userID uint) (*model.FollowStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.FollowStats), args.Error(1)
+}


### PR DESCRIPTION
## 概要
- ユーザーごとのフォロー関係統計（フォロワー数・フォロー数）を取得するAPIエンドポイントを追加
- GET `/api/v1/users/:id/follow-stats`

## 変更内容
- `model/follow_stats.go` 新規作成（FollowerCount, FollowingCount）
- TDD: 4テスト（Success/InvalidUserID/RepoError/NoActivity）
- service → handler → repository → DI → router の全レイヤー実装

## テスト
- 4テスト全てPASS確認済み

Closes #797