### PR TITLE
feat: CodeSnippetServiceにユーザー別言語フィルタリング取得メソッドを追加

### DIFF
--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -10,6 +10,7 @@ import (
 type CodeSnippetHandlerServiceInterface interface {
 	Create(snippet *model.CodeSnippet) (*model.CodeSnippet, error)
 	GetByPostID(postID uint) ([]model.CodeSnippet, error)
+	GetByUserLanguage(userID uint, language string) ([]model.CodeSnippet, error)
 	Update(id, userID uint, language, fileName, code string) (*model.CodeSnippet, error)
 	Delete(id, userID uint) error
 	GetComments(snippetID uint) ([]model.SnippetComment, error)
@@ -175,4 +176,21 @@ func (h *CodeSnippetHandler) DeleteComment(c *gin.Context) {
 		return
 	}
 	respondDeleted(c)
+}
+
+// GetByUserLanguage は認証ユーザーのスニペットを言語でフィルタリングして取得する。
+func (h *CodeSnippetHandler) GetByUserLanguage(c *gin.Context) {
+	userID := c.GetUint("userID")
+	language := c.Param("language")
+
+	snippets, err := h.service.GetByUserLanguage(userID, language)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if snippets == nil {
+		snippets = []model.CodeSnippet{}
+	}
+
+	respondOK(c, snippets)
 }

--- a/backend/internal/repository/code_snippet.go
+++ b/backend/internal/repository/code_snippet.go
@@ -34,6 +34,13 @@ func (r *CodeSnippetRepository) FindByPostID(postID uint) ([]model.CodeSnippet, 
 	return snippets, err
 }
 
+// FindByUserIDAndLanguage は指定ユーザーのスニペットをプログラミング言語でフィルタリングして取得する。
+func (r *CodeSnippetRepository) FindByUserIDAndLanguage(userID uint, language string) ([]model.CodeSnippet, error) {
+	var snippets []model.CodeSnippet
+	err := r.db.Where("user_id = ? AND language = ?", userID, language).Order("created_at DESC").Find(&snippets).Error
+	return snippets, err
+}
+
 // Update は既存のコードスニペットを更新する。
 func (r *CodeSnippetRepository) Update(snippet *model.CodeSnippet) error {
 	return r.db.Save(snippet).Error

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -263,6 +263,7 @@ type CodeSnippetRepositoryInterface interface {
 	Create(snippet *model.CodeSnippet) error
 	FindByID(id uint) (*model.CodeSnippet, error)
 	FindByPostID(postID uint) ([]model.CodeSnippet, error)
+	FindByUserIDAndLanguage(userID uint, language string) ([]model.CodeSnippet, error)
 	Update(snippet *model.CodeSnippet) error
 	Delete(id uint) error
 	CreateComment(comment *model.SnippetComment) error

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -241,6 +241,7 @@ func registerSnippetRoutes(g *gin.RouterGroup, c *di.Container) {
 		snippets.GET("/:id/comments", c.CodeSnippetHandler.GetComments)
 		snippets.POST("/:id/comments", c.CodeSnippetHandler.CreateComment)
 		snippets.DELETE("/:id/comments/:commentId", c.CodeSnippetHandler.DeleteComment)
+		snippets.GET("/language/:language", c.CodeSnippetHandler.GetByUserLanguage)
 	}
 }
 

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -41,6 +42,14 @@ func (s *CodeSnippetService) Create(snippet *model.CodeSnippet) (*model.CodeSnip
 // GetByPostID は指定投稿IDに紐づくスニペット一覧を返す。
 func (s *CodeSnippetService) GetByPostID(postID uint) ([]model.CodeSnippet, error) {
 	return s.repo.FindByPostID(postID)
+}
+
+// GetByUserLanguage は指定ユーザーのスニペットをプログラミング言語でフィルタリングして取得する。
+func (s *CodeSnippetService) GetByUserLanguage(userID uint, language string) ([]model.CodeSnippet, error) {
+	if language == "" {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "言語の指定は必須です", nil)
+	}
+	return s.repo.FindByUserIDAndLanguage(userID, language)
 }
 
 // findAndCheckOwnership はスニペットを取得し、指定ユーザーが所有者かを検証する。

--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -306,3 +306,46 @@ func TestSnippetUpdate_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 }
+
+// ---------- ユーザー別言語フィルタリング ----------
+
+func TestCodeSnippetGetByUserLanguage_Success(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+	expected := []model.CodeSnippet{
+		{PostID: 1, UserID: 1, Language: "go", Code: "package main"},
+		{PostID: 2, UserID: 1, Language: "go", Code: "func main()"},
+	}
+	snippetRepo.On("FindByUserIDAndLanguage", uint(1), "go").Return(expected, nil)
+
+	result, err := svc.GetByUserLanguage(1, "go")
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	snippetRepo.AssertExpectations(t)
+}
+
+func TestCodeSnippetGetByUserLanguage_EmptyResult(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+	snippetRepo.On("FindByUserIDAndLanguage", uint(1), "rust").Return([]model.CodeSnippet{}, nil)
+
+	result, err := svc.GetByUserLanguage(1, "rust")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	snippetRepo.AssertExpectations(t)
+}
+
+func TestCodeSnippetGetByUserLanguage_EmptyLanguage(t *testing.T) {
+	svc, _, _ := newTestCodeSnippetService()
+
+	_, err := svc.GetByUserLanguage(1, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "言語の指定は必須です")
+}
+
+func TestCodeSnippetGetByUserLanguage_RepoError(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+	snippetRepo.On("FindByUserIDAndLanguage", uint(1), "go").Return([]model.CodeSnippet{}, gorm.ErrInvalidDB)
+
+	_, err := svc.GetByUserLanguage(1, "go")
+	assert.Error(t, err)
+	snippetRepo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -959,6 +959,11 @@ func (m *MockCodeSnippetRepository) FindByPostID(postID uint) ([]model.CodeSnipp
 	return args.Get(0).([]model.CodeSnippet), args.Error(1)
 }
 
+func (m *MockCodeSnippetRepository) FindByUserIDAndLanguage(userID uint, language string) ([]model.CodeSnippet, error) {
+	args := m.Called(userID, language)
+	return args.Get(0).([]model.CodeSnippet), args.Error(1)
+}
+
 func (m *MockCodeSnippetRepository) Update(snippet *model.CodeSnippet) error {
 	args := m.Called(snippet)
 	return args.Error(0)


### PR DESCRIPTION
## 概要
- `GET /api/v1/snippets/language/:language` エンドポイントを新規追加
- ユーザーのスニペットをプログラミング言語でフィルタリングして取得可能
- 空文字の言語指定はバリデーションエラーを返す

## 変更内容
- `code_snippet.go` (service): GetByUserLanguageメソッド追加
- `code_snippet.go` (handler): GetByUserLanguageハンドラ追加
- `code_snippet.go` (repository): FindByUserIDAndLanguageクエリ実装
- `interfaces.go`: FindByUserIDAndLanguageインターフェース追加
- `mock_test.go`: モックメソッド追加
- `router.go`: ルーティング追加

## テスト
- TDDで4件のテスト先行作成（Success/EmptyResult/EmptyLanguage/RepoError）
- 全サービステストPASS

closes #877