### PR TITLE
fix: PostCollectionService.AddPostに重複追加チェックを追加

### DIFF
--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -465,6 +465,7 @@ type PostCollectionRepositoryInterface interface {
 	Delete(id uint) error
 	AddPost(item *model.PostCollectionItem) error
 	RemovePost(collectionID, postID uint) error
+	HasPost(collectionID, postID uint) (bool, error)
 	GetPostsByCollectionID(collectionID uint) ([]model.PostCollectionItem, error)
 }
 

--- a/backend/internal/repository/post_collection.go
+++ b/backend/internal/repository/post_collection.go
@@ -66,6 +66,15 @@ func (r *PostCollectionRepository) AddPost(item *model.PostCollectionItem) error
 	return r.db.Create(item).Error
 }
 
+// HasPost は指定コレクションに指定投稿が存在するかを確認する。
+func (r *PostCollectionRepository) HasPost(collectionID, postID uint) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.PostCollectionItem{}).
+		Where("collection_id = ? AND post_id = ?", collectionID, postID).
+		Count(&count).Error
+	return count > 0, err
+}
+
 // RemovePost はコレクションから投稿を削除する。
 func (r *PostCollectionRepository) RemovePost(collectionID, postID uint) error {
 	return r.db.Where("collection_id = ? AND post_id = ?", collectionID, postID).

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1616,6 +1616,11 @@ func (m *MockPostCollectionRepository) AddPost(item *model.PostCollectionItem) e
 	return args.Error(0)
 }
 
+func (m *MockPostCollectionRepository) HasPost(collectionID, postID uint) (bool, error) {
+	args := m.Called(collectionID, postID)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockPostCollectionRepository) RemovePost(collectionID, postID uint) error {
 	args := m.Called(collectionID, postID)
 	return args.Error(0)

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -81,9 +81,18 @@ func (s *PostCollectionService) Delete(id, userID uint) error {
 }
 
 // AddPost は所有権を検証した後、コレクションに投稿を追加する。
+// 同じ投稿がすでに追加されている場合はエラーを返す。
 func (s *PostCollectionService) AddPost(collectionID, userID, postID uint, note string) error {
 	if _, err := s.findAndCheckOwnership(collectionID, userID); err != nil {
 		return err
+	}
+
+	exists, err := s.repo.HasPost(collectionID, postID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return domain.NewError(domain.ErrCodeBadRequest, "すでに追加済みの投稿です", nil)
 	}
 
 	item := &model.PostCollectionItem{

--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -256,6 +256,7 @@ func TestPostCollectionAddPost_Success(t *testing.T) {
 	collection := &model.PostCollection{UserID: 1}
 	collection.ID = 10
 	repo.On("FindByID", uint(10)).Return(collection, nil)
+	repo.On("HasPost", uint(10), uint(5)).Return(false, nil)
 	repo.On("AddPost", mock.MatchedBy(func(item *model.PostCollectionItem) bool {
 		return item.CollectionID == 10 && item.PostID == 5
 	})).Return(nil)
@@ -284,6 +285,21 @@ func TestPostCollectionAddPost_NotFound(t *testing.T) {
 
 	err := svc.AddPost(999, 1, 5, "")
 	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostCollectionAddPost_Duplicate(t *testing.T) {
+	svc, repo := newTestPostCollectionService()
+
+	collection := &model.PostCollection{UserID: 1}
+	collection.ID = 10
+	repo.On("FindByID", uint(10)).Return(collection, nil)
+	repo.On("HasPost", uint(10), uint(5)).Return(true, nil)
+
+	err := svc.AddPost(10, 1, 5, "良い記事")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "すでに追加済み")
+	repo.AssertNotCalled(t, "AddPost")
 	repo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
- PostCollectionService.AddPostで同じ投稿を重複追加できてしまう脆弱性を修正

## 変更内容
- `PostCollectionRepositoryInterface`に`HasPost(collectionID, postID uint) (bool, error)`を追加
- リポジトリ実装: `WHERE collection_id = ? AND post_id = ?` でカウント判定
- Service層: AddPost内で重複チェックを実施、すでに追加済みの場合はBadRequestエラー
- テスト: `TestPostCollectionAddPost_Duplicate` を追加

## テスト結果
全19テストPASS（既存テスト + 新規1件）

Closes #891