### PR TITLE
feat: お気に入りノート一覧取得（GetFavorites）機能追加

### DIFF
--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -18,6 +18,7 @@ type NoteServiceInterface interface {
 	Search(userID uint, query string, page, limit int) ([]model.Note, int64, error)
 	CountByUserID(userID uint) (int64, error)
 	ToggleFavorite(id, userID uint) error
+	GetFavorites(userID uint, page, limit int) ([]model.Note, error)
 	Archive(id, userID uint) error
 	Unarchive(id, userID uint) error
 	GetArchived(userID uint, page, limit int) ([]model.Note, error)
@@ -232,6 +233,19 @@ func (h *NoteHandler) Unarchive(c *gin.Context) {
 	}
 
 	respondOK(c, domain.NewMessageResponse("ノートのアーカイブを解除しました"))
+}
+
+// GetFavorites は現在のユーザーのお気に入りノート一覧をページネーション付きで取得する。
+func (h *NoteHandler) GetFavorites(c *gin.Context) {
+	userID := c.GetUint("userID")
+	page, limit := parsePagination(c)
+
+	notes, err := h.service.GetFavorites(userID, page, limit)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, notes)
 }
 
 // GetArchived は現在のユーザーのアーカイブ済みノート一覧をページネーション付きで取得する。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -448,6 +448,7 @@ type NoteRepositoryInterface interface {
 	Search(userID uint, query string, limit, offset int) ([]model.Note, int64, error)
 	CountByUserID(userID uint) (int64, error)
 	ToggleFavorite(id uint) error
+	FindFavorites(userID uint, page, limit int) ([]model.Note, error)
 	Archive(id uint) error
 	Unarchive(id uint) error
 	FindArchived(userID uint, page, limit int) ([]model.Note, error)

--- a/backend/internal/repository/note.go
+++ b/backend/internal/repository/note.go
@@ -91,6 +91,18 @@ func (r *NoteRepository) ToggleFavorite(id uint) error {
 		Update("is_favorite", gorm.Expr("NOT is_favorite")).Error
 }
 
+// FindFavorites は指定ユーザーのお気に入りノート一覧をページネーション付きで取得する。
+func (r *NoteRepository) FindFavorites(userID uint, page, limit int) ([]model.Note, error) {
+	var notes []model.Note
+	offset := (page - 1) * limit
+	err := r.db.Preload("Folder").
+		Where("user_id = ? AND is_favorite = ?", userID, true).
+		Order("updated_at DESC").
+		Offset(offset).Limit(limit).
+		Find(&notes).Error
+	return notes, err
+}
+
 // Archive は指定IDのノートをアーカイブする。
 func (r *NoteRepository) Archive(id uint) error {
 	return r.db.Model(&model.Note{}).Where("id = ?", id).

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -392,6 +392,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		notes.POST("", c.NoteHandler.Create)
 		notes.GET("", c.NoteHandler.GetByUserID)
 		notes.GET("/search", c.NoteHandler.Search)
+		notes.GET("/favorites", c.NoteHandler.GetFavorites)
 		notes.GET("/archived", c.NoteHandler.GetArchived)
 		notes.GET("/folder/:folderId", c.NoteHandler.GetByFolderID)
 		notes.GET("/:id", c.NoteHandler.GetByID)

--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -129,6 +129,11 @@ func (s *NoteService) Unarchive(id, userID uint) error {
 	return s.repo.Unarchive(id)
 }
 
+// GetFavorites は指定ユーザーのお気に入りノート一覧をページネーション付きで取得する。
+func (s *NoteService) GetFavorites(userID uint, page, limit int) ([]model.Note, error) {
+	return s.repo.FindFavorites(userID, page, limit)
+}
+
 // GetArchived は指定ユーザーのアーカイブ済みノート一覧を取得する。
 func (s *NoteService) GetArchived(userID uint, page, limit int) ([]model.Note, error) {
 	return s.repo.FindArchived(userID, page, limit)

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -77,6 +77,11 @@ func (m *MockNoteRepository) CountArchivedByUserID(userID uint) (int64, error) {
 	return args.Get(0).(int64), args.Error(1)
 }
 
+func (m *MockNoteRepository) FindFavorites(userID uint, page, limit int) ([]model.Note, error) {
+	args := m.Called(userID, page, limit)
+	return args.Get(0).([]model.Note), args.Error(1)
+}
+
 // newTestNoteService はテスト用のNoteServiceを生成する。
 func newTestNoteService() (*NoteService, *MockNoteRepository) {
 	repo := new(MockNoteRepository)
@@ -586,4 +591,46 @@ func TestNoteService_Duplicate_ValidationError(t *testing.T) {
 	result, err := svc.Duplicate(1, 1)
 	assert.Error(t, err)
 	assert.Nil(t, result)
+}
+
+// ============================================================
+// GetFavorites テスト
+// ============================================================
+
+func TestNoteService_GetFavorites_Success(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	favorites := []model.Note{
+		{Title: "お気に入りノート1", UserID: 1, IsFavorite: true},
+		{Title: "お気に入りノート2", UserID: 1, IsFavorite: true},
+	}
+	repo.On("FindFavorites", uint(1), 1, 10).Return(favorites, nil)
+
+	result, err := svc.GetFavorites(1, 1, 10)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.True(t, result[0].IsFavorite)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteService_GetFavorites_Empty(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	repo.On("FindFavorites", uint(1), 1, 10).Return([]model.Note{}, nil)
+
+	result, err := svc.GetFavorites(1, 1, 10)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteService_GetFavorites_RepoError(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	repo.On("FindFavorites", uint(1), 1, 10).Return([]model.Note{}, errors.New("db error"))
+
+	result, err := svc.GetFavorites(1, 1, 10)
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
ToggleFavoriteの補完として、お気に入りノート一覧取得機能をTDDで実装。

## 変更内容
- `NoteService.GetFavorites()`: ページネーション付きお気に入りノート取得
- `NoteRepository.FindFavorites()`: `is_favorite = true` でフィルタ（Folder Preload付き）
- `GET /api/notes/favorites` エンドポイント追加
- `NoteServiceInterface` / `NoteRepositoryInterface` にメソッド追加

## テスト
- Service層3テスト（Success / Empty / RepoError）

Closes #973