### PR TITLE
feat: お気に入りノート一覧のページネーション対応

### DIFF
--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -19,6 +19,7 @@ type NoteServiceInterface interface {
 	CountByUserID(userID uint) (int64, error)
 	ToggleFavorite(id, userID uint) error
 	GetFavorites(userID uint, page, limit int) ([]model.Note, error)
+	CountFavoritesByUserID(userID uint) (int64, error)
 	Archive(id, userID uint) error
 	Unarchive(id, userID uint) error
 	GetArchived(userID uint, page, limit int) ([]model.Note, error)
@@ -245,7 +246,14 @@ func (h *NoteHandler) GetFavorites(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, notes)
+
+	total, err := h.service.CountFavoritesByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondPaginated(c, notes, total, page, limit)
 }
 
 // GetArchived は現在のユーザーのアーカイブ済みノート一覧をページネーション付きで取得する。

--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -71,6 +71,11 @@ func (m *MockNoteService) GetFavorites(userID uint, page, limit int) ([]model.No
 	return args.Get(0).([]model.Note), args.Error(1)
 }
 
+func (m *MockNoteService) CountFavoritesByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func (m *MockNoteService) Archive(id, userID uint) error {
 	return m.Called(id, userID).Error(0)
 }
@@ -912,6 +917,7 @@ func TestNoteHandler_GetFavorites_Success(t *testing.T) {
 	}
 
 	mockService.On("GetFavorites", uint(1), 1, 20).Return(notes, nil)
+	mockService.On("CountFavoritesByUserID", uint(1)).Return(int64(1), nil)
 
 	req, _ := http.NewRequest("GET", "/notes/favorites?page=1&limit=20", nil)
 	w := httptest.NewRecorder()
@@ -931,6 +937,30 @@ func TestNoteHandler_GetFavorites_ServiceError(t *testing.T) {
 	})
 
 	mockService.On("GetFavorites", uint(1), 1, 20).Return([]model.Note{}, assert.AnError)
+
+	req, _ := http.NewRequest("GET", "/notes/favorites?page=1&limit=20", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+	mockService.AssertExpectations(t)
+}
+
+func TestNoteHandler_GetFavorites_CountError(t *testing.T) {
+	handler, mockService := newTestNoteHandler()
+	router := setupRouter()
+
+	router.GET("/notes/favorites", func(c *gin.Context) {
+		c.Set("userID", uint(1))
+		handler.GetFavorites(c)
+	})
+
+	notes := []model.Note{
+		{ID: 1, UserID: 1, Title: "お気に入りノート"},
+	}
+
+	mockService.On("GetFavorites", uint(1), 1, 20).Return(notes, nil)
+	mockService.On("CountFavoritesByUserID", uint(1)).Return(int64(0), assert.AnError)
 
 	req, _ := http.NewRequest("GET", "/notes/favorites?page=1&limit=20", nil)
 	w := httptest.NewRecorder()

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -449,6 +449,7 @@ type NoteRepositoryInterface interface {
 	CountByUserID(userID uint) (int64, error)
 	ToggleFavorite(id uint) error
 	FindFavorites(userID uint, page, limit int) ([]model.Note, error)
+	CountFavoritesByUserID(userID uint) (int64, error)
 	Archive(id uint) error
 	Unarchive(id uint) error
 	FindArchived(userID uint, page, limit int) ([]model.Note, error)

--- a/backend/internal/repository/note.go
+++ b/backend/internal/repository/note.go
@@ -103,6 +103,13 @@ func (r *NoteRepository) FindFavorites(userID uint, page, limit int) ([]model.No
 	return notes, err
 }
 
+// CountFavoritesByUserID は指定ユーザーのお気に入りノート総数を取得する。
+func (r *NoteRepository) CountFavoritesByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.Note{}).Where("user_id = ? AND is_favorite = ?", userID, true).Count(&count).Error
+	return count, err
+}
+
 // Archive は指定IDのノートをアーカイブする。
 func (r *NoteRepository) Archive(id uint) error {
 	return r.db.Model(&model.Note{}).Where("id = ?", id).

--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -143,6 +143,11 @@ func (s *NoteService) GetFavorites(userID uint, page, limit int) ([]model.Note, 
 	return s.repo.FindFavorites(userID, page, limit)
 }
 
+// CountFavoritesByUserID は指定ユーザーのお気に入りノート総数を取得する。
+func (s *NoteService) CountFavoritesByUserID(userID uint) (int64, error) {
+	return s.repo.CountFavoritesByUserID(userID)
+}
+
 // GetArchived は指定ユーザーのアーカイブ済みノート一覧を取得する。
 func (s *NoteService) GetArchived(userID uint, page, limit int) ([]model.Note, error) {
 	return s.repo.FindArchived(userID, page, limit)

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -82,6 +82,11 @@ func (m *MockNoteRepository) FindFavorites(userID uint, page, limit int) ([]mode
 	return args.Get(0).([]model.Note), args.Error(1)
 }
 
+func (m *MockNoteRepository) CountFavoritesByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // newTestNoteService はテスト用のNoteServiceを生成する。
 func newTestNoteService() (*NoteService, *MockNoteRepository) {
 	repo := new(MockNoteRepository)
@@ -661,4 +666,41 @@ func TestNoteService_Update_WhitespaceContent(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "本文は空白のみにできません")
+}
+
+// ============================================================
+// CountFavoritesByUserID テスト
+// ============================================================
+
+func TestNoteService_CountFavoritesByUserID_Success(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	repo.On("CountFavoritesByUserID", uint(1)).Return(int64(5), nil)
+
+	count, err := svc.CountFavoritesByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteService_CountFavoritesByUserID_Zero(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	repo.On("CountFavoritesByUserID", uint(1)).Return(int64(0), nil)
+
+	count, err := svc.CountFavoritesByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteService_CountFavoritesByUserID_RepoError(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	repo.On("CountFavoritesByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountFavoritesByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
`GetFavorites` エンドポイントにページネーション情報を追加。`GetArchived` と同等の対応。

## 変更内容
- `CountFavoritesByUserID` を全層に追加（Repository interface/実装, Service, Handler interface）
- `GetFavorites` ハンドラを `respondOK` → `respondPaginated` に変更
- TDDテスト: Service 3件（Success/Zero/RepoError）+ Handler 1件（CountError）追加

## テスト
- `go build ./...` — PASS
- `go test ./internal/service/...` — 全PASS
- `go test ./internal/handler/...` — 全PASS

Closes #981