### PR TITLE
fix: StudyCircleService.AddMemberに重複メンバー追加防止チェックを追加

### DIFF
--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -134,6 +134,7 @@ func (s *StudyCircleService) GetMembers(circleID, userID uint) ([]model.StudyCir
 }
 
 // AddMember はメンバーを追加する。リクエスト者がメンバーであること＋上限チェック。
+// 既にメンバーのユーザーは追加できない。
 func (s *StudyCircleService) AddMember(circleID, userID, targetUserID uint) error {
 	isMember, err := s.repo.IsMember(circleID, userID)
 	if err != nil {
@@ -141,6 +142,14 @@ func (s *StudyCircleService) AddMember(circleID, userID, targetUserID uint) erro
 	}
 	if !isMember {
 		return ErrForbidden
+	}
+
+	alreadyMember, err := s.repo.IsMember(circleID, targetUserID)
+	if err != nil {
+		return err
+	}
+	if alreadyMember {
+		return ErrBadRequest
 	}
 
 	circle, err := s.repo.FindByID(circleID)

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -175,6 +175,7 @@ func TestStudyCircleAddMember_Success(t *testing.T) {
 
 	circle := &model.StudyCircle{ID: 1, MaxMembers: 5}
 	repo.On("IsMember", uint(1), uint(1)).Return(true, nil)
+	repo.On("IsMember", uint(1), uint(5)).Return(false, nil)
 	repo.On("FindByID", uint(1)).Return(circle, nil)
 	repo.On("GetMemberCount", uint(1)).Return(3, nil)
 	repo.On("AddMember", uint(1), uint(5), model.StudyCircleRoleMember).Return(nil)
@@ -183,11 +184,23 @@ func TestStudyCircleAddMember_Success(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestStudyCircleAddMember_AlreadyMember(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("IsMember", uint(1), uint(1)).Return(true, nil)
+	repo.On("IsMember", uint(1), uint(5)).Return(true, nil)
+
+	err := svc.AddMember(1, 1, 5)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	repo.AssertNotCalled(t, "AddMember")
+}
+
 func TestStudyCircleAddMember_MemberLimitReached(t *testing.T) {
 	svc, repo := newTestStudyCircleService()
 
 	circle := &model.StudyCircle{ID: 1, MaxMembers: 5}
 	repo.On("IsMember", uint(1), uint(1)).Return(true, nil)
+	repo.On("IsMember", uint(1), uint(10)).Return(false, nil)
 	repo.On("FindByID", uint(1)).Return(circle, nil)
 	repo.On("GetMemberCount", uint(1)).Return(5, nil)
 
@@ -677,6 +690,7 @@ func TestStudyCircleAddMember_IsMemberError(t *testing.T) {
 func TestStudyCircleAddMember_FindByIDError(t *testing.T) {
 	svc, repo := newTestStudyCircleService()
 	repo.On("IsMember", uint(1), uint(1)).Return(true, nil)
+	repo.On("IsMember", uint(1), uint(5)).Return(false, nil)
 	repo.On("FindByID", uint(1)).Return(nil, errors.New("not found"))
 	err := svc.AddMember(1, 1, 5)
 	assert.ErrorIs(t, err, ErrNotFound)
@@ -686,6 +700,7 @@ func TestStudyCircleAddMember_GetMemberCountError(t *testing.T) {
 	svc, repo := newTestStudyCircleService()
 	circle := &model.StudyCircle{ID: 1, MaxMembers: 5}
 	repo.On("IsMember", uint(1), uint(1)).Return(true, nil)
+	repo.On("IsMember", uint(1), uint(5)).Return(false, nil)
 	repo.On("FindByID", uint(1)).Return(circle, nil)
 	repo.On("GetMemberCount", uint(1)).Return(0, errors.New("db error"))
 	err := svc.AddMember(1, 1, 5)


### PR DESCRIPTION
## 概要
- StudyCircleService.AddMemberでtargetUserIDが既にメンバーかどうかのチェックが欠如していた
- 重複メンバー追加時はErrBadRequestを返すよう修正（ChatRoomService.AddMemberと同パターン）

## 変更内容
- `study_circle.go`: AddMemberにIsMemberチェック追加
- `study_circle_test.go`: `TestStudyCircleAddMember_AlreadyMember`テスト追加、既存テストのmock更新

## テスト
- 全StudyCircleテストPASS

closes #875