### PR TITLE
fix: AnswerService.Update 空文字bodyバリデーション追加

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"strings"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -45,6 +48,9 @@ func (s *AnswerService) findAndCheckOwnership(answerID, userID uint) (*model.Ans
 
 // Update は所有権を検証した後、回答を更新する。
 func (s *AnswerService) Update(answerID, userID uint, body string) (*model.Answer, error) {
+	if strings.TrimSpace(body) == "" {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "回答内容は必須です", nil)
+	}
 	answer, err := s.findAndCheckOwnership(answerID, userID)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -106,6 +106,24 @@ func TestAnswerUpdate_RepoError(t *testing.T) {
 	answerRepo.AssertExpectations(t)
 }
 
+func TestAnswerUpdate_EmptyBody(t *testing.T) {
+	svc, _, _ := newTestAnswerService()
+
+	result, err := svc.Update(1, 1, "")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "回答内容は必須です")
+}
+
+func TestAnswerUpdate_WhitespaceBody(t *testing.T) {
+	svc, _, _ := newTestAnswerService()
+
+	result, err := svc.Update(1, 1, "   ")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "回答内容は必須です")
+}
+
 // ============================================================
 // 回答削除テスト
 // ============================================================


### PR DESCRIPTION
## 概要
- AnswerService.Updateで空文字列・空白のみのbodyで回答が上書きされる脆弱性を修正
- strings.TrimSpace + domain.NewError でバリデーション追加
- テスト2件（EmptyBody/WhitespaceBody）追加、全テストPASS

closes #923