### PR TITLE
feat: QuestionHandler.GetByUserID のページネーション対応

### DIFF
--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -14,7 +14,7 @@ type QuestionServiceInterface interface {
 	GetAll(limit, offset int, tag, sort string) ([]model.Question, int64, error)
 	Search(q string, limit, offset int) ([]model.Question, int64, error)
 	GetByID(id uint) (*model.Question, error)
-	GetByUserID(userID uint) ([]model.Question, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.Question, int64, error)
 	GetUserVote(userID, questionID uint) (int, error)
 	Update(id, userID uint, title, body, tags string) (*model.Question, error)
 	Delete(id, userID uint) error
@@ -124,20 +124,27 @@ func (h *QuestionHandler) GetByID(c *gin.Context) {
 	})
 }
 
-// GetByUserID は指定されたユーザーの質問一覧を取得する。
+// GetByUserID は指定されたユーザーの質問一覧をページネーション付きで取得する。
 func (h *QuestionHandler) GetByUserID(c *gin.Context) {
 	userID, ok := parseID(c, "userId")
 	if !ok {
 		return
 	}
 
-	questions, err := h.service.GetByUserID(userID)
+	limit, offset := parseLimitOffset(c)
+
+	questions, total, err := h.service.GetByUserID(userID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, questions)
+	respondOK(c, dto.QuestionListResponse{
+		Questions: questions,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
 }
 
 // Update は指定された質問を更新する。

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -248,9 +248,9 @@ func (m *MockQuestionRepository) Search(q string, limit, offset int) ([]model.Qu
 	args := m.Called(q, limit, offset)
 	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
 }
-func (m *MockQuestionRepository) FindByUserID(userID uint) ([]model.Question, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.Question), args.Error(1)
+func (m *MockQuestionRepository) FindByUserID(userID uint, limit, offset int) ([]model.Question, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
 }
 func (m *MockQuestionRepository) Update(q *model.Question) error {
 	return m.Called(q).Error(0)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -120,7 +120,7 @@ type QuestionRepositoryInterface interface {
 	FindByID(id uint) (*model.Question, error)
 	FindAll(limit, offset int, tag string, sort string) ([]model.Question, int64, error)
 	Search(q string, limit, offset int) ([]model.Question, int64, error)
-	FindByUserID(userID uint) ([]model.Question, error)
+	FindByUserID(userID uint, limit, offset int) ([]model.Question, int64, error)
 	Update(question *model.Question) error
 	Delete(id uint) error
 	Vote(userID, questionID uint, value int) error

--- a/backend/internal/repository/question.go
+++ b/backend/internal/repository/question.go
@@ -81,13 +81,19 @@ func (r *QuestionRepository) Search(q string, limit, offset int) ([]model.Questi
 	return questions, total, err
 }
 
-// FindByUserID は指定ユーザーの全質問を取得する（新しい順）。
-func (r *QuestionRepository) FindByUserID(userID uint) ([]model.Question, error) {
+// FindByUserID は指定ユーザーの質問をページネーション付きで取得する（新しい順）。
+func (r *QuestionRepository) FindByUserID(userID uint, limit, offset int) ([]model.Question, int64, error) {
 	var questions []model.Question
-	err := r.db.Where("user_id = ?", userID).
-		Order("created_at DESC").
+	var total int64
+	q := r.db.Where("user_id = ?", userID)
+	if err := q.Model(&model.Question{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+	err := q.Order("created_at DESC").
+		Limit(limit).
+		Offset(offset).
 		Find(&questions).Error
-	return questions, err
+	return questions, total, err
 }
 
 // Update は既存の質問を更新する。

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -367,9 +367,9 @@ func (m *MockQuestionRepository) Search(q string, limit, offset int) ([]model.Qu
 	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
 }
 
-func (m *MockQuestionRepository) FindByUserID(userID uint) ([]model.Question, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.Question), args.Error(1)
+func (m *MockQuestionRepository) FindByUserID(userID uint, limit, offset int) ([]model.Question, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockQuestionRepository) Update(question *model.Question) error {

--- a/backend/internal/service/question.go
+++ b/backend/internal/service/question.go
@@ -41,9 +41,9 @@ func (s *QuestionService) GetByID(id uint) (*model.Question, error) {
 	return s.repo.FindByID(id)
 }
 
-// GetByUserID は指定ユーザーの全質問を取得する。
-func (s *QuestionService) GetByUserID(userID uint) ([]model.Question, error) {
-	return s.repo.FindByUserID(userID)
+// GetByUserID は指定ユーザーの質問をページネーション付きで取得する。
+func (s *QuestionService) GetByUserID(userID uint, limit, offset int) ([]model.Question, int64, error) {
+	return s.repo.FindByUserID(userID, limit, offset)
 }
 
 // GetUserVote は指定ユーザーの質問への投票値を取得する。

--- a/backend/internal/service/question_test.go
+++ b/backend/internal/service/question_test.go
@@ -333,12 +333,41 @@ func TestQuestionGetByUserID_Success(t *testing.T) {
 		{Title: "ユーザー1の質問", UserID: 1},
 	}
 
-	repo.On("FindByUserID", uint(1)).Return(questions, nil)
+	repo.On("FindByUserID", uint(1), 20, 0).Return(questions, int64(1), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
 	assert.Equal(t, uint(1), result[0].UserID)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionGetByUserID_Empty(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindByUserID", uint(1), 20, 0).Return([]model.Question{}, int64(0), nil)
+
+	result, total, err := svc.GetByUserID(1, 20, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionGetByUserID_Page2(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	questions := []model.Question{
+		{Title: "質問21", UserID: 1},
+	}
+
+	repo.On("FindByUserID", uint(1), 20, 20).Return(questions, int64(21), nil)
+
+	result, total, err := svc.GetByUserID(1, 20, 20)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(21), total)
 	repo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
- QuestionHandler.GetByUserID を respondOK → dto.QuestionListResponse に変更
- 全レイヤー（Repository/Service/Handler）にページネーション対応追加
- GetAll/Searchと同じ parseLimitOffset + QuestionListResponse パターンに統一
- テスト2件追加（Empty/Page2）、既存テスト・モック引数更新

## テスト結果
全テストPASS（Service + Handler）

Closes #1005