### PR TITLE
feat: リアクション統計API（ReactionStats）をTDDで新規追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -76,6 +76,7 @@ type Container struct {
 	NotificationStatsHandler      *handler.NotificationStatsHandler
 	MessageStatsHandler           *handler.MessageStatsHandler
 	MentionStatsHandler           *handler.MentionStatsHandler
+	ReactionStatsHandler          *handler.ReactionStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -329,6 +330,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	mentionStatsRepo := repository.NewMentionStatsRepository(db)
 	mentionStatsService := service.NewMentionStatsService(mentionStatsRepo)
 	c.MentionStatsHandler = handler.NewMentionStatsHandler(mentionStatsService)
+
+	reactionStatsRepo := repository.NewReactionStatsRepository(db)
+	reactionStatsService := service.NewReactionStatsService(reactionStatsRepo)
+	c.ReactionStatsHandler = handler.NewReactionStatsHandler(reactionStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/reaction_stats.go
+++ b/backend/internal/handler/reaction_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// ReactionStatsServiceInterface はReactionStatsHandlerが依存するサービスメソッドを定義する。
+type ReactionStatsServiceInterface interface {
+	GetReactionStats(userID uint) (*model.ReactionStats, error)
+}
+
+// ReactionStatsHandler はユーザーリアクション統計関連のHTTPハンドラ。
+type ReactionStatsHandler struct {
+	service ReactionStatsServiceInterface
+}
+
+// NewReactionStatsHandler は新しいReactionStatsHandlerインスタンスを生成する。
+func NewReactionStatsHandler(s ReactionStatsServiceInterface) *ReactionStatsHandler {
+	return &ReactionStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのリアクション集計統計を返す。
+func (h *ReactionStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetReactionStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/reaction_stats.go
+++ b/backend/internal/model/reaction_stats.go
@@ -1,0 +1,8 @@
+package model
+
+// ReactionStats はユーザーが受け取ったリアクション集計統計を表す。
+type ReactionStats struct {
+	TotalReactionsReceived int64 `json:"total_reactions_received"`
+	UniqueReactors         int64 `json:"unique_reactors"`
+	ReactionsThisMonth     int64 `json:"reactions_this_month"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -591,3 +591,8 @@ type MessageStatsRepositoryInterface interface {
 type MentionStatsRepositoryInterface interface {
 	GetMentionStats(userID uint) (*model.MentionStats, error)
 }
+
+// ReactionStatsRepositoryInterface はユーザーリアクション集計統計データ操作の契約を定義する。
+type ReactionStatsRepositoryInterface interface {
+	GetReactionStats(userID uint) (*model.ReactionStats, error)
+}

--- a/backend/internal/repository/reaction_stats.go
+++ b/backend/internal/repository/reaction_stats.go
@@ -1,0 +1,52 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// ReactionStatsRepository はユーザーリアクション集計統計の取得を担当するリポジトリ実装。
+type ReactionStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewReactionStatsRepository は新しいReactionStatsRepositoryインスタンスを生成する。
+func NewReactionStatsRepository(db *gorm.DB) *ReactionStatsRepository {
+	return &ReactionStatsRepository{db: db}
+}
+
+// GetReactionStats は指定ユーザーが受け取ったリアクション集計統計を返す。
+func (r *ReactionStatsRepository) GetReactionStats(userID uint) (*model.ReactionStats, error) {
+	var stats model.ReactionStats
+
+	// 受け取ったリアクション総数（自分の投稿へのリアクション）
+	if err := r.db.Model(&model.Reaction{}).
+		Joins("JOIN posts ON posts.id = reactions.post_id").
+		Where("posts.user_id = ?", userID).
+		Count(&stats.TotalReactionsReceived).Error; err != nil {
+		return nil, err
+	}
+
+	// リアクションしたユニークユーザー数
+	if err := r.db.Model(&model.Reaction{}).
+		Joins("JOIN posts ON posts.id = reactions.post_id").
+		Where("posts.user_id = ?", userID).
+		Distinct("reactions.user_id").
+		Count(&stats.UniqueReactors).Error; err != nil {
+		return nil, err
+	}
+
+	// 今月受け取ったリアクション数
+	now := time.Now()
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	if err := r.db.Model(&model.Reaction{}).
+		Joins("JOIN posts ON posts.id = reactions.post_id").
+		Where("posts.user_id = ? AND reactions.created_at >= ?", userID, startOfMonth).
+		Count(&stats.ReactionsThisMonth).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -112,6 +112,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerNotificationStatsRoutes(protected, c)
 		registerMessageStatsRoutes(protected, c)
 		registerMentionStatsRoutes(protected, c)
+		registerReactionStatsRoutes(protected, c)
 	}
 
 	return r
@@ -718,5 +719,12 @@ func registerMentionStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/mention-stats", c.MentionStatsHandler.GetStats)
+	}
+}
+
+func registerReactionStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/reaction-stats", c.ReactionStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2085,3 +2085,18 @@ func (m *MockMentionStatsRepository) GetMentionStats(userID uint) (*model.Mentio
 	}
 	return args.Get(0).(*model.MentionStats), args.Error(1)
 }
+
+// MockReactionStatsRepository は repository.ReactionStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockReactionStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockReactionStatsRepository) GetReactionStats(userID uint) (*model.ReactionStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.ReactionStats), args.Error(1)
+}

--- a/backend/internal/service/reaction_stats.go
+++ b/backend/internal/service/reaction_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// ReactionStatsService はユーザーリアクション集計統計のビジネスロジックを提供する。
+type ReactionStatsService struct {
+	repo repository.ReactionStatsRepositoryInterface
+}
+
+// NewReactionStatsService は新しいReactionStatsServiceインスタンスを生成する。
+func NewReactionStatsService(repo repository.ReactionStatsRepositoryInterface) *ReactionStatsService {
+	return &ReactionStatsService{repo: repo}
+}
+
+// GetReactionStats は指定ユーザーのリアクション集計統計を取得する。
+func (s *ReactionStatsService) GetReactionStats(userID uint) (*model.ReactionStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetReactionStats(userID)
+}

--- a/backend/internal/service/reaction_stats_test.go
+++ b/backend/internal/service/reaction_stats_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newReactionStatsTestService() (*ReactionStatsService, *MockReactionStatsRepository) {
+	repo := new(MockReactionStatsRepository)
+	svc := NewReactionStatsService(repo)
+	return svc, repo
+}
+
+func TestReactionStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newReactionStatsTestService()
+	expected := &model.ReactionStats{
+		TotalReactionsReceived: 120,
+		UniqueReactors:         35,
+		ReactionsThisMonth:     18,
+	}
+	repo.On("GetReactionStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetReactionStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestReactionStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newReactionStatsTestService()
+
+	_, err := svc.GetReactionStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestReactionStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newReactionStatsTestService()
+	repo.On("GetReactionStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetReactionStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestReactionStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newReactionStatsTestService()
+	expected := &model.ReactionStats{}
+	repo.On("GetReactionStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetReactionStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalReactionsReceived)
+	assert.Equal(t, int64(0), result.UniqueReactors)
+	assert.Equal(t, int64(0), result.ReactionsThisMonth)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- `GET /api/v1/users/:id/reaction-stats` エンドポイントを新規追加
- ユーザーが受け取ったリアクション集計統計を取得するAPI

## 集計指標
- `total_reactions_received`: 受け取ったリアクション総数
- `unique_reactors`: リアクションした人の数（ユニーク）
- `reactions_this_month`: 今月受け取ったリアクション数

## 変更ファイル
- model/reaction_stats.go — モデル定義
- repository/interfaces.go — インターフェース追加
- repository/reaction_stats.go — GORM実装（JOINクエリ）
- service/reaction_stats.go — ビジネスロジック
- service/reaction_stats_test.go — テスト4件（Success/InvalidUserID/RepoError/NoActivity）
- service/mock_test.go — モック追加
- handler/reaction_stats.go — HTTPハンドラ
- di/container.go — DI登録
- router/router.go — ルーティング登録

## テスト
- TDDで4件のテスト先行作成、全PASS

closes #853