### PR TITLE
feat: LearningLogService.GetByCategoryでカテゴリ別学習ログ取得

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -20,6 +20,7 @@ type LearningLogServiceInterface interface {
 	GetStreakInfo(userID uint) (*model.StreakInfo, error)
 	GetCalendarData(userID uint) ([]model.CalendarEntry, error)
 	ExportCSV(userID uint, days int) ([]byte, error)
+	GetByCategory(userID uint, category string) ([]model.LearningLog, error)
 }
 
 // LearningLogHandler は学習ログ関連のHTTPハンドラ。
@@ -193,6 +194,23 @@ func (h *LearningLogHandler) GetCalendarData(c *gin.Context) {
 	}
 
 	respondOK(c, entries)
+}
+
+// GetByCategory はカテゴリで学習ログをフィルタリングして取得する。
+func (h *LearningLogHandler) GetByCategory(c *gin.Context) {
+	userID := c.GetUint("userID")
+	category := c.Param("category")
+
+	logs, err := h.service.GetByCategory(userID, category)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if logs == nil {
+		logs = []model.LearningLog{}
+	}
+
+	respondOK(c, logs)
 }
 
 // ExportLogs は学習ログをCSV形式でダウンロードする。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -149,6 +149,7 @@ type LearningLogRepositoryInterface interface {
 	Delete(id, userID uint) error
 	FindByID(id uint) (*model.LearningLog, error)
 	GetByUserID(userID uint) ([]model.LearningLog, error)
+	GetByCategory(userID uint, category string) ([]model.LearningLog, error)
 	GetByPeriod(userID uint, days int) ([]model.LearningLog, error)
 	GetStreakInfo(userID uint) (*model.StreakInfo, error)
 	GetCalendarData(userID uint) ([]model.CalendarEntry, error)

--- a/backend/internal/repository/learning_log.go
+++ b/backend/internal/repository/learning_log.go
@@ -50,6 +50,13 @@ func (r *LearningLogRepository) GetByUserID(userID uint) ([]model.LearningLog, e
 	return logs, err
 }
 
+// GetByCategory は指定ユーザーの学習ログをカテゴリでフィルタリングして取得する（新しい順）。
+func (r *LearningLogRepository) GetByCategory(userID uint, category string) ([]model.LearningLog, error) {
+	var logs []model.LearningLog
+	err := r.db.Where("user_id = ? AND category = ?", userID, category).Order("created_at DESC").Find(&logs).Error
+	return logs, err
+}
+
 // GetByPeriod は指定ユーザーの指定期間分の学習ログを取得する。
 // days=0 の場合は全期間を取得する。
 func (r *LearningLogRepository) GetByPeriod(userID uint, days int) ([]model.LearningLog, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -374,6 +374,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		learningLogs.POST("", c.LearningLogHandler.Create)
 		learningLogs.GET("", c.LearningLogHandler.GetMyLogs)
 		learningLogs.GET("/export", c.LearningLogHandler.ExportLogs)
+		learningLogs.GET("/category/:category", c.LearningLogHandler.GetByCategory)
 		learningLogs.GET("/user/:userId", c.LearningLogHandler.GetByUserID)
 		learningLogs.GET("/calendar/:userId", c.LearningLogHandler.GetCalendarData)
 		learningLogs.GET("/streak/:userId", c.LearningLogHandler.GetStreakInfo)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -49,6 +49,14 @@ func (s *LearningLogService) GetByUserID(userID uint) ([]model.LearningLog, erro
 	return s.repo.GetByUserID(userID)
 }
 
+// GetByCategory は指定ユーザーの学習ログをカテゴリでフィルタリングして取得する。
+func (s *LearningLogService) GetByCategory(userID uint, category string) ([]model.LearningLog, error) {
+	if !model.ValidCategories[model.LogCategory(category)] {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なカテゴリです", nil)
+	}
+	return s.repo.GetByCategory(userID, category)
+}
+
 // findAndCheckOwnership は学習ログを取得し、指定ユーザーが所有者かを検証する。
 func (s *LearningLogService) findAndCheckOwnership(id, userID uint) (*model.LearningLog, error) {
 	log, err := s.repo.FindByID(id)

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -393,3 +393,53 @@ func TestLearningLogExportCSV_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// GetByCategory テスト
+// ============================================================
+
+func TestLearningLogGetByCategory_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	logs := []model.LearningLog{
+		{Title: "Go勉強", Category: model.LogCategoryCoding, UserID: 1},
+	}
+	repo.On("GetByCategory", uint(1), "coding").Return(logs, nil)
+
+	result, err := svc.GetByCategory(1, "coding")
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, model.LogCategoryCoding, result[0].Category)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogGetByCategory_EmptyResult(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetByCategory", uint(1), "meetup").Return([]model.LearningLog{}, nil)
+
+	result, err := svc.GetByCategory(1, "meetup")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogGetByCategory_InvalidCategory(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	result, err := svc.GetByCategory(1, "invalid")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "無効なカテゴリ")
+}
+
+func TestLearningLogGetByCategory_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetByCategory", uint(1), "coding").Return([]model.LearningLog{}, errors.New("db error"))
+
+	result, err := svc.GetByCategory(1, "coding")
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -484,6 +484,11 @@ func (m *MockLearningLogRepository) GetByUserID(userID uint) ([]model.LearningLo
 	return args.Get(0).([]model.LearningLog), args.Error(1)
 }
 
+func (m *MockLearningLogRepository) GetByCategory(userID uint, category string) ([]model.LearningLog, error) {
+	args := m.Called(userID, category)
+	return args.Get(0).([]model.LearningLog), args.Error(1)
+}
+
 func (m *MockLearningLogRepository) GetByPeriod(userID uint, days int) ([]model.LearningLog, error) {
 	args := m.Called(userID, days)
 	return args.Get(0).([]model.LearningLog), args.Error(1)


### PR DESCRIPTION
## 概要
- 学習ログをカテゴリ（coding/reading/course/meetup/other）でフィルタリングするAPI追加
- TDD: テスト4件先行作成 → 実装
- `model.ValidCategories`マップで有効カテゴリをバリデーション

## 変更内容
- Service: `GetByCategory`メソッド追加（バリデーション付き）
- Repository: `GetByCategory`インターフェース・実装追加
- Handler: `GetByCategory`ハンドラ追加
- Router: `GET /api/v1/learning-logs/category/:category`エンドポイント追加
- テスト: Success/EmptyResult/InvalidCategory/RepoError 4件

## テスト結果
- 全4件PASS、Service層全体テストもPASS

closes #901