### PR TITLE
fix: LearningLogService.Update の空白バイパスを修正

### DIFF
--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/csv"
 	"fmt"
+	"strings"
 
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -92,13 +93,13 @@ func (s *LearningLogService) Update(id, userID uint, updates *model.LearningLog)
 		return nil, err
 	}
 
-	if updates.Title != "" {
+	if strings.TrimSpace(updates.Title) != "" {
 		log.Title = updates.Title
 	}
-	if updates.Content != "" {
+	if strings.TrimSpace(updates.Content) != "" {
 		log.Content = updates.Content
 	}
-	if updates.Category != "" {
+	if strings.TrimSpace(string(updates.Category)) != "" {
 		log.Category = updates.Category
 	}
 	if updates.Duration != 0 {

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -341,6 +341,51 @@ func TestLearningLogUpdate_DurationExceedsMax(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestLearningLogUpdate_WhitespaceTitle(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	existing := &model.LearningLog{Title: "Test", Content: "Content", UserID: 1, Duration: 30}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	// 空白のみのTitleは更新されず、元の値が保持されるべき
+	updates := &model.LearningLog{Title: "   "}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "Test", result.Title) // 変更されない
+}
+
+func TestLearningLogUpdate_WhitespaceContent(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	existing := &model.LearningLog{Title: "Test", Content: "Content", UserID: 1, Duration: 30}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	// 空白のみのContentは更新されず、元の値が保持されるべき
+	updates := &model.LearningLog{Content: "  \t  "}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "Content", result.Content) // 変更されない
+}
+
+func TestLearningLogUpdate_WhitespaceCategory(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	existing := &model.LearningLog{Title: "Test", Content: "Content", Category: "coding", UserID: 1, Duration: 30}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	// 空白のみのCategoryは更新されず、元の値が保持されるべき
+	updates := &model.LearningLog{Category: "   "}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, model.LogCategory("coding"), result.Category) // 変更されない
+}
+
 // --- ExportCSV ---
 
 func TestLearningLogExportCSV_Success(t *testing.T) {


### PR DESCRIPTION
## 概要
- LearningLogService.Update の Title/Content/Category の空文字チェックを strings.TrimSpace() に変更
- 空白のみの入力でフィールドが上書きされる問題を防止
- TDDアプローチでテスト3件追加（WhitespaceTitle/Content/Category）

## テスト結果
全テストPASS

Closes #1003