### PR TITLE
fix: PostSeriesService.AddPostに重複追加チェックを追加

### DIFF
--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -479,6 +479,7 @@ type PostSeriesRepositoryInterface interface {
 	Delete(id uint) error
 	AddPost(item *model.PostSeriesItem) error
 	RemovePost(seriesID, postID uint) error
+	HasPost(seriesID, postID uint) (bool, error)
 	GetPostsBySeriesID(seriesID uint) ([]model.PostSeriesItem, error)
 }
 

--- a/backend/internal/repository/post_series.go
+++ b/backend/internal/repository/post_series.go
@@ -57,6 +57,15 @@ func (r *PostSeriesRepository) AddPost(item *model.PostSeriesItem) error {
 	return r.db.Create(item).Error
 }
 
+// HasPost は指定シリーズに指定投稿が存在するかを確認する。
+func (r *PostSeriesRepository) HasPost(seriesID, postID uint) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.PostSeriesItem{}).
+		Where("series_id = ? AND post_id = ?", seriesID, postID).
+		Count(&count).Error
+	return count > 0, err
+}
+
 // RemovePost はシリーズから投稿を削除する。
 func (r *PostSeriesRepository) RemovePost(seriesID, postID uint) error {
 	return r.db.Where("series_id = ? AND post_id = ?", seriesID, postID).

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1566,6 +1566,11 @@ func (m *MockPostSeriesRepository) AddPost(item *model.PostSeriesItem) error {
 	return args.Error(0)
 }
 
+func (m *MockPostSeriesRepository) HasPost(seriesID, postID uint) (bool, error) {
+	args := m.Called(seriesID, postID)
+	return args.Bool(0), args.Error(1)
+}
+
 func (m *MockPostSeriesRepository) RemovePost(seriesID, postID uint) error {
 	args := m.Called(seriesID, postID)
 	return args.Error(0)

--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -76,9 +76,18 @@ func (s *PostSeriesService) Delete(id, userID uint) error {
 }
 
 // AddPost は所有権を検証した後、シリーズに投稿を追加する。
+// 同じ投稿がすでに追加されている場合はエラーを返す。
 func (s *PostSeriesService) AddPost(seriesID, postID uint, orderIndex int, userID uint) error {
 	if _, err := s.findAndCheckOwnership(seriesID, userID); err != nil {
 		return err
+	}
+
+	exists, err := s.repo.HasPost(seriesID, postID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return domain.NewError(domain.ErrCodeBadRequest, "すでに追加済みの投稿です", nil)
 	}
 
 	item := &model.PostSeriesItem{

--- a/backend/internal/service/post_series_test.go
+++ b/backend/internal/service/post_series_test.go
@@ -234,6 +234,7 @@ func TestPostSeriesAddPost_Success(t *testing.T) {
 	existing.ID = 1
 
 	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("HasPost", uint(1), uint(10)).Return(false, nil)
 	repo.On("AddPost", &model.PostSeriesItem{SeriesID: 1, PostID: 10, OrderIndex: 0}).Return(nil)
 
 	err := svc.AddPost(1, 10, 0, 1)
@@ -261,6 +262,37 @@ func TestPostSeriesAddPost_NotFound(t *testing.T) {
 
 	err := svc.AddPost(999, 10, 0, 1)
 	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostSeriesAddPost_Duplicate(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	existing := &model.PostSeries{UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("HasPost", uint(1), uint(10)).Return(true, nil)
+
+	err := svc.AddPost(1, 10, 0, 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "すでに追加済み")
+	repo.AssertNotCalled(t, "AddPost")
+	repo.AssertExpectations(t)
+}
+
+func TestPostSeriesAddPost_HasPostError(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	existing := &model.PostSeries{UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("HasPost", uint(1), uint(10)).Return(false, errors.New("db error"))
+
+	err := svc.AddPost(1, 10, 0, 1)
+	assert.Error(t, err)
+	repo.AssertNotCalled(t, "AddPost")
 	repo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
- PostSeriesService.AddPostで同じ投稿を重複追加できてしまう脆弱性を修正

## 変更内容
- `PostSeriesRepositoryInterface`に`HasPost(seriesID, postID uint) (bool, error)`を追加
- リポジトリ実装: `WHERE series_id = ? AND post_id = ?`でカウント判定
- Service層: AddPost内で重複チェックを実施、すでに追加済みの場合はBadRequestエラー
- テスト: `TestPostSeriesAddPost_Duplicate` / `TestPostSeriesAddPost_HasPostError` を追加
- PostCollectionService.AddPostと同パターンの修正

## テスト結果
全テストPASS（既存テスト + 新規2件）

Closes #899