### PR TITLE
refactor: Handler層のShouldBindJSONをbindJSON[T]ヘルパーに統一

### DIFF
--- a/backend/internal/handler/badge.go
+++ b/backend/internal/handler/badge.go
@@ -44,13 +44,12 @@ func (h *BadgeHandler) GetUserBadges(c *gin.Context) {
 func (h *BadgeHandler) NotifyBadgeEarned(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req dto.NotifyBadgeEarnedRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "badge_id is required")
+	input := bindJSON[dto.NotifyBadgeEarnedRequest](c)
+	if input == nil {
 		return
 	}
 
-	if err := h.service.NotifyBadgeEarned(userID, req.BadgeID); err != nil {
+	if err := h.service.NotifyBadgeEarned(userID, input.BadgeID); err != nil {
 		respondError(c, err)
 		return
 	}

--- a/backend/internal/handler/email_preferences.go
+++ b/backend/internal/handler/email_preferences.go
@@ -43,9 +43,8 @@ func (h *EmailPreferencesHandler) GetPreferences(c *gin.Context) {
 func (h *EmailPreferencesHandler) UpdatePreferences(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req dto.UpdateEmailPreferencesRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "invalid request")
+	input := bindJSON[dto.UpdateEmailPreferencesRequest](c)
+	if input == nil {
 		return
 	}
 
@@ -55,20 +54,20 @@ func (h *EmailPreferencesHandler) UpdatePreferences(c *gin.Context) {
 		return
 	}
 
-	if req.EmailWeeklyReport != nil {
-		user.EmailWeeklyReport = *req.EmailWeeklyReport
+	if input.EmailWeeklyReport != nil {
+		user.EmailWeeklyReport = *input.EmailWeeklyReport
 	}
-	if req.EmailLanguage != nil {
+	if input.EmailLanguage != nil {
 		// 言語バリデーション
 		validLangs := map[string]bool{
 			"ja": true, "en": true, "ko": true, "zh-CN": true, "zh-TW": true,
 			"es": true, "fr": true, "de": true, "pt": true, "ru": true,
 		}
-		if !validLangs[*req.EmailLanguage] {
+		if !validLangs[*input.EmailLanguage] {
 			respondBadRequest(c, "invalid email language")
 			return
 		}
-		user.EmailLanguage = *req.EmailLanguage
+		user.EmailLanguage = *input.EmailLanguage
 	}
 
 	if err := h.userService.Update(user); err != nil {

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -39,23 +39,22 @@ func NewLearningLogHandler(s LearningLogServiceInterface) *LearningLogHandler {
 func (h *LearningLogHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req dto.CreateLearningLogRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "title and content are required")
+	input := bindJSON[dto.CreateLearningLogRequest](c)
+	if input == nil {
 		return
 	}
 
 	log := &model.LearningLog{
 		UserID:   userID,
-		Title:    req.Title,
-		Content:  req.Content,
-		Category: model.LogCategory(req.Category),
-		Duration: req.Duration,
-		Source:   model.LogSource(req.Source),
+		Title:    input.Title,
+		Content:  input.Content,
+		Category: model.LogCategory(input.Category),
+		Duration: input.Duration,
+		Source:   model.LogSource(input.Source),
 	}
 
 	// カテゴリが未指定の場合はデフォルト値を設定
-	if req.Category == "" {
+	if input.Category == "" {
 		log.Category = model.LogCategoryOther
 	}
 
@@ -75,24 +74,23 @@ func (h *LearningLogHandler) Update(c *gin.Context) {
 		return
 	}
 
-	var req dto.UpdateLearningLogRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "invalid request")
+	input := bindJSON[dto.UpdateLearningLogRequest](c)
+	if input == nil {
 		return
 	}
 
 	updates := &model.LearningLog{}
-	if req.Title != nil {
-		updates.Title = *req.Title
+	if input.Title != nil {
+		updates.Title = *input.Title
 	}
-	if req.Content != nil {
-		updates.Content = *req.Content
+	if input.Content != nil {
+		updates.Content = *input.Content
 	}
-	if req.Category != nil {
-		updates.Category = model.LogCategory(*req.Category)
+	if input.Category != nil {
+		updates.Category = model.LogCategory(*input.Category)
 	}
-	if req.Duration != nil {
-		updates.Duration = *req.Duration
+	if input.Duration != nil {
+		updates.Duration = *input.Duration
 	}
 
 	log, err := h.service.Update(logID, userID, updates)

--- a/backend/internal/handler/qiita.go
+++ b/backend/internal/handler/qiita.go
@@ -31,14 +31,12 @@ func NewQiitaHandler(s QiitaServiceInterface) *QiitaHandler {
 func (h *QiitaHandler) Connect(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req dto.ConnectUsernameRequest
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "username is required")
+	input := bindJSON[dto.ConnectUsernameRequest](c)
+	if input == nil {
 		return
 	}
 
-	count, err := h.service.Connect(userID, req.Username)
+	count, err := h.service.Connect(userID, input.Username)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -44,23 +44,21 @@ func NewRoadmapHandler(s RoadmapServiceInterface) *RoadmapHandler {
 func (h *RoadmapHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req dto.CreateRoadmapRequest
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "title is required")
+	input := bindJSON[dto.CreateRoadmapRequest](c)
+	if input == nil {
 		return
 	}
 
 	roadmap := &model.Roadmap{
 		UserID:      userID,
-		Title:       req.Title,
-		Description: req.Description,
-		Category:    model.RoadmapCategory(req.Category),
-		IsPublic:    req.IsPublic,
+		Title:       input.Title,
+		Description: input.Description,
+		Category:    model.RoadmapCategory(input.Category),
+		IsPublic:    input.IsPublic,
 		Status:      model.RoadmapStatusActive,
 	}
 
-	if req.Category == "" {
+	if input.Category == "" {
 		roadmap.Category = model.RoadmapCategoryOther
 	}
 
@@ -144,25 +142,23 @@ func (h *RoadmapHandler) Update(c *gin.Context) {
 		return
 	}
 
-	var req dto.UpdateRoadmapRequest
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "invalid request")
+	input := bindJSON[dto.UpdateRoadmapRequest](c)
+	if input == nil {
 		return
 	}
 
 	updates := &model.Roadmap{}
-	if req.Title != nil {
-		updates.Title = *req.Title
+	if input.Title != nil {
+		updates.Title = *input.Title
 	}
-	if req.Description != nil {
-		updates.Description = *req.Description
+	if input.Description != nil {
+		updates.Description = *input.Description
 	}
-	if req.Category != nil {
-		updates.Category = model.RoadmapCategory(*req.Category)
+	if input.Category != nil {
+		updates.Category = model.RoadmapCategory(*input.Category)
 	}
-	if req.Status != nil {
-		updates.Status = model.RoadmapStatus(*req.Status)
+	if input.Status != nil {
+		updates.Status = model.RoadmapStatus(*input.Status)
 	}
 
 	roadmap, err := h.service.Update(roadmapID, userID, updates)
@@ -172,8 +168,8 @@ func (h *RoadmapHandler) Update(c *gin.Context) {
 	}
 
 	// IsPublicが指定されている場合は別途処理する
-	if req.IsPublic != nil {
-		roadmap, err = h.service.UpdateVisibility(roadmapID, userID, *req.IsPublic)
+	if input.IsPublic != nil {
+		roadmap, err = h.service.UpdateVisibility(roadmapID, userID, *input.IsPublic)
 		if err != nil {
 			respondError(c, err)
 			return
@@ -253,20 +249,18 @@ func (h *RoadmapHandler) CreateStep(c *gin.Context) {
 		return
 	}
 
-	var req dto.CreateRoadmapStepRequest
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "title is required")
+	input := bindJSON[dto.CreateRoadmapStepRequest](c)
+	if input == nil {
 		return
 	}
 
 	step := &model.RoadmapStep{
-		Title:       req.Title,
-		Description: req.Description,
-		ResourceURL: req.ResourceURL,
+		Title:       input.Title,
+		Description: input.Description,
+		ResourceURL: input.ResourceURL,
 	}
-	if req.OrderIndex != nil {
-		step.OrderIndex = *req.OrderIndex
+	if input.OrderIndex != nil {
+		step.OrderIndex = *input.OrderIndex
 	}
 
 	if err := h.service.CreateStep(roadmapID, userID, step); err != nil {
@@ -289,36 +283,34 @@ func (h *RoadmapHandler) UpdateStep(c *gin.Context) {
 		return
 	}
 
-	var req dto.UpdateRoadmapStepRequest
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "invalid request")
+	input := bindJSON[dto.UpdateRoadmapStepRequest](c)
+	if input == nil {
 		return
 	}
 
 	// 完了ステータスの変更を別途処理する
-	if req.IsCompleted != nil {
-		step, err := h.service.UpdateStepCompletion(roadmapID, stepID, userID, *req.IsCompleted)
+	if input.IsCompleted != nil {
+		step, err := h.service.UpdateStepCompletion(roadmapID, stepID, userID, *input.IsCompleted)
 		if err != nil {
 			respondError(c, err)
 			return
 		}
 		// 完了ステータスのみの更新の場合は早期リターンする
-		if req.Title == nil && req.Description == nil && req.ResourceURL == nil {
+		if input.Title == nil && input.Description == nil && input.ResourceURL == nil {
 			respondOK(c, step)
 			return
 		}
 	}
 
 	updates := &model.RoadmapStep{}
-	if req.Title != nil {
-		updates.Title = *req.Title
+	if input.Title != nil {
+		updates.Title = *input.Title
 	}
-	if req.Description != nil {
-		updates.Description = *req.Description
+	if input.Description != nil {
+		updates.Description = *input.Description
 	}
-	if req.ResourceURL != nil {
-		updates.ResourceURL = *req.ResourceURL
+	if input.ResourceURL != nil {
+		updates.ResourceURL = *input.ResourceURL
 	}
 
 	step, err := h.service.UpdateStep(roadmapID, stepID, userID, updates)
@@ -358,14 +350,12 @@ func (h *RoadmapHandler) ReorderSteps(c *gin.Context) {
 		return
 	}
 
-	var req dto.ReorderRoadmapStepsRequest
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "invalid request")
+	input := bindJSON[dto.ReorderRoadmapStepsRequest](c)
+	if input == nil {
 		return
 	}
 
-	if err := h.service.ReorderSteps(roadmapID, userID, req.Orders); err != nil {
+	if err := h.service.ReorderSteps(roadmapID, userID, input.Orders); err != nil {
 		respondError(c, err)
 		return
 	}

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -41,22 +41,21 @@ func NewStudyCircleHandler(svc StudyCircleServiceInterface) *StudyCircleHandler 
 
 // Create はサークルを作成する。
 func (h *StudyCircleHandler) Create(c *gin.Context) {
-	var req dto.CreateStudyCircleRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.CreateStudyCircleRequest](c)
+	if input == nil {
 		return
 	}
 
 	userID := c.GetUint("userID")
 	circle := &model.StudyCircle{
-		Name:        req.Name,
-		Topic:       req.Topic,
-		Description: req.Description,
+		Name:        input.Name,
+		Topic:       input.Topic,
+		Description: input.Description,
 		OwnerID:     userID,
-		MaxMembers:  req.MaxMembers,
+		MaxMembers:  input.MaxMembers,
 	}
 
-	if err := h.service.Create(circle, req.MemberIDs); err != nil {
+	if err := h.service.Create(circle, input.MemberIDs); err != nil {
 		respondError(c, err)
 		return
 	}
@@ -95,13 +94,12 @@ func (h *StudyCircleHandler) Update(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req dto.UpdateStudyCircleRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.UpdateStudyCircleRequest](c)
+	if input == nil {
 		return
 	}
 	userID := c.GetUint("userID")
-	circle, err := h.service.Update(id, userID, req.Name, req.Topic, req.Description)
+	circle, err := h.service.Update(id, userID, input.Name, input.Topic, input.Description)
 	if err != nil {
 		respondError(c, err)
 		return
@@ -144,13 +142,12 @@ func (h *StudyCircleHandler) AddMember(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req dto.AddStudyCircleMemberRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.AddStudyCircleMemberRequest](c)
+	if input == nil {
 		return
 	}
 	userID := c.GetUint("userID")
-	if err := h.service.AddMember(id, userID, req.UserID); err != nil {
+	if err := h.service.AddMember(id, userID, input.UserID); err != nil {
 		respondError(c, err)
 		return
 	}
@@ -181,18 +178,17 @@ func (h *StudyCircleHandler) CreateStep(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req dto.CreateStudyCircleStepRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.CreateStudyCircleStepRequest](c)
+	if input == nil {
 		return
 	}
 	userID := c.GetUint("userID")
 
 	step := &model.StudyCircleStep{
-		Title:       req.Title,
-		Description: req.Description,
-		ResourceURL: req.ResourceURL,
-		OrderIndex:  req.OrderIndex,
+		Title:       input.Title,
+		Description: input.Description,
+		ResourceURL: input.ResourceURL,
+		OrderIndex:  input.OrderIndex,
 	}
 	if err := h.service.CreateStep(id, userID, step); err != nil {
 		respondError(c, err)
@@ -211,13 +207,12 @@ func (h *StudyCircleHandler) UpdateStep(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req dto.UpdateStudyCircleStepRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.UpdateStudyCircleStepRequest](c)
+	if input == nil {
 		return
 	}
 	userID := c.GetUint("userID")
-	step, err := h.service.UpdateStep(id, userID, stepID, req.Title, req.Description)
+	step, err := h.service.UpdateStep(id, userID, stepID, input.Title, input.Description)
 	if err != nil {
 		respondError(c, err)
 		return
@@ -249,13 +244,12 @@ func (h *StudyCircleHandler) ReorderSteps(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req dto.ReorderStudyCircleStepsRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.ReorderStudyCircleStepsRequest](c)
+	if input == nil {
 		return
 	}
 	userID := c.GetUint("userID")
-	if err := h.service.ReorderSteps(id, userID, req.Orders); err != nil {
+	if err := h.service.ReorderSteps(id, userID, input.Orders); err != nil {
 		respondError(c, err)
 		return
 	}
@@ -272,13 +266,12 @@ func (h *StudyCircleHandler) UpdateProgress(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req dto.UpdateStudyCircleProgressRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.UpdateStudyCircleProgressRequest](c)
+	if input == nil {
 		return
 	}
 	userID := c.GetUint("userID")
-	if err := h.service.UpdateProgress(id, userID, stepID, req.IsCompleted); err != nil {
+	if err := h.service.UpdateProgress(id, userID, stepID, input.IsCompleted); err != nil {
 		respondError(c, err)
 		return
 	}
@@ -306,13 +299,12 @@ func (h *StudyCircleHandler) CreateCheckin(c *gin.Context) {
 	if !ok {
 		return
 	}
-	var req dto.CreateStudyCircleCheckinRequest
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, err.Error())
+	input := bindJSON[dto.CreateStudyCircleCheckinRequest](c)
+	if input == nil {
 		return
 	}
 	userID := c.GetUint("userID")
-	checkin, err := h.service.CreateCheckin(id, userID, req.Content)
+	checkin, err := h.service.CreateCheckin(id, userID, input.Content)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/zenn.go
+++ b/backend/internal/handler/zenn.go
@@ -31,14 +31,12 @@ func NewZennHandler(s ZennServiceInterface) *ZennHandler {
 func (h *ZennHandler) Connect(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	var req dto.ConnectUsernameRequest
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		respondBadRequest(c, "username is required")
+	input := bindJSON[dto.ConnectUsernameRequest](c)
+	if input == nil {
 		return
 	}
 
-	count, err := h.service.Connect(userID, req.Username)
+	count, err := h.service.Connect(userID, input.Username)
 	if err != nil {
 		respondError(c, err)
 		return


### PR DESCRIPTION
## 概要
7ファイル19箇所の手動 `ShouldBindJSON` パターンを既存の `bindJSON[T]` ジェネリックヘルパーに統一。

## 変更内容
- `roadmap.go` (5箇所)、`study_circle.go` (8箇所)、`learning_log.go` (2箇所)
- `email_preferences.go`、`badge.go`、`qiita.go`、`zenn.go` (各1箇所)
- 変数名を `req` → `input` に統一（既存の `bindJSON` 使用パターンと合わせる）

## 効果
- 全ハンドラで同一パターン使用によるコード一貫性向上
- 26行削減（131行 → 105行）

Closes #967