### PR TITLE
fix: PostSeriesService.Updateの説明フィールド空白バイパス修正

### DIFF
--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -63,6 +63,9 @@ func (s *PostSeriesService) Update(id, userID uint, updates *model.PostSeries) (
 		series.Title = updates.Title
 	}
 	if updates.Description != "" {
+		if strings.TrimSpace(updates.Description) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "説明は空白のみでは入力できません", nil)
+		}
 		series.Description = updates.Description
 	}
 

--- a/backend/internal/service/post_series_test.go
+++ b/backend/internal/service/post_series_test.go
@@ -398,6 +398,21 @@ func TestPostSeriesUpdate_WhitespaceTitle(t *testing.T) {
 	assert.Contains(t, err.Error(), "空白のみ")
 }
 
+func TestPostSeriesUpdate_WhitespaceDescription(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	existing := &model.PostSeries{Title: "Title", Description: "Old Desc", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.PostSeries{Description: "  \t  "}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "空白のみ")
+}
+
 func TestPostSeriesUpdate_Description(t *testing.T) {
 	svc, repo := newTestPostSeriesService()
 


### PR DESCRIPTION
## 概要
PostSeriesService.UpdateのDescriptionフィールドに空白文字のみを設定できるセキュリティバグを修正。

## 変更内容
- Descriptionフィールドに`strings.TrimSpace`バリデーションを追加
- Titleフィールドと同じパターンで空白のみの入力を拒否
- TDDアプローチでテストを先行追加

## テスト
- `TestPostSeriesUpdate_WhitespaceDescription` を追加
- 既存テスト全件PASS

Closes #987