### PR TITLE
feat: 通知統計API（NotificationStats）エンドポイント追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -73,6 +73,7 @@ type Container struct {
 	RoadmapStatsHandler           *handler.RoadmapStatsHandler
 	LearningLogStatsHandler       *handler.LearningLogStatsHandler
 	CommentStatsHandler           *handler.CommentStatsHandler
+	NotificationStatsHandler      *handler.NotificationStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -314,6 +315,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	commentStatsRepo := repository.NewCommentStatsRepository(db)
 	commentStatsService := service.NewCommentStatsService(commentStatsRepo)
 	c.CommentStatsHandler = handler.NewCommentStatsHandler(commentStatsService)
+
+	notificationStatsRepo := repository.NewNotificationStatsRepository(db)
+	notificationStatsService := service.NewNotificationStatsService(notificationStatsRepo)
+	c.NotificationStatsHandler = handler.NewNotificationStatsHandler(notificationStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/notification_stats.go
+++ b/backend/internal/handler/notification_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// NotificationStatsServiceInterface はNotificationStatsHandlerが依存するサービスメソッドを定義する。
+type NotificationStatsServiceInterface interface {
+	GetNotificationStats(userID uint) (*model.NotificationStats, error)
+}
+
+// NotificationStatsHandler はユーザー通知統計関連のHTTPハンドラ。
+type NotificationStatsHandler struct {
+	service NotificationStatsServiceInterface
+}
+
+// NewNotificationStatsHandler は新しいNotificationStatsHandlerインスタンスを生成する。
+func NewNotificationStatsHandler(s NotificationStatsServiceInterface) *NotificationStatsHandler {
+	return &NotificationStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーの通知集計統計を返す。
+func (h *NotificationStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetNotificationStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/notification_stats.go
+++ b/backend/internal/model/notification_stats.go
@@ -1,0 +1,8 @@
+package model
+
+// NotificationStats はユーザーの通知に関する集計統計を表す。
+type NotificationStats struct {
+	TotalNotifications    int64 `json:"total_notifications"`
+	UnreadCount           int64 `json:"unread_count"`
+	NotificationsThisMonth int64 `json:"notifications_this_month"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -576,3 +576,8 @@ type LearningLogStatsRepositoryInterface interface {
 type CommentStatsRepositoryInterface interface {
 	GetCommentStats(userID uint) (*model.CommentStats, error)
 }
+
+// NotificationStatsRepositoryInterface はユーザー通知集計統計データ操作の契約を定義する。
+type NotificationStatsRepositoryInterface interface {
+	GetNotificationStats(userID uint) (*model.NotificationStats, error)
+}

--- a/backend/internal/repository/notification_stats.go
+++ b/backend/internal/repository/notification_stats.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// NotificationStatsRepository はユーザー通知集計統計の取得を担当するリポジトリ実装。
+type NotificationStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewNotificationStatsRepository は新しいNotificationStatsRepositoryインスタンスを生成する。
+func NewNotificationStatsRepository(db *gorm.DB) *NotificationStatsRepository {
+	return &NotificationStatsRepository{db: db}
+}
+
+// GetNotificationStats は指定ユーザーの通知集計統計を返す。
+func (r *NotificationStatsRepository) GetNotificationStats(userID uint) (*model.NotificationStats, error) {
+	var stats model.NotificationStats
+
+	// 通知総数
+	if err := r.db.Model(&model.Notification{}).Where("user_id = ?", userID).Count(&stats.TotalNotifications).Error; err != nil {
+		return nil, err
+	}
+
+	// 未読通知数
+	if err := r.db.Model(&model.Notification{}).Where("user_id = ? AND read = ?", userID, false).Count(&stats.UnreadCount).Error; err != nil {
+		return nil, err
+	}
+
+	// 今月の通知数
+	now := time.Now()
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	if err := r.db.Model(&model.Notification{}).Where("user_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.NotificationsThisMonth).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -109,6 +109,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerRoadmapStatsRoutes(protected, c)
 		registerLearningLogStatsRoutes(protected, c)
 		registerCommentStatsRoutes(protected, c)
+		registerNotificationStatsRoutes(protected, c)
 	}
 
 	return r
@@ -694,5 +695,12 @@ func registerCommentStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/comment-stats", c.CommentStatsHandler.GetStats)
+	}
+}
+
+func registerNotificationStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/notification-stats", c.NotificationStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2040,3 +2040,18 @@ func (m *MockCommentStatsRepository) GetCommentStats(userID uint) (*model.Commen
 	}
 	return args.Get(0).(*model.CommentStats), args.Error(1)
 }
+
+// MockNotificationStatsRepository は repository.NotificationStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockNotificationStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockNotificationStatsRepository) GetNotificationStats(userID uint) (*model.NotificationStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.NotificationStats), args.Error(1)
+}

--- a/backend/internal/service/notification_stats.go
+++ b/backend/internal/service/notification_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// NotificationStatsService はユーザー通知集計統計のビジネスロジックを提供する。
+type NotificationStatsService struct {
+	repo repository.NotificationStatsRepositoryInterface
+}
+
+// NewNotificationStatsService は新しいNotificationStatsServiceインスタンスを生成する。
+func NewNotificationStatsService(repo repository.NotificationStatsRepositoryInterface) *NotificationStatsService {
+	return &NotificationStatsService{repo: repo}
+}
+
+// GetNotificationStats は指定ユーザーの通知集計統計を取得する。
+func (s *NotificationStatsService) GetNotificationStats(userID uint) (*model.NotificationStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetNotificationStats(userID)
+}

--- a/backend/internal/service/notification_stats_test.go
+++ b/backend/internal/service/notification_stats_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newNotificationStatsTestService() (*NotificationStatsService, *MockNotificationStatsRepository) {
+	repo := new(MockNotificationStatsRepository)
+	svc := NewNotificationStatsService(repo)
+	return svc, repo
+}
+
+func TestNotificationStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newNotificationStatsTestService()
+	expected := &model.NotificationStats{
+		TotalNotifications:     120,
+		UnreadCount:            15,
+		NotificationsThisMonth: 32,
+	}
+	repo.On("GetNotificationStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetNotificationStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestNotificationStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newNotificationStatsTestService()
+
+	_, err := svc.GetNotificationStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestNotificationStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newNotificationStatsTestService()
+	repo.On("GetNotificationStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetNotificationStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestNotificationStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newNotificationStatsTestService()
+	expected := &model.NotificationStats{}
+	repo.On("GetNotificationStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetNotificationStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalNotifications)
+	assert.Equal(t, int64(0), result.UnreadCount)
+	assert.Equal(t, int64(0), result.NotificationsThisMonth)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- ユーザーの通知統計を返す `GET /api/v1/users/:id/notification-stats` エンドポイントを追加
- TDDで4件のテスト（Success/InvalidUserID/RepoError/NoActivity）を先行作成
- 通知総数・未読数・今月通知数の3指標を集計

## テスト計画
- [x] NotificationStatsService テスト 4/4 PASS
- [x] ビルド成功確認

Closes #829