### PR TITLE
feat: AIAdviceService.GetUnreadAdvice 未読アドバイス取得機能追加

### DIFF
--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -20,6 +20,7 @@ type AIAdviceServiceInterface interface {
 	DeleteConversation(id, userID uint) error
 	GetConversations(userID uint, limit, offset int) ([]model.AIConversation, error)
 	GetConversation(id, userID uint) (*model.AIConversation, error)
+	GetUnreadAdvice(userID uint) ([]model.AIAdvice, error)
 }
 
 // AIAdviceHandler はAIアドバイス関連のHTTPハンドラ。
@@ -152,4 +153,20 @@ func (h *AIAdviceHandler) GetConversation(c *gin.Context) {
 	}
 
 	respondOK(c, conv)
+}
+
+// GetUnreadAdvice は未読のアドバイスを取得する。
+func (h *AIAdviceHandler) GetUnreadAdvice(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	advices, err := h.service.GetUnreadAdvice(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if advices == nil {
+		advices = []model.AIAdvice{}
+	}
+
+	respondOK(c, advices)
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -532,6 +532,7 @@ func registerAnalyticsRoutes(g *gin.RouterGroup, c *di.Container) {
 	advice := g.Group("/advice")
 	{
 		advice.GET("", c.AIAdviceHandler.GetAdvice)
+		advice.GET("/unread", c.AIAdviceHandler.GetUnreadAdvice)
 		advice.PUT("/:id/read", c.AIAdviceHandler.MarkAsRead)
 		advice.POST("/chat", c.AIAdviceHandler.Chat)
 		advice.GET("/conversations", c.AIAdviceHandler.GetConversations)

--- a/backend/internal/service/ai_advice.go
+++ b/backend/internal/service/ai_advice.go
@@ -49,6 +49,11 @@ func (s *AIAdviceService) GetAdvice(userID uint, limit int) ([]model.AIAdvice, e
 	return s.adviceRepo.FindByUserID(userID, limit)
 }
 
+// GetUnreadAdvice は未読のアドバイスを優先度順で取得する。
+func (s *AIAdviceService) GetUnreadAdvice(userID uint) ([]model.AIAdvice, error) {
+	return s.adviceRepo.FindUnreadByUserID(userID)
+}
+
 // MarkAsRead はアドバイスを既読にする。
 func (s *AIAdviceService) MarkAsRead(id, userID uint) error {
 	return s.adviceRepo.MarkAsRead(id, userID)

--- a/backend/internal/service/ai_advice_test.go
+++ b/backend/internal/service/ai_advice_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -938,4 +939,46 @@ func TestChat_RefetchFallback(t *testing.T) {
 	assert.Equal(t, model.AIMessageRoleUser, conv.Messages[0].Role)
 	assert.Equal(t, model.AIMessageRoleAssistant, conv.Messages[1].Role)
 	assert.Equal(t, "回答です", conv.Messages[1].Content)
+}
+
+// ============================================================
+// GetUnreadAdvice テスト
+// ============================================================
+
+func TestAIAdviceGetUnreadAdvice_Success(t *testing.T) {
+	svc, mocks := newTestAIAdviceService(false)
+
+	advices := []model.AIAdvice{
+		{TitleKey: "advice.study_hint", IsRead: false, Priority: 1},
+		{TitleKey: "advice.resource_tip", IsRead: false, Priority: 3},
+	}
+	mocks.adviceRepo.On("FindUnreadByUserID", uint(1)).Return(advices, nil)
+
+	result, err := svc.GetUnreadAdvice(1)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.False(t, result[0].IsRead)
+	mocks.adviceRepo.AssertExpectations(t)
+}
+
+func TestAIAdviceGetUnreadAdvice_Empty(t *testing.T) {
+	svc, mocks := newTestAIAdviceService(false)
+
+	mocks.adviceRepo.On("FindUnreadByUserID", uint(1)).Return([]model.AIAdvice{}, nil)
+
+	result, err := svc.GetUnreadAdvice(1)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	mocks.adviceRepo.AssertExpectations(t)
+}
+
+func TestAIAdviceGetUnreadAdvice_RepoError(t *testing.T) {
+	svc, mocks := newTestAIAdviceService(false)
+
+	mocks.adviceRepo.On("FindUnreadByUserID", uint(1)).Return([]model.AIAdvice{}, fmt.Errorf("db error"))
+
+	result, err := svc.GetUnreadAdvice(1)
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	mocks.adviceRepo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
- AIAdviceServiceに未読アドバイス取得メソッド（GetUnreadAdvice）を追加
- Handler・Routerにエンドポイント（GET /api/v1/advice/unread）を追加
- TDDで実装、テスト3件（Success/Empty/RepoError）全てPASS

closes #917