### PR TITLE
fix: PostCollectionService.Update タイトル空文字バリデーション追加

### DIFF
--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -57,6 +59,9 @@ func (s *PostCollectionService) findAndCheckOwnership(id, userID uint) (*model.P
 
 // Update は所有権を検証した後、コレクションを更新する。
 func (s *PostCollectionService) Update(id, userID uint, title, description string, isPublic bool) (*model.PostCollection, error) {
+	if strings.TrimSpace(title) == "" {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは必須です", nil)
+	}
 	collection, err := s.findAndCheckOwnership(id, userID)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -207,6 +207,24 @@ func TestPostCollectionUpdate_RepoError(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestPostCollectionUpdate_EmptyTitle(t *testing.T) {
+	svc, _ := newTestPostCollectionService()
+
+	result, err := svc.Update(10, 1, "", "desc", false)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトルは必須です")
+}
+
+func TestPostCollectionUpdate_WhitespaceTitle(t *testing.T) {
+	svc, _ := newTestPostCollectionService()
+
+	result, err := svc.Update(10, 1, "   ", "desc", false)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトルは必須です")
+}
+
 // ============================================================
 // Delete テスト（所有権チェック）
 // ============================================================


### PR DESCRIPTION
## 概要
- PostCollectionService.Updateでtitleが空文字・空白のみの場合にバリデーションなしで上書きされる脆弱性を修正
- strings.TrimSpace + domain.NewErrorでバリデーション追加
- テスト2件（EmptyTitle/WhitespaceTitle）追加、全テストPASS

closes #931