### PR TITLE
feat: PostSeries.GetByUserID のページネーション対応

### DIFF
--- a/backend/internal/handler/post_series.go
+++ b/backend/internal/handler/post_series.go
@@ -10,7 +10,8 @@ import (
 type PostSeriesServiceInterface interface {
 	Create(series *model.PostSeries) error
 	GetByID(id uint) (*model.PostSeries, error)
-	GetByUserID(userID uint) ([]model.PostSeries, error)
+	GetByUserID(userID uint, page, limit int) ([]model.PostSeries, error)
+	CountByUser(userID uint) (int64, error)
 	Update(id, userID uint, updates *model.PostSeries) (*model.PostSeries, error)
 	Delete(id, userID uint) error
 	AddPost(seriesID, postID uint, orderIndex int, userID uint) error
@@ -67,20 +68,28 @@ func (h *PostSeriesHandler) GetByID(c *gin.Context) {
 	respondOK(c, series)
 }
 
-// GetByUserID は指定ユーザーのシリーズ一覧を取得する。
+// GetByUserID は指定ユーザーのシリーズ一覧をページネーション付きで取得する。
 func (h *PostSeriesHandler) GetByUserID(c *gin.Context) {
 	userID, ok := parseID(c, "userId")
 	if !ok {
 		return
 	}
 
-	series, err := h.service.GetByUserID(userID)
+	page, limit := parsePagination(c)
+
+	series, err := h.service.GetByUserID(userID, page, limit)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, series)
+	total, err := h.service.CountByUser(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondPaginated(c, series, total, page, limit)
 }
 
 // Update は指定IDのシリーズを更新する。

--- a/backend/internal/handler/post_series_test.go
+++ b/backend/internal/handler/post_series_test.go
@@ -22,12 +22,16 @@ func (m *MockPostSeriesService) GetByID(id uint) (*model.PostSeries, error) {
 	}
 	return nil, args.Error(1)
 }
-func (m *MockPostSeriesService) GetByUserID(userID uint) ([]model.PostSeries, error) {
-	args := m.Called(userID)
+func (m *MockPostSeriesService) GetByUserID(userID uint, page, limit int) ([]model.PostSeries, error) {
+	args := m.Called(userID, page, limit)
 	if v := args.Get(0); v != nil {
 		return v.([]model.PostSeries), args.Error(1)
 	}
 	return nil, args.Error(1)
+}
+func (m *MockPostSeriesService) CountByUser(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
 }
 func (m *MockPostSeriesService) Update(id, userID uint, updates *model.PostSeries) (*model.PostSeries, error) {
 	args := m.Called(id, userID, updates)
@@ -148,7 +152,8 @@ func TestPostSeriesGetByID_ServiceError(t *testing.T) {
 func TestPostSeriesGetByUserID_Success(t *testing.T) {
 	h, svc := setupPostSeriesHandler()
 	seriesList := []model.PostSeries{{Title: "Go入門シリーズ", UserID: 1}}
-	svc.On("GetByUserID", uint(1)).Return(seriesList, nil)
+	svc.On("GetByUserID", uint(1), 1, 20).Return(seriesList, nil)
+	svc.On("CountByUser", uint(1)).Return(int64(1), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:userId/series", h.GetByUserID)
@@ -170,7 +175,21 @@ func TestPostSeriesGetByUserID_InvalidID(t *testing.T) {
 
 func TestPostSeriesGetByUserID_ServiceError(t *testing.T) {
 	h, svc := setupPostSeriesHandler()
-	svc.On("GetByUserID", uint(1)).Return(nil, errors.New("db error"))
+	svc.On("GetByUserID", uint(1), 1, 20).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/users/:userId/series", h.GetByUserID)
+
+	w := doRequest(r, http.MethodGet, "/users/1/series", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestPostSeriesGetByUserID_CountError(t *testing.T) {
+	h, svc := setupPostSeriesHandler()
+	seriesList := []model.PostSeries{{Title: "Go入門シリーズ", UserID: 1}}
+	svc.On("GetByUserID", uint(1), 1, 20).Return(seriesList, nil)
+	svc.On("CountByUser", uint(1)).Return(int64(0), errors.New("db error"))
 
 	r := newRouter(1)
 	r.GET("/users/:userId/series", h.GetByUserID)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -486,7 +486,8 @@ type PostCollectionRepositoryInterface interface {
 type PostSeriesRepositoryInterface interface {
 	Create(series *model.PostSeries) error
 	FindByID(id uint) (*model.PostSeries, error)
-	FindByUserID(userID uint) ([]model.PostSeries, error)
+	FindByUserID(userID uint, offset, limit int) ([]model.PostSeries, error)
+	CountByUser(userID uint) (int64, error)
 	Update(series *model.PostSeries) error
 	Delete(id uint) error
 	AddPost(item *model.PostSeriesItem) error

--- a/backend/internal/repository/post_series.go
+++ b/backend/internal/repository/post_series.go
@@ -30,13 +30,22 @@ func (r *PostSeriesRepository) FindByID(id uint) (*model.PostSeries, error) {
 	return &series, nil
 }
 
-// FindByUserID は指定ユーザーの全シリーズを取得する（新しい順）。
-func (r *PostSeriesRepository) FindByUserID(userID uint) ([]model.PostSeries, error) {
+// FindByUserID は指定ユーザーのシリーズをページネーション付きで取得する（新しい順）。
+func (r *PostSeriesRepository) FindByUserID(userID uint, offset, limit int) ([]model.PostSeries, error) {
 	var series []model.PostSeries
 	err := r.db.Where("user_id = ?", userID).
 		Order("created_at DESC").
+		Offset(offset).
+		Limit(limit).
 		Find(&series).Error
 	return series, err
+}
+
+// CountByUser は指定ユーザーのシリーズ数をカウントする。
+func (r *PostSeriesRepository) CountByUser(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.PostSeries{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
 }
 
 // Update は既存のシリーズを更新する。

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1586,9 +1586,14 @@ func (m *MockPostSeriesRepository) FindByID(id uint) (*model.PostSeries, error) 
 	return args.Get(0).(*model.PostSeries), args.Error(1)
 }
 
-func (m *MockPostSeriesRepository) FindByUserID(userID uint) ([]model.PostSeries, error) {
-	args := m.Called(userID)
+func (m *MockPostSeriesRepository) FindByUserID(userID uint, offset, limit int) ([]model.PostSeries, error) {
+	args := m.Called(userID, offset, limit)
 	return args.Get(0).([]model.PostSeries), args.Error(1)
+}
+
+func (m *MockPostSeriesRepository) CountByUser(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
 }
 
 func (m *MockPostSeriesRepository) Update(series *model.PostSeries) error {

--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -32,9 +32,15 @@ func (s *PostSeriesService) GetByID(id uint) (*model.PostSeries, error) {
 	return s.repo.FindByID(id)
 }
 
-// GetByUserID は指定ユーザーの全シリーズを取得する。
-func (s *PostSeriesService) GetByUserID(userID uint) ([]model.PostSeries, error) {
-	return s.repo.FindByUserID(userID)
+// GetByUserID は指定ユーザーのシリーズをページネーション付きで取得する。
+func (s *PostSeriesService) GetByUserID(userID uint, page, limit int) ([]model.PostSeries, error) {
+	offset := (page - 1) * limit
+	return s.repo.FindByUserID(userID, offset, limit)
+}
+
+// CountByUser は指定ユーザーのシリーズ数をカウントする。
+func (s *PostSeriesService) CountByUser(userID uint) (int64, error) {
+	return s.repo.CountByUser(userID)
 }
 
 // findAndCheckOwnership はシリーズを取得し、指定ユーザーが所有者かを検証する。

--- a/backend/internal/service/post_series_test.go
+++ b/backend/internal/service/post_series_test.go
@@ -99,9 +99,9 @@ func TestPostSeriesGetByUserID_Success(t *testing.T) {
 		{Title: "React入門", UserID: 1},
 	}
 
-	repo.On("FindByUserID", uint(1)).Return(expected, nil)
+	repo.On("FindByUserID", uint(1), 0, 10).Return(expected, nil)
 
-	result, err := svc.GetByUserID(1)
+	result, err := svc.GetByUserID(1, 1, 10)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 	repo.AssertExpectations(t)
@@ -110,12 +110,59 @@ func TestPostSeriesGetByUserID_Success(t *testing.T) {
 func TestPostSeriesGetByUserID_Empty(t *testing.T) {
 	svc, repo := newTestPostSeriesService()
 
-	repo.On("FindByUserID", uint(1)).Return([]model.PostSeries{}, nil)
+	repo.On("FindByUserID", uint(1), 0, 10).Return([]model.PostSeries{}, nil)
 
-	result, err := svc.GetByUserID(1)
+	result, err := svc.GetByUserID(1, 1, 10)
 	assert.NoError(t, err)
 	assert.Empty(t, result)
 	repo.AssertExpectations(t)
+}
+
+func TestPostSeriesGetByUserID_Page2(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	expected := []model.PostSeries{
+		{Title: "シリーズ11", UserID: 1},
+	}
+
+	repo.On("FindByUserID", uint(1), 10, 10).Return(expected, nil)
+
+	result, err := svc.GetByUserID(1, 2, 10)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	repo.AssertExpectations(t)
+}
+
+func TestPostSeriesCountByUser_Success(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	repo.On("CountByUser", uint(1)).Return(int64(5), nil)
+
+	count, err := svc.CountByUser(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+	repo.AssertExpectations(t)
+}
+
+func TestPostSeriesCountByUser_Zero(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	repo.On("CountByUser", uint(1)).Return(int64(0), nil)
+
+	count, err := svc.CountByUser(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
+}
+
+func TestPostSeriesCountByUser_RepoError(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	repo.On("CountByUser", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountByUser(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
- PostSeriesHandler.GetByUserID を respondOK → respondPaginated に変更
- 全レイヤー（Repository/Service/Handler）にページネーション対応追加
- CountByUser メソッドを Repository/Service/Handler インターフェースに追加
- テスト5件追加（Service: Page2/CountByUser×3, Handler: CountError）

## テスト結果
全テストPASS（Service + Handler）

Closes #997