### PR TITLE
fix: LearningLogService.UpdateのDurationバリデーション欠落を修正

### DIFF
--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -78,6 +78,9 @@ func (s *LearningLogService) Update(id, userID uint, updates *model.LearningLog)
 		log.Category = updates.Category
 	}
 	if updates.Duration != 0 {
+		if updates.Duration < 0 || updates.Duration > 1440 {
+			return nil, ErrBadRequest
+		}
 		log.Duration = updates.Duration
 	}
 

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -315,6 +315,32 @@ func TestLearningLogUpdate_AllFields(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestLearningLogUpdate_DurationNegative(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	existing := &model.LearningLog{Title: "Test", Content: "Content", UserID: 1, Duration: 30}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.LearningLog{Duration: -10}
+	result, err := svc.Update(1, 1, updates)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Nil(t, result)
+}
+
+func TestLearningLogUpdate_DurationExceedsMax(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	existing := &model.LearningLog{Title: "Test", Content: "Content", UserID: 1, Duration: 30}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.LearningLog{Duration: 1441}
+	result, err := svc.Update(1, 1, updates)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Nil(t, result)
+}
+
 // --- ExportCSV ---
 
 func TestLearningLogExportCSV_Success(t *testing.T) {


### PR DESCRIPTION
## 概要
- LearningLogService.Updateで学習時間（Duration）のバリデーションが行われていなかった問題を修正
- Create時と同様に0〜1440分の範囲チェックを追加
- 負の値や1440超の異常値による学習統計データ破損を防止

## テスト
- `TestLearningLogUpdate_DurationNegative`: 負の値でErrBadRequest
- `TestLearningLogUpdate_DurationExceedsMax`: 1440超でErrBadRequest
- 既存テスト全PASS

closes #883