### PR TITLE
fix: ChatRoomService.RemoveMemberでオーナー自己退出を防止

### DIFF
--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -119,6 +119,9 @@ func (s *ChatRoomService) RemoveMember(roomID, userID, targetUserID uint) error 
 	if err != nil {
 		return err
 	}
+	if room.OwnerID == targetUserID {
+		return ErrBadRequest
+	}
 	if room.OwnerID != userID && userID != targetUserID {
 		return ErrForbidden
 	}

--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -243,6 +243,20 @@ func TestChatRoomRemoveMember_MemberCanRemoveSelf(t *testing.T) {
 	roomRepo.AssertExpectations(t)
 }
 
+func TestChatRoomRemoveMember_OwnerCannotRemoveSelf(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{OwnerID: 1}
+	room.ID = 10
+
+	roomRepo.On("FindByID", uint(10)).Return(room, nil)
+
+	// オーナー(1)が自分自身を退出しようとする
+	err := svc.RemoveMember(10, 1, 1)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	roomRepo.AssertNotCalled(t, "RemoveMember")
+}
+
 func TestChatRoomRemoveMember_NonOwnerCannotRemoveOthers(t *testing.T) {
 	svc, roomRepo, _ := newTestChatRoomService()
 


### PR DESCRIPTION
## 概要
- ChatRoomService.RemoveMemberでオーナーがtargetUserIDとして自分自身を指定した場合にErrBadRequestを返すバリデーションを追加
- オーナー不在のルームが発生することを防止

## 変更内容
- `chat_room.go`: targetUserIDがオーナーIDと一致する場合にErrBadRequestを返す
- `chat_room_test.go`: `TestChatRoomRemoveMember_OwnerCannotRemoveSelf` テスト追加

## テスト
- 既存テスト含め全5件PASS

closes #859