### PR TITLE
refactor: ForbiddenエラーをErrForbidden定数に統一

### DIFF
--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -51,7 +50,7 @@ func (s *NoteService) findAndCheckOwnership(id, userID uint) (*model.Note, error
 		return nil, err
 	}
 	if note.UserID != userID {
-		return nil, domain.NewError(domain.ErrCodeForbidden, "この操作を行う権限がありません", nil)
+		return nil, ErrForbidden
 	}
 	return note, nil
 }

--- a/backend/internal/service/note_link.go
+++ b/backend/internal/service/note_link.go
@@ -36,7 +36,7 @@ func (s *NoteLinkService) findAndCheckSourceNoteOwnership(sourceNoteID, userID u
 		return domain.NewError(domain.ErrCodeNotFound, "ソースノートが見つかりません", err)
 	}
 	if sourceNote.UserID != userID {
-		return domain.NewError(domain.ErrCodeForbidden, "この操作を行う権限がありません", nil)
+		return ErrForbidden
 	}
 	return nil
 }

--- a/backend/internal/service/note_link_test.go
+++ b/backend/internal/service/note_link_test.go
@@ -96,7 +96,7 @@ func TestNoteLinkService_CreateLink_Forbidden(t *testing.T) {
 
 	err := svc.CreateLink(1, 2, 1)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "この操作を行う権限がありません")
+	assert.ErrorIs(t, err, ErrForbidden)
 	noteRepo.AssertExpectations(t)
 }
 
@@ -194,7 +194,7 @@ func TestNoteLinkService_DeleteLink_Forbidden(t *testing.T) {
 
 	err := svc.DeleteLink(1, 2, 1)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "この操作を行う権限がありません")
+	assert.ErrorIs(t, err, ErrForbidden)
 	noteRepo.AssertExpectations(t)
 }
 

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -225,7 +225,7 @@ func (s *PostService) DeleteComment(id, userID uint) error {
 	}
 
 	if comment.UserID != userID {
-		return domain.NewError(domain.ErrCodeForbidden, "この操作を行う権限がありません", nil)
+		return ErrForbidden
 	}
 
 	return s.repo.DeleteComment(id)


### PR DESCRIPTION
## 概要
- NoteService、PostService.DeleteComment、NoteLinkServiceで直接使用していたdomain.NewError(domain.ErrCodeForbidden, ...)をErrForbidden定数に統一
- note.goのdomain import削除（不要になったため）
- テストをErrorIsアサーションに更新

closes #927