### PR TITLE
fix: FollowService.Unfollowに自己アンフォロー防止チェックを追加

### DIFF
--- a/backend/internal/service/follow.go
+++ b/backend/internal/service/follow.go
@@ -23,8 +23,11 @@ func (s *FollowService) Follow(followerID, followeeID uint) error {
 	return s.repo.Follow(followerID, followeeID)
 }
 
-// Unfollow は指定ユーザーのフォローを解除する。
+// Unfollow は指定ユーザーのフォローを解除する。自分自身のアンフォローは許可しない。
 func (s *FollowService) Unfollow(followerID, followeeID uint) error {
+	if followerID == followeeID {
+		return ErrBadRequest
+	}
 	return s.repo.Unfollow(followerID, followeeID)
 }
 

--- a/backend/internal/service/follow_test.go
+++ b/backend/internal/service/follow_test.go
@@ -93,11 +93,9 @@ func TestFollowService_Unfollow_SelfUnfollow(t *testing.T) {
 	repo := new(MockFollowRepository)
 	svc := NewFollowService(repo)
 
-	repo.On("Unfollow", uint(1), uint(1)).Return(nil)
-
 	err := svc.Unfollow(1, 1)
-	assert.NoError(t, err)
-	repo.AssertExpectations(t)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	repo.AssertNotCalled(t, "Unfollow")
 }
 
 func TestFollowService_GetFollowers_EmptyList(t *testing.T) {


### PR DESCRIPTION
## 概要
- FollowService.Unfollowに自己アンフォロー防止チェックを追加
- Follow()と一貫性のある`followerID == followeeID → ErrBadRequest`パターンを適用

## 変更内容
- `Unfollow`に自己チェックを追加
- 既存テスト`TestFollowService_Unfollow_SelfUnfollow`をErrBadRequest検証に更新

## テスト
- 全テストPASS確認済み

Closes #803