### PR TITLE
feat: LearningGoalServiceにステータス別目標取得（GetByStatus）を追加

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -14,6 +14,7 @@ type LearningGoalServiceInterface interface {
 	GetByID(id uint) (*model.LearningGoal, error)
 	GetByUserID(userID uint) ([]model.LearningGoal, error)
 	GetByCategory(userID uint, category string) ([]model.LearningGoal, error)
+	GetByStatus(userID uint, status string) ([]model.LearningGoal, error)
 	GetStats(userID uint) (*model.LearningGoalStats, error)
 	Update(id, userID uint, updates *model.LearningGoal) (*model.LearningGoal, error)
 	Delete(id, userID uint) error
@@ -202,6 +203,23 @@ func (h *LearningGoalHandler) GetByCategory(c *gin.Context) {
 	category := c.Param("category")
 
 	goals, err := h.service.GetByCategory(userID, category)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if goals == nil {
+		goals = []model.LearningGoal{}
+	}
+
+	respondOK(c, goals)
+}
+
+// GetByStatus は認証ユーザーの学習目標をステータスでフィルタリングして取得する。
+func (h *LearningGoalHandler) GetByStatus(c *gin.Context) {
+	userID := c.GetUint("userID")
+	status := c.Param("status")
+
+	goals, err := h.service.GetByStatus(userID, status)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -164,6 +164,7 @@ type LearningGoalRepositoryInterface interface {
 	GetByUserID(userID uint) ([]model.LearningGoal, error)
 	GetActiveByUserID(userID uint) ([]model.LearningGoal, error)
 	GetByCategory(userID uint, category string) ([]model.LearningGoal, error)
+	GetByStatus(userID uint, status string) ([]model.LearningGoal, error)
 	GetStats(userID uint) (*model.LearningGoalStats, error)
 }
 

--- a/backend/internal/repository/learning_goal.go
+++ b/backend/internal/repository/learning_goal.go
@@ -61,6 +61,13 @@ func (r *LearningGoalRepository) GetByCategory(userID uint, category string) ([]
 	return goals, err
 }
 
+// GetByStatus は指定ユーザーの学習目標をステータスでフィルタリングして取得する（新しい順）。
+func (r *LearningGoalRepository) GetByStatus(userID uint, status string) ([]model.LearningGoal, error) {
+	var goals []model.LearningGoal
+	err := r.db.Where("user_id = ? AND status = ?", userID, status).Order("created_at DESC").Find(&goals).Error
+	return goals, err
+}
+
 // GetStats は指定ユーザーの学習目標統計情報を算出する。
 // 目標総数、アクティブ数、完了数、平均進捗率を返す。
 func (r *LearningGoalRepository) GetStats(userID uint) (*model.LearningGoalStats, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -326,6 +326,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		goals.GET("/stats/:userId", c.LearningGoalHandler.GetStats)
 		goals.GET("/deadline-alerts", c.LearningGoalHandler.GetDeadlineAlerts)
 		goals.GET("/category/:category", c.LearningGoalHandler.GetByCategory)
+		goals.GET("/status/:status", c.LearningGoalHandler.GetByStatus)
 	}
 
 	// アクティビティレポート

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -56,6 +56,21 @@ func (s *LearningGoalService) GetByCategory(userID uint, category string) ([]mod
 	return s.repo.GetByCategory(userID, category)
 }
 
+// validGoalStatuses は有効なGoalStatusの集合。
+var validGoalStatuses = map[string]bool{
+	string(model.GoalStatusActive):    true,
+	string(model.GoalStatusCompleted): true,
+	string(model.GoalStatusPaused):    true,
+}
+
+// GetByStatus は指定ユーザーの学習目標をステータスでフィルタリングして取得する。
+func (s *LearningGoalService) GetByStatus(userID uint, status string) ([]model.LearningGoal, error) {
+	if !validGoalStatuses[status] {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なステータスです", nil)
+	}
+	return s.repo.GetByStatus(userID, status)
+}
+
 // GetStats は指定ユーザーの学習目標統計情報を取得する。
 func (s *LearningGoalService) GetStats(userID uint) (*model.LearningGoalStats, error) {
 	return s.repo.GetStats(userID)

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -537,3 +537,48 @@ func TestLearningGoalGetByCategory_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// ステータス別目標取得テスト
+// ============================================================
+
+func TestLearningGoalGetByStatus_Success(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	expected := []model.LearningGoal{
+		{UserID: 1, Title: "Go学習", Status: model.GoalStatusCompleted},
+		{UserID: 1, Title: "React学習", Status: model.GoalStatusCompleted},
+	}
+	repo.On("GetByStatus", uint(1), "completed").Return(expected, nil)
+
+	result, err := svc.GetByStatus(1, "completed")
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalGetByStatus_EmptyResult(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	repo.On("GetByStatus", uint(1), "paused").Return([]model.LearningGoal{}, nil)
+
+	result, err := svc.GetByStatus(1, "paused")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalGetByStatus_InvalidStatus(t *testing.T) {
+	svc, _ := newTestLearningGoalService()
+
+	_, err := svc.GetByStatus(1, "invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "無効なステータスです")
+}
+
+func TestLearningGoalGetByStatus_RepoError(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	repo.On("GetByStatus", uint(1), "active").Return([]model.LearningGoal{}, errors.New("db error"))
+
+	_, err := svc.GetByStatus(1, "active")
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -548,6 +548,11 @@ func (m *MockLearningGoalRepository) GetByCategory(userID uint, category string)
 	return args.Get(0).([]model.LearningGoal), args.Error(1)
 }
 
+func (m *MockLearningGoalRepository) GetByStatus(userID uint, status string) ([]model.LearningGoal, error) {
+	args := m.Called(userID, status)
+	return args.Get(0).([]model.LearningGoal), args.Error(1)
+}
+
 func (m *MockLearningGoalRepository) GetStats(userID uint) (*model.LearningGoalStats, error) {
 	args := m.Called(userID)
 	if args.Get(0) == nil {


### PR DESCRIPTION
## 概要
- `GET /api/v1/goals/status/:status` エンドポイントを新規追加
- active/completed/pausedの3ステータスでフィルタリング可能
- 無効なステータスはバリデーションエラーを返す
- GetByCategoryと同パターンで実装

## テスト
- TDDで4件テスト先行作成（Success/EmptyResult/InvalidStatus/RepoError）
- 全テストPASS

closes #885