### PR TITLE
fix: BookReviewService Create/UpdateにRating範囲バリデーション追加

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -17,6 +18,9 @@ func NewBookReviewService(repo repository.BookReviewRepositoryInterface) *BookRe
 
 // Create は新しい書籍レビューを作成する。
 func (s *BookReviewService) Create(review *model.BookReview) error {
+	if review.Rating < 1 || review.Rating > 5 {
+		return domain.NewError(domain.ErrCodeBadRequest, "評価は1〜5の範囲で指定してください", nil)
+	}
 	return s.repo.Create(review)
 }
 
@@ -64,6 +68,9 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		review.ISBN = updates.ISBN
 	}
 	if updates.Rating != 0 {
+		if updates.Rating < 1 || updates.Rating > 5 {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "評価は1〜5の範囲で指定してください", nil)
+		}
 		review.Rating = updates.Rating
 	}
 	if updates.Review != "" {

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -40,7 +40,7 @@ func TestBookReviewCreate_Success(t *testing.T) {
 func TestBookReviewCreate_RepoError(t *testing.T) {
 	svc, repo := newTestBookReviewService()
 
-	review := &model.BookReview{UserID: 1, Title: "テスト本"}
+	review := &model.BookReview{UserID: 1, Title: "テスト本", Rating: 3}
 
 	repo.On("Create", review).Return(errors.New("db error"))
 
@@ -240,4 +240,52 @@ func TestBookReviewUpdate_AllFields(t *testing.T) {
 	assert.Equal(t, "Great book!", result.Review)
 	assert.Equal(t, "https://example.com/image.jpg", result.ImageURL)
 	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// Rating バリデーションテスト
+// ============================================================
+
+func TestBookReviewCreate_InvalidRatingTooLow(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{
+		Title:  "テスト本",
+		Author: "テスト著者",
+		UserID: 1,
+		Rating: 0,
+	}
+
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "評価は1〜5")
+}
+
+func TestBookReviewCreate_InvalidRatingTooHigh(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{
+		Title:  "テスト本",
+		Author: "テスト著者",
+		UserID: 1,
+		Rating: 6,
+	}
+
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "評価は1〜5")
+}
+
+func TestBookReviewUpdate_InvalidRating(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{Title: "Old", Author: "Author", UserID: 1, Rating: 3}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.BookReview{Rating: -1}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "評価は1〜5")
 }


### PR DESCRIPTION
## 概要
- BookReviewService の Create/Update で Rating（1〜5）のバリデーションが欠落していた脆弱性を修正
- 範囲外の値（0, -1, 6等）が保存可能な状態だった

## 修正内容
- Create: Rating < 1 || Rating > 5 で ErrBadRequest
- Update: Rating更新時に同様の範囲チェック
- テスト3件追加: InvalidRatingTooLow / InvalidRatingTooHigh / UpdateInvalidRating
- 既存テストのRating未指定を修正

## テスト結果
- 全21テストPASS

closes #915