### PR TITLE
test: ChatRoomService.AddMemberのtargetUserID IsMemberエラーテストを追加

### DIFF
--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -298,6 +298,17 @@ func TestChatRoomAddMember_AlreadyMember(t *testing.T) {
 	roomRepo.AssertNotCalled(t, "AddMember")
 }
 
+func TestChatRoomAddMember_TargetIsMemberError(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	roomRepo.On("IsMember", uint(10), uint(1)).Return(true, nil)
+	roomRepo.On("IsMember", uint(10), uint(3)).Return(false, errors.New("db error"))
+
+	err := svc.AddMember(10, 1, 3)
+	assert.Error(t, err)
+	roomRepo.AssertNotCalled(t, "AddMember")
+}
+
 func TestChatRoomAddMember_NotMember(t *testing.T) {
 	svc, roomRepo, _ := newTestChatRoomService()
 


### PR DESCRIPTION
## 概要
- ChatRoomService.AddMemberでtargetUserIDのIsMemberチェックがDBエラーを返す場合のテスト追加
- AddMemberカバレッジ: 88.9% → 100%

## テスト
- `TestChatRoomAddMember_TargetIsMemberError`: IsMemberエラー時にAddMemberが呼ばれないことを確認

closes #873