### PR TITLE
feat: LearningLogService.GetBySource（ソース別学習ログ取得）を追加

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -21,6 +21,7 @@ type LearningLogServiceInterface interface {
 	GetCalendarData(userID uint) ([]model.CalendarEntry, error)
 	ExportCSV(userID uint, days int) ([]byte, error)
 	GetByCategory(userID uint, category string) ([]model.LearningLog, error)
+	GetBySource(userID uint, source string) ([]model.LearningLog, error)
 }
 
 // LearningLogHandler は学習ログ関連のHTTPハンドラ。
@@ -202,6 +203,23 @@ func (h *LearningLogHandler) GetByCategory(c *gin.Context) {
 	category := c.Param("category")
 
 	logs, err := h.service.GetByCategory(userID, category)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	if logs == nil {
+		logs = []model.LearningLog{}
+	}
+
+	respondOK(c, logs)
+}
+
+// GetBySource はソース（manual/pomodoro）で学習ログをフィルタリングして取得する。
+func (h *LearningLogHandler) GetBySource(c *gin.Context) {
+	userID := c.GetUint("userID")
+	source := c.Param("source")
+
+	logs, err := h.service.GetBySource(userID, source)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -152,6 +152,7 @@ type LearningLogRepositoryInterface interface {
 	GetByUserID(userID uint) ([]model.LearningLog, error)
 	GetByCategory(userID uint, category string) ([]model.LearningLog, error)
 	GetByPeriod(userID uint, days int) ([]model.LearningLog, error)
+	GetBySource(userID uint, source string) ([]model.LearningLog, error)
 	GetStreakInfo(userID uint) (*model.StreakInfo, error)
 	GetCalendarData(userID uint) ([]model.CalendarEntry, error)
 }

--- a/backend/internal/repository/learning_log.go
+++ b/backend/internal/repository/learning_log.go
@@ -57,6 +57,13 @@ func (r *LearningLogRepository) GetByCategory(userID uint, category string) ([]m
 	return logs, err
 }
 
+// GetBySource は指定ユーザーの学習ログをソースでフィルタリングして取得する（新しい順）。
+func (r *LearningLogRepository) GetBySource(userID uint, source string) ([]model.LearningLog, error) {
+	var logs []model.LearningLog
+	err := r.db.Where("user_id = ? AND source = ?", userID, source).Order("created_at DESC").Find(&logs).Error
+	return logs, err
+}
+
 // GetByPeriod は指定ユーザーの指定期間分の学習ログを取得する。
 // days=0 の場合は全期間を取得する。
 func (r *LearningLogRepository) GetByPeriod(userID uint, days int) ([]model.LearningLog, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -376,6 +376,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		learningLogs.GET("", c.LearningLogHandler.GetMyLogs)
 		learningLogs.GET("/export", c.LearningLogHandler.ExportLogs)
 		learningLogs.GET("/category/:category", c.LearningLogHandler.GetByCategory)
+		learningLogs.GET("/source/:source", c.LearningLogHandler.GetBySource)
 		learningLogs.GET("/user/:userId", c.LearningLogHandler.GetByUserID)
 		learningLogs.GET("/calendar/:userId", c.LearningLogHandler.GetCalendarData)
 		learningLogs.GET("/streak/:userId", c.LearningLogHandler.GetStreakInfo)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -57,6 +57,14 @@ func (s *LearningLogService) GetByCategory(userID uint, category string) ([]mode
 	return s.repo.GetByCategory(userID, category)
 }
 
+// GetBySource は指定ユーザーの学習ログをソース（manual/pomodoro）でフィルタリングして取得する。
+func (s *LearningLogService) GetBySource(userID uint, source string) ([]model.LearningLog, error) {
+	if !model.ValidSources[model.LogSource(source)] {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なソースです", nil)
+	}
+	return s.repo.GetBySource(userID, source)
+}
+
 // findAndCheckOwnership は学習ログを取得し、指定ユーザーが所有者かを検証する。
 func (s *LearningLogService) findAndCheckOwnership(id, userID uint) (*model.LearningLog, error) {
 	log, err := s.repo.FindByID(id)

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -443,3 +443,54 @@ func TestLearningLogGetByCategory_RepoError(t *testing.T) {
 	assert.Empty(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// GetBySource テスト
+// ============================================================
+
+func TestLearningLogGetBySource_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	logs := []model.LearningLog{
+		{Title: "ポモドーロ学習1", Source: model.LogSourcePomodoro, UserID: 1},
+		{Title: "ポモドーロ学習2", Source: model.LogSourcePomodoro, UserID: 1},
+	}
+	repo.On("GetBySource", uint(1), "pomodoro").Return(logs, nil)
+
+	result, err := svc.GetBySource(1, "pomodoro")
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, model.LogSourcePomodoro, result[0].Source)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogGetBySource_InvalidSource(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	result, err := svc.GetBySource(1, "invalid")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "無効なソースです")
+}
+
+func TestLearningLogGetBySource_Empty(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetBySource", uint(1), "pomodoro").Return([]model.LearningLog{}, nil)
+
+	result, err := svc.GetBySource(1, "pomodoro")
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogGetBySource_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetBySource", uint(1), "manual").Return([]model.LearningLog{}, errors.New("db error"))
+
+	result, err := svc.GetBySource(1, "manual")
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -494,6 +494,11 @@ func (m *MockLearningLogRepository) GetByCategory(userID uint, category string) 
 	return args.Get(0).([]model.LearningLog), args.Error(1)
 }
 
+func (m *MockLearningLogRepository) GetBySource(userID uint, source string) ([]model.LearningLog, error) {
+	args := m.Called(userID, source)
+	return args.Get(0).([]model.LearningLog), args.Error(1)
+}
+
 func (m *MockLearningLogRepository) GetByPeriod(userID uint, days int) ([]model.LearningLog, error) {
 	args := m.Called(userID, days)
 	return args.Get(0).([]model.LearningLog), args.Error(1)


### PR DESCRIPTION
## 概要
- LearningLogServiceにGetBySourceメソッドを追加
- `GET /api/v1/learning-logs/source/:source` エンドポイントでmanual/pomodoroのソース別取得が可能に
- ValidSourcesマップによるバリデーション付き

## テスト
- [x] TestLearningLogGetBySource_Success — 正常取得
- [x] TestLearningLogGetBySource_InvalidSource — 無効ソースエラー
- [x] TestLearningLogGetBySource_Empty — 空結果
- [x] TestLearningLogGetBySource_RepoError — DBエラー

Closes #941