### PR TITLE
refactor: LearningResourceServiceの自己アクション防止チェックを共通化

### DIFF
--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -144,15 +144,23 @@ func (s *LearningResourceService) Delete(id, userID uint) error {
 	return s.repo.Delete(id)
 }
 
-// Like は学習リソースにいいねを追加する。
-// 自分のリソースにはいいねできない。
-func (s *LearningResourceService) Like(userID, resourceID uint) error {
+// findAndPreventSelfAction はリソースを取得し、自分のリソースへの操作を防止する。
+func (s *LearningResourceService) findAndPreventSelfAction(userID, resourceID uint) error {
 	resource, err := s.repo.FindByID(resourceID)
 	if err != nil {
 		return ErrNotFound
 	}
 	if resource.UserID == userID {
 		return ErrForbidden
+	}
+	return nil
+}
+
+// Like は学習リソースにいいねを追加する。
+// 自分のリソースにはいいねできない。
+func (s *LearningResourceService) Like(userID, resourceID uint) error {
+	if err := s.findAndPreventSelfAction(userID, resourceID); err != nil {
+		return err
 	}
 	return s.repo.Like(userID, resourceID)
 }
@@ -160,12 +168,8 @@ func (s *LearningResourceService) Like(userID, resourceID uint) error {
 // Unlike は学習リソースのいいねを取り消す。
 // 自分のリソースのいいねは取り消せない（そもそもいいねできないため）。
 func (s *LearningResourceService) Unlike(userID, resourceID uint) error {
-	resource, err := s.repo.FindByID(resourceID)
-	if err != nil {
-		return ErrNotFound
-	}
-	if resource.UserID == userID {
-		return ErrForbidden
+	if err := s.findAndPreventSelfAction(userID, resourceID); err != nil {
+		return err
 	}
 	return s.repo.Unlike(userID, resourceID)
 }
@@ -173,12 +177,8 @@ func (s *LearningResourceService) Unlike(userID, resourceID uint) error {
 // Save は学習リソースを保存する。
 // 自分のリソースは保存できない。
 func (s *LearningResourceService) Save(userID, resourceID uint) error {
-	resource, err := s.repo.FindByID(resourceID)
-	if err != nil {
-		return ErrNotFound
-	}
-	if resource.UserID == userID {
-		return ErrForbidden
+	if err := s.findAndPreventSelfAction(userID, resourceID); err != nil {
+		return err
 	}
 	return s.repo.Save(userID, resourceID)
 }
@@ -186,12 +186,8 @@ func (s *LearningResourceService) Save(userID, resourceID uint) error {
 // Unsave は学習リソースの保存を取り消す。
 // 自分のリソースの保存は取り消せない（そもそも保存できないため）。
 func (s *LearningResourceService) Unsave(userID, resourceID uint) error {
-	resource, err := s.repo.FindByID(resourceID)
-	if err != nil {
-		return ErrNotFound
-	}
-	if resource.UserID == userID {
-		return ErrForbidden
+	if err := s.findAndPreventSelfAction(userID, resourceID); err != nil {
+		return err
 	}
 	return s.repo.Unsave(userID, resourceID)
 }


### PR DESCRIPTION
## 概要
- Like/Unlike/Save/Unsaveの4メソッドで重複していたFindByID + 自己アクション防止チェックをfindAndPreventSelfActionヘルパーに抽出
- 差分: +17行, -21行（4行削減）

## 変更内容
- `findAndPreventSelfAction`: リソース取得 + 自己リソースへの操作防止を共通化
- 4メソッド（Like, Unlike, Save, Unsave）が共通ヘルパーを使用するように変更

## テスト
- 既存の全LearningResourceテストPASS

closes #871