### PR TITLE
test: PostCollectionService.AddPostのHasPostエラーパステスト追加

### DIFF
--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -303,6 +303,20 @@ func TestPostCollectionAddPost_Duplicate(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestPostCollectionAddPost_HasPostError(t *testing.T) {
+	svc, repo := newTestPostCollectionService()
+
+	collection := &model.PostCollection{UserID: 1}
+	collection.ID = 10
+	repo.On("FindByID", uint(10)).Return(collection, nil)
+	repo.On("HasPost", uint(10), uint(5)).Return(false, errors.New("db error"))
+
+	err := svc.AddPost(10, 1, 5, "メモ")
+	assert.Error(t, err)
+	repo.AssertNotCalled(t, "AddPost")
+	repo.AssertExpectations(t)
+}
+
 // ============================================================
 // RemovePost テスト（所有権チェック）
 // ============================================================


### PR DESCRIPTION
## 概要
- PostCollectionService.AddPostのHasPostエラーパスのテストカバレッジを向上

## 変更内容
- `TestPostCollectionAddPost_HasPostError`: HasPostがDBエラーを返した場合、AddPostが呼ばれずエラーが返ることを検証
- AddPostカバレッジ: 88.9% → 100.0%

## テスト結果
全テストPASS

Closes #897