### PR TITLE
fix: PostService.RemoveReactionに自己リアクション削除防止チェック追加

### DIFF
--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -275,7 +275,15 @@ func (s *PostService) AddReaction(userID, postID uint, emoji string) error {
 }
 
 // RemoveReaction は投稿のリアクションを削除する。
+// 自分の投稿へのリアクション削除は禁止する（そもそもリアクションできないため）。
 func (s *PostService) RemoveReaction(userID, postID uint, emoji string) error {
+	post, err := s.repo.FindByID(postID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if post.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.RemoveReaction(userID, postID, emoji)
 }
 

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -762,6 +762,9 @@ func TestPostAddReaction_PostNotFound(t *testing.T) {
 func TestPostRemoveReaction_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	post := &model.Post{UserID: 99}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
 	postRepo.On("RemoveReaction", uint(1), uint(10), "👍").Return(nil)
 
 	err := svc.RemoveReaction(1, 10, "👍")
@@ -772,11 +775,36 @@ func TestPostRemoveReaction_Success(t *testing.T) {
 func TestPostRemoveReaction_Error(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
+	post := &model.Post{UserID: 99}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
 	postRepo.On("RemoveReaction", uint(1), uint(10), "👍").Return(errors.New("not found"))
 
 	err := svc.RemoveReaction(1, 10, "👍")
 	assert.Error(t, err)
 	postRepo.AssertExpectations(t)
+}
+
+func TestPostRemoveReaction_SelfReaction_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	err := svc.RemoveReaction(1, 10, "👍")
+	assert.ErrorIs(t, err, ErrForbidden)
+	postRepo.AssertNotCalled(t, "RemoveReaction")
+}
+
+func TestPostRemoveReaction_PostNotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.RemoveReaction(1, 99, "👍")
+	assert.ErrorIs(t, err, ErrNotFound)
+	postRepo.AssertNotCalled(t, "RemoveReaction")
 }
 
 func TestPostGetReactionsByPostID_Success(t *testing.T) {


### PR DESCRIPTION
## 概要
- RemoveReactionにAddReactionと同様の自己リアクション削除防止チェックを追加
- FindByIDで投稿取得後、所有者の場合はErrForbiddenを返す
- テスト追加: SelfReaction_Forbidden, PostNotFound + 既存テスト2件更新

## テスト計画
- [x] TestPostRemoveReaction 4/4 PASS

Closes #827