### PR TITLE
feat: メッセージ統計API（MessageStats）エンドポイント追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -74,6 +74,7 @@ type Container struct {
 	LearningLogStatsHandler       *handler.LearningLogStatsHandler
 	CommentStatsHandler           *handler.CommentStatsHandler
 	NotificationStatsHandler      *handler.NotificationStatsHandler
+	MessageStatsHandler           *handler.MessageStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -319,6 +320,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	notificationStatsRepo := repository.NewNotificationStatsRepository(db)
 	notificationStatsService := service.NewNotificationStatsService(notificationStatsRepo)
 	c.NotificationStatsHandler = handler.NewNotificationStatsHandler(notificationStatsService)
+
+	messageStatsRepo := repository.NewMessageStatsRepository(db)
+	messageStatsService := service.NewMessageStatsService(messageStatsRepo)
+	c.MessageStatsHandler = handler.NewMessageStatsHandler(messageStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/message_stats.go
+++ b/backend/internal/handler/message_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// MessageStatsServiceInterface はMessageStatsHandlerが依存するサービスメソッドを定義する。
+type MessageStatsServiceInterface interface {
+	GetMessageStats(userID uint) (*model.MessageStats, error)
+}
+
+// MessageStatsHandler はユーザーメッセージ統計関連のHTTPハンドラ。
+type MessageStatsHandler struct {
+	service MessageStatsServiceInterface
+}
+
+// NewMessageStatsHandler は新しいMessageStatsHandlerインスタンスを生成する。
+func NewMessageStatsHandler(s MessageStatsServiceInterface) *MessageStatsHandler {
+	return &MessageStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのメッセージ集計統計を返す。
+func (h *MessageStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetMessageStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/message_stats.go
+++ b/backend/internal/model/message_stats.go
@@ -1,0 +1,9 @@
+package model
+
+// MessageStats はユーザーのダイレクトメッセージに関する集計統計を表す。
+type MessageStats struct {
+	TotalSent          int64 `json:"total_sent"`
+	TotalReceived      int64 `json:"total_received"`
+	ConversationsCount int64 `json:"conversations_count"`
+	MessagesThisMonth  int64 `json:"messages_this_month"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -581,3 +581,8 @@ type CommentStatsRepositoryInterface interface {
 type NotificationStatsRepositoryInterface interface {
 	GetNotificationStats(userID uint) (*model.NotificationStats, error)
 }
+
+// MessageStatsRepositoryInterface はユーザーメッセージ集計統計データ操作の契約を定義する。
+type MessageStatsRepositoryInterface interface {
+	GetMessageStats(userID uint) (*model.MessageStats, error)
+}

--- a/backend/internal/repository/message_stats.go
+++ b/backend/internal/repository/message_stats.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// MessageStatsRepository はユーザーメッセージ集計統計の取得を担当するリポジトリ実装。
+type MessageStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewMessageStatsRepository は新しいMessageStatsRepositoryインスタンスを生成する。
+func NewMessageStatsRepository(db *gorm.DB) *MessageStatsRepository {
+	return &MessageStatsRepository{db: db}
+}
+
+// GetMessageStats は指定ユーザーのメッセージ集計統計を返す。
+func (r *MessageStatsRepository) GetMessageStats(userID uint) (*model.MessageStats, error) {
+	var stats model.MessageStats
+
+	// 送信メッセージ総数
+	if err := r.db.Model(&model.Message{}).Where("sender_id = ?", userID).Count(&stats.TotalSent).Error; err != nil {
+		return nil, err
+	}
+
+	// 受信メッセージ総数
+	if err := r.db.Model(&model.Message{}).Where("receiver_id = ?", userID).Count(&stats.TotalReceived).Error; err != nil {
+		return nil, err
+	}
+
+	// 会話相手数（送信先+受信元のユニーク数）
+	if err := r.db.Model(&model.Message{}).
+		Select("COUNT(DISTINCT CASE WHEN sender_id = ? THEN receiver_id ELSE sender_id END)", userID).
+		Where("sender_id = ? OR receiver_id = ?", userID, userID).
+		Scan(&stats.ConversationsCount).Error; err != nil {
+		return nil, err
+	}
+
+	// 今月の送信メッセージ数
+	now := time.Now()
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	if err := r.db.Model(&model.Message{}).Where("sender_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.MessagesThisMonth).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -110,6 +110,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerLearningLogStatsRoutes(protected, c)
 		registerCommentStatsRoutes(protected, c)
 		registerNotificationStatsRoutes(protected, c)
+		registerMessageStatsRoutes(protected, c)
 	}
 
 	return r
@@ -702,5 +703,12 @@ func registerNotificationStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/notification-stats", c.NotificationStatsHandler.GetStats)
+	}
+}
+
+func registerMessageStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/message-stats", c.MessageStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/message_stats.go
+++ b/backend/internal/service/message_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// MessageStatsService はユーザーメッセージ集計統計のビジネスロジックを提供する。
+type MessageStatsService struct {
+	repo repository.MessageStatsRepositoryInterface
+}
+
+// NewMessageStatsService は新しいMessageStatsServiceインスタンスを生成する。
+func NewMessageStatsService(repo repository.MessageStatsRepositoryInterface) *MessageStatsService {
+	return &MessageStatsService{repo: repo}
+}
+
+// GetMessageStats は指定ユーザーのメッセージ集計統計を取得する。
+func (s *MessageStatsService) GetMessageStats(userID uint) (*model.MessageStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetMessageStats(userID)
+}

--- a/backend/internal/service/message_stats_test.go
+++ b/backend/internal/service/message_stats_test.go
@@ -1,0 +1,62 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newMessageStatsTestService() (*MessageStatsService, *MockMessageStatsRepository) {
+	repo := new(MockMessageStatsRepository)
+	svc := NewMessageStatsService(repo)
+	return svc, repo
+}
+
+func TestMessageStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newMessageStatsTestService()
+	expected := &model.MessageStats{
+		TotalSent:          150,
+		TotalReceived:      200,
+		ConversationsCount: 12,
+		MessagesThisMonth:  45,
+	}
+	repo.On("GetMessageStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetMessageStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestMessageStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newMessageStatsTestService()
+
+	_, err := svc.GetMessageStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestMessageStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newMessageStatsTestService()
+	repo.On("GetMessageStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetMessageStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestMessageStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newMessageStatsTestService()
+	expected := &model.MessageStats{}
+	repo.On("GetMessageStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetMessageStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalSent)
+	assert.Equal(t, int64(0), result.TotalReceived)
+	assert.Equal(t, int64(0), result.ConversationsCount)
+	assert.Equal(t, int64(0), result.MessagesThisMonth)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2055,3 +2055,18 @@ func (m *MockNotificationStatsRepository) GetNotificationStats(userID uint) (*mo
 	}
 	return args.Get(0).(*model.NotificationStats), args.Error(1)
 }
+
+// MockMessageStatsRepository は repository.MessageStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockMessageStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockMessageStatsRepository) GetMessageStats(userID uint) (*model.MessageStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.MessageStats), args.Error(1)
+}


### PR DESCRIPTION
## 概要
- ユーザーのDM統計を返す `GET /api/v1/users/:id/message-stats` エンドポイントを追加
- TDDで4件のテスト（Success/InvalidUserID/RepoError/NoActivity）を先行作成
- 送信数・受信数・会話相手数・今月送信数の4指標を集計

## テスト計画
- [x] MessageStatsService テスト 4/4 PASS
- [x] ビルド成功確認

Closes #837