### PR TITLE
fix: ChatRoomService.AddMemberに重複メンバー追加防止チェックを追加

### DIFF
--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -104,10 +104,18 @@ func (s *ChatRoomService) GetMembers(roomID, userID uint) ([]model.ChatRoomMembe
 }
 
 // AddMember はリクエスト者のメンバーシップを検証した後、新しいメンバーを追加する。
+// 既にメンバーのユーザーは追加できない。
 func (s *ChatRoomService) AddMember(roomID, userID, targetUserID uint) error {
 	isMember, err := s.roomRepo.IsMember(roomID, userID)
 	if err != nil || !isMember {
 		return ErrForbidden
+	}
+	alreadyMember, err := s.roomRepo.IsMember(roomID, targetUserID)
+	if err != nil {
+		return err
+	}
+	if alreadyMember {
+		return ErrBadRequest
 	}
 	return s.roomRepo.AddMember(roomID, targetUserID)
 }

--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -279,11 +279,23 @@ func TestChatRoomAddMember_Success(t *testing.T) {
 	svc, roomRepo, _ := newTestChatRoomService()
 
 	roomRepo.On("IsMember", uint(10), uint(1)).Return(true, nil)
+	roomRepo.On("IsMember", uint(10), uint(3)).Return(false, nil)
 	roomRepo.On("AddMember", uint(10), uint(3)).Return(nil)
 
 	err := svc.AddMember(10, 1, 3)
 	assert.NoError(t, err)
 	roomRepo.AssertExpectations(t)
+}
+
+func TestChatRoomAddMember_AlreadyMember(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	roomRepo.On("IsMember", uint(10), uint(1)).Return(true, nil)
+	roomRepo.On("IsMember", uint(10), uint(3)).Return(true, nil)
+
+	err := svc.AddMember(10, 1, 3)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	roomRepo.AssertNotCalled(t, "AddMember")
 }
 
 func TestChatRoomAddMember_NotMember(t *testing.T) {


### PR DESCRIPTION
## 概要
- ChatRoomService.AddMemberでtargetUserIDが既にメンバーかどうかのチェックが欠如していた
- 重複メンバー追加時はErrBadRequestを返すよう修正

## 変更内容
- `chat_room.go`: AddMemberにIsMemberチェック追加（既存メンバーの場合ErrBadRequest）
- `chat_room_test.go`: `TestChatRoomAddMember_AlreadyMember`テスト追加、既存テストのmock更新

## テスト
- 全ChatRoomテストPASS

closes #867