### PR TITLE
BookReviewService.Updateの空白バイパス脆弱性修正

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -74,13 +76,13 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		return nil, err
 	}
 
-	if updates.Title != "" {
+	if strings.TrimSpace(updates.Title) != "" {
 		review.Title = updates.Title
 	}
-	if updates.Author != "" {
+	if strings.TrimSpace(updates.Author) != "" {
 		review.Author = updates.Author
 	}
-	if updates.ISBN != "" {
+	if strings.TrimSpace(updates.ISBN) != "" {
 		review.ISBN = updates.ISBN
 	}
 	if updates.Rating != 0 {
@@ -89,10 +91,10 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		}
 		review.Rating = updates.Rating
 	}
-	if updates.Review != "" {
+	if strings.TrimSpace(updates.Review) != "" {
 		review.Review = updates.Review
 	}
-	if updates.ImageURL != "" {
+	if strings.TrimSpace(updates.ImageURL) != "" {
 		review.ImageURL = updates.ImageURL
 	}
 

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -343,3 +343,43 @@ func TestBookReviewUpdate_InvalidRating(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "評価は1〜5")
 }
+
+// ============================================================
+// 空白バイパス脆弱性テスト
+// ============================================================
+
+func TestBookReviewUpdate_WhitespaceTitle(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+	existing := &model.BookReview{Title: "Original Title", Author: "Author", Rating: 4, Review: "Good", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.BookReview{Title: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "Original Title", result.Title)
+}
+
+func TestBookReviewUpdate_WhitespaceAuthor(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+	existing := &model.BookReview{Title: "Title", Author: "Original Author", Rating: 4, Review: "Good", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.BookReview{Author: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "Original Author", result.Author)
+}
+
+func TestBookReviewUpdate_WhitespaceReview(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+	existing := &model.BookReview{Title: "Title", Author: "Author", Rating: 4, Review: "Original Review", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.BookReview{Review: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "Original Review", result.Review)
+}


### PR DESCRIPTION
## 概要
closes #1011

BookReviewService.Updateで空白のみの入力が元の値を上書きする脆弱性を修正。

## 変更内容
- `book_review.go`: Title/Author/ISBN/Review/ImageURLの5フィールドを `strings.TrimSpace() != ""` に変更
- `book_review_test.go`: 空白バイパステスト3件追加（Title/Author/Review）

## テスト結果
- 全28テストPASS（既存25件 + 新規3件）