### PR TITLE
test: StudyCircleService.AddMemberの2回目IsMemberエラーパスのテスト追加

### DIFF
--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -707,6 +707,16 @@ func TestStudyCircleAddMember_GetMemberCountError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestStudyCircleAddMember_TargetIsMemberError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	repo.On("IsMember", uint(1), uint(1)).Return(true, nil)
+	repo.On("IsMember", uint(1), uint(5)).Return(false, errors.New("db error"))
+	err := svc.AddMember(1, 1, 5)
+	assert.Error(t, err)
+	repo.AssertNotCalled(t, "FindByID")
+	repo.AssertExpectations(t)
+}
+
 func TestStudyCircleRemoveMember_NotFound(t *testing.T) {
 	svc, repo := newTestStudyCircleService()
 	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))


### PR DESCRIPTION
## 概要
- StudyCircleService.AddMember の2回目 IsMember（targetUserID確認）のエラーパスが未テスト
- `TestStudyCircleAddMember_TargetIsMemberError` テスト追加

## テスト結果
- AddMemberカバレッジ: 94.7% → 100.0%
- 全テストPASS

closes #905