### PR TITLE
refactor: Service層のID必須バリデーションをvalidateRequiredIDヘルパーに統一

### DIFF
--- a/backend/internal/service/book_review_stats.go
+++ b/backend/internal/service/book_review_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewBookReviewStatsService(repo repository.BookReviewStatsRepositoryInterfac
 
 // GetBookReviewStats は指定ユーザーの書籍レビュー集計統計を取得する。
 func (s *BookReviewStatsService) GetBookReviewStats(userID uint) (*model.BookReviewStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetBookReviewStats(userID)
 }

--- a/backend/internal/service/bookmark_stats.go
+++ b/backend/internal/service/bookmark_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewBookmarkStatsService(repo repository.BookmarkStatsRepositoryInterface) *
 
 // GetBookmarkStats は指定ユーザーのブックマーク集計統計を取得する。
 func (s *BookmarkStatsService) GetBookmarkStats(userID uint) (*model.BookmarkStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetBookmarkStats(userID)
 }

--- a/backend/internal/service/code_snippet_stats.go
+++ b/backend/internal/service/code_snippet_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewCodeSnippetStatsService(repo repository.CodeSnippetStatsRepositoryInterf
 
 // GetCodeSnippetStats は指定ユーザーのコードスニペット活動集計統計を取得する。
 func (s *CodeSnippetStatsService) GetCodeSnippetStats(userID uint) (*model.CodeSnippetStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetCodeSnippetStats(userID)
 }

--- a/backend/internal/service/comment_stats.go
+++ b/backend/internal/service/comment_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewCommentStatsService(repo repository.CommentStatsRepositoryInterface) *Co
 
 // GetCommentStats は指定ユーザーのコメント活動集計統計を取得する。
 func (s *CommentStatsService) GetCommentStats(userID uint) (*model.CommentStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetCommentStats(userID)
 }

--- a/backend/internal/service/errors.go
+++ b/backend/internal/service/errors.go
@@ -16,3 +16,12 @@ var (
 	ErrRateLimitExceeded = domain.ErrRateLimitExceeded // レート制限超過（429）
 	ErrLLMNotConfigured  = domain.ErrServiceUnavailable // LLM未設定（503）
 )
+
+// validateRequiredID はIDが0でないことを検証する。
+// 0の場合はBadRequestエラーを返す。
+func validateRequiredID(id uint, name string) error {
+	if id == 0 {
+		return domain.NewError(domain.ErrCodeBadRequest, name+"は必須です", nil)
+	}
+	return nil
+}

--- a/backend/internal/service/follow_stats.go
+++ b/backend/internal/service/follow_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewFollowStatsService(repo repository.FollowStatsRepositoryInterface) *Foll
 
 // GetFollowStats は指定ユーザーのフォロー関係集計統計を取得する。
 func (s *FollowStatsService) GetFollowStats(userID uint) (*model.FollowStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetFollowStats(userID)
 }

--- a/backend/internal/service/learning_log_stats.go
+++ b/backend/internal/service/learning_log_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewLearningLogStatsService(repo repository.LearningLogStatsRepositoryInterf
 
 // GetLearningLogStats は指定ユーザーの学習ログ集計統計を取得する。
 func (s *LearningLogStatsService) GetLearningLogStats(userID uint) (*model.LearningLogStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetLearningLogStats(userID)
 }

--- a/backend/internal/service/learning_resource_stats.go
+++ b/backend/internal/service/learning_resource_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewLearningResourceStatsService(repo repository.LearningResourceStatsReposi
 
 // GetLearningResourceStats は指定ユーザーの学習リソース活動集計統計を取得する。
 func (s *LearningResourceStatsService) GetLearningResourceStats(userID uint) (*model.LearningResourceStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetLearningResourceStats(userID)
 }

--- a/backend/internal/service/mention_stats.go
+++ b/backend/internal/service/mention_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewMentionStatsService(repo repository.MentionStatsRepositoryInterface) *Me
 
 // GetMentionStats は指定ユーザーのメンション集計統計を取得する。
 func (s *MentionStatsService) GetMentionStats(userID uint) (*model.MentionStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetMentionStats(userID)
 }

--- a/backend/internal/service/message_stats.go
+++ b/backend/internal/service/message_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewMessageStatsService(repo repository.MessageStatsRepositoryInterface) *Me
 
 // GetMessageStats は指定ユーザーのメッセージ集計統計を取得する。
 func (s *MessageStatsService) GetMessageStats(userID uint) (*model.MessageStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetMessageStats(userID)
 }

--- a/backend/internal/service/note_stats.go
+++ b/backend/internal/service/note_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewNoteStatsService(repo repository.NoteStatsRepositoryInterface) *NoteStat
 
 // GetNoteStats は指定ユーザーのノート集計統計を返す。
 func (s *NoteStatsService) GetNoteStats(userID uint) (*model.NoteStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetNoteStats(userID)
 }

--- a/backend/internal/service/notification_stats.go
+++ b/backend/internal/service/notification_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewNotificationStatsService(repo repository.NotificationStatsRepositoryInte
 
 // GetNotificationStats は指定ユーザーの通知集計統計を取得する。
 func (s *NotificationStatsService) GetNotificationStats(userID uint) (*model.NotificationStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetNotificationStats(userID)
 }

--- a/backend/internal/service/post_stats.go
+++ b/backend/internal/service/post_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewPostStatsService(repo repository.PostStatsRepositoryInterface) *PostStat
 
 // GetPostStats は指定ユーザーの投稿集計統計を取得する。
 func (s *PostStatsService) GetPostStats(userID uint) (*model.PostStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetPostStats(userID)
 }

--- a/backend/internal/service/post_view.go
+++ b/backend/internal/service/post_view.go
@@ -19,11 +19,11 @@ func NewPostViewService(repo repository.PostViewRepositoryInterface) *PostViewSe
 // RecordView はユーザーの投稿閲覧を記録する。
 // 既に閲覧済みの場合は何もしない（ユニーク閲覧のみカウント）。
 func (s *PostViewService) RecordView(userID, postID uint) error {
-	if userID == 0 {
-		return domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return err
 	}
-	if postID == 0 {
-		return domain.NewError(domain.ErrCodeBadRequest, "postIDは必須です", nil)
+	if err := validateRequiredID(postID, "postID"); err != nil {
+		return err
 	}
 	viewed, err := s.repo.HasViewed(userID, postID)
 	if err != nil {
@@ -40,19 +40,19 @@ func (s *PostViewService) RecordView(userID, postID uint) error {
 
 // GetViewCount は投稿のユニーク閲覧数を取得する。
 func (s *PostViewService) GetViewCount(postID uint) (int64, error) {
-	if postID == 0 {
-		return 0, domain.NewError(domain.ErrCodeBadRequest, "postIDは必須です", nil)
+	if err := validateRequiredID(postID, "postID"); err != nil {
+		return 0, err
 	}
 	return s.repo.GetViewCount(postID)
 }
 
 // HasViewed はユーザーが投稿を閲覧済みかどうかを判定する。
 func (s *PostViewService) HasViewed(userID, postID uint) (bool, error) {
-	if userID == 0 {
-		return false, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return false, err
 	}
-	if postID == 0 {
-		return false, domain.NewError(domain.ErrCodeBadRequest, "postIDは必須です", nil)
+	if err := validateRequiredID(postID, "postID"); err != nil {
+		return false, err
 	}
 	return s.repo.HasViewed(userID, postID)
 }

--- a/backend/internal/service/project_stats.go
+++ b/backend/internal/service/project_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewProjectStatsService(repo repository.ProjectStatsRepositoryInterface) *Pr
 
 // GetProjectStats は指定ユーザーのプロジェクト活動集計統計を取得する。
 func (s *ProjectStatsService) GetProjectStats(userID uint) (*model.ProjectStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetProjectStats(userID)
 }

--- a/backend/internal/service/qa_stats.go
+++ b/backend/internal/service/qa_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewQAStatsService(repo repository.QAStatsRepositoryInterface) *QAStatsServi
 
 // GetQAStats は指定ユーザーのQ&A活動集計統計を取得する。
 func (s *QAStatsService) GetQAStats(userID uint) (*model.QAStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetQAStats(userID)
 }

--- a/backend/internal/service/reaction_stats.go
+++ b/backend/internal/service/reaction_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewReactionStatsService(repo repository.ReactionStatsRepositoryInterface) *
 
 // GetReactionStats は指定ユーザーのリアクション集計統計を取得する。
 func (s *ReactionStatsService) GetReactionStats(userID uint) (*model.ReactionStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetReactionStats(userID)
 }

--- a/backend/internal/service/roadmap_stats.go
+++ b/backend/internal/service/roadmap_stats.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -18,8 +17,8 @@ func NewRoadmapStatsService(repo repository.RoadmapStatsRepositoryInterface) *Ro
 
 // GetRoadmapStats は指定ユーザーのロードマップ統計を取得する。
 func (s *RoadmapStatsService) GetRoadmapStats(userID uint) (*model.RoadmapStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetRoadmapStats(userID)
 }

--- a/backend/internal/service/user_dashboard.go
+++ b/backend/internal/service/user_dashboard.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -19,8 +18,8 @@ func NewUserDashboardService(repo repository.UserDashboardRepositoryInterface) *
 // GetStats は指定ユーザーのダッシュボード統計情報を取得する。
 // userID=0 の場合はBadRequestエラーを返す。
 func (s *UserDashboardService) GetStats(userID uint) (*model.UserDashboardStats, error) {
-	if userID == 0 {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "userIDは必須です", nil)
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
 	}
 	return s.repo.GetDashboardStats(userID)
 }


### PR DESCRIPTION
## 概要
18ファイル・22箇所で重複していた`if userID == 0`バリデーションパターンを`validateRequiredID`共通ヘルパーに統一。

## 変更内容
- `errors.go`に`validateRequiredID(id uint, name string) error`ヘルパー追加
- 16個のStats系サービス + user_dashboard + post_viewの計18ファイルを置換
- 17ファイルから不要な`domain`パッケージimportを削除
- 19ファイル変更、53行追加、61行削除（ネット-8行）

## テスト
- 全Service層テストPASS（既存テストで動作保証）

closes #959