### PR TITLE
feat: LearningResourceService.GetByDifficulty 難易度別リソース取得機能追加

### DIFF
--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -25,6 +25,7 @@ type LearningResourceServiceInterface interface {
 	Save(userID, resourceID uint) error
 	Unsave(userID, resourceID uint) error
 	GetSavedByUserID(userID uint, limit, offset int) ([]model.LearningResource, int64, error)
+	GetByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error)
 }
 
 // LearningResourceHandler は学習リソース関連のHTTPハンドラ。
@@ -312,6 +313,25 @@ func (h *LearningResourceHandler) UnsaveResource(c *gin.Context) {
 	}
 
 	respondOK(c, domain.NewMessageResponse("Resource unsaved"))
+}
+
+// GetByDifficulty は難易度別の公開学習リソースを取得する。
+func (h *LearningResourceHandler) GetByDifficulty(c *gin.Context) {
+	difficulty := c.Param("difficulty")
+	limit, offset := parseLimitOffset(c)
+
+	resources, total, err := h.service.GetByDifficulty(difficulty, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.ResourceListResponse{
+		Resources: resources,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
 }
 
 // GetSaved は認証ユーザーの保存済み学習リソース一覧を取得する。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -216,6 +216,7 @@ type LearningResourceRepositoryInterface interface {
 	Unsave(userID, resourceID uint) error
 	HasSaved(userID, resourceID uint) (bool, error)
 	FindSavedByUserID(userID uint, limit, offset int) ([]model.LearningResource, int64, error)
+	FindByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error)
 }
 
 // RoadmapRepositoryInterface は学習ロードマップデータ操作の契約を定義する。

--- a/backend/internal/repository/learning_resource.go
+++ b/backend/internal/repository/learning_resource.go
@@ -182,3 +182,19 @@ func (r *LearningResourceRepository) FindSavedByUserID(userID uint, limit, offse
 
 	return resources, total, err
 }
+
+// FindByDifficulty は公開リソースを難易度でフィルタリングして取得する。
+func (r *LearningResourceRepository) FindByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error) {
+	var resources []model.LearningResource
+	var total int64
+
+	query := r.db.Where("is_public = ? AND difficulty = ?", true, difficulty)
+	query.Model(&model.LearningResource{}).Count(&total)
+
+	err := query.Preload("User").
+		Order("created_at DESC").
+		Limit(limit).Offset(offset).
+		Find(&resources).Error
+
+	return resources, total, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -366,6 +366,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		resources.POST("/:id/save", c.LearningResourceHandler.SaveResource)
 		resources.DELETE("/:id/save", c.LearningResourceHandler.UnsaveResource)
 		resources.GET("/user/:userId", c.LearningResourceHandler.GetByUserID)
+		resources.GET("/difficulty/:difficulty", c.LearningResourceHandler.GetByDifficulty)
 	}
 
 	// 学習ログ

--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -62,6 +63,21 @@ func (s *LearningResourceService) GetByUserID(targetUserID, currentUserID uint) 
 // GetPublic は公開学習リソースをページネーション・フィルタ付きで取得する。
 func (s *LearningResourceService) GetPublic(limit, offset int, category, difficulty string) ([]model.LearningResource, int64, error) {
 	return s.repo.FindPublic(limit, offset, category, difficulty)
+}
+
+// validDifficulties は有効な難易度の一覧。
+var validDifficulties = map[string]bool{
+	string(model.ResourceDifficultyBeginner):     true,
+	string(model.ResourceDifficultyIntermediate): true,
+	string(model.ResourceDifficultyAdvanced):     true,
+}
+
+// GetByDifficulty は公開学習リソースを難易度でフィルタリングして取得する。
+func (s *LearningResourceService) GetByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error) {
+	if !validDifficulties[difficulty] {
+		return nil, 0, domain.NewError(domain.ErrCodeBadRequest, "無効な難易度です", nil)
+	}
+	return s.repo.FindByDifficulty(difficulty, limit, offset)
 }
 
 // Search は学習リソースをキーワードで検索する。

--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -713,3 +713,57 @@ func TestLearningResourceDelete_NotFound(t *testing.T) {
 	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// GetByDifficulty テスト
+// ============================================================
+
+func TestLearningResourceGetByDifficulty_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	resources := []model.LearningResource{
+		{Title: "Go入門", Difficulty: model.ResourceDifficultyBeginner},
+		{Title: "HTML基礎", Difficulty: model.ResourceDifficultyBeginner},
+	}
+	repo.On("FindByDifficulty", "beginner", 20, 0).Return(resources, int64(2), nil)
+
+	result, total, err := svc.GetByDifficulty("beginner", 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceGetByDifficulty_InvalidDifficulty(t *testing.T) {
+	svc, _ := newTestLearningResourceService()
+
+	result, total, err := svc.GetByDifficulty("expert", 20, 0)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, int64(0), total)
+	assert.Contains(t, err.Error(), "無効な難易度です")
+}
+
+func TestLearningResourceGetByDifficulty_Empty(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("FindByDifficulty", "advanced", 20, 0).Return([]model.LearningResource{}, int64(0), nil)
+
+	result, total, err := svc.GetByDifficulty("advanced", 20, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceGetByDifficulty_RepoError(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("FindByDifficulty", "intermediate", 20, 0).Return([]model.LearningResource{}, int64(0), errors.New("db error"))
+
+	result, total, err := svc.GetByDifficulty("intermediate", 20, 0)
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -734,6 +734,11 @@ func (m *MockLearningResourceRepository) FindSavedByUserID(userID uint, limit, o
 	return args.Get(0).([]model.LearningResource), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockLearningResourceRepository) FindByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error) {
+	args := m.Called(difficulty, limit, offset)
+	return args.Get(0).([]model.LearningResource), args.Get(1).(int64), args.Error(2)
+}
+
 // ============================================================
 // MockPasswordResetRepository は repository.PasswordResetRepositoryInterface のテスト用モック実装。
 // ============================================================


### PR DESCRIPTION
## 概要
- 学習リソースを難易度（beginner/intermediate/advanced）でフィルタリングする機能を追加
- リポジトリ・サービス・ハンドラ・ルーター全レイヤー対応
- TDDで実装、テスト4件（Success/InvalidDifficulty/Empty/RepoError）全PASS
- エンドポイント: GET /api/v1/resources/difficulty/:difficulty

closes #925