### PR TITLE
feat: RoadmapStats APIエンドポイントを追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -70,6 +70,7 @@ type Container struct {
 	LearningResourceStatsHandler  *handler.LearningResourceStatsHandler
 	ProjectStatsHandler           *handler.ProjectStatsHandler
 	FollowStatsHandler            *handler.FollowStatsHandler
+	RoadmapStatsHandler           *handler.RoadmapStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -299,6 +300,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	followStatsRepo := repository.NewFollowStatsRepository(db)
 	followStatsService := service.NewFollowStatsService(followStatsRepo)
 	c.FollowStatsHandler = handler.NewFollowStatsHandler(followStatsService)
+
+	roadmapStatsRepo := repository.NewRoadmapStatsRepository(db)
+	roadmapStatsService := service.NewRoadmapStatsService(roadmapStatsRepo)
+	c.RoadmapStatsHandler = handler.NewRoadmapStatsHandler(roadmapStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/roadmap_stats.go
+++ b/backend/internal/handler/roadmap_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// RoadmapStatsServiceInterface はRoadmapStatsHandlerが依存するサービスメソッドを定義する。
+type RoadmapStatsServiceInterface interface {
+	GetRoadmapStats(userID uint) (*model.RoadmapStats, error)
+}
+
+// RoadmapStatsHandler はユーザーロードマップ統計関連のHTTPハンドラ。
+type RoadmapStatsHandler struct {
+	service RoadmapStatsServiceInterface
+}
+
+// NewRoadmapStatsHandler は新しいRoadmapStatsHandlerインスタンスを生成する。
+func NewRoadmapStatsHandler(s RoadmapStatsServiceInterface) *RoadmapStatsHandler {
+	return &RoadmapStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのロードマップ統計を返す。
+func (h *RoadmapStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetRoadmapStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -561,3 +561,8 @@ type ProjectStatsRepositoryInterface interface {
 type FollowStatsRepositoryInterface interface {
 	GetFollowStats(userID uint) (*model.FollowStats, error)
 }
+
+// RoadmapStatsRepositoryInterface はユーザーロードマップ統計データ操作の契約を定義する。
+type RoadmapStatsRepositoryInterface interface {
+	GetRoadmapStats(userID uint) (*model.RoadmapStats, error)
+}

--- a/backend/internal/repository/roadmap_stats.go
+++ b/backend/internal/repository/roadmap_stats.go
@@ -1,0 +1,53 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// RoadmapStatsRepository はユーザーロードマップ統計の取得を担当するリポジトリ実装。
+type RoadmapStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewRoadmapStatsRepository は新しいRoadmapStatsRepositoryインスタンスを生成する。
+func NewRoadmapStatsRepository(db *gorm.DB) *RoadmapStatsRepository {
+	return &RoadmapStatsRepository{db: db}
+}
+
+// GetRoadmapStats は指定ユーザーのロードマップ統計を返す。
+func (r *RoadmapStatsRepository) GetRoadmapStats(userID uint) (*model.RoadmapStats, error) {
+	var stats model.RoadmapStats
+
+	var totalCount int64
+	if err := r.db.Model(&model.Roadmap{}).Where("user_id = ?", userID).Count(&totalCount).Error; err != nil {
+		return nil, err
+	}
+	stats.TotalRoadmaps = int(totalCount)
+
+	var activeCount int64
+	if err := r.db.Model(&model.Roadmap{}).Where("user_id = ? AND status = ?", userID, model.RoadmapStatusActive).Count(&activeCount).Error; err != nil {
+		return nil, err
+	}
+	stats.ActiveRoadmaps = int(activeCount)
+
+	var completedCount int64
+	if err := r.db.Model(&model.Roadmap{}).Where("user_id = ? AND status = ?", userID, model.RoadmapStatusCompleted).Count(&completedCount).Error; err != nil {
+		return nil, err
+	}
+	stats.CompletedRoadmaps = int(completedCount)
+
+	var totalSteps int64
+	if err := r.db.Model(&model.Roadmap{}).Where("user_id = ?", userID).Select("COALESCE(SUM(step_count), 0)").Scan(&totalSteps).Error; err != nil {
+		return nil, err
+	}
+	stats.TotalSteps = int(totalSteps)
+
+	var completedSteps int64
+	if err := r.db.Model(&model.Roadmap{}).Where("user_id = ?", userID).Select("COALESCE(SUM(completed_step_count), 0)").Scan(&completedSteps).Error; err != nil {
+		return nil, err
+	}
+	stats.CompletedSteps = int(completedSteps)
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -106,6 +106,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerLearningResourceStatsRoutes(protected, c)
 		registerProjectStatsRoutes(protected, c)
 		registerFollowStatsRoutes(protected, c)
+		registerRoadmapStatsRoutes(protected, c)
 	}
 
 	return r
@@ -670,5 +671,12 @@ func registerFollowStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/follow-stats", c.FollowStatsHandler.GetStats)
+	}
+}
+
+func registerRoadmapStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/roadmap-stats", c.RoadmapStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1995,3 +1995,18 @@ func (m *MockFollowStatsRepository) GetFollowStats(userID uint) (*model.FollowSt
 	}
 	return args.Get(0).(*model.FollowStats), args.Error(1)
 }
+
+// MockRoadmapStatsRepository は repository.RoadmapStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockRoadmapStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockRoadmapStatsRepository) GetRoadmapStats(userID uint) (*model.RoadmapStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.RoadmapStats), args.Error(1)
+}

--- a/backend/internal/service/roadmap_stats.go
+++ b/backend/internal/service/roadmap_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// RoadmapStatsService はユーザーロードマップ統計のビジネスロジックを提供する。
+type RoadmapStatsService struct {
+	repo repository.RoadmapStatsRepositoryInterface
+}
+
+// NewRoadmapStatsService は新しいRoadmapStatsServiceインスタンスを生成する。
+func NewRoadmapStatsService(repo repository.RoadmapStatsRepositoryInterface) *RoadmapStatsService {
+	return &RoadmapStatsService{repo: repo}
+}
+
+// GetRoadmapStats は指定ユーザーのロードマップ統計を取得する。
+func (s *RoadmapStatsService) GetRoadmapStats(userID uint) (*model.RoadmapStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetRoadmapStats(userID)
+}

--- a/backend/internal/service/roadmap_stats_test.go
+++ b/backend/internal/service/roadmap_stats_test.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newRoadmapStatsTestService() (*RoadmapStatsService, *MockRoadmapStatsRepository) {
+	repo := new(MockRoadmapStatsRepository)
+	svc := NewRoadmapStatsService(repo)
+	return svc, repo
+}
+
+func TestRoadmapStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newRoadmapStatsTestService()
+	expected := &model.RoadmapStats{
+		TotalRoadmaps:     5,
+		ActiveRoadmaps:    3,
+		CompletedRoadmaps: 2,
+		TotalSteps:        20,
+		CompletedSteps:    12,
+	}
+	repo.On("GetRoadmapStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetRoadmapStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newRoadmapStatsTestService()
+
+	_, err := svc.GetRoadmapStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestRoadmapStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newRoadmapStatsTestService()
+	repo.On("GetRoadmapStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetRoadmapStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newRoadmapStatsTestService()
+	expected := &model.RoadmapStats{}
+	repo.On("GetRoadmapStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetRoadmapStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, result.TotalRoadmaps)
+	assert.Equal(t, 0, result.CompletedSteps)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- ユーザーごとのロードマップ統計を取得するAPIエンドポイントを追加
- GET `/api/v1/users/:id/roadmap-stats`

## 変更内容
- `RoadmapStatsService/Handler/Repository` を独立モジュールとして新規作成
- TDD: 4テスト（Success/InvalidUserID/RepoError/NoActivity）
- DI・ルーティング登録

## テスト
- 4テスト全てPASS確認済み

Closes #805