### PR TITLE
fix: PostSeriesServiceのTitle空白チェック追加

### DIFF
--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -19,7 +21,7 @@ func NewPostSeriesService(repo repository.PostSeriesRepositoryInterface) *PostSe
 
 // Create は新しい投稿シリーズを作成する。
 func (s *PostSeriesService) Create(series *model.PostSeries) error {
-	if series.Title == "" {
+	if strings.TrimSpace(series.Title) == "" {
 		return domain.NewError(domain.ErrCodeValidation, "タイトルは必須です", nil)
 	}
 	return s.repo.Create(series)
@@ -55,6 +57,9 @@ func (s *PostSeriesService) Update(id, userID uint, updates *model.PostSeries) (
 	}
 
 	if updates.Title != "" {
+		if strings.TrimSpace(updates.Title) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみでは入力できません", nil)
+		}
 		series.Title = updates.Title
 	}
 	if updates.Description != "" {

--- a/backend/internal/service/post_series_test.go
+++ b/backend/internal/service/post_series_test.go
@@ -370,6 +370,34 @@ func TestPostSeriesRemovePost_NotFound(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestPostSeriesCreate_WhitespaceTitle(t *testing.T) {
+	svc, _ := newTestPostSeriesService()
+
+	series := &model.PostSeries{
+		Title:  "   ",
+		UserID: 1,
+	}
+
+	err := svc.Create(series)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "タイトルは必須です")
+}
+
+func TestPostSeriesUpdate_WhitespaceTitle(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	existing := &model.PostSeries{Title: "Old Title", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.PostSeries{Title: "  \t  "}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "空白のみ")
+}
+
 func TestPostSeriesUpdate_Description(t *testing.T) {
 	svc, repo := newTestPostSeriesService()
 


### PR DESCRIPTION
## 概要
- PostSeriesServiceのCreate/Updateでタイトルの空白のみ入力を許可していた問題を修正
- `strings.TrimSpace`によるバリデーションを追加

## 変更内容
- Create: `series.Title == ""` → `strings.TrimSpace(series.Title) == ""` に変更
- Update: タイトルが空白のみの場合にBadRequestエラーを返すバリデーション追加

## テスト
- 新規テスト2件追加（Create空白タイトル、Update空白タイトル）
- 既存テスト含め全27件PASS

Closes #947