### PR TITLE
fix: LearningResourceService.Save/Unsaveに自己保存防止チェックを追加

### DIFF
--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -171,12 +171,28 @@ func (s *LearningResourceService) Unlike(userID, resourceID uint) error {
 }
 
 // Save は学習リソースを保存する。
+// 自分のリソースは保存できない。
 func (s *LearningResourceService) Save(userID, resourceID uint) error {
+	resource, err := s.repo.FindByID(resourceID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if resource.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.Save(userID, resourceID)
 }
 
 // Unsave は学習リソースの保存を取り消す。
+// 自分のリソースの保存は取り消せない（そもそも保存できないため）。
 func (s *LearningResourceService) Unsave(userID, resourceID uint) error {
+	resource, err := s.repo.FindByID(resourceID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if resource.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.Unsave(userID, resourceID)
 }
 

--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -567,6 +567,7 @@ func TestLearningResourceUnlike_Error(t *testing.T) {
 
 func TestLearningResourceSave_Success(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
+	repo.On("FindByID", uint(10)).Return(&model.LearningResource{UserID: 2}, nil)
 	repo.On("Save", uint(1), uint(10)).Return(nil)
 
 	err := svc.Save(1, 10)
@@ -576,6 +577,7 @@ func TestLearningResourceSave_Success(t *testing.T) {
 
 func TestLearningResourceSave_Error(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
+	repo.On("FindByID", uint(10)).Return(&model.LearningResource{UserID: 2}, nil)
 	repo.On("Save", uint(1), uint(10)).Return(errors.New("already saved"))
 
 	err := svc.Save(1, 10)
@@ -583,8 +585,27 @@ func TestLearningResourceSave_Error(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestLearningResourceSave_SelfSave_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("FindByID", uint(10)).Return(&model.LearningResource{UserID: 1}, nil)
+
+	err := svc.Save(1, 10)
+	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertNotCalled(t, "Save")
+}
+
+func TestLearningResourceSave_NotFound(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.Save(1, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertNotCalled(t, "Save")
+}
+
 func TestLearningResourceUnsave_Success(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
+	repo.On("FindByID", uint(10)).Return(&model.LearningResource{UserID: 2}, nil)
 	repo.On("Unsave", uint(1), uint(10)).Return(nil)
 
 	err := svc.Unsave(1, 10)
@@ -594,11 +615,21 @@ func TestLearningResourceUnsave_Success(t *testing.T) {
 
 func TestLearningResourceUnsave_Error(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
+	repo.On("FindByID", uint(10)).Return(&model.LearningResource{UserID: 2}, nil)
 	repo.On("Unsave", uint(1), uint(10)).Return(errors.New("not saved"))
 
 	err := svc.Unsave(1, 10)
 	assert.Error(t, err)
 	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceUnsave_SelfUnsave_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("FindByID", uint(10)).Return(&model.LearningResource{UserID: 1}, nil)
+
+	err := svc.Unsave(1, 10)
+	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertNotCalled(t, "Unsave")
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
- LearningResourceService.Save/Unsaveに自己保存防止チェックを追加
- Like/Unlikeと同様のFindByID→所有者確認→ErrForbiddenパターンを適用

## 変更内容
- Save/UnsaveにFindByIDによるリソース取得と自己保存防止チェックを追加
- 既存テスト（Success/Error）にFindByIDモックを追加
- 新規テスト3件追加（SelfSave_Forbidden, NotFound, SelfUnsave_Forbidden）

## テスト
- 全テストPASS確認済み

Closes #811