### PR TITLE
feat: LearningGoalServiceにカテゴリ別目標取得メソッドを追加

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -13,6 +13,7 @@ type LearningGoalServiceInterface interface {
 	Create(goal *model.LearningGoal) error
 	GetByID(id uint) (*model.LearningGoal, error)
 	GetByUserID(userID uint) ([]model.LearningGoal, error)
+	GetByCategory(userID uint, category string) ([]model.LearningGoal, error)
 	GetStats(userID uint) (*model.LearningGoalStats, error)
 	Update(id, userID uint, updates *model.LearningGoal) (*model.LearningGoal, error)
 	Delete(id, userID uint) error
@@ -193,6 +194,23 @@ func (h *LearningGoalHandler) GetDeadlineAlerts(c *gin.Context) {
 	}
 
 	respondOK(c, alerts)
+}
+
+// GetByCategory は認証ユーザーの学習目標をカテゴリでフィルタリングして取得する。
+func (h *LearningGoalHandler) GetByCategory(c *gin.Context) {
+	userID := c.GetUint("userID")
+	category := c.Param("category")
+
+	goals, err := h.service.GetByCategory(userID, category)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if goals == nil {
+		goals = []model.LearningGoal{}
+	}
+
+	respondOK(c, goals)
 }
 
 // GetStats は指定されたユーザーの学習目標統計情報を取得する。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -163,6 +163,7 @@ type LearningGoalRepositoryInterface interface {
 	FindByID(id uint) (*model.LearningGoal, error)
 	GetByUserID(userID uint) ([]model.LearningGoal, error)
 	GetActiveByUserID(userID uint) ([]model.LearningGoal, error)
+	GetByCategory(userID uint, category string) ([]model.LearningGoal, error)
 	GetStats(userID uint) (*model.LearningGoalStats, error)
 }
 

--- a/backend/internal/repository/learning_goal.go
+++ b/backend/internal/repository/learning_goal.go
@@ -54,6 +54,13 @@ func (r *LearningGoalRepository) GetActiveByUserID(userID uint) ([]model.Learnin
 	return goals, err
 }
 
+// GetByCategory は指定ユーザーの学習目標をカテゴリでフィルタリングして取得する（新しい順）。
+func (r *LearningGoalRepository) GetByCategory(userID uint, category string) ([]model.LearningGoal, error) {
+	var goals []model.LearningGoal
+	err := r.db.Where("user_id = ? AND category = ?", userID, category).Order("created_at DESC").Find(&goals).Error
+	return goals, err
+}
+
 // GetStats は指定ユーザーの学習目標統計情報を算出する。
 // 目標総数、アクティブ数、完了数、平均進捗率を返す。
 func (r *LearningGoalRepository) GetStats(userID uint) (*model.LearningGoalStats, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -324,6 +324,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		goals.GET("/user/:userId", c.LearningGoalHandler.GetByUserID)
 		goals.GET("/stats/:userId", c.LearningGoalHandler.GetStats)
 		goals.GET("/deadline-alerts", c.LearningGoalHandler.GetDeadlineAlerts)
+		goals.GET("/category/:category", c.LearningGoalHandler.GetByCategory)
 	}
 
 	// アクティビティレポート

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -3,6 +3,7 @@ package service
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -36,6 +37,23 @@ func (s *LearningGoalService) GetByUserID(userID uint) ([]model.LearningGoal, er
 // GetActiveByUserID は指定ユーザーのアクティブな学習目標のみを取得する。
 func (s *LearningGoalService) GetActiveByUserID(userID uint) ([]model.LearningGoal, error) {
 	return s.repo.GetActiveByUserID(userID)
+}
+
+// validGoalCategories は有効なGoalCategoryの集合。
+var validGoalCategories = map[string]bool{
+	string(model.GoalCategoryLanguage):  true,
+	string(model.GoalCategoryFramework): true,
+	string(model.GoalCategorySkill):     true,
+	string(model.GoalCategoryProject):   true,
+	string(model.GoalCategoryOther):     true,
+}
+
+// GetByCategory は指定ユーザーの学習目標をカテゴリでフィルタリングして取得する。
+func (s *LearningGoalService) GetByCategory(userID uint, category string) ([]model.LearningGoal, error) {
+	if !validGoalCategories[category] {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なカテゴリです", nil)
+	}
+	return s.repo.GetByCategory(userID, category)
 }
 
 // GetStats は指定ユーザーの学習目標統計情報を取得する。

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -492,3 +492,48 @@ func TestLearningGoalUpdate_WithTargetDate(t *testing.T) {
 	assert.Equal(t, "Desc", result.Description)
 	assert.NotNil(t, result.TargetDate)
 }
+
+// ============================================================
+// カテゴリ別取得テスト
+// ============================================================
+
+func TestLearningGoalGetByCategory_Success(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	expected := []model.LearningGoal{
+		{ID: 1, UserID: 1, Title: "Go習得", Category: model.GoalCategoryLanguage},
+		{ID: 2, UserID: 1, Title: "Rust入門", Category: model.GoalCategoryLanguage},
+	}
+	repo.On("GetByCategory", uint(1), "language").Return(expected, nil)
+
+	result, err := svc.GetByCategory(1, "language")
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalGetByCategory_EmptyResult(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	repo.On("GetByCategory", uint(1), "framework").Return([]model.LearningGoal{}, nil)
+
+	result, err := svc.GetByCategory(1, "framework")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalGetByCategory_InvalidCategory(t *testing.T) {
+	svc, _ := newTestLearningGoalService()
+
+	_, err := svc.GetByCategory(1, "invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "無効なカテゴリ")
+}
+
+func TestLearningGoalGetByCategory_RepoError(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	repo.On("GetByCategory", uint(1), "language").Return([]model.LearningGoal{}, errors.New("db error"))
+
+	_, err := svc.GetByCategory(1, "language")
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -543,6 +543,11 @@ func (m *MockLearningGoalRepository) GetActiveByUserID(userID uint) ([]model.Lea
 	return args.Get(0).([]model.LearningGoal), args.Error(1)
 }
 
+func (m *MockLearningGoalRepository) GetByCategory(userID uint, category string) ([]model.LearningGoal, error) {
+	args := m.Called(userID, category)
+	return args.Get(0).([]model.LearningGoal), args.Error(1)
+}
+
 func (m *MockLearningGoalRepository) GetStats(userID uint) (*model.LearningGoalStats, error) {
 	args := m.Called(userID)
 	if args.Get(0) == nil {


### PR DESCRIPTION
## 概要
- `GET /api/v1/goals/category/:category` エンドポイントを新規追加
- 5カテゴリ（language/framework/skill/project/other）でフィルタリング可能
- 無効なカテゴリ指定時はバリデーションエラーを返す

## 変更内容
- `learning_goal.go` (service): GetByCategoryメソッド追加、カテゴリバリデーション
- `learning_goal.go` (handler): GetByCategoryハンドラ追加
- `learning_goal.go` (repository): GetByCategoryクエリ実装
- `interfaces.go`: GetByCategoryインターフェース追加
- `mock_test.go`: モックメソッド追加
- `router.go`: ルーティング追加

## テスト
- TDDで4件のテスト先行作成（Success/EmptyResult/InvalidCategory/RepoError）
- 全サービステストPASS

closes #869