### PR TITLE
fix: AnswerService.RemoveVoteに自己投票削除防止チェック追加

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -106,7 +106,15 @@ func (s *AnswerService) Vote(userID, answerID uint, value int) error {
 }
 
 // RemoveVote は回答への投票を取り消す。
+// 自分の回答への投票削除は禁止する（そもそも投票できないため）。
 func (s *AnswerService) RemoveVote(userID, answerID uint) error {
+	answer, err := s.answerRepo.FindByID(answerID)
+	if err != nil {
+		return ErrNotFound
+	}
+	if answer.UserID == userID {
+		return ErrForbidden
+	}
 	return s.answerRepo.RemoveVote(userID, answerID)
 }
 

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -301,6 +301,9 @@ func TestAnswerVote_AnswerNotFound(t *testing.T) {
 func TestAnswerRemoveVote_Success(t *testing.T) {
 	svc, answerRepo, _ := newTestAnswerService()
 
+	answer := &model.Answer{UserID: 99}
+	answer.ID = 5
+	answerRepo.On("FindByID", uint(5)).Return(answer, nil)
 	answerRepo.On("RemoveVote", uint(1), uint(5)).Return(nil)
 
 	err := svc.RemoveVote(1, 5)
@@ -311,12 +314,37 @@ func TestAnswerRemoveVote_Success(t *testing.T) {
 func TestAnswerRemoveVote_RepoError(t *testing.T) {
 	svc, answerRepo, _ := newTestAnswerService()
 
+	answer := &model.Answer{UserID: 99}
+	answer.ID = 5
+	answerRepo.On("FindByID", uint(5)).Return(answer, nil)
 	answerRepo.On("RemoveVote", uint(1), uint(5)).Return(errors.New("db error"))
 
 	err := svc.RemoveVote(1, 5)
 	assert.Error(t, err)
 	assert.Equal(t, "db error", err.Error())
 	answerRepo.AssertExpectations(t)
+}
+
+func TestAnswerRemoveVote_SelfVote_Forbidden(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answer := &model.Answer{UserID: 1}
+	answer.ID = 5
+	answerRepo.On("FindByID", uint(5)).Return(answer, nil)
+
+	err := svc.RemoveVote(1, 5)
+	assert.ErrorIs(t, err, ErrForbidden)
+	answerRepo.AssertNotCalled(t, "RemoveVote")
+}
+
+func TestAnswerRemoveVote_AnswerNotFound(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answerRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.RemoveVote(1, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+	answerRepo.AssertNotCalled(t, "RemoveVote")
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
- RemoveVoteにVoteと同様の自己投票削除防止チェックを追加
- FindByIDで回答取得後、所有者の場合はErrForbiddenを返す
- テスト追加: SelfVote_Forbidden, AnswerNotFound + 既存テスト2件更新

## テスト計画
- [x] TestAnswerRemoveVote 4/4 PASS

Closes #843