### PR TITLE
test: Handler層テストのモック定義をService/Repository層に追従 (#953)

### DIFF
--- a/backend/internal/handler/chat_room_test.go
+++ b/backend/internal/handler/chat_room_test.go
@@ -212,6 +212,7 @@ func TestChatRoomAddMember_Success(t *testing.T) {
 	r.POST("/rooms/:id/members", h.AddMember)
 
 	roomRepo.On("IsMember", uint(10), uint(1)).Return(true, nil)
+	roomRepo.On("IsMember", uint(10), uint(5)).Return(false, nil)
 	roomRepo.On("AddMember", uint(10), uint(5)).Return(nil)
 
 	w := doRequest(r, http.MethodPost, "/rooms/10/members", map[string]uint{

--- a/backend/internal/handler/learning_goal_test.go
+++ b/backend/internal/handler/learning_goal_test.go
@@ -50,6 +50,16 @@ func (m *MockLearningGoalRepository) GetStats(userID uint) (*model.LearningGoalS
 	return nil, args.Error(1)
 }
 
+func (m *MockLearningGoalRepository) GetByCategory(userID uint, category string) ([]model.LearningGoal, error) {
+	args := m.Called(userID, category)
+	return args.Get(0).([]model.LearningGoal), args.Error(1)
+}
+
+func (m *MockLearningGoalRepository) GetByStatus(userID uint, status string) ([]model.LearningGoal, error) {
+	args := m.Called(userID, status)
+	return args.Get(0).([]model.LearningGoal), args.Error(1)
+}
+
 // setupLearningGoalHandler はテスト用のLearningGoalHandlerとモックを準備する。
 func setupLearningGoalHandler() (*LearningGoalHandler, *MockLearningGoalRepository) {
 	repo := new(MockLearningGoalRepository)

--- a/backend/internal/handler/learning_resource_test.go
+++ b/backend/internal/handler/learning_resource_test.go
@@ -249,6 +249,9 @@ func TestResourceLike_Success(t *testing.T) {
 	r := newRouter(1)
 	r.POST("/resources/:id/like", h.Like)
 
+	otherResource := &model.LearningResource{UserID: 99}
+	otherResource.ID = 5
+	repo.On("FindByID", uint(5)).Return(otherResource, nil)
 	repo.On("Like", uint(1), uint(5)).Return(nil)
 
 	w := doRequest(r, http.MethodPost, "/resources/5/like", nil)
@@ -260,6 +263,9 @@ func TestResourceUnlike_Success(t *testing.T) {
 	r := newRouter(1)
 	r.DELETE("/resources/:id/like", h.Unlike)
 
+	otherResource := &model.LearningResource{UserID: 99}
+	otherResource.ID = 5
+	repo.On("FindByID", uint(5)).Return(otherResource, nil)
 	repo.On("Unlike", uint(1), uint(5)).Return(nil)
 
 	w := doRequest(r, http.MethodDelete, "/resources/5/like", nil)
@@ -273,6 +279,9 @@ func TestResourceSave_Success(t *testing.T) {
 	r := newRouter(1)
 	r.POST("/resources/:id/save", h.SaveResource)
 
+	otherResource := &model.LearningResource{UserID: 99}
+	otherResource.ID = 5
+	repo.On("FindByID", uint(5)).Return(otherResource, nil)
 	repo.On("Save", uint(1), uint(5)).Return(nil)
 
 	w := doRequest(r, http.MethodPost, "/resources/5/save", nil)
@@ -284,6 +293,9 @@ func TestResourceUnsave_Success(t *testing.T) {
 	r := newRouter(1)
 	r.DELETE("/resources/:id/save", h.UnsaveResource)
 
+	otherResource := &model.LearningResource{UserID: 99}
+	otherResource.ID = 5
+	repo.On("FindByID", uint(5)).Return(otherResource, nil)
 	repo.On("Unsave", uint(1), uint(5)).Return(nil)
 
 	w := doRequest(r, http.MethodDelete, "/resources/5/save", nil)

--- a/backend/internal/handler/note_link_test.go
+++ b/backend/internal/handler/note_link_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestNoteLinkCreateLink_Success(t *testing.T) {
 	h, svc := setupNoteLinkHandler()
-	svc.On("CreateLink", uint(1), uint(2)).Return(nil)
+	svc.On("CreateLink", uint(1), uint(2), uint(1)).Return(nil)
 
 	r := newRouter(1)
 	r.POST("/notes/:id/links", h.CreateLink)
@@ -22,7 +22,7 @@ func TestNoteLinkCreateLink_Success(t *testing.T) {
 
 func TestNoteLinkCreateLink_ServiceError(t *testing.T) {
 	h, svc := setupNoteLinkHandler()
-	svc.On("CreateLink", uint(1), uint(2)).Return(service.ErrConflict)
+	svc.On("CreateLink", uint(1), uint(2), uint(1)).Return(service.ErrConflict)
 
 	r := newRouter(1)
 	r.POST("/notes/:id/links", h.CreateLink)
@@ -94,7 +94,7 @@ func TestNoteLinkGetBacklinks_ServiceError(t *testing.T) {
 
 func TestNoteLinkDeleteLink_Success(t *testing.T) {
 	h, svc := setupNoteLinkHandler()
-	svc.On("DeleteLink", uint(1), uint(2)).Return(nil)
+	svc.On("DeleteLink", uint(1), uint(2), uint(1)).Return(nil)
 
 	r := newRouter(1)
 	r.DELETE("/notes/:id/links/:targetId", h.DeleteLink)
@@ -106,7 +106,7 @@ func TestNoteLinkDeleteLink_Success(t *testing.T) {
 
 func TestNoteLinkDeleteLink_ServiceError(t *testing.T) {
 	h, svc := setupNoteLinkHandler()
-	svc.On("DeleteLink", uint(1), uint(2)).Return(service.ErrNotFound)
+	svc.On("DeleteLink", uint(1), uint(2), uint(1)).Return(service.ErrNotFound)
 
 	r := newRouter(1)
 	r.DELETE("/notes/:id/links/:targetId", h.DeleteLink)

--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -48,8 +48,8 @@ func (m *MockNoteService) Update(id, userID uint, title, content, tags string, f
 	return nil, args.Error(1)
 }
 
-func (m *MockNoteService) Delete(id uint) error {
-	return m.Called(id).Error(0)
+func (m *MockNoteService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
 }
 
 func (m *MockNoteService) Search(userID uint, query string, page, limit int) ([]model.Note, int64, error) {
@@ -62,16 +62,16 @@ func (m *MockNoteService) CountByUserID(userID uint) (int64, error) {
 	return args.Get(0).(int64), args.Error(1)
 }
 
-func (m *MockNoteService) ToggleFavorite(id uint) error {
-	return m.Called(id).Error(0)
+func (m *MockNoteService) ToggleFavorite(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
 }
 
-func (m *MockNoteService) Archive(id uint) error {
-	return m.Called(id).Error(0)
+func (m *MockNoteService) Archive(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
 }
 
-func (m *MockNoteService) Unarchive(id uint) error {
-	return m.Called(id).Error(0)
+func (m *MockNoteService) Unarchive(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
 }
 
 func (m *MockNoteService) GetArchived(userID uint, page, limit int) ([]model.Note, error) {
@@ -238,9 +238,12 @@ func TestNoteHandler_Delete(t *testing.T) {
 	handler, mockService := newTestNoteHandler()
 	router := setupRouter()
 
-	router.DELETE("/notes/:id", handler.Delete)
+	router.DELETE("/notes/:id", func(c *gin.Context) {
+		c.Set("userID", uint(1))
+		handler.Delete(c)
+	})
 
-	mockService.On("Delete", uint(1)).Return(nil)
+	mockService.On("Delete", uint(1), uint(1)).Return(nil)
 
 	req, _ := http.NewRequest("DELETE", "/notes/1", nil)
 	w := httptest.NewRecorder()
@@ -285,9 +288,12 @@ func TestNoteHandler_ToggleFavorite(t *testing.T) {
 	handler, mockService := newTestNoteHandler()
 	router := setupRouter()
 
-	router.PUT("/notes/:id/favorite", handler.ToggleFavorite)
+	router.PUT("/notes/:id/favorite", func(c *gin.Context) {
+		c.Set("userID", uint(1))
+		handler.ToggleFavorite(c)
+	})
 
-	mockService.On("ToggleFavorite", uint(1)).Return(nil)
+	mockService.On("ToggleFavorite", uint(1), uint(1)).Return(nil)
 
 	req, _ := http.NewRequest("PUT", "/notes/1/favorite", nil)
 	w := httptest.NewRecorder()
@@ -362,9 +368,12 @@ func TestNoteHandler_Archive(t *testing.T) {
 		handler, mockService := newTestNoteHandler()
 		router := setupRouter()
 
-		router.PUT("/notes/:id/archive", handler.Archive)
+		router.PUT("/notes/:id/archive", func(c *gin.Context) {
+			c.Set("userID", uint(1))
+			handler.Archive(c)
+		})
 
-		mockService.On("Archive", uint(1)).Return(nil)
+		mockService.On("Archive", uint(1), uint(1)).Return(nil)
 
 		req, _ := http.NewRequest("PUT", "/notes/1/archive", nil)
 		w := httptest.NewRecorder()
@@ -391,9 +400,12 @@ func TestNoteHandler_Archive(t *testing.T) {
 		handler, mockService := newTestNoteHandler()
 		router := setupRouter()
 
-		router.PUT("/notes/:id/archive", handler.Archive)
+		router.PUT("/notes/:id/archive", func(c *gin.Context) {
+			c.Set("userID", uint(1))
+			handler.Archive(c)
+		})
 
-		mockService.On("Archive", uint(1)).Return(assert.AnError)
+		mockService.On("Archive", uint(1), uint(1)).Return(assert.AnError)
 
 		req, _ := http.NewRequest("PUT", "/notes/1/archive", nil)
 		w := httptest.NewRecorder()
@@ -413,9 +425,12 @@ func TestNoteHandler_Unarchive(t *testing.T) {
 		handler, mockService := newTestNoteHandler()
 		router := setupRouter()
 
-		router.PUT("/notes/:id/unarchive", handler.Unarchive)
+		router.PUT("/notes/:id/unarchive", func(c *gin.Context) {
+			c.Set("userID", uint(1))
+			handler.Unarchive(c)
+		})
 
-		mockService.On("Unarchive", uint(1)).Return(nil)
+		mockService.On("Unarchive", uint(1), uint(1)).Return(nil)
 
 		req, _ := http.NewRequest("PUT", "/notes/1/unarchive", nil)
 		w := httptest.NewRecorder()
@@ -442,9 +457,12 @@ func TestNoteHandler_Unarchive(t *testing.T) {
 		handler, mockService := newTestNoteHandler()
 		router := setupRouter()
 
-		router.PUT("/notes/:id/unarchive", handler.Unarchive)
+		router.PUT("/notes/:id/unarchive", func(c *gin.Context) {
+			c.Set("userID", uint(1))
+			handler.Unarchive(c)
+		})
 
-		mockService.On("Unarchive", uint(1)).Return(assert.AnError)
+		mockService.On("Unarchive", uint(1), uint(1)).Return(assert.AnError)
 
 		req, _ := http.NewRequest("PUT", "/notes/1/unarchive", nil)
 		w := httptest.NewRecorder()

--- a/backend/internal/handler/post_test.go
+++ b/backend/internal/handler/post_test.go
@@ -234,6 +234,9 @@ func TestPostLike_Success(t *testing.T) {
 	r := newRouter(1)
 	r.POST("/posts/:id/like", h.Like)
 
+	otherPost := &model.Post{UserID: 99}
+	otherPost.ID = 5
+	postRepo.On("FindByID", uint(5)).Return(otherPost, nil)
 	postRepo.On("Like", uint(1), uint(5)).Return(nil)
 
 	w := doRequest(r, http.MethodPost, "/posts/5/like", nil)
@@ -245,6 +248,9 @@ func TestPostUnlike_Success(t *testing.T) {
 	r := newRouter(1)
 	r.DELETE("/posts/:id/like", h.Unlike)
 
+	otherPost := &model.Post{UserID: 99}
+	otherPost.ID = 5
+	postRepo.On("FindByID", uint(5)).Return(otherPost, nil)
 	postRepo.On("Unlike", uint(1), uint(5)).Return(nil)
 
 	w := doRequest(r, http.MethodDelete, "/posts/5/like", nil)
@@ -311,7 +317,10 @@ func TestPostDeleteComment_Success(t *testing.T) {
 	r := newRouter(1)
 	r.DELETE("/posts/:id/comments/:commentId", h.DeleteComment)
 
-	postRepo.On("DeleteComment", uint(3), uint(1)).Return(nil)
+	comment := &model.Comment{UserID: 1}
+	comment.ID = 3
+	postRepo.On("FindCommentByID", uint(3)).Return(comment, nil)
+	postRepo.On("DeleteComment", uint(3)).Return(nil)
 
 	w := doRequest(r, http.MethodDelete, "/posts/5/comments/3", nil)
 	assertStatus(t, w, http.StatusOK)

--- a/backend/internal/handler/question_test.go
+++ b/backend/internal/handler/question_test.go
@@ -234,6 +234,9 @@ func TestQuestionVote_Success(t *testing.T) {
 	r := newRouter(1)
 	r.POST("/questions/:id/vote", h.Vote)
 
+	otherQuestion := &model.Question{UserID: 99}
+	otherQuestion.ID = 5
+	repo.On("FindByID", uint(5)).Return(otherQuestion, nil)
 	repo.On("Vote", uint(1), uint(5), 1).Return(nil)
 
 	w := doRequest(r, http.MethodPost, "/questions/5/vote", map[string]int{
@@ -259,6 +262,9 @@ func TestQuestionRemoveVote_Success(t *testing.T) {
 	r := newRouter(1)
 	r.DELETE("/questions/:id/vote", h.RemoveVote)
 
+	otherQuestion := &model.Question{UserID: 99}
+	otherQuestion.ID = 5
+	repo.On("FindByID", uint(5)).Return(otherQuestion, nil)
 	repo.On("RemoveVote", uint(1), uint(5)).Return(nil)
 
 	w := doRequest(r, http.MethodDelete, "/questions/5/vote", nil)

--- a/backend/internal/handler/study_circle_test.go
+++ b/backend/internal/handler/study_circle_test.go
@@ -190,6 +190,7 @@ func TestStudyCircleAddMember_Success(t *testing.T) {
 	r.POST("/study-circles/:id/members", h.AddMember)
 
 	repo.On("IsMember", uint(10), uint(1)).Return(true, nil)
+	repo.On("IsMember", uint(10), uint(5)).Return(false, nil)
 	repo.On("FindByID", uint(10)).Return(&model.StudyCircle{MaxMembers: 5, OwnerID: 1}, nil)
 	repo.On("GetMemberCount", uint(10)).Return(3, nil)
 	repo.On("AddMember", uint(10), uint(5), model.StudyCircleRoleMember).Return(nil)
@@ -206,6 +207,7 @@ func TestStudyCircleAddMember_LimitReached(t *testing.T) {
 	r.POST("/study-circles/:id/members", h.AddMember)
 
 	repo.On("IsMember", uint(10), uint(1)).Return(true, nil)
+	repo.On("IsMember", uint(10), uint(5)).Return(false, nil)
 	repo.On("FindByID", uint(10)).Return(&model.StudyCircle{MaxMembers: 5, OwnerID: 1}, nil)
 	repo.On("GetMemberCount", uint(10)).Return(5, nil)
 

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -107,8 +107,8 @@ func (m *MockPostRepository) GetComments(postID uint) ([]model.Comment, error) {
 	args := m.Called(postID)
 	return args.Get(0).([]model.Comment), args.Error(1)
 }
-func (m *MockPostRepository) DeleteComment(id, userID uint) error {
-	return m.Called(id, userID).Error(0)
+func (m *MockPostRepository) DeleteComment(id uint) error {
+	return m.Called(id).Error(0)
 }
 func (m *MockPostRepository) Bookmark(userID, postID uint) error {
 	return m.Called(userID, postID).Error(0)
@@ -218,6 +218,10 @@ func (m *MockCodeSnippetRepository) GetComments(snippetID uint) ([]model.Snippet
 func (m *MockCodeSnippetRepository) DeleteComment(id, userID uint) error {
 	return m.Called(id, userID).Error(0)
 }
+func (m *MockCodeSnippetRepository) FindByUserIDAndLanguage(userID uint, language string) ([]model.CodeSnippet, error) {
+	args := m.Called(userID, language)
+	return args.Get(0).([]model.CodeSnippet), args.Error(1)
+}
 
 // MockQuestionRepository は QuestionRepositoryInterface のモック実装。
 type MockQuestionRepository struct{ mock.Mock }
@@ -259,6 +263,10 @@ func (m *MockQuestionRepository) RemoveVote(userID, questionID uint) error {
 func (m *MockQuestionRepository) GetUserVote(userID, questionID uint) (int, error) {
 	args := m.Called(userID, questionID)
 	return args.Int(0), args.Error(1)
+}
+func (m *MockQuestionRepository) FindSolved(limit, offset int) ([]model.Question, int64, error) {
+	args := m.Called(limit, offset)
+	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
 }
 
 // MockLearningResourceRepository は LearningResourceRepositoryInterface のモック実装。
@@ -314,6 +322,10 @@ func (m *MockLearningResourceRepository) HasSaved(userID, resourceID uint) (bool
 }
 func (m *MockLearningResourceRepository) FindSavedByUserID(userID uint, limit, offset int) ([]model.LearningResource, int64, error) {
 	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.LearningResource), args.Get(1).(int64), args.Error(2)
+}
+func (m *MockLearningResourceRepository) FindByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error) {
+	args := m.Called(difficulty, limit, offset)
 	return args.Get(0).([]model.LearningResource), args.Get(1).(int64), args.Error(2)
 }
 
@@ -379,6 +391,10 @@ func (m *MockRoadmapRepository) ReorderSteps(roadmapID uint, stepOrders []model.
 }
 func (m *MockRoadmapRepository) GetTemplates() ([]model.Roadmap, error) {
 	args := m.Called()
+	return args.Get(0).([]model.Roadmap), args.Error(1)
+}
+func (m *MockRoadmapRepository) GetByStatus(userID uint, status string) ([]model.Roadmap, error) {
+	args := m.Called(userID, status)
 	return args.Get(0).([]model.Roadmap), args.Error(1)
 }
 
@@ -686,6 +702,10 @@ func (m *MockStudyCircleRepository) Search(query string, limit, offset int) (int
 	args := m.Called(query, limit, offset)
 	return args.Get(0), args.Get(1).(int64), args.Error(2)
 }
+func (m *MockStudyCircleRepository) GetByStatus(userID uint, status string) ([]model.StudyCircle, error) {
+	args := m.Called(userID, status)
+	return args.Get(0).([]model.StudyCircle), args.Error(1)
+}
 
 // setupStudyCircleHandler はStudyCircleHandlerテスト用のセットアップを行う。
 func setupStudyCircleHandler() (*StudyCircleHandler, *MockStudyCircleRepository) {
@@ -725,6 +745,10 @@ func (m *MockBookReviewService) Update(id, userID uint, updates *model.BookRevie
 }
 func (m *MockBookReviewService) Delete(id, userID uint) error {
 	return m.Called(id, userID).Error(0)
+}
+func (m *MockBookReviewService) GetByRating(userID uint, minRating, maxRating int) ([]model.BookReview, error) {
+	args := m.Called(userID, minRating, maxRating)
+	return args.Get(0).([]model.BookReview), args.Error(1)
 }
 
 // setupBookReviewHandler はBookReviewHandlerテスト用のセットアップを行う。
@@ -957,6 +981,10 @@ func (m *MockRoadmapService) DeleteStep(roadmapID, stepID, userID uint) error {
 func (m *MockRoadmapService) ReorderSteps(roadmapID, userID uint, orders []model.StepOrder) error {
 	return m.Called(roadmapID, userID, orders).Error(0)
 }
+func (m *MockRoadmapService) GetByStatus(userID uint, status string) ([]model.Roadmap, error) {
+	args := m.Called(userID, status)
+	return args.Get(0).([]model.Roadmap), args.Error(1)
+}
 
 // setupRoadmapHandlerMock はRoadmapHandlerテスト用のモックセットアップを行う。
 func setupRoadmapHandlerMock() (*RoadmapHandler, *MockRoadmapService) {
@@ -1105,6 +1133,10 @@ func (m *MockAIAdviceService) GetConversation(id, userID uint) (*model.AIConvers
 	}
 	return nil, args.Error(1)
 }
+func (m *MockAIAdviceService) GetUnreadAdvice(userID uint) ([]model.AIAdvice, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.AIAdvice), args.Error(1)
+}
 
 // setupAIAdviceHandler はAIAdviceHandlerテスト用のセットアップを行う。
 func setupAIAdviceHandler() (*AIAdviceHandler, *MockAIAdviceService) {
@@ -1252,6 +1284,14 @@ func (m *MockLearningLogService) ExportCSV(userID uint, days int) ([]byte, error
 		return nil, args.Error(1)
 	}
 	return args.Get(0).([]byte), args.Error(1)
+}
+func (m *MockLearningLogService) GetByCategory(userID uint, category string) ([]model.LearningLog, error) {
+	args := m.Called(userID, category)
+	return args.Get(0).([]model.LearningLog), args.Error(1)
+}
+func (m *MockLearningLogService) GetBySource(userID uint, source string) ([]model.LearningLog, error) {
+	args := m.Called(userID, source)
+	return args.Get(0).([]model.LearningLog), args.Error(1)
 }
 
 // setupLearningLogHandler はLearningLogHandlerテスト用のセットアップを行う。
@@ -1595,6 +1635,10 @@ func (m *MockCodeSnippetHandlerService) CreateComment(comment *model.SnippetComm
 func (m *MockCodeSnippetHandlerService) DeleteComment(id, userID uint) error {
 	return m.Called(id, userID).Error(0)
 }
+func (m *MockCodeSnippetHandlerService) GetByUserLanguage(userID uint, language string) ([]model.CodeSnippet, error) {
+	args := m.Called(userID, language)
+	return args.Get(0).([]model.CodeSnippet), args.Error(1)
+}
 
 // setupCodeSnippetHandler はCodeSnippetHandlerテスト用のセットアップを行う。
 func setupCodeSnippetHandler() (*CodeSnippetHandler, *MockCodeSnippetHandlerService) {
@@ -1608,8 +1652,8 @@ func setupCodeSnippetHandler() (*CodeSnippetHandler, *MockCodeSnippetHandlerServ
 // MockNoteLinkService は NoteLinkServiceInterface のモック実装。
 type MockNoteLinkService struct{ mock.Mock }
 
-func (m *MockNoteLinkService) CreateLink(sourceNoteID, targetNoteID uint) error {
-	return m.Called(sourceNoteID, targetNoteID).Error(0)
+func (m *MockNoteLinkService) CreateLink(sourceNoteID, targetNoteID, userID uint) error {
+	return m.Called(sourceNoteID, targetNoteID, userID).Error(0)
 }
 func (m *MockNoteLinkService) GetLinks(sourceNoteID uint) ([]model.NoteLink, error) {
 	args := m.Called(sourceNoteID)
@@ -1619,8 +1663,8 @@ func (m *MockNoteLinkService) GetBacklinks(targetNoteID uint) ([]model.NoteLink,
 	args := m.Called(targetNoteID)
 	return args.Get(0).([]model.NoteLink), args.Error(1)
 }
-func (m *MockNoteLinkService) DeleteLink(sourceNoteID, targetNoteID uint) error {
-	return m.Called(sourceNoteID, targetNoteID).Error(0)
+func (m *MockNoteLinkService) DeleteLink(sourceNoteID, targetNoteID, userID uint) error {
+	return m.Called(sourceNoteID, targetNoteID, userID).Error(0)
 }
 
 func setupNoteLinkHandler() (*NoteLinkHandler, *MockNoteLinkService) {


### PR DESCRIPTION
## 概要
過去の複数サイクルでService/Repository層にメソッド追加やシグネチャ変更を行った際、Handler層テストのモック定義が追従していなかったため、Handler層テスト全体がコンパイルエラーでビルド不可になっていた問題を修正。

## 変更内容
### モック定義追加・修正（testutil_test.go）
- 12個の不足モックメソッド追加（GetByRating, GetByStatus, GetUnreadAdvice等）
- 4個のシグネチャ修正（CreateLink/DeleteLink/DeleteComment等）

### テストファイル修正
- **learning_goal_test.go**: GetByCategory/GetByStatus追加
- **note_test.go**: Delete/ToggleFavorite/Archive/Unarchiveのシグネチャ修正+userIDコンテキスト設定
- **chat_room_test.go/study_circle_test.go**: AddMemberの重複チェック用IsMemberモック追加
- **learning_resource_test.go/post_test.go/question_test.go**: 自己アクション防止チェック用FindByIDモック追加
- **note_link_test.go**: CreateLink/DeleteLinkのuserIDパラメータ追加

## テスト結果
- Handler層: 599テスト全PASS
- Service層: 全テストPASS

Closes #953