### PR TITLE
feat: ブックマーク統計API（BookmarkStats）をTDDで新規追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -77,6 +77,7 @@ type Container struct {
 	MessageStatsHandler           *handler.MessageStatsHandler
 	MentionStatsHandler           *handler.MentionStatsHandler
 	ReactionStatsHandler          *handler.ReactionStatsHandler
+	BookmarkStatsHandler          *handler.BookmarkStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
 
@@ -334,6 +335,10 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	reactionStatsRepo := repository.NewReactionStatsRepository(db)
 	reactionStatsService := service.NewReactionStatsService(reactionStatsRepo)
 	c.ReactionStatsHandler = handler.NewReactionStatsHandler(reactionStatsService)
+
+	bookmarkStatsRepo := repository.NewBookmarkStatsRepository(db)
+	bookmarkStatsService := service.NewBookmarkStatsService(bookmarkStatsRepo)
+	c.BookmarkStatsHandler = handler.NewBookmarkStatsHandler(bookmarkStatsService)
 
 	// Spotifyサービス
 	spotifyRepo := repository.NewSpotifyRepository(db)

--- a/backend/internal/handler/bookmark_stats.go
+++ b/backend/internal/handler/bookmark_stats.go
@@ -1,0 +1,37 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// BookmarkStatsServiceInterface はBookmarkStatsHandlerが依存するサービスメソッドを定義する。
+type BookmarkStatsServiceInterface interface {
+	GetBookmarkStats(userID uint) (*model.BookmarkStats, error)
+}
+
+// BookmarkStatsHandler はユーザーブックマーク統計関連のHTTPハンドラ。
+type BookmarkStatsHandler struct {
+	service BookmarkStatsServiceInterface
+}
+
+// NewBookmarkStatsHandler は新しいBookmarkStatsHandlerインスタンスを生成する。
+func NewBookmarkStatsHandler(s BookmarkStatsServiceInterface) *BookmarkStatsHandler {
+	return &BookmarkStatsHandler{service: s}
+}
+
+// GetStats は指定ユーザーのブックマーク集計統計を返す。
+func (h *BookmarkStatsHandler) GetStats(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	stats, err := h.service.GetBookmarkStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
+}

--- a/backend/internal/model/bookmark_stats.go
+++ b/backend/internal/model/bookmark_stats.go
@@ -1,0 +1,8 @@
+package model
+
+// BookmarkStats はユーザーのブックマーク集計統計を表す。
+type BookmarkStats struct {
+	TotalBookmarksMade     int64 `json:"total_bookmarks_made"`
+	TotalBookmarksReceived int64 `json:"total_bookmarks_received"`
+	BookmarksThisMonth     int64 `json:"bookmarks_this_month"`
+}

--- a/backend/internal/repository/bookmark_stats.go
+++ b/backend/internal/repository/bookmark_stats.go
@@ -1,0 +1,45 @@
+package repository
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// BookmarkStatsRepository はユーザーブックマーク集計統計の取得を担当するリポジトリ実装。
+type BookmarkStatsRepository struct {
+	db *gorm.DB
+}
+
+// NewBookmarkStatsRepository は新しいBookmarkStatsRepositoryインスタンスを生成する。
+func NewBookmarkStatsRepository(db *gorm.DB) *BookmarkStatsRepository {
+	return &BookmarkStatsRepository{db: db}
+}
+
+// GetBookmarkStats は指定ユーザーのブックマーク集計統計を返す。
+func (r *BookmarkStatsRepository) GetBookmarkStats(userID uint) (*model.BookmarkStats, error) {
+	var stats model.BookmarkStats
+
+	// ブックマークした数
+	if err := r.db.Model(&model.Bookmark{}).Where("user_id = ?", userID).Count(&stats.TotalBookmarksMade).Error; err != nil {
+		return nil, err
+	}
+
+	// 投稿がブックマークされた回数
+	if err := r.db.Model(&model.Bookmark{}).
+		Joins("JOIN posts ON posts.id = bookmarks.post_id").
+		Where("posts.user_id = ?", userID).
+		Count(&stats.TotalBookmarksReceived).Error; err != nil {
+		return nil, err
+	}
+
+	// 今月ブックマークした数
+	now := time.Now()
+	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	if err := r.db.Model(&model.Bookmark{}).Where("user_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.BookmarksThisMonth).Error; err != nil {
+		return nil, err
+	}
+
+	return &stats, nil
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -596,3 +596,8 @@ type MentionStatsRepositoryInterface interface {
 type ReactionStatsRepositoryInterface interface {
 	GetReactionStats(userID uint) (*model.ReactionStats, error)
 }
+
+// BookmarkStatsRepositoryInterface はユーザーブックマーク集計統計データ操作の契約を定義する。
+type BookmarkStatsRepositoryInterface interface {
+	GetBookmarkStats(userID uint) (*model.BookmarkStats, error)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -113,6 +113,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerMessageStatsRoutes(protected, c)
 		registerMentionStatsRoutes(protected, c)
 		registerReactionStatsRoutes(protected, c)
+		registerBookmarkStatsRoutes(protected, c)
 	}
 
 	return r
@@ -726,5 +727,12 @@ func registerReactionStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 	users := g.Group("/users")
 	{
 		users.GET("/:id/reaction-stats", c.ReactionStatsHandler.GetStats)
+	}
+}
+
+func registerBookmarkStatsRoutes(g *gin.RouterGroup, c *di.Container) {
+	users := g.Group("/users")
+	{
+		users.GET("/:id/bookmark-stats", c.BookmarkStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/bookmark_stats.go
+++ b/backend/internal/service/bookmark_stats.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// BookmarkStatsService はユーザーブックマーク集計統計のビジネスロジックを提供する。
+type BookmarkStatsService struct {
+	repo repository.BookmarkStatsRepositoryInterface
+}
+
+// NewBookmarkStatsService は新しいBookmarkStatsServiceインスタンスを生成する。
+func NewBookmarkStatsService(repo repository.BookmarkStatsRepositoryInterface) *BookmarkStatsService {
+	return &BookmarkStatsService{repo: repo}
+}
+
+// GetBookmarkStats は指定ユーザーのブックマーク集計統計を取得する。
+func (s *BookmarkStatsService) GetBookmarkStats(userID uint) (*model.BookmarkStats, error) {
+	if userID == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	}
+	return s.repo.GetBookmarkStats(userID)
+}

--- a/backend/internal/service/bookmark_stats_test.go
+++ b/backend/internal/service/bookmark_stats_test.go
@@ -1,0 +1,60 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func newBookmarkStatsTestService() (*BookmarkStatsService, *MockBookmarkStatsRepository) {
+	repo := new(MockBookmarkStatsRepository)
+	svc := NewBookmarkStatsService(repo)
+	return svc, repo
+}
+
+func TestBookmarkStatsService_GetStats_Success(t *testing.T) {
+	svc, repo := newBookmarkStatsTestService()
+	expected := &model.BookmarkStats{
+		TotalBookmarksMade:     50,
+		TotalBookmarksReceived: 200,
+		BookmarksThisMonth:     12,
+	}
+	repo.On("GetBookmarkStats", uint(1)).Return(expected, nil)
+
+	result, err := svc.GetBookmarkStats(1)
+	assert.NoError(t, err)
+	assert.Equal(t, expected, result)
+	repo.AssertExpectations(t)
+}
+
+func TestBookmarkStatsService_GetStats_InvalidUserID(t *testing.T) {
+	svc, _ := newBookmarkStatsTestService()
+
+	_, err := svc.GetBookmarkStats(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestBookmarkStatsService_GetStats_RepoError(t *testing.T) {
+	svc, repo := newBookmarkStatsTestService()
+	repo.On("GetBookmarkStats", uint(1)).Return(nil, errors.New("db error"))
+
+	_, err := svc.GetBookmarkStats(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestBookmarkStatsService_GetStats_NoActivity(t *testing.T) {
+	svc, repo := newBookmarkStatsTestService()
+	expected := &model.BookmarkStats{}
+	repo.On("GetBookmarkStats", uint(99)).Return(expected, nil)
+
+	result, err := svc.GetBookmarkStats(99)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), result.TotalBookmarksMade)
+	assert.Equal(t, int64(0), result.TotalBookmarksReceived)
+	assert.Equal(t, int64(0), result.BookmarksThisMonth)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2100,3 +2100,18 @@ func (m *MockReactionStatsRepository) GetReactionStats(userID uint) (*model.Reac
 	}
 	return args.Get(0).(*model.ReactionStats), args.Error(1)
 }
+
+// MockBookmarkStatsRepository は repository.BookmarkStatsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockBookmarkStatsRepository struct {
+	mock.Mock
+}
+
+func (m *MockBookmarkStatsRepository) GetBookmarkStats(userID uint) (*model.BookmarkStats, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.BookmarkStats), args.Error(1)
+}


### PR DESCRIPTION
## 概要
- `GET /api/v1/users/:id/bookmark-stats` エンドポイントを新規追加
- ユーザーのブックマーク集計統計を取得するAPI

## 集計指標
- `total_bookmarks_made`: ブックマークした数
- `total_bookmarks_received`: 投稿がブックマークされた回数
- `bookmarks_this_month`: 今月ブックマークした数

## テスト
- TDDで4件のテスト先行作成、全PASS

closes #861