### PR TITLE
feat: RoadmapService.GetByStatusでステータス別ロードマップ取得

### DIFF
--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -12,6 +12,7 @@ type RoadmapServiceInterface interface {
 	Create(roadmap *model.Roadmap) error
 	GetByID(id, userID uint) (*model.Roadmap, error)
 	GetByUserID(userID uint) ([]model.Roadmap, error)
+	GetByStatus(userID uint, status string) ([]model.Roadmap, error)
 	GetPublicRoadmaps(limit, offset int) ([]model.Roadmap, int64, error)
 	Update(id, userID uint, updates *model.Roadmap) (*model.Roadmap, error)
 	UpdateVisibility(id, userID uint, isPublic bool) (*model.Roadmap, error)
@@ -79,6 +80,23 @@ func (h *RoadmapHandler) GetMyRoadmaps(c *gin.Context) {
 	if err != nil {
 		respondError(c, err)
 		return
+	}
+
+	respondOK(c, roadmaps)
+}
+
+// GetByStatus はステータス別にロードマップを取得する。
+func (h *RoadmapHandler) GetByStatus(c *gin.Context) {
+	userID := c.GetUint("userID")
+	status := c.Param("status")
+
+	roadmaps, err := h.service.GetByStatus(userID, status)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if roadmaps == nil {
+		roadmaps = []model.Roadmap{}
 	}
 
 	respondOK(c, roadmaps)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -225,6 +225,7 @@ type RoadmapRepositoryInterface interface {
 	Delete(id uint) error
 	FindByID(id uint) (*model.Roadmap, error)
 	GetByUserID(userID uint) ([]model.Roadmap, error)
+	GetByStatus(userID uint, status string) ([]model.Roadmap, error)
 	GetPublicRoadmaps(limit, offset int) ([]model.Roadmap, int64, error)
 	CopyRoadmap(originalID, newUserID uint) (*model.Roadmap, error)
 	GetStats(userID uint) (*model.RoadmapStats, error)

--- a/backend/internal/repository/roadmap.go
+++ b/backend/internal/repository/roadmap.go
@@ -56,6 +56,15 @@ func (r *RoadmapRepository) GetByUserID(userID uint) ([]model.Roadmap, error) {
 	return roadmaps, err
 }
 
+// GetByStatus は指定ユーザーのロードマップをステータスでフィルタリングして取得する（新しい順）。
+func (r *RoadmapRepository) GetByStatus(userID uint, status string) ([]model.Roadmap, error) {
+	var roadmaps []model.Roadmap
+	err := r.db.Where("user_id = ? AND status = ?", userID, status).
+		Order("created_at DESC").
+		Find(&roadmaps).Error
+	return roadmaps, err
+}
+
 // GetPublicRoadmaps は公開ロードマップをページネーション付きで取得する。
 func (r *RoadmapRepository) GetPublicRoadmaps(limit, offset int) ([]model.Roadmap, int64, error) {
 	var roadmaps []model.Roadmap

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -461,6 +461,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		roadmaps.POST("", c.RoadmapHandler.Create)
 		roadmaps.GET("", c.RoadmapHandler.GetMyRoadmaps)
 		roadmaps.GET("/public", c.RoadmapHandler.GetPublicRoadmaps)
+		roadmaps.GET("/status/:status", c.RoadmapHandler.GetByStatus)
 		roadmaps.GET("/templates", c.RoadmapHandler.GetTemplates)
 		roadmaps.POST("/templates/:id/use", c.RoadmapHandler.CreateFromTemplate)
 		roadmaps.GET("/:id", c.RoadmapHandler.GetByID)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -801,6 +801,11 @@ func (m *MockRoadmapRepository) GetByUserID(userID uint) ([]model.Roadmap, error
 	return args.Get(0).([]model.Roadmap), args.Error(1)
 }
 
+func (m *MockRoadmapRepository) GetByStatus(userID uint, status string) ([]model.Roadmap, error) {
+	args := m.Called(userID, status)
+	return args.Get(0).([]model.Roadmap), args.Error(1)
+}
+
 func (m *MockRoadmapRepository) GetPublicRoadmaps(limit, offset int) ([]model.Roadmap, int64, error) {
 	args := m.Called(limit, offset)
 	return args.Get(0).([]model.Roadmap), args.Get(1).(int64), args.Error(2)

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -3,9 +3,16 @@ package service
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
+
+// validRoadmapStatuses はロードマップの有効なステータス値を定義する。
+var validRoadmapStatuses = map[string]bool{
+	string(model.RoadmapStatusActive):    true,
+	string(model.RoadmapStatusCompleted): true,
+}
 
 
 // RoadmapService は学習ロードマップのビジネスロジックを提供する。
@@ -40,6 +47,14 @@ func (s *RoadmapService) GetByID(id, userID uint) (*model.Roadmap, error) {
 // GetByUserID は指定ユーザーの全ロードマップを取得する。
 func (s *RoadmapService) GetByUserID(userID uint) ([]model.Roadmap, error) {
 	return s.repo.GetByUserID(userID)
+}
+
+// GetByStatus は指定ユーザーのロードマップをステータスでフィルタリングして取得する。
+func (s *RoadmapService) GetByStatus(userID uint, status string) ([]model.Roadmap, error) {
+	if !validRoadmapStatuses[status] {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なステータスです", nil)
+	}
+	return s.repo.GetByStatus(userID, status)
 }
 
 // GetPublicRoadmaps は公開ロードマップをページネーション付きで取得する。

--- a/backend/internal/service/roadmap_test.go
+++ b/backend/internal/service/roadmap_test.go
@@ -1039,3 +1039,53 @@ func TestRoadmapUpdateStepCompletion_FindByIDError(t *testing.T) {
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// GetByStatus テスト
+// ============================================================
+
+func TestRoadmapGetByStatus_Success(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmaps := []model.Roadmap{
+		{Title: "Active Roadmap", UserID: 1, Status: model.RoadmapStatusActive},
+	}
+	repo.On("GetByStatus", uint(1), "active").Return(roadmaps, nil)
+
+	result, err := svc.GetByStatus(1, "active")
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, "Active Roadmap", result[0].Title)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapGetByStatus_EmptyResult(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	repo.On("GetByStatus", uint(1), "completed").Return([]model.Roadmap{}, nil)
+
+	result, err := svc.GetByStatus(1, "completed")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapGetByStatus_InvalidStatus(t *testing.T) {
+	svc, _ := newTestRoadmapService()
+
+	result, err := svc.GetByStatus(1, "invalid")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "無効なステータス")
+}
+
+func TestRoadmapGetByStatus_RepoError(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	repo.On("GetByStatus", uint(1), "active").Return([]model.Roadmap{}, errors.New("db error"))
+
+	result, err := svc.GetByStatus(1, "active")
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- ロードマップをステータス（active/completed）でフィルタリングして取得するAPIを追加

## 変更内容
- `RoadmapRepositoryInterface`に`GetByStatus(userID uint, status string)`を追加
- リポジトリ実装: `WHERE user_id = ? AND status = ?`でフィルタリング
- Service層: `validRoadmapStatuses`マップによるバリデーション付き`GetByStatus`メソッド
- Handler・Router: `GET /api/v1/roadmaps/status/:status`エンドポイント追加
- TDDで4件のテスト先行作成（Success/EmptyResult/InvalidStatus/RepoError）

## テスト結果
全テストPASS

Closes #893