### PR TITLE
fix: NoteFolderService.Updateに循環参照チェック追加

### DIFF
--- a/backend/internal/service/note_folder.go
+++ b/backend/internal/service/note_folder.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -59,6 +60,27 @@ func (s *NoteFolderService) findAndCheckOwnership(id, userID uint) (*model.NoteF
 	return folder, nil
 }
 
+// isDescendant は targetID が ancestorID の子孫かを再帰的にチェックする。
+func (s *NoteFolderService) isDescendant(ancestorID, targetID uint) (bool, error) {
+	children, err := s.repo.FindByParentID(ancestorID)
+	if err != nil {
+		return false, err
+	}
+	for _, child := range children {
+		if child.ID == targetID {
+			return true, nil
+		}
+		desc, err := s.isDescendant(child.ID, targetID)
+		if err != nil {
+			return false, err
+		}
+		if desc {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // Update は所有権を検証した後、フォルダを更新する。
 func (s *NoteFolderService) Update(id, userID uint, name string, parentID *uint) (*model.NoteFolder, error) {
 	folder, err := s.findAndCheckOwnership(id, userID)
@@ -70,6 +92,18 @@ func (s *NoteFolderService) Update(id, userID uint, name string, parentID *uint)
 		folder.Name = name
 	}
 	if parentID != nil {
+		// 自己参照チェック
+		if *parentID == id {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "フォルダを自分自身の子にすることはできません", nil)
+		}
+		// 循環参照チェック: parentIDが自分の子孫でないことを確認
+		isDesc, err := s.isDescendant(id, *parentID)
+		if err != nil {
+			return nil, err
+		}
+		if isDesc {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "循環参照が発生するため、この親フォルダは設定できません", nil)
+		}
 		folder.ParentID = parentID
 	}
 

--- a/backend/internal/service/note_folder_test.go
+++ b/backend/internal/service/note_folder_test.go
@@ -308,6 +308,7 @@ func TestNoteFolderService_Update_ValidationError(t *testing.T) {
 	// name="" の場合は更新されないのでバリデーションは通る
 	// 代わりにparentID付きの正常更新をテスト
 	parentID := uint(5)
+	mockRepo.On("FindByParentID", uint(1)).Return([]model.NoteFolder{}, nil)
 	mockRepo.On("Update", mock.AnythingOfType("*model.NoteFolder")).Return(nil)
 
 	result, err := service.Update(1, 1, "更新名", &parentID)
@@ -315,6 +316,58 @@ func TestNoteFolderService_Update_ValidationError(t *testing.T) {
 	assert.Equal(t, "更新名", result.Name)
 	assert.Equal(t, &parentID, result.ParentID)
 	mockRepo.AssertExpectations(t)
+}
+
+func TestNoteFolderService_Update_SelfReference(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	existing := &model.NoteFolder{ID: 1, UserID: 1, Name: "フォルダA"}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// 自分自身を親に設定 → エラー
+	selfID := uint(1)
+	result, err := service.Update(1, 1, "", &selfID)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "自分自身")
+}
+
+func TestNoteFolderService_Update_CircularReference(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	// フォルダA(ID=1) → 子フォルダB(ID=2) → 子フォルダC(ID=3)
+	existing := &model.NoteFolder{ID: 1, UserID: 1, Name: "フォルダA"}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+	mockRepo.On("FindByParentID", uint(1)).Return([]model.NoteFolder{
+		{ID: 2, UserID: 1, Name: "フォルダB"},
+	}, nil)
+	mockRepo.On("FindByParentID", uint(2)).Return([]model.NoteFolder{
+		{ID: 3, UserID: 1, Name: "フォルダC"},
+	}, nil)
+	mockRepo.On("FindByParentID", uint(3)).Return([]model.NoteFolder{}, nil)
+
+	// フォルダAの親をフォルダC(孫)に設定 → 循環参照エラー
+	childID := uint(3)
+	result, err := service.Update(1, 1, "", &childID)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "循環参照")
+}
+
+func TestNoteFolderService_Update_CircularCheckRepoError(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	existing := &model.NoteFolder{ID: 1, UserID: 1, Name: "フォルダA"}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+	mockRepo.On("FindByParentID", uint(1)).Return([]model.NoteFolder{}, errors.New("db error"))
+
+	parentID := uint(5)
+	result, err := service.Update(1, 1, "", &parentID)
+	assert.Error(t, err)
+	assert.Nil(t, result)
 }
 
 func TestNoteFolderService_Delete_FindByIDError(t *testing.T) {


### PR DESCRIPTION
## 概要
- NoteFolderService.Update で parentID 変更時に循環参照チェックが欠落していた脆弱性を修正
- フォルダの親を自分自身や子孫に設定すると無限ループが発生する可能性があった

## 修正内容
- 自己参照チェック（parentID == id）
- `isDescendant` ヘルパーで子孫フォルダへの循環参照を再帰的に検出
- テスト3件追加: SelfReference / CircularReference / CircularCheckRepoError

## テスト結果
- NoteFolder全24テストPASS

closes #907