### PR TITLE
feat: 解決済み質問一覧取得API（GetSolved）を追加

### DIFF
--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -20,6 +20,7 @@ type QuestionServiceInterface interface {
 	Delete(id, userID uint) error
 	Vote(userID, questionID uint, value int) error
 	RemoveVote(userID, questionID uint) error
+	GetSolved(limit, offset int) ([]model.Question, int64, error)
 }
 
 // QuestionHandler は質問関連のHTTPハンドラ。
@@ -196,6 +197,24 @@ func (h *QuestionHandler) Vote(c *gin.Context) {
 	}
 
 	respondOK(c, domain.NewMessageResponse("Voted successfully"))
+}
+
+// GetSolved は解決済みの質問一覧を取得する。
+func (h *QuestionHandler) GetSolved(c *gin.Context) {
+	limit, offset := parseLimitOffset(c)
+
+	questions, total, err := h.service.GetSolved(limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.QuestionListResponse{
+		Questions: questions,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
 }
 
 // RemoveVote は質問への投票を取り消す。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -125,6 +125,7 @@ type QuestionRepositoryInterface interface {
 	Vote(userID, questionID uint, value int) error
 	RemoveVote(userID, questionID uint) error
 	GetUserVote(userID, questionID uint) (int, error)
+	FindSolved(limit, offset int) ([]model.Question, int64, error)
 }
 
 // AnswerRepositoryInterface はQ&A回答データ操作の契約を定義する。

--- a/backend/internal/repository/question.go
+++ b/backend/internal/repository/question.go
@@ -147,6 +147,22 @@ func (r *QuestionRepository) RemoveVote(userID, questionID uint) error {
 		UpdateColumn("vote_count", gorm.Expr("vote_count - ?", oldValue)).Error
 }
 
+// FindSolved は解決済みの質問一覧をページネーション付きで取得する。
+func (r *QuestionRepository) FindSolved(limit, offset int) ([]model.Question, int64, error) {
+	var questions []model.Question
+	var total int64
+
+	query := r.db.Model(&model.Question{}).Where("is_solved = ?", true)
+	query.Count(&total)
+
+	err := query.Preload("User").
+		Order("created_at DESC").
+		Limit(limit).Offset(offset).
+		Find(&questions).Error
+
+	return questions, total, err
+}
+
 // GetUserVote は指定ユーザーの指定質問への投票値を取得する（未投票の場合は0を返す）。
 func (r *QuestionRepository) GetUserVote(userID, questionID uint) (int, error) {
 	var vote model.QuestionVote

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -441,6 +441,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		questions.POST("", c.QuestionHandler.Create)
 		questions.GET("", c.QuestionHandler.GetAll)
 		questions.GET("/search", c.QuestionHandler.Search)
+		questions.GET("/solved", c.QuestionHandler.GetSolved)
 		questions.GET("/:id", c.QuestionHandler.GetByID)
 		questions.PUT("/:id", c.QuestionHandler.Update)
 		questions.DELETE("/:id", c.QuestionHandler.Delete)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -392,6 +392,11 @@ func (m *MockQuestionRepository) GetUserVote(userID, questionID uint) (int, erro
 	return args.Int(0), args.Error(1)
 }
 
+func (m *MockQuestionRepository) FindSolved(limit, offset int) ([]model.Question, int64, error) {
+	args := m.Called(limit, offset)
+	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
+}
+
 // ============================================================
 // MockAnswerRepository は repository.AnswerRepositoryInterface のテスト用モック実装。
 // ============================================================

--- a/backend/internal/service/question.go
+++ b/backend/internal/service/question.go
@@ -124,6 +124,11 @@ func (s *QuestionService) Vote(userID, questionID uint, value int) error {
 	return s.repo.Vote(userID, questionID, value)
 }
 
+// GetSolved は解決済みの質問一覧をページネーション付きで取得する。
+func (s *QuestionService) GetSolved(limit, offset int) ([]model.Question, int64, error) {
+	return s.repo.FindSolved(limit, offset)
+}
+
 // RemoveVote は質問への投票を取り消す。
 // 自分の質問への投票削除は禁止する（そもそも投票できないため）。
 func (s *QuestionService) RemoveVote(userID, questionID uint) error {

--- a/backend/internal/service/question_test.go
+++ b/backend/internal/service/question_test.go
@@ -420,3 +420,48 @@ func TestQuestionUpdate_ValidationError(t *testing.T) {
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// GetSolved テスト
+// ============================================================
+
+func TestQuestionGetSolved_Success(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	questions := []model.Question{
+		{Title: "Solved Q1", IsSolved: true},
+		{Title: "Solved Q2", IsSolved: true},
+	}
+	repo.On("FindSolved", 20, 0).Return(questions, int64(2), nil)
+
+	result, total, err := svc.GetSolved(20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	assert.True(t, result[0].IsSolved)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionGetSolved_Empty(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindSolved", 20, 0).Return([]model.Question{}, int64(0), nil)
+
+	result, total, err := svc.GetSolved(20, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionGetSolved_RepoError(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindSolved", 20, 0).Return([]model.Question{}, int64(0), errors.New("db error"))
+
+	result, total, err := svc.GetSolved(20, 0)
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- QuestionServiceにGetSolvedメソッドを追加
- `GET /api/v1/questions/solved` エンドポイントで解決済み質問をページネーション付きで取得可能に
- リポジトリ・サービス・ハンドラ・ルーター全レイヤーを実装

## テスト
- [x] TestQuestionGetSolved_Success — 正常取得
- [x] TestQuestionGetSolved_Empty — 空結果
- [x] TestQuestionGetSolved_RepoError — DBエラー

Closes #933