### PR TITLE
fix: PostCollectionService.Createで空白のみタイトルを拒否

### DIFF
--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -21,7 +21,7 @@ func NewPostCollectionService(repo repository.PostCollectionRepositoryInterface)
 
 // Create は新しい投稿コレクションを作成する。
 func (s *PostCollectionService) Create(collection *model.PostCollection) (*model.PostCollection, error) {
-	if collection.Title == "" {
+	if strings.TrimSpace(collection.Title) == "" {
 		return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは必須です", nil)
 	}
 	if err := s.repo.Create(collection); err != nil {

--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -55,6 +55,20 @@ func TestPostCollectionCreate_EmptyTitle(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestPostCollectionCreate_WhitespaceTitle(t *testing.T) {
+	svc, _ := newTestPostCollectionService()
+
+	collection := &model.PostCollection{
+		UserID: 1,
+		Title:  "   \t\n  ",
+	}
+
+	result, err := svc.Create(collection)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトルは必須です")
+}
+
 func TestPostCollectionCreate_RepoError(t *testing.T) {
 	svc, repo := newTestPostCollectionService()
 


### PR DESCRIPTION
## 概要
PostCollectionService.Create()で空白文字のみのタイトルがバリデーションを通過する問題を修正。

## 変更内容
- `collection.Title == ""` → `strings.TrimSpace(collection.Title) == ""` に変更
- WhitespaceTitleテスト追加（TDDアプローチ）

## テスト
- 全28 PostCollectionテストPASS

closes #963