### PR TITLE
feat: LearningLogStats API（学習ログ統計）を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -71,6 +71,7 @@ type Container struct {
 	ProjectStatsHandler           *handler.ProjectStatsHandler
 	FollowStatsHandler            *handler.FollowStatsHandler
 	RoadmapStatsHandler           *handler.RoadmapStatsHandler
+	LearningLogStatsHandler       *handler.LearningLogStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -304,6 +305,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	roadmapStatsRepo := repository.NewRoadmapStatsRepository(db)
 	roadmapStatsService := service.NewRoadmapStatsService(roadmapStatsRepo)
 	c.RoadmapStatsHandler = handler.NewRoadmapStatsHandler(roadmapStatsService)
+
+	learningLogStatsRepo := repository.NewLearningLogStatsRepository(db)
+	learningLogStatsService := service.NewLearningLogStatsService(learningLogStatsRepo)
+	c.LearningLogStatsHandler = handler.NewLearningLogStatsHandler(learningLogStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/learning_log_stats.go
+++ b/backend/internal/handler/learning_log_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// LearningLogStatsServiceInterface はLearningLogStatsHandlerが依存するサービスメソッドを定義する。
+type LearningLogStatsServiceInterface interface {
+	GetLearningLogStats(userID uint) (*model.LearningLogStats, error)
+}
+
+// LearningLogStatsHandler はユーザー学習ログ統計関連のHTTPハンドラ。
+type LearningLogStatsHandler struct {
+	service LearningLogStatsServiceInterface
+}
+
+// NewLearningLogStatsHandler は新しいLearningLogStatsHandlerインスタンスを生成する。
+func NewLearningLogStatsHandler(s LearningLogStatsServiceInterface) *LearningLogStatsHandler {
+	return &LearningLogStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーの学習ログ集計統計を返す。
+func (h *LearningLogStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetLearningLogStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/learning_log_stats.go
+++ b/backend/internal/model/learning_log_stats.go
@@ -1,0 +1,9 @@
+package model
+
+// LearningLogStats はユーザーの学習ログ集計統計を表す。
+type LearningLogStats struct {
+	TotalLogs      int64 `json:"total_logs"`
+	TotalDuration  int64 `json:"total_duration"`
+	CategoryCount  int64 `json:"category_count"`
+	LogsThisMonth  int64 `json:"logs_this_month"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -566,3 +566,8 @@ type FollowStatsRepositoryInterface interface {
 type RoadmapStatsRepositoryInterface interface {
 	GetRoadmapStats(userID uint) (*model.RoadmapStats, error)
 }
+
+// LearningLogStatsRepositoryInterface はユーザー学習ログ集計統計データ操作の契約を定義する。
+type LearningLogStatsRepositoryInterface interface {
+	GetLearningLogStats(userID uint) (*model.LearningLogStats, error)
+}

--- a/backend/internal/repository/learning_log_stats.go
+++ b/backend/internal/repository/learning_log_stats.go
@@ -1,0 +1,47 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// LearningLogStatsRepository はユーザー学習ログ集計統計の取得を担当するリポジトリ実装。
+type LearningLogStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewLearningLogStatsRepository は新しいLearningLogStatsRepositoryインスタンスを生成する。
+func NewLearningLogStatsRepository(db *gorm.DB) *LearningLogStatsRepository {
+	return &LearningLogStatsRepository{db: db}
+}
+
+// GetLearningLogStats は指定ユーザーの学習ログ集計統計を返す。
+func (r *LearningLogStatsRepository) GetLearningLogStats(userID uint) (*model.LearningLogStats, error) {
+	var stats model.LearningLogStats
+
+	// 総ログ数
+	if err := r.db.Model(&model.LearningLog{}).Where("user_id = ?", userID).Count(&stats.TotalLogs).Error; err != nil {
+		return nil, err
+	}
+
+	// 総学習時間（分単位）
+	if err := r.db.Model(&model.LearningLog{}).Where("user_id = ?", userID).Select("COALESCE(SUM(duration), 0)").Scan(&stats.TotalDuration).Error; err != nil {
+		return nil, err
+	}
+
+	// カテゴリ数
+	if err := r.db.Model(&model.LearningLog{}).Where("user_id = ?", userID).Select("COUNT(DISTINCT category)").Scan(&stats.CategoryCount).Error; err != nil {
+		return nil, err
+	}
+
+	// 今月のログ数
+	now := time.Now()
+	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	if err := r.db.Model(&model.LearningLog{}).Where("user_id = ? AND created_at >= ?", userID, monthStart).Count(&stats.LogsThisMonth).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -107,6 +107,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerProjectStatsRoutes(protected, c)
 		registerFollowStatsRoutes(protected, c)
 		registerRoadmapStatsRoutes(protected, c)
+		registerLearningLogStatsRoutes(protected, c)
 	}
 
 	return r
@@ -678,5 +679,12 @@ func registerRoadmapStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/roadmap-stats", c.RoadmapStatsHandler.GetStats)
+	}
+}
+
+func registerLearningLogStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/learning-log-stats", c.LearningLogStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/learning_log_stats.go
+++ b/backend/internal/service/learning_log_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// LearningLogStatsService はユーザー学習ログ集計統計のビジネスロジックを提供する。
+type LearningLogStatsService struct {
+	repo repository.LearningLogStatsRepositoryInterface
+}
+
+// NewLearningLogStatsService は新しいLearningLogStatsServiceインスタンスを生成する。
+func NewLearningLogStatsService(repo repository.LearningLogStatsRepositoryInterface) *LearningLogStatsService {
+	return &LearningLogStatsService{repo: repo}
+}
+
+// GetLearningLogStats は指定ユーザーの学習ログ集計統計を取得する。
+func (s *LearningLogStatsService) GetLearningLogStats(userID uint) (*model.LearningLogStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetLearningLogStats(userID)
+}

--- a/backend/internal/service/learning_log_stats_test.go
+++ b/backend/internal/service/learning_log_stats_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newLearningLogStatsTestService() (*LearningLogStatsService, *MockLearningLogStatsRepository) {
+	repo := new(MockLearningLogStatsRepository)
+	svc := NewLearningLogStatsService(repo)
+	return svc, repo
+}
+
+func TestLearningLogStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newLearningLogStatsTestService()
+	expected := &model.LearningLogStats{
+		TotalLogs:     120,
+		TotalDuration: 3600,
+		CategoryCount: 4,
+		LogsThisMonth: 15,
+	}
+	repo.On("GetLearningLogStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetLearningLogStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newLearningLogStatsTestService()
+
+	_, err := svc.GetLearningLogStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestLearningLogStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newLearningLogStatsTestService()
+	repo.On("GetLearningLogStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetLearningLogStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newLearningLogStatsTestService()
+	expected := &model.LearningLogStats{}
+	repo.On("GetLearningLogStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetLearningLogStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalLogs)
+	assert.Equal(t, int64(0), result.TotalDuration)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2010,3 +2010,18 @@ func (m *MockRoadmapStatsRepository) GetRoadmapStats(userID uint) (*model.Roadma
 	}
 	return args.Get(0).(*model.RoadmapStats), args.Error(1)
 }
+
+// MockLearningLogStatsRepository は repository.LearningLogStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockLearningLogStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockLearningLogStatsRepository) GetLearningLogStats(userID uint) (*model.LearningLogStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.LearningLogStats), args.Error(1)
+}


### PR DESCRIPTION
## 概要
- ユーザーごとの学習ログ統計を取得するAPIエンドポイントを追加
- GET `/api/v1/users/:id/learning-log-stats`

## 変更内容
- `model/learning_log_stats.go` 新規作成（TotalLogs, TotalDuration, CategoryCount, LogsThisMonth）
- TDD: 4テスト（Success/InvalidUserID/RepoError/NoActivity）
- service → handler → repository → DI → router の全レイヤー実装

## テスト
- 4テスト全てPASS確認済み

Closes #813