### PR TITLE
refactor: handler の gin.H データレスポンスを DTO 構造体に置換

### DIFF
--- a/backend/internal/dto/response.go
+++ b/backend/internal/dto/response.go
@@ -26,3 +26,15 @@ type CountResponse struct {
 	Count int64 `json:"count"`
 }
 
+// LikeStatusResponse はいいね状態レスポンス
+type LikeStatusResponse struct {
+	Liked bool  `json:"liked"`
+	Count int64 `json:"count"`
+}
+
+// ViewCountResponse は閲覧数レスポンス
+type ViewCountResponse struct {
+	PostID    uint  `json:"post_id"`
+	ViewCount int64 `json:"view_count"`
+}
+

--- a/backend/internal/handler/comment_like.go
+++ b/backend/internal/handler/comment_like.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 )
 
 // CommentLikeServiceInterface はCommentLikeHandlerが依存するサービスインターフェース。
@@ -65,8 +66,5 @@ func (h *CommentLikeHandler) GetStatus(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{
-		"liked": liked,
-		"count": count,
-	})
+	respondOK(c, dto.LikeStatusResponse{Liked: liked, Count: count})
 }

--- a/backend/internal/handler/post_view.go
+++ b/backend/internal/handler/post_view.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -35,7 +37,7 @@ func (h *PostViewHandler) RecordView(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"recorded": true})
+	respondOK(c, domain.NewMessageResponse("記録しました"))
 }
 
 // GetViewCount は投稿の閲覧数を取得する。
@@ -50,7 +52,7 @@ func (h *PostViewHandler) GetViewCount(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"post_id": postID, "view_count": count})
+	respondOK(c, dto.ViewCountResponse{PostID: postID, ViewCount: count})
 }
 
 // GetMostViewed は閲覧数の多い投稿ランキングを取得する。

--- a/backend/internal/handler/post_view_test.go
+++ b/backend/internal/handler/post_view_test.go
@@ -52,7 +52,7 @@ func TestPostViewRecordView_Success(t *testing.T) {
 	w := doRequest(r, http.MethodPost, "/posts/5/views", nil)
 	assertStatus(t, w, http.StatusOK)
 	body := parseJSON(t, w)
-	assert.Equal(t, true, body["recorded"])
+	assert.Equal(t, "記録しました", body["message"])
 	svc.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
- dto.LikeStatusResponse / dto.ViewCountResponse をresponse.goに追加
- comment_like.go の GetStatus を gin.H → dto.LikeStatusResponse に変更
- post_view.go の RecordView を gin.H → domain.NewMessageResponse に変更
- post_view.go の GetViewCount を gin.H → dto.ViewCountResponse に変更
- テスト1件更新（recorded→message チェック）

## テスト結果
全テストPASS

Closes #999