### PR TITLE
feat: メンション統計API（MentionStats）エンドポイント追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -75,6 +75,7 @@ type Container struct {
 	CommentStatsHandler           *handler.CommentStatsHandler
 	NotificationStatsHandler      *handler.NotificationStatsHandler
 	MessageStatsHandler           *handler.MessageStatsHandler
+	MentionStatsHandler           *handler.MentionStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -324,6 +325,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	messageStatsRepo := repository.NewMessageStatsRepository(db)
 	messageStatsService := service.NewMessageStatsService(messageStatsRepo)
 	c.MessageStatsHandler = handler.NewMessageStatsHandler(messageStatsService)
+
+	mentionStatsRepo := repository.NewMentionStatsRepository(db)
+	mentionStatsService := service.NewMentionStatsService(mentionStatsRepo)
+	c.MentionStatsHandler = handler.NewMentionStatsHandler(mentionStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/mention_stats.go
+++ b/backend/internal/handler/mention_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// MentionStatsServiceInterface はMentionStatsHandlerが依存するサービスメソッドを定義する。
+type MentionStatsServiceInterface interface {
+	GetMentionStats(userID uint) (*model.MentionStats, error)
+}
+
+// MentionStatsHandler はユーザーメンション統計関連のHTTPハンドラ。
+type MentionStatsHandler struct {
+	service MentionStatsServiceInterface
+}
+
+// NewMentionStatsHandler は新しいMentionStatsHandlerインスタンスを生成する。
+func NewMentionStatsHandler(s MentionStatsServiceInterface) *MentionStatsHandler {
+	return &MentionStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのメンション集計統計を返す。
+func (h *MentionStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetMentionStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/mention_stats.go
+++ b/backend/internal/model/mention_stats.go
@@ -1,0 +1,8 @@
+package model
+
+// MentionStats はユーザーのメンション活動に関する集計統計を表す。
+type MentionStats struct {
+	MentionsReceived  int64 `json:"mentions_received"`
+	MentionsMade      int64 `json:"mentions_made"`
+	MentionsThisMonth int64 `json:"mentions_this_month"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -586,3 +586,8 @@ type NotificationStatsRepositoryInterface interface {
 type MessageStatsRepositoryInterface interface {
 	GetMessageStats(userID uint) (*model.MessageStats, error)
 }
+
+// MentionStatsRepositoryInterface はユーザーメンション集計統計データ操作の契約を定義する。
+type MentionStatsRepositoryInterface interface {
+	GetMentionStats(userID uint) (*model.MentionStats, error)
+}

--- a/backend/internal/repository/mention_stats.go
+++ b/backend/internal/repository/mention_stats.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// MentionStatsRepository はユーザーメンション集計統計の取得を担当するリポジトリ実装。
+type MentionStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewMentionStatsRepository は新しいMentionStatsRepositoryインスタンスを生成する。
+func NewMentionStatsRepository(db *gorm.DB) *MentionStatsRepository {
+	return &MentionStatsRepository{db: db}
+}
+
+// GetMentionStats は指定ユーザーのメンション集計統計を返す。
+func (r *MentionStatsRepository) GetMentionStats(userID uint) (*model.MentionStats, error) {
+	var stats model.MentionStats
+
+	// メンションされた回数
+	if err := r.db.Model(&model.Mention{}).Where("user_id = ?", userID).Count(&stats.MentionsReceived).Error; err != nil {
+		return nil, err
+	}
+
+	// メンションした回数
+	if err := r.db.Model(&model.Mention{}).Where("actor_id = ?", userID).Count(&stats.MentionsMade).Error; err != nil {
+		return nil, err
+	}
+
+	// 今月メンションされた回数
+	now := time.Now()
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	if err := r.db.Model(&model.Mention{}).Where("user_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.MentionsThisMonth).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -111,6 +111,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerCommentStatsRoutes(protected, c)
 		registerNotificationStatsRoutes(protected, c)
 		registerMessageStatsRoutes(protected, c)
+		registerMentionStatsRoutes(protected, c)
 	}
 
 	return r
@@ -710,5 +711,12 @@ func registerMessageStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/message-stats", c.MessageStatsHandler.GetStats)
+	}
+}
+
+func registerMentionStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/mention-stats", c.MentionStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mention_stats.go
+++ b/backend/internal/service/mention_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// MentionStatsService はユーザーメンション集計統計のビジネスロジックを提供する。
+type MentionStatsService struct {
+	repo repository.MentionStatsRepositoryInterface
+}
+
+// NewMentionStatsService は新しいMentionStatsServiceインスタンスを生成する。
+func NewMentionStatsService(repo repository.MentionStatsRepositoryInterface) *MentionStatsService {
+	return &MentionStatsService{repo: repo}
+}
+
+// GetMentionStats は指定ユーザーのメンション集計統計を取得する。
+func (s *MentionStatsService) GetMentionStats(userID uint) (*model.MentionStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetMentionStats(userID)
+}

--- a/backend/internal/service/mention_stats_test.go
+++ b/backend/internal/service/mention_stats_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newMentionStatsTestService() (*MentionStatsService, *MockMentionStatsRepository) {
+	repo := new(MockMentionStatsRepository)
+	svc := NewMentionStatsService(repo)
+	return svc, repo
+}
+
+func TestMentionStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newMentionStatsTestService()
+	expected := &model.MentionStats{
+		MentionsReceived:  42,
+		MentionsMade:      15,
+		MentionsThisMonth: 8,
+	}
+	repo.On("GetMentionStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetMentionStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestMentionStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newMentionStatsTestService()
+
+	_, err := svc.GetMentionStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestMentionStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newMentionStatsTestService()
+	repo.On("GetMentionStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetMentionStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestMentionStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newMentionStatsTestService()
+	expected := &model.MentionStats{}
+	repo.On("GetMentionStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetMentionStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.MentionsReceived)
+	assert.Equal(t, int64(0), result.MentionsMade)
+	assert.Equal(t, int64(0), result.MentionsThisMonth)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2070,3 +2070,18 @@ func (m *MockMessageStatsRepository) GetMessageStats(userID uint) (*model.Messag
 	}
 	return args.Get(0).(*model.MessageStats), args.Error(1)
 }
+
+// MockMentionStatsRepository は repository.MentionStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockMentionStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockMentionStatsRepository) GetMentionStats(userID uint) (*model.MentionStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.MentionStats), args.Error(1)
+}


### PR DESCRIPTION
## 概要
- ユーザーのメンション統計を返す `GET /api/v1/users/:id/mention-stats` エンドポイントを追加
- TDDで4件のテスト先行作成
- 被メンション数・メンション数・今月被メンション数の3指標を集計

## テスト計画
- [x] MentionStatsService テスト 4/4 PASS
- [x] ビルド成功確認

Closes #845