### PR TITLE
fix: CodeSnippetService.CreateCommentに空コメントバリデーション追加

### DIFF
--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -99,6 +101,9 @@ func (s *CodeSnippetService) Delete(id, userID uint) error {
 // CreateComment はスニペットへのインラインコメントを作成する。
 // スニペットの存在を確認してからコメントを作成する。
 func (s *CodeSnippetService) CreateComment(comment *model.SnippetComment) error {
+	if strings.TrimSpace(comment.Content) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "コメント内容は必須です", nil)
+	}
 	if _, err := s.repo.FindByID(comment.SnippetID); err != nil {
 		return err
 	}

--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -159,6 +159,36 @@ func TestSnippetCommentCreate_Success(t *testing.T) {
 	snippetRepo.AssertCalled(t, "CreateComment", comment)
 }
 
+func TestSnippetCommentCreate_EmptyContent(t *testing.T) {
+	svc, _, _ := newTestCodeSnippetService()
+
+	comment := &model.SnippetComment{
+		SnippetID:  10,
+		UserID:     2,
+		LineNumber: 1,
+		Content:    "",
+	}
+
+	err := svc.CreateComment(comment)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "コメント内容は必須です")
+}
+
+func TestSnippetCommentCreate_WhitespaceContent(t *testing.T) {
+	svc, _, _ := newTestCodeSnippetService()
+
+	comment := &model.SnippetComment{
+		SnippetID:  10,
+		UserID:     2,
+		LineNumber: 1,
+		Content:    "   ",
+	}
+
+	err := svc.CreateComment(comment)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "コメント内容は必須です")
+}
+
 func TestSnippetCommentCreate_SnippetNotFound(t *testing.T) {
 	svc, snippetRepo, _ := newTestCodeSnippetService()
 


### PR DESCRIPTION
## 概要
- CodeSnippetService.CreateCommentで空文字・空白のみのコメント作成が可能だった問題を修正
- `strings.TrimSpace(comment.Content) == ""` チェックを追加

## テスト
- [x] TestSnippetCommentCreate_EmptyContent — 空文字エラー
- [x] TestSnippetCommentCreate_WhitespaceContent — 空白のみエラー
- [x] 既存テスト全PASS

Closes #939