### PR TITLE
feat: コメント統計API（CommentStats）エンドポイント追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -72,6 +72,7 @@ type Container struct {
 	FollowStatsHandler            *handler.FollowStatsHandler
 	RoadmapStatsHandler           *handler.RoadmapStatsHandler
 	LearningLogStatsHandler       *handler.LearningLogStatsHandler
+	CommentStatsHandler           *handler.CommentStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -309,6 +310,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	learningLogStatsRepo := repository.NewLearningLogStatsRepository(db)
 	learningLogStatsService := service.NewLearningLogStatsService(learningLogStatsRepo)
 	c.LearningLogStatsHandler = handler.NewLearningLogStatsHandler(learningLogStatsService)
+
+	commentStatsRepo := repository.NewCommentStatsRepository(db)
+	commentStatsService := service.NewCommentStatsService(commentStatsRepo)
+	c.CommentStatsHandler = handler.NewCommentStatsHandler(commentStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/comment_stats.go
+++ b/backend/internal/handler/comment_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// CommentStatsServiceInterface はCommentStatsHandlerが依存するサービスメソッドを定義する。
+type CommentStatsServiceInterface interface {
+	GetCommentStats(userID uint) (*model.CommentStats, error)
+}
+
+// CommentStatsHandler はユーザーコメント活動統計関連のHTTPハンドラ。
+type CommentStatsHandler struct {
+	service CommentStatsServiceInterface
+}
+
+// NewCommentStatsHandler は新しいCommentStatsHandlerインスタンスを生成する。
+func NewCommentStatsHandler(s CommentStatsServiceInterface) *CommentStatsHandler {
+	return &CommentStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのコメント活動集計統計を返す。
+func (h *CommentStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetCommentStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/comment_stats.go
+++ b/backend/internal/model/comment_stats.go
@@ -1,0 +1,9 @@
+package model
+
+// CommentStats はユーザーのコメント活動に関する集計統計を表す。
+type CommentStats struct {
+	TotalComments    int64 `json:"total_comments"`
+	TotalReplies     int64 `json:"total_replies"`
+	CommentsReceived int64 `json:"comments_received"`
+	CommentsThisMonth int64 `json:"comments_this_month"`
+}

--- a/backend/internal/repository/comment_stats.go
+++ b/backend/internal/repository/comment_stats.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// CommentStatsRepository はユーザーコメント活動集計統計の取得を担当するリポジトリ実装。
+type CommentStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewCommentStatsRepository は新しいCommentStatsRepositoryインスタンスを生成する。
+func NewCommentStatsRepository(db *gorm.DB) *CommentStatsRepository {
+	return &CommentStatsRepository{db: db}
+}
+
+// GetCommentStats は指定ユーザーのコメント活動集計統計を返す。
+func (r *CommentStatsRepository) GetCommentStats(userID uint) (*model.CommentStats, error) {
+	var stats model.CommentStats
+
+	// ユーザーが投稿したコメント総数（parent_id IS NULL = トップレベルコメント）
+	if err := r.db.Model(&model.Comment{}).Where("user_id = ? AND parent_id IS NULL", userID).Count(&stats.TotalComments).Error; err != nil {
+		return nil, err
+	}
+
+	// ユーザーが投稿した返信総数（parent_id IS NOT NULL）
+	if err := r.db.Model(&model.Comment{}).Where("user_id = ? AND parent_id IS NOT NULL", userID).Count(&stats.TotalReplies).Error; err != nil {
+		return nil, err
+	}
+
+	// ユーザーの投稿に付いたコメント数
+	if err := r.db.Model(&model.Comment{}).
+		Joins("JOIN posts ON posts.id = comments.post_id").
+		Where("posts.user_id = ? AND comments.user_id != ?", userID, userID).
+		Count(&stats.CommentsReceived).Error; err != nil {
+		return nil, err
+	}
+
+	// 今月のコメント数
+	now := time.Now()
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	if err := r.db.Model(&model.Comment{}).Where("user_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.CommentsThisMonth).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -571,3 +571,8 @@ type RoadmapStatsRepositoryInterface interface {
 type LearningLogStatsRepositoryInterface interface {
 	GetLearningLogStats(userID uint) (*model.LearningLogStats, error)
 }
+
+// CommentStatsRepositoryInterface はユーザーコメント活動集計統計データ操作の契約を定義する。
+type CommentStatsRepositoryInterface interface {
+	GetCommentStats(userID uint) (*model.CommentStats, error)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -108,6 +108,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerFollowStatsRoutes(protected, c)
 		registerRoadmapStatsRoutes(protected, c)
 		registerLearningLogStatsRoutes(protected, c)
+		registerCommentStatsRoutes(protected, c)
 	}
 
 	return r
@@ -686,5 +687,12 @@ func registerLearningLogStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/learning-log-stats", c.LearningLogStatsHandler.GetStats)
+	}
+}
+
+func registerCommentStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/comment-stats", c.CommentStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/comment_stats.go
+++ b/backend/internal/service/comment_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// CommentStatsService はユーザーコメント活動集計統計のビジネスロジックを提供する。
+type CommentStatsService struct {
+	repo repository.CommentStatsRepositoryInterface
+}
+
+// NewCommentStatsService は新しいCommentStatsServiceインスタンスを生成する。
+func NewCommentStatsService(repo repository.CommentStatsRepositoryInterface) *CommentStatsService {
+	return &CommentStatsService{repo: repo}
+}
+
+// GetCommentStats は指定ユーザーのコメント活動集計統計を取得する。
+func (s *CommentStatsService) GetCommentStats(userID uint) (*model.CommentStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetCommentStats(userID)
+}

--- a/backend/internal/service/comment_stats_test.go
+++ b/backend/internal/service/comment_stats_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newCommentStatsTestService() (*CommentStatsService, *MockCommentStatsRepository) {
+	repo := new(MockCommentStatsRepository)
+	svc := NewCommentStatsService(repo)
+	return svc, repo
+}
+
+func TestCommentStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newCommentStatsTestService()
+	expected := &model.CommentStats{
+		TotalComments:     42,
+		TotalReplies:      15,
+		CommentsReceived:  28,
+		CommentsThisMonth: 8,
+	}
+	repo.On("GetCommentStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetCommentStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestCommentStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newCommentStatsTestService()
+
+	_, err := svc.GetCommentStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestCommentStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newCommentStatsTestService()
+	repo.On("GetCommentStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetCommentStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestCommentStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newCommentStatsTestService()
+	expected := &model.CommentStats{}
+	repo.On("GetCommentStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetCommentStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalComments)
+	assert.Equal(t, int64(0), result.TotalReplies)
+	assert.Equal(t, int64(0), result.CommentsReceived)
+	assert.Equal(t, int64(0), result.CommentsThisMonth)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2025,3 +2025,18 @@ func (m *MockLearningLogStatsRepository) GetLearningLogStats(userID uint) (*mode
 	}
 	return args.Get(0).(*model.LearningLogStats), args.Error(1)
 }
+
+// MockCommentStatsRepository は repository.CommentStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockCommentStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockCommentStatsRepository) GetCommentStats(userID uint) (*model.CommentStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.CommentStats), args.Error(1)
+}


### PR DESCRIPTION
## 概要
- ユーザーのコメント活動統計を返す `GET /api/v1/users/:id/comment-stats` エンドポイントを追加
- TDDで4件のテスト（Success/InvalidUserID/RepoError/NoActivity）を先行作成
- トップレベルコメント数・返信数・受信コメント数・今月コメント数の4指標を集計

## テスト計画
- [x] CommentStatsService テスト 4/4 PASS
- [x] ビルド成功確認

Closes #821