### PR TITLE
refactor: メッセージレスポンスをdomain.NewMessageResponseに統一

### DIFF
--- a/backend/internal/handler/comment_like.go
+++ b/backend/internal/handler/comment_like.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 )
 
 // CommentLikeServiceInterface はCommentLikeHandlerが依存するサービスインターフェース。
@@ -33,7 +34,7 @@ func (h *CommentLikeHandler) Like(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "いいねしました"})
+	respondOK(c, domain.NewMessageResponse("いいねしました"))
 }
 
 // Unlike はコメントのいいねを取り消す。
@@ -48,7 +49,7 @@ func (h *CommentLikeHandler) Unlike(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "いいねを取り消しました"})
+	respondOK(c, domain.NewMessageResponse("いいねを取り消しました"))
 }
 
 // GetStatus はコメントのいいね状態（いいねしているか・いいね数）を返す。

--- a/backend/internal/handler/post_pin.go
+++ b/backend/internal/handler/post_pin.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -37,7 +38,7 @@ func (h *PostPinHandler) Pin(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "ピン留めしました"})
+	respondOK(c, domain.NewMessageResponse("ピン留めしました"))
 }
 
 // Unpin は投稿のピン留めを解除する。
@@ -52,7 +53,7 @@ func (h *PostPinHandler) Unpin(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "ピン留めを解除しました"})
+	respondOK(c, domain.NewMessageResponse("ピン留めを解除しました"))
 }
 
 // GetByUserID はユーザーのピン留め投稿を取得する。
@@ -83,5 +84,5 @@ func (h *PostPinHandler) Reorder(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "順序を更新しました"})
+	respondOK(c, domain.NewMessageResponse("順序を更新しました"))
 }

--- a/backend/internal/handler/post_tag.go
+++ b/backend/internal/handler/post_tag.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -42,7 +43,7 @@ func (h *PostTagHandler) SetTags(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"message": "タグを更新しました"})
+	respondOK(c, domain.NewMessageResponse("タグを更新しました"))
 }
 
 // GetByPostID は投稿のタグ一覧を取得する。


### PR DESCRIPTION
## 概要
handler層でメッセージレスポンスの書き方が混在していた問題を統一。

## 変更内容
- `gin.H{"message": "..."}` → `domain.NewMessageResponse("...")` に変換（6箇所）
- 対象: comment_like.go, post_pin.go, post_tag.go
- データレスポンス（`gin.H{"liked": ..., "count": ...}` 等）は変更なし

## テスト
- 全ハンドラテストPASS

Closes #991