### PR TITLE
test: PostService.GetCommentsのリポジトリエラーテスト追加

### DIFF
--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -329,6 +329,18 @@ func TestPostGetComments_Success(t *testing.T) {
 	assert.Len(t, result, 2)
 }
 
+func TestPostGetComments_RepoError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("GetComments", uint(10)).Return([]model.Comment(nil), errors.New("db error"))
+
+	result, err := svc.GetComments(10)
+	assert.Error(t, err)
+	assert.Equal(t, "db error", err.Error())
+	assert.Nil(t, result)
+	postRepo.AssertExpectations(t)
+}
+
 func TestPostDeleteComment_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 


### PR DESCRIPTION
## 概要
- PostService.GetCommentsのリポジトリエラーハンドリングテストを追加
- エラー伝播の正常動作を検証

## テスト計画
- [x] TestPostGetComments_RepoError PASS

Closes #825