### PR TITLE
test: validateRequiredIDヘルパーとDeleteAccountエラーケースのテスト追加

### DIFF
--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -311,6 +311,22 @@ func TestDeleteAccount_PasswordRequired(t *testing.T) {
 	userRepo.AssertExpectations(t)
 }
 
+func TestDeleteAccount_DeleteWithRelatedDataError(t *testing.T) {
+	svc, userRepo, _ := newTestAuthService()
+
+	hashed, _ := bcrypt.GenerateFromPassword([]byte("password123"), bcrypt.DefaultCost)
+	user := &model.User{Name: "Test", Email: "test@example.com", Password: string(hashed)}
+	user.ID = 1
+
+	userRepo.On("FindByID", uint(1)).Return(user, nil)
+	userRepo.On("DeleteWithRelatedData", uint(1)).Return(errors.New("db error"))
+
+	err := svc.DeleteAccount(1, "password123")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+	userRepo.AssertExpectations(t)
+}
+
 // ============================================================
 // ユーザー情報取得テスト
 // ============================================================

--- a/backend/internal/service/errors_test.go
+++ b/backend/internal/service/errors_test.go
@@ -1,0 +1,38 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/stretchr/testify/assert"
+)
+
+// ============================================================
+// validateRequiredID テスト
+// ============================================================
+
+func TestValidateRequiredID_ValidID(t *testing.T) {
+	err := validateRequiredID(1, "userID")
+	assert.NoError(t, err)
+}
+
+func TestValidateRequiredID_LargeID(t *testing.T) {
+	err := validateRequiredID(999999, "postID")
+	assert.NoError(t, err)
+}
+
+func TestValidateRequiredID_ZeroID(t *testing.T) {
+	err := validateRequiredID(0, "userID")
+	assert.Error(t, err)
+
+	var domainErr *domain.DomainError
+	assert.ErrorAs(t, err, &domainErr)
+	assert.Equal(t, domain.ErrCodeBadRequest, domainErr.Code)
+	assert.Contains(t, domainErr.Message, "userIDは必須です")
+}
+
+func TestValidateRequiredID_ZeroID_PostID(t *testing.T) {
+	err := validateRequiredID(0, "postID")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "postIDは必須です")
+}


### PR DESCRIPTION
## 概要
Cycle 198で追加したvalidateRequiredIDヘルパーのユニットテストと、AuthService.DeleteAccountの未テスト分岐のテストを追加。

## 変更内容
- `errors_test.go`新規作成: validateRequiredIDの4テスト
- `auth_test.go`: DeleteAccount_DeleteWithRelatedDataError追加

## テスト
- 全5テストPASS

closes #961