### PR TITLE
fix: QuestionService.RemoveVoteに自己投票削除防止チェック追加

### DIFF
--- a/backend/internal/service/question.go
+++ b/backend/internal/service/question.go
@@ -117,6 +117,14 @@ func (s *QuestionService) Vote(userID, questionID uint, value int) error {
 }
 
 // RemoveVote は質問への投票を取り消す。
+// 自分の質問への投票削除は禁止する（そもそも投票できないため）。
 func (s *QuestionService) RemoveVote(userID, questionID uint) error {
+	question, err := s.repo.FindByID(questionID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if question.UserID == userID {
+		return ErrForbidden
+	}
 	return s.repo.RemoveVote(userID, questionID)
 }

--- a/backend/internal/service/question_test.go
+++ b/backend/internal/service/question_test.go
@@ -155,6 +155,9 @@ func TestQuestionVote_QuestionNotFound(t *testing.T) {
 func TestQuestionRemoveVote_Success(t *testing.T) {
 	svc, repo := newTestQuestionService()
 
+	question := &model.Question{UserID: 99}
+	question.ID = 10
+	repo.On("FindByID", uint(10)).Return(question, nil)
 	repo.On("RemoveVote", uint(1), uint(10)).Return(nil)
 
 	err := svc.RemoveVote(1, 10)
@@ -165,12 +168,37 @@ func TestQuestionRemoveVote_Success(t *testing.T) {
 func TestQuestionRemoveVote_RepoError(t *testing.T) {
 	svc, repo := newTestQuestionService()
 
+	question := &model.Question{UserID: 99}
+	question.ID = 10
+	repo.On("FindByID", uint(10)).Return(question, nil)
 	repo.On("RemoveVote", uint(1), uint(10)).Return(errors.New("db error"))
 
 	err := svc.RemoveVote(1, 10)
 	assert.Error(t, err)
 	assert.Equal(t, "db error", err.Error())
 	repo.AssertExpectations(t)
+}
+
+func TestQuestionRemoveVote_SelfVote_Forbidden(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	question := &model.Question{UserID: 1}
+	question.ID = 10
+	repo.On("FindByID", uint(10)).Return(question, nil)
+
+	err := svc.RemoveVote(1, 10)
+	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertNotCalled(t, "RemoveVote")
+}
+
+func TestQuestionRemoveVote_QuestionNotFound(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.RemoveVote(1, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertNotCalled(t, "RemoveVote")
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
- RemoveVoteにVoteと同様の自己投票削除防止チェックを追加
- FindByIDで質問取得後、所有者の場合はErrForbiddenを返す
- テスト追加: SelfVote_Forbidden, QuestionNotFound + 既存テスト2件更新

## テスト計画
- [x] TestQuestionRemoveVote 4/4 PASS

Closes #835