### PR TITLE
feat: BookReviewService.GetByRatingで評価範囲による書籍レビュー取得

### DIFF
--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/dto"
@@ -15,6 +16,7 @@ type BookReviewServiceInterface interface {
 	GetAll(limit, offset int) ([]model.BookReview, int64, error)
 	Update(id, userID uint, updates *model.BookReview) (*model.BookReview, error)
 	Delete(id, userID uint) error
+	GetByRating(userID uint, minRating, maxRating int) ([]model.BookReview, error)
 }
 
 // BookReviewHandler は書籍レビュー関連のHTTPハンドラ。
@@ -145,6 +147,31 @@ func (h *BookReviewHandler) Update(c *gin.Context) {
 	}
 
 	respondOK(c, review)
+}
+
+// GetByRating は評価範囲で書籍レビューをフィルタリングして取得する。
+// クエリパラメータ: min_rating, max_rating（1〜5）
+func (h *BookReviewHandler) GetByRating(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	minRating, err := strconv.Atoi(c.Query("min_rating"))
+	if err != nil {
+		respondBadRequest(c, "min_ratingは数値で指定してください")
+		return
+	}
+	maxRating, err := strconv.Atoi(c.Query("max_rating"))
+	if err != nil {
+		respondBadRequest(c, "max_ratingは数値で指定してください")
+		return
+	}
+
+	reviews, err := h.service.GetByRating(userID, minRating, maxRating)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, reviews)
 }
 
 // Delete は指定IDの書籍レビューを削除する。

--- a/backend/internal/repository/book_review.go
+++ b/backend/internal/repository/book_review.go
@@ -54,6 +54,15 @@ func (r *BookReviewRepository) FindAll(limit, offset int) ([]model.BookReview, i
 	return reviews, total, err
 }
 
+// FindByRating は指定ユーザーの書籍レビューを評価範囲でフィルタリングして取得する（新しい順）。
+func (r *BookReviewRepository) FindByRating(userID uint, minRating, maxRating int) ([]model.BookReview, error) {
+	var reviews []model.BookReview
+	err := r.db.Where("user_id = ? AND rating >= ? AND rating <= ?", userID, minRating, maxRating).
+		Order("created_at DESC").
+		Find(&reviews).Error
+	return reviews, err
+}
+
 // Update は既存の書籍レビューを更新する。
 func (r *BookReviewRepository) Update(review *model.BookReview) error {
 	return r.db.Save(review).Error

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -197,6 +197,7 @@ type BookReviewRepositoryInterface interface {
 	FindByID(id uint) (*model.BookReview, error)
 	FindByUserID(userID uint) ([]model.BookReview, error)
 	FindAll(limit, offset int) ([]model.BookReview, int64, error)
+	FindByRating(userID uint, minRating, maxRating int) ([]model.BookReview, error)
 	Update(review *model.BookReview) error
 	Delete(id uint) error
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -502,6 +502,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		bookReviews.PUT("/:id", c.BookReviewHandler.Update)
 		bookReviews.DELETE("/:id", c.BookReviewHandler.Delete)
 		bookReviews.GET("/user/:userId", c.BookReviewHandler.GetByUserID)
+		bookReviews.GET("/rating", c.BookReviewHandler.GetByRating)
 	}
 
 	// バッジ

--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -47,6 +47,14 @@ func (s *BookReviewService) GetAll(limit, offset int) ([]model.BookReview, int64
 	return s.repo.FindAll(limit, offset)
 }
 
+// GetByRating は指定ユーザーの書籍レビューを評価範囲でフィルタリングして取得する。
+func (s *BookReviewService) GetByRating(userID uint, minRating, maxRating int) ([]model.BookReview, error) {
+	if minRating < 1 || minRating > 5 || maxRating < 1 || maxRating > 5 || minRating > maxRating {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "評価範囲が無効です", nil)
+	}
+	return s.repo.FindByRating(userID, minRating, maxRating)
+}
+
 // findAndCheckOwnership は書籍レビューを取得し、指定ユーザーが所有者かを検証する。
 func (s *BookReviewService) findAndCheckOwnership(id, userID uint) (*model.BookReview, error) {
 	review, err := s.repo.FindByID(id)

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -276,6 +276,60 @@ func TestBookReviewCreate_InvalidRatingTooHigh(t *testing.T) {
 	assert.Contains(t, err.Error(), "評価は1〜5")
 }
 
+// ============================================================
+// 評価範囲による取得テスト
+// ============================================================
+
+func TestBookReviewGetByRating_Success(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	expected := []model.BookReview{
+		{Title: "良書A", UserID: 1, Rating: 4},
+		{Title: "良書B", UserID: 1, Rating: 5},
+	}
+	repo.On("FindByRating", uint(1), 4, 5).Return(expected, nil)
+
+	result, err := svc.GetByRating(1, 4, 5)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewGetByRating_InvalidRange(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	// minRating > maxRating
+	result, err := svc.GetByRating(1, 5, 3)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "評価範囲が無効です")
+}
+
+func TestBookReviewGetByRating_OutOfRange(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	// minRating < 1
+	result, err := svc.GetByRating(1, 0, 5)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+
+	// maxRating > 5
+	result2, err2 := svc.GetByRating(1, 1, 6)
+	assert.Error(t, err2)
+	assert.Nil(t, result2)
+}
+
+func TestBookReviewGetByRating_RepoError(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	repo.On("FindByRating", uint(1), 1, 3).Return([]model.BookReview(nil), errors.New("db error"))
+
+	result, err := svc.GetByRating(1, 1, 3)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
 func TestBookReviewUpdate_InvalidRating(t *testing.T) {
 	svc, repo := newTestBookReviewService()
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -663,6 +663,11 @@ func (m *MockBookReviewRepository) Delete(id uint) error {
 	return args.Error(0)
 }
 
+func (m *MockBookReviewRepository) FindByRating(userID uint, minRating, maxRating int) ([]model.BookReview, error) {
+	args := m.Called(userID, minRating, maxRating)
+	return args.Get(0).([]model.BookReview), args.Error(1)
+}
+
 // ============================================================
 // MockLearningResourceRepository は repository.LearningResourceRepositoryInterface のテスト用モック実装。
 // ============================================================


### PR DESCRIPTION
## 概要
- 評価範囲（minRating〜maxRating）で書籍レビューをフィルタリングして取得する機能を追加
- TDDでテスト先行作成→実装の流れで開発

## 変更内容
- `BookReviewRepositoryInterface`に`FindByRating`メソッド追加
- `BookReviewService.GetByRating`メソッド追加（1〜5範囲・min<=maxバリデーション付き）
- `BookReviewRepository.FindByRating`実装追加
- ハンドラ・ルーター追加（`GET /book-reviews/rating?min_rating=X&max_rating=Y`）

## テスト
- 新規テスト4件（Success/InvalidRange/OutOfRange/RepoError）
- 既存テスト含め全25件PASS

Closes #949