### PR TITLE
fix: PostService.Bookmark/Unbookmarkに自己ブックマーク防止チェックを追加

### DIFF
--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -223,12 +223,28 @@ func (s *PostService) DeleteComment(id, userID uint) error {
 }
 
 // Bookmark は投稿をブックマークする。
+// 自分の投稿へのブックマークは禁止する。
 func (s *PostService) Bookmark(userID, postID uint) error {
+	post, err := s.repo.FindByID(postID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if post.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.Bookmark(userID, postID)
 }
 
 // Unbookmark は投稿のブックマークを解除する。
+// 自分の投稿のブックマークは解除できない（そもそもブックマークできないため）。
 func (s *PostService) Unbookmark(userID, postID uint) error {
+	post, err := s.repo.FindByID(postID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if post.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.Unbookmark(userID, postID)
 }
 

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -582,6 +582,7 @@ func TestPostCreate_ValidationError(t *testing.T) {
 func TestPostBookmark_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	postRepo.On("FindByID", uint(10)).Return(&model.Post{UserID: 2}, nil)
 	postRepo.On("Bookmark", uint(1), uint(10)).Return(nil)
 
 	err := svc.Bookmark(1, 10)
@@ -592,6 +593,7 @@ func TestPostBookmark_Success(t *testing.T) {
 func TestPostBookmark_Error(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	postRepo.On("FindByID", uint(10)).Return(&model.Post{UserID: 2}, nil)
 	postRepo.On("Bookmark", uint(1), uint(10)).Return(errors.New("already bookmarked"))
 
 	err := svc.Bookmark(1, 10)
@@ -599,9 +601,30 @@ func TestPostBookmark_Error(t *testing.T) {
 	postRepo.AssertExpectations(t)
 }
 
+func TestPostBookmark_SelfBookmark_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(10)).Return(&model.Post{UserID: 1}, nil)
+
+	err := svc.Bookmark(1, 10)
+	assert.ErrorIs(t, err, ErrForbidden)
+	postRepo.AssertNotCalled(t, "Bookmark")
+}
+
+func TestPostBookmark_PostNotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.Bookmark(1, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+	postRepo.AssertNotCalled(t, "Bookmark")
+}
+
 func TestPostUnbookmark_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	postRepo.On("FindByID", uint(10)).Return(&model.Post{UserID: 2}, nil)
 	postRepo.On("Unbookmark", uint(1), uint(10)).Return(nil)
 
 	err := svc.Unbookmark(1, 10)
@@ -612,11 +635,22 @@ func TestPostUnbookmark_Success(t *testing.T) {
 func TestPostUnbookmark_Error(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	postRepo.On("FindByID", uint(10)).Return(&model.Post{UserID: 2}, nil)
 	postRepo.On("Unbookmark", uint(1), uint(10)).Return(errors.New("not bookmarked"))
 
 	err := svc.Unbookmark(1, 10)
 	assert.Error(t, err)
 	postRepo.AssertExpectations(t)
+}
+
+func TestPostUnbookmark_SelfUnbookmark_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(10)).Return(&model.Post{UserID: 1}, nil)
+
+	err := svc.Unbookmark(1, 10)
+	assert.ErrorIs(t, err, ErrForbidden)
+	postRepo.AssertNotCalled(t, "Unbookmark")
 }
 
 func TestPostHasBookmarked_True(t *testing.T) {


### PR DESCRIPTION
## 概要
- PostService.Bookmark/Unbookmarkに自己ブックマーク防止チェックを追加
- Like/Unlikeと同様のFindByID→所有者確認→ErrForbiddenパターンを適用

## 変更内容
- Bookmark/UnbookmarkにFindByIDによる投稿取得と自己ブックマーク防止チェックを追加
- 既存テスト（Success/Error）にFindByIDモックを追加
- 新規テスト3件追加（SelfBookmark_Forbidden, PostNotFound, SelfUnbookmark_Forbidden）

## テスト
- 全テストPASS確認済み

Closes #819