### PR TITLE
fix: NoteService.Updateの空白のみタイトル・本文バイパス修正

### DIFF
--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"strings"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -63,9 +66,15 @@ func (s *NoteService) Update(id, userID uint, title, content, tags string, folde
 	}
 
 	if title != "" {
+		if strings.TrimSpace(title) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみにできません", nil)
+		}
 		note.Title = title
 	}
 	if content != "" {
+		if strings.TrimSpace(content) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "本文は空白のみにできません", nil)
+		}
 		note.Content = content
 	}
 	if tags != "" {

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -634,3 +634,31 @@ func TestNoteService_GetFavorites_RepoError(t *testing.T) {
 	assert.Empty(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// Update 空白バイパス テスト
+// ============================================================
+
+func TestNoteService_Update_WhitespaceTitle(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	existing := &model.Note{ID: 1, UserID: 1, Title: "元のタイトル", Content: "元の内容"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	result, err := svc.Update(1, 1, "   \t\n  ", "", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトルは空白のみにできません")
+}
+
+func TestNoteService_Update_WhitespaceContent(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	existing := &model.Note{ID: 1, UserID: 1, Title: "タイトル", Content: "元の内容"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	result, err := svc.Update(1, 1, "", "   \t\n  ", "", nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "本文は空白のみにできません")
+}


### PR DESCRIPTION
## 概要
`NoteService.Update()` でタイトル・本文に空白のみの文字列が通過する脆弱性を修正。

## 変更内容
- `note.go`: `title`/`content` 更新前に `strings.TrimSpace` チェック追加
- `note_test.go`: TDDテスト2件追加（WhitespaceTitle, WhitespaceContent）
- Cycle 204（note_folder.go空白バイパス修正）と同パターン

## テスト
- `go test ./internal/service/...` — 全PASS
- `go test ./internal/handler/...` — 全PASS
- `go build ./...` — PASS

Closes #979