### PR TITLE
fix: ChatRoomServiceの空白のみ入力バリデーション追加 (#955)

### DIFF
--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"encoding/json"
+	"strings"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -22,6 +24,9 @@ func NewChatRoomService(roomRepo repository.ChatRoomRepositoryInterface, message
 
 // Create は新しいチャットルームを作成し、オーナーと指定メンバーを追加する。
 func (s *ChatRoomService) Create(room *model.ChatRoom, memberIDs []uint) (*model.ChatRoom, error) {
+	if strings.TrimSpace(room.Name) == "" {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "チャットルーム名は空白のみでは入力できません", nil)
+	}
 	if err := s.roomRepo.Create(room); err != nil {
 		return nil, err
 	}
@@ -88,7 +93,13 @@ func (s *ChatRoomService) Update(roomID, userID uint, name, description string) 
 	}
 
 	if name != "" {
+		if strings.TrimSpace(name) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "チャットルーム名は空白のみでは入力できません", nil)
+		}
 		room.Name = name
+	}
+	if description != "" && strings.TrimSpace(description) == "" {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "説明は空白のみでは入力できません", nil)
 	}
 	room.Description = description
 

--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -555,3 +555,42 @@ func TestChatRoomRemoveMember_NotFound(t *testing.T) {
 	err := svc.RemoveMember(99, 1, 2)
 	assert.Error(t, err)
 }
+
+// ============================================================
+// 空白のみ入力バリデーションテスト
+// ============================================================
+
+func TestChatRoomCreate_WhitespaceName(t *testing.T) {
+	svc, _, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{Name: "   ", OwnerID: 1}
+	_, err := svc.Create(room, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "空白のみ")
+}
+
+func TestChatRoomUpdate_WhitespaceName(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{Name: "Room", OwnerID: 1}
+	room.ID = 10
+	roomRepo.On("FindByID", uint(10)).Return(room, nil)
+
+	result, err := svc.Update(10, 1, "   ", "Valid description")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "空白のみ")
+}
+
+func TestChatRoomUpdate_WhitespaceDescription(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{Name: "Room", OwnerID: 1}
+	room.ID = 10
+	roomRepo.On("FindByID", uint(10)).Return(room, nil)
+
+	result, err := svc.Update(10, 1, "New Name", "   \t  ")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "空白のみ")
+}


### PR DESCRIPTION
## 概要
ChatRoomServiceのCreate/Updateメソッドで空白のみのチャットルーム名・説明が入力可能だった問題を修正。

## 変更内容
- **Create**: `strings.TrimSpace(room.Name)` による空白のみNameチェック追加
- **Update**: name/descriptionの空白のみ入力バリデーション追加
- **テスト**: 3ケース追加（Create空白Name、Update空白Name、Update空白Description）

## テスト結果
- ChatRoom関連: 40テスト全PASS
- Service層全体: 全PASS
- Handler層全体: 599テスト全PASS

Closes #955