### PR TITLE
feat: 投稿の非公開化（Unpublish）機能追加

### DIFF
--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -25,6 +25,7 @@ type PostServiceInterface interface {
 	GetReplies(parentID uint) ([]model.Comment, error)
 	DeleteComment(id, userID uint) error
 	Publish(id, userID uint) (*model.Post, error)
+	Unpublish(id, userID uint) (*model.Post, error)
 	Bookmark(userID, postID uint) error
 	Unbookmark(userID, postID uint) error
 	HasBookmarked(userID, postID uint) bool
@@ -310,6 +311,22 @@ func (h *PostHandler) Publish(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	post, err := h.service.Publish(id, userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, post)
+}
+
+// Unpublish は公開済みの投稿を下書きに戻す。所有者のみ操作可能。
+func (h *PostHandler) Unpublish(c *gin.Context) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	post, err := h.service.Unpublish(id, userID)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -157,6 +157,7 @@ func registerPostRoutes(g *gin.RouterGroup, c *di.Container) {
 		posts.GET("/:id", c.PostHandler.GetByID)
 		posts.PUT("/:id", c.PostHandler.Update)
 		posts.PUT("/:id/publish", c.PostHandler.Publish)
+		posts.PUT("/:id/unpublish", c.PostHandler.Unpublish)
 		posts.DELETE("/:id", c.PostHandler.Delete)
 		posts.POST("/:id/like", c.PostHandler.Like)
 		posts.DELETE("/:id/like", c.PostHandler.Unlike)

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -310,3 +310,22 @@ func (s *PostService) Publish(id, userID uint) (*model.Post, error) {
 
 	return post, nil
 }
+
+// Unpublish は公開済みの投稿を下書きに戻す。
+// 既に下書きの場合はBadRequestエラーを返す。
+func (s *PostService) Unpublish(id, userID uint) (*model.Post, error) {
+	post, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
+	}
+	if post.IsDraft {
+		return nil, ErrBadRequest
+	}
+
+	post.IsDraft = true
+	if err := s.repo.Update(post); err != nil {
+		return nil, err
+	}
+
+	return post, nil
+}

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -577,6 +577,60 @@ func TestPostPublish_UpdateError(t *testing.T) {
 }
 
 // ============================================================
+// 投稿非公開化（Unpublish）テスト
+// ============================================================
+
+func TestPostUnpublish_Success(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	published := &model.Post{Title: "Published Post", UserID: 1, IsDraft: false}
+	published.ID = 1
+
+	postRepo.On("FindByID", uint(1)).Return(published, nil)
+	postRepo.On("Update", published).Return(nil)
+
+	result, err := svc.Unpublish(1, 1)
+	assert.NoError(t, err)
+	assert.True(t, result.IsDraft)
+}
+
+func TestPostUnpublish_AlreadyDraft(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	draft := &model.Post{Title: "Draft", UserID: 1, IsDraft: true}
+	draft.ID = 1
+
+	postRepo.On("FindByID", uint(1)).Return(draft, nil)
+
+	result, err := svc.Unpublish(1, 1)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Nil(t, result)
+}
+
+func TestPostUnpublish_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	published := &model.Post{Title: "Published", UserID: 1, IsDraft: false}
+	published.ID = 1
+
+	postRepo.On("FindByID", uint(1)).Return(published, nil)
+
+	result, err := svc.Unpublish(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
+	assert.Nil(t, result)
+}
+
+func TestPostUnpublish_NotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	result, err := svc.Unpublish(99, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// ============================================================
 // 投稿作成 追加テスト
 // ============================================================
 


### PR DESCRIPTION
## 概要
公開済みの投稿を下書きに戻す `Unpublish` 機能をTDDで実装。

## 変更内容
- `PostService.Unpublish()`: 所有権チェック付きで公開済み投稿を下書きに変更
- 既に下書きの投稿に対してはBadRequestエラーを返す
- `PUT /api/posts/:id/unpublish` エンドポイント追加
- `PostServiceInterface` に `Unpublish` メソッド追加

## テスト
- Service層4テスト（Success / AlreadyDraft / Forbidden / NotFound）

Closes #965