### PR TITLE
feat: StudyCircleService.GetByStatusでステータス別サークル取得

### DIFF
--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -26,6 +26,7 @@ type StudyCircleServiceInterface interface {
 	CreateCheckin(circleID, userID uint, content string) (*model.StudyCircleCheckin, error)
 	GetCheckins(circleID, userID uint) ([]model.StudyCircleCheckin, error)
 	GetStreakRanking(circleID, userID uint) ([]model.CircleMemberStreak, error)
+	GetByStatus(userID uint, status string) ([]model.StudyCircle, error)
 }
 
 // StudyCircleHandler はスタディサークル関連のHTTPリクエストを処理する。
@@ -347,4 +348,21 @@ func (h *StudyCircleHandler) GetStreakRanking(c *gin.Context) {
 		return
 	}
 	respondOK(c, ranking)
+}
+
+// GetByStatus はステータスでサークルをフィルタリングして取得する。
+func (h *StudyCircleHandler) GetByStatus(c *gin.Context) {
+	userID := c.GetUint("userID")
+	status := c.Param("status")
+
+	circles, err := h.service.GetByStatus(userID, status)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if circles == nil {
+		circles = []model.StudyCircle{}
+	}
+
+	respondOK(c, circles)
 }

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -383,6 +383,9 @@ type StudyCircleRepositoryInterface interface {
 	Update(circle *model.StudyCircle) error
 	Delete(id uint) error
 
+	// フィルタリング
+	GetByStatus(userID uint, status string) ([]model.StudyCircle, error)
+
 	// 検索
 	Search(query string, limit, offset int) (interface{}, int64, error)
 

--- a/backend/internal/repository/study_circle.go
+++ b/backend/internal/repository/study_circle.go
@@ -41,6 +41,20 @@ func (r *StudyCircleRepository) FindByID(id uint) (*model.StudyCircle, error) {
 	return &circle, nil
 }
 
+// GetByStatus はユーザーが参加しているサークルをステータスでフィルタリングして返す。
+func (r *StudyCircleRepository) GetByStatus(userID uint, status string) ([]model.StudyCircle, error) {
+	var circles []model.StudyCircle
+	err := r.db.
+		Preload("Owner").
+		Preload("Members").
+		Preload("Members.User").
+		Joins("JOIN study_circle_members ON study_circle_members.circle_id = study_circles.id").
+		Where("study_circle_members.user_id = ? AND study_circles.status = ?", userID, status).
+		Order("study_circles.updated_at DESC").
+		Find(&circles).Error
+	return circles, err
+}
+
 // FindByUserID はユーザーが参加しているサークル一覧を返す。
 func (r *StudyCircleRepository) FindByUserID(userID uint) ([]model.StudyCircle, error) {
 	var circles []model.StudyCircle

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -545,6 +545,7 @@ func registerStudyCircleRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		circles.POST("", c.StudyCircleHandler.Create)
 		circles.GET("", c.StudyCircleHandler.GetMyCircles)
+		circles.GET("/status/:status", c.StudyCircleHandler.GetByStatus)
 		circles.GET("/:id", c.StudyCircleHandler.GetByID)
 		circles.PUT("/:id", c.StudyCircleHandler.Update)
 		circles.DELETE("/:id", c.StudyCircleHandler.Delete)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1456,6 +1456,11 @@ func (m *MockStudyCircleRepository) Search(query string, limit, offset int) (int
 	return args.Get(0), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockStudyCircleRepository) GetByStatus(userID uint, status string) ([]model.StudyCircle, error) {
+	args := m.Called(userID, status)
+	return args.Get(0).([]model.StudyCircle), args.Error(1)
+}
+
 // インターフェース適合チェック
 var _ EmailSenderInterface = (*MockEmailSender)(nil)
 var _ repository.ActivityReportRepositoryInterface = (*MockActivityReportRepository)(nil)

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -72,6 +72,21 @@ func (s *StudyCircleService) GetMyCircles(userID uint) ([]model.StudyCircle, err
 	return s.repo.FindByUserID(userID)
 }
 
+// validStudyCircleStatuses は有効なスタディサークルステータスのマップ。
+var validStudyCircleStatuses = map[string]bool{
+	string(model.StudyCircleStatusActive):    true,
+	string(model.StudyCircleStatusCompleted): true,
+	string(model.StudyCircleStatusArchived):  true,
+}
+
+// GetByStatus はユーザーが参加しているサークルをステータスでフィルタリングして返す。
+func (s *StudyCircleService) GetByStatus(userID uint, status string) ([]model.StudyCircle, error) {
+	if !validStudyCircleStatuses[status] {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なステータスです", nil)
+	}
+	return s.repo.GetByStatus(userID, status)
+}
+
 // GetByID はサークル詳細を返す。メンバーのみアクセス可能。
 func (s *StudyCircleService) GetByID(id, userID uint) (*model.StudyCircle, error) {
 	circle, err := s.repo.FindByID(id)

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -917,3 +917,53 @@ func TestStudyCircleCreateCheckin_IsMemberError(t *testing.T) {
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// GetByStatus テスト
+// ============================================================
+
+func TestStudyCircleGetByStatus_Success(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	circles := []model.StudyCircle{
+		{ID: 1, Name: "Go勉強会", Status: model.StudyCircleStatusActive},
+	}
+	repo.On("GetByStatus", uint(1), "active").Return(circles, nil)
+
+	result, err := svc.GetByStatus(1, "active")
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, model.StudyCircleStatusActive, result[0].Status)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleGetByStatus_EmptyResult(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("GetByStatus", uint(1), "archived").Return([]model.StudyCircle{}, nil)
+
+	result, err := svc.GetByStatus(1, "archived")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleGetByStatus_InvalidStatus(t *testing.T) {
+	svc, _ := newTestStudyCircleService()
+
+	result, err := svc.GetByStatus(1, "invalid")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "無効なステータス")
+}
+
+func TestStudyCircleGetByStatus_RepoError(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("GetByStatus", uint(1), "active").Return([]model.StudyCircle{}, errors.New("db error"))
+
+	result, err := svc.GetByStatus(1, "active")
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- スタディサークルをステータス（active/completed/archived）でフィルタリングするAPI追加
- TDD: テスト4件先行作成 → 実装

## 変更内容
- Service: `GetByStatus`メソッド追加（バリデーション付き）
- Repository: `GetByStatus`インターフェース・実装追加
- Handler: `GetByStatus`ハンドラ追加
- Router: `GET /api/v1/study-circles/status/:status`エンドポイント追加
- テスト: Success/EmptyResult/InvalidStatus/RepoError 4件

## テスト結果
- 全4件PASS、Service層全体テストもPASS

closes #909