### PR TITLE
test: PostService.UnbookmarkのPostNotFoundテスト追加

### DIFF
--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -679,6 +679,16 @@ func TestPostUnbookmark_Error(t *testing.T) {
 	postRepo.AssertExpectations(t)
 }
 
+func TestPostUnbookmark_PostNotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(10)).Return(nil, errors.New("not found"))
+
+	err := svc.Unbookmark(1, 10)
+	assert.ErrorIs(t, err, ErrNotFound)
+	postRepo.AssertNotCalled(t, "Unbookmark")
+}
+
 func TestPostUnbookmark_SelfUnbookmark_Forbidden(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 


### PR DESCRIPTION
## 概要
- PostService.Unbookmarkで投稿が見つからない場合（FindByIDエラー）のテストを追加
- ErrNotFoundが返ることを確認

## テスト
- `TestPostUnbookmark_PostNotFound` — FindByIDエラー時にErrNotFoundが返り、Unbookmarkが呼ばれないことを確認

closes #849