### PR TITLE
feat: 回答の投票スコア範囲フィルタリング機能を追加

### DIFF
--- a/backend/internal/handler/answer.go
+++ b/backend/internal/handler/answer.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"strconv"
+
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
@@ -16,6 +18,7 @@ type AnswerServiceInterface interface {
 	SetBestAnswer(questionID, answerID, userID uint) error
 	Vote(userID, answerID uint, value int) error
 	RemoveVote(userID, answerID uint) error
+	GetByVoteRange(questionID uint, minVote, maxVote int) ([]model.Answer, error)
 }
 
 // AnswerHandler は回答関連のHTTPハンドラ。
@@ -161,6 +164,36 @@ func (h *AnswerHandler) Vote(c *gin.Context) {
 	}
 
 	respondOK(c, domain.NewMessageResponse("Voted successfully"))
+}
+
+// GetByVoteRange は指定質問の回答を投票スコア範囲でフィルタリングして取得する。
+func (h *AnswerHandler) GetByVoteRange(c *gin.Context) {
+	questionID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	minVoteStr := c.DefaultQuery("min_vote", "0")
+	maxVoteStr := c.DefaultQuery("max_vote", "100")
+
+	minVote, err := strconv.Atoi(minVoteStr)
+	if err != nil {
+		respondError(c, domain.NewError(domain.ErrCodeBadRequest, "min_voteは数値で指定してください", nil))
+		return
+	}
+	maxVote, err := strconv.Atoi(maxVoteStr)
+	if err != nil {
+		respondError(c, domain.NewError(domain.ErrCodeBadRequest, "max_voteは数値で指定してください", nil))
+		return
+	}
+
+	answers, err := h.service.GetByVoteRange(questionID, minVote, maxVote)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, answers)
 }
 
 // RemoveVote は回答への投票を取り消す。

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -787,6 +787,10 @@ func (m *MockAnswerService) Vote(userID, answerID uint, value int) error {
 func (m *MockAnswerService) RemoveVote(userID, answerID uint) error {
 	return m.Called(userID, answerID).Error(0)
 }
+func (m *MockAnswerService) GetByVoteRange(questionID uint, minVote, maxVote int) ([]model.Answer, error) {
+	args := m.Called(questionID, minVote, maxVote)
+	return args.Get(0).([]model.Answer), args.Error(1)
+}
 
 // setupAnswerHandler はAnswerHandlerテスト用のセットアップを行う。
 func setupAnswerHandler() (*AnswerHandler, *MockAnswerService) {

--- a/backend/internal/repository/answer.go
+++ b/backend/internal/repository/answer.go
@@ -125,6 +125,16 @@ func (r *AnswerRepository) RemoveVote(userID, answerID uint) error {
 		UpdateColumn("vote_count", gorm.Expr("vote_count - ?", oldValue)).Error
 }
 
+// FindByVoteRange は指定質問の回答を投票スコア範囲でフィルタリングして取得する。
+func (r *AnswerRepository) FindByVoteRange(questionID uint, minVote, maxVote int) ([]model.Answer, error) {
+	var answers []model.Answer
+	err := r.db.Preload("User").
+		Where("question_id = ? AND vote_count >= ? AND vote_count <= ?", questionID, minVote, maxVote).
+		Order("vote_count DESC, created_at ASC").
+		Find(&answers).Error
+	return answers, err
+}
+
 // GetUserVotes は指定ユーザーの複数回答への投票値をマップで取得する。
 func (r *AnswerRepository) GetUserVotes(userID uint, answerIDs []uint) (map[uint]int, error) {
 	var votes []model.AnswerVote

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -140,6 +140,7 @@ type AnswerRepositoryInterface interface {
 	Vote(userID, answerID uint, value int) error
 	RemoveVote(userID, answerID uint) error
 	GetUserVotes(userID uint, answerIDs []uint) (map[uint]int, error)
+	FindByVoteRange(questionID uint, minVote, maxVote int) ([]model.Answer, error)
 }
 
 // LearningLogRepositoryInterface は学習ログデータ操作の契約を定義する。

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -451,6 +451,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		questions.GET("/user/:userId", c.QuestionHandler.GetByUserID)
 
 		questions.GET("/:id/answers", c.AnswerHandler.GetByQuestionID)
+		questions.GET("/:id/answers/vote-range", c.AnswerHandler.GetByVoteRange)
 		questions.POST("/:id/answers", c.AnswerHandler.Create)
 		questions.PUT("/:id/answers/:answerId", c.AnswerHandler.Update)
 		questions.DELETE("/:id/answers/:answerId", c.AnswerHandler.Delete)

--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -132,3 +132,11 @@ func (s *AnswerService) RemoveVote(userID, answerID uint) error {
 func (s *AnswerService) GetUserVotes(userID uint, answerIDs []uint) (map[uint]int, error) {
 	return s.answerRepo.GetUserVotes(userID, answerIDs)
 }
+
+// GetByVoteRange は指定質問の回答を投票スコア範囲でフィルタリングして取得する。
+func (s *AnswerService) GetByVoteRange(questionID uint, minVote, maxVote int) ([]model.Answer, error) {
+	if minVote > maxVote {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "投票範囲が無効です", nil)
+	}
+	return s.answerRepo.FindByVoteRange(questionID, minVote, maxVote)
+}

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -473,3 +473,57 @@ func TestAnswerVote_ValidDownvote(t *testing.T) {
 	assert.NoError(t, err)
 	answerRepo.AssertExpectations(t)
 }
+
+// ============================================================
+// 投票範囲による回答取得テスト
+// ============================================================
+
+func TestAnswerGetByVoteRange_Success(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	expected := []model.Answer{
+		{Body: "高評価回答", QuestionID: 10, VoteCount: 5},
+		{Body: "中評価回答", QuestionID: 10, VoteCount: 3},
+	}
+	answerRepo.On("FindByVoteRange", uint(10), 3, 10).Return(expected, nil)
+
+	result, err := svc.GetByVoteRange(10, 3, 10)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	answerRepo.AssertExpectations(t)
+}
+
+func TestAnswerGetByVoteRange_InvalidRange(t *testing.T) {
+	svc, _, _ := newTestAnswerService()
+
+	// minVote > maxVote
+	result, err := svc.GetByVoteRange(10, 10, 3)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "投票範囲が無効です")
+}
+
+func TestAnswerGetByVoteRange_NegativeRange(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	expected := []model.Answer{
+		{Body: "低評価回答", QuestionID: 10, VoteCount: -2},
+	}
+	answerRepo.On("FindByVoteRange", uint(10), -5, 0).Return(expected, nil)
+
+	result, err := svc.GetByVoteRange(10, -5, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	answerRepo.AssertExpectations(t)
+}
+
+func TestAnswerGetByVoteRange_RepoError(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answerRepo.On("FindByVoteRange", uint(10), 0, 5).Return([]model.Answer(nil), errors.New("db error"))
+
+	result, err := svc.GetByVoteRange(10, 0, 5)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	answerRepo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -453,6 +453,11 @@ func (m *MockAnswerRepository) GetUserVotes(userID uint, answerIDs []uint) (map[
 	return args.Get(0).(map[uint]int), args.Error(1)
 }
 
+func (m *MockAnswerRepository) FindByVoteRange(questionID uint, minVote, maxVote int) ([]model.Answer, error) {
+	args := m.Called(questionID, minVote, maxVote)
+	return args.Get(0).([]model.Answer), args.Error(1)
+}
+
 // ============================================================
 // MockLearningLogRepository は repository.LearningLogRepositoryInterface のテスト用モック実装。
 // ============================================================


### PR DESCRIPTION
## 概要
質問の回答を投票スコア範囲でフィルタリングして取得する機能を追加。

## 変更内容
- AnswerService.GetByVoteRange: min/maxバリデーション付きフィルタリング
- AnswerRepository.FindByVoteRange: vote_count範囲でのDBクエリ
- AnswerHandler.GetByVoteRange: クエリパラメータ（min_vote, max_vote）によるフィルタ
- GET /api/questions/:id/answers/vote-range ルート追加

## テスト
- TDDアプローチで4テスト先行作成（Success, InvalidRange, NegativeRange, RepoError）
- 全テストPASS

closes #957