### PR TITLE
fix: NoteFolderService.Updateで空白のみフォルダ名のバリデーション追加

### DIFF
--- a/backend/internal/service/note_folder.go
+++ b/backend/internal/service/note_folder.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -89,6 +91,9 @@ func (s *NoteFolderService) Update(id, userID uint, name string, parentID *uint)
 	}
 
 	if name != "" {
+		if strings.TrimSpace(name) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "フォルダ名は空白のみにできません", nil)
+		}
 		folder.Name = name
 	}
 	if parentID != nil {

--- a/backend/internal/service/note_folder_test.go
+++ b/backend/internal/service/note_folder_test.go
@@ -425,3 +425,17 @@ func TestNoteFolderService_Update_ValidateLongNameError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 }
+
+func TestNoteFolderService_Update_WhitespaceName(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	service := NewNoteFolderService(mockRepo)
+
+	existing := &model.NoteFolder{ID: 1, UserID: 1, Name: "元の名前"}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	// 空白のみの名前 → バリデーションエラーになるべき
+	result, err := service.Update(1, 1, "   \t\n  ", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "フォルダ名は空白のみにできません")
+}


### PR DESCRIPTION
## 概要
空白のみのフォルダ名がバリデーションをすり抜けて保存されるセキュリティバグを修正。

## 原因
- `name != ""` で空白のみ文字列が通過
- `ValidateUpdate()` が TrimSpace 後の空文字を「更新しない」と判定

## 修正内容
- `note_folder.go`: `name` が非空だが TrimSpace で空になる場合にバリデーションエラーを返す
- `note_folder_test.go`: `TestNoteFolderService_Update_WhitespaceName` テスト追加

Closes #971