### PR TITLE
test: LearningResourceService.UnsaveのResourceNotFoundテスト追加

### DIFF
--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -623,6 +623,15 @@ func TestLearningResourceUnsave_Error(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestLearningResourceUnsave_ResourceNotFound(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	repo.On("FindByID", uint(10)).Return(nil, errors.New("not found"))
+
+	err := svc.Unsave(1, 10)
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertNotCalled(t, "Unsave")
+}
+
 func TestLearningResourceUnsave_SelfUnsave_Forbidden(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
 	repo.On("FindByID", uint(10)).Return(&model.LearningResource{UserID: 1}, nil)


### PR DESCRIPTION
## 概要
- LearningResourceService.Unsaveでリソースが見つからない場合（FindByIDエラー）のテストを追加
- ErrNotFoundが返りUnsaveが呼ばれないことを確認

## テスト
- `TestLearningResourceUnsave_ResourceNotFound` 追加、既存テスト含め全PASS

closes #857