### PR TITLE
fix: MessageService.SendMessageに自己メッセージ送信防止チェックを追加

### DIFF
--- a/backend/internal/service/message.go
+++ b/backend/internal/service/message.go
@@ -32,7 +32,11 @@ func (s *MessageService) GetConversation(userID, otherUserID uint, page, limit i
 }
 
 // SendMessage はメッセージを送信し、受信者に非同期で通知を作成する。
+// 自分自身へのメッセージ送信は許可しない。
 func (s *MessageService) SendMessage(msg *model.Message) error {
+	if msg.SenderID == msg.ReceiverID {
+		return ErrBadRequest
+	}
 	if err := s.repo.Create(msg); err != nil {
 		return err
 	}

--- a/backend/internal/service/message_test.go
+++ b/backend/internal/service/message_test.go
@@ -150,6 +150,16 @@ func TestMessageGetConversation_RepoError(t *testing.T) {
 // メッセージ送信エラーテスト
 // ============================================================
 
+func TestMessageSendMessage_SelfMessage_BadRequest(t *testing.T) {
+	svc, msgRepo, _ := newTestMessageService()
+
+	msg := &model.Message{SenderID: 1, ReceiverID: 1, Content: "Hello myself!"}
+
+	err := svc.SendMessage(msg)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	msgRepo.AssertNotCalled(t, "Create")
+}
+
 func TestMessageSendMessage_CreateError(t *testing.T) {
 	svc, msgRepo, notifRepo := newTestMessageService()
 


### PR DESCRIPTION
## 概要
- MessageService.SendMessageでSenderID == ReceiverID（自分自身へのメッセージ送信）を防止するバリデーションを追加
- FollowService.Follow/Unfollowの自己操作防止パターンに準拠

## 変更内容
- `message.go`: SendMessage冒頭でSenderID == ReceiverIDの場合ErrBadRequestを返す
- `message_test.go`: `TestMessageSendMessage_SelfMessage_BadRequest` テスト追加

## テスト
- 既存テスト含め全15件PASS

closes #851