### PR TITLE
LearningResource.GetByUserIDページネーション対応

### DIFF
--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -14,7 +14,7 @@ type LearningResourceServiceInterface interface {
 	GetByID(id, userID uint) (*model.LearningResource, error)
 	HasLiked(userID, resourceID uint) (bool, error)
 	HasSaved(userID, resourceID uint) (bool, error)
-	GetByUserID(targetUserID, currentUserID uint) ([]model.LearningResource, error)
+	GetByUserID(targetUserID, currentUserID uint, limit, offset int) ([]model.LearningResource, int64, error)
 	GetPublic(limit, offset int, category, difficulty string) ([]model.LearningResource, int64, error)
 	Search(query string, limit, offset int) ([]model.LearningResource, int64, error)
 	Update(id, userID uint, updates *model.LearningResource) (*model.LearningResource, error)
@@ -124,7 +124,7 @@ func (h *LearningResourceHandler) GetByID(c *gin.Context) {
 	})
 }
 
-// GetByUserID は指定されたユーザーの学習リソース一覧を取得する。
+// GetByUserID は指定されたユーザーの学習リソース一覧をページネーション付きで取得する。
 func (h *LearningResourceHandler) GetByUserID(c *gin.Context) {
 	targetUserID, ok := parseID(c, "userId")
 	if !ok {
@@ -132,14 +132,20 @@ func (h *LearningResourceHandler) GetByUserID(c *gin.Context) {
 	}
 
 	currentUserID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
 
-	resources, err := h.service.GetByUserID(targetUserID, currentUserID)
+	resources, total, err := h.service.GetByUserID(targetUserID, currentUserID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, resources)
+	respondOK(c, dto.ResourceListResponse{
+		Resources: resources,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
 }
 
 // GetPublic は公開学習リソース一覧をページネーション・フィルター付きで取得する。

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -286,9 +286,9 @@ func (m *MockLearningResourceRepository) FindByID(id uint) (*model.LearningResou
 	}
 	return nil, args.Error(1)
 }
-func (m *MockLearningResourceRepository) FindByUserID(userID uint, includePrivate bool) ([]model.LearningResource, error) {
-	args := m.Called(userID, includePrivate)
-	return args.Get(0).([]model.LearningResource), args.Error(1)
+func (m *MockLearningResourceRepository) FindByUserID(userID uint, includePrivate bool, limit, offset int) ([]model.LearningResource, int64, error) {
+	args := m.Called(userID, includePrivate, limit, offset)
+	return args.Get(0).([]model.LearningResource), args.Get(1).(int64), args.Error(2)
 }
 func (m *MockLearningResourceRepository) FindPublic(limit, offset int, category string, difficulty string) ([]model.LearningResource, int64, error) {
 	args := m.Called(limit, offset, category, difficulty)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -209,7 +209,7 @@ type BookReviewRepositoryInterface interface {
 type LearningResourceRepositoryInterface interface {
 	Create(resource *model.LearningResource) error
 	FindByID(id uint) (*model.LearningResource, error)
-	FindByUserID(userID uint, includePrivate bool) ([]model.LearningResource, error)
+	FindByUserID(userID uint, includePrivate bool, limit, offset int) ([]model.LearningResource, int64, error)
 	FindPublic(limit, offset int, category string, difficulty string) ([]model.LearningResource, int64, error)
 	Update(resource *model.LearningResource) error
 	Delete(id uint) error

--- a/backend/internal/repository/learning_resource.go
+++ b/backend/internal/repository/learning_resource.go
@@ -32,14 +32,16 @@ func (r *LearningResourceRepository) FindByID(id uint) (*model.LearningResource,
 
 // FindByUserID は指定ユーザーの学習リソースを取得する。
 // includePrivateがfalseの場合、公開リソースのみを返す。
-func (r *LearningResourceRepository) FindByUserID(userID uint, includePrivate bool) ([]model.LearningResource, error) {
+func (r *LearningResourceRepository) FindByUserID(userID uint, includePrivate bool, limit, offset int) ([]model.LearningResource, int64, error) {
 	var resources []model.LearningResource
+	var total int64
 	query := r.db.Where("user_id = ?", userID)
 	if !includePrivate {
 		query = query.Where("is_public = ?", true)
 	}
-	err := query.Order("created_at DESC").Find(&resources).Error
-	return resources, err
+	query.Model(&model.LearningResource{}).Count(&total)
+	err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&resources).Error
+	return resources, total, err
 }
 
 // FindPublic は公開学習リソースをフィルタ・ページネーション付きで取得する。

--- a/backend/internal/service/ai_advice_test.go
+++ b/backend/internal/service/ai_advice_test.go
@@ -76,7 +76,7 @@ func TestRuleEngine_StreakBroken(t *testing.T) {
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)
@@ -111,7 +111,7 @@ func TestRuleEngine_RoadmapStalled(t *testing.T) {
 	}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)
@@ -139,7 +139,7 @@ func TestRuleEngine_GoalOverdue(t *testing.T) {
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)
@@ -169,7 +169,7 @@ func TestRuleEngine_TechGapReact(t *testing.T) {
 		{Language: "JavaScript", Bytes: 50000, RepoCount: 3},
 	}, nil)
 	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)
@@ -196,7 +196,7 @@ func TestRuleEngine_NoGoalsWithGitHub(t *testing.T) {
 		{Language: "Go", Bytes: 80000, RepoCount: 3},
 	}, nil)
 	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)
@@ -230,9 +230,9 @@ func TestRuleEngine_HighCompletionRate(t *testing.T) {
 	}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{
 		{}, {}, {},
-	}, nil)
+	}, int64(3), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)
@@ -270,9 +270,9 @@ func TestRuleEngine_ConsistentLearner(t *testing.T) {
 		}
 	}
 	deps.logRepo.On("GetByUserID", uint(1)).Return(logs, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{
 		{}, {}, {},
-	}, nil)
+	}, int64(3), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)
@@ -299,7 +299,7 @@ func TestRuleEngine_NoRoadmap(t *testing.T) {
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)
@@ -329,7 +329,7 @@ func TestRuleEngine_PriorityOrdering(t *testing.T) {
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)
@@ -353,7 +353,7 @@ func TestRuleEngine_NewUserNoData(t *testing.T) {
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	deps.resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 	advices := svc.GenerateAdvice(1)

--- a/backend/internal/service/ai_rule_engine.go
+++ b/backend/internal/service/ai_rule_engine.go
@@ -57,7 +57,7 @@ func (s *AIAdviceService) collectContext(userID uint) (*userContext, error) {
 		return nil, err
 	}
 
-	ctx.resources, err = s.resourceRepo.FindByUserID(userID, true)
+	ctx.resources, _, err = s.resourceRepo.FindByUserID(userID, true, 100, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/ai_rule_engine_test.go
+++ b/backend/internal/service/ai_rule_engine_test.go
@@ -46,7 +46,7 @@ func setupDefaultMocks(
 	roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-	resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+	resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 }
 
@@ -59,7 +59,7 @@ func TestGenerateAdvice_StreakBroken(t *testing.T) {
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -84,7 +84,7 @@ func TestGenerateAdvice_StreakBroken(t *testing.T) {
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -107,7 +107,7 @@ func TestGenerateAdvice_StalledRoadmap(t *testing.T) {
 		}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -136,7 +136,7 @@ func TestGenerateAdvice_GoalOverdue(t *testing.T) {
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -166,7 +166,7 @@ func TestGenerateAdvice_ReactSuggestion(t *testing.T) {
 			{Language: "TypeScript", Bytes: 50000},
 		}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -194,7 +194,7 @@ func TestGenerateAdvice_ReactSuggestion(t *testing.T) {
 			{Language: "TypeScript", Bytes: 50000},
 		}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -218,7 +218,7 @@ func TestGenerateAdvice_NoGoals(t *testing.T) {
 			{Language: "Go", Bytes: 20000},
 		}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -246,7 +246,7 @@ func TestGenerateAdvice_NoRoadmap(t *testing.T) {
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -272,7 +272,7 @@ func TestGenerateAdvice_DifficultyUp(t *testing.T) {
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -305,7 +305,7 @@ func TestGenerateAdvice_Praise(t *testing.T) {
 			logs[i].CreatedAt = now.Add(-time.Duration(i) * 24 * time.Hour)
 		}
 		logRepo.On("GetByUserID", uint(1)).Return(logs, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -331,7 +331,7 @@ func TestGenerateAdvice_ExploreResources(t *testing.T) {
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}}, int64(2), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -355,7 +355,7 @@ func TestGenerateAdvice_ExploreResources(t *testing.T) {
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -383,7 +383,7 @@ func TestGenerateAdvice_LowStudyTime(t *testing.T) {
 		logs[0].CreatedAt = now.Add(-1 * 24 * time.Hour)
 		logs[1].CreatedAt = now.Add(-3 * 24 * time.Hour)
 		logRepo.On("GetByUserID", uint(1)).Return(logs, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -418,7 +418,7 @@ func TestGenerateAdvice_LowStudyTime(t *testing.T) {
 		logs[1].CreatedAt = now.Add(-3 * 24 * time.Hour)
 		logs[2].CreatedAt = now.Add(-5 * 24 * time.Hour)
 		logRepo.On("GetByUserID", uint(1)).Return(logs, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -446,7 +446,7 @@ func TestGenerateAdvice_TechSuggestionFromTopLanguage(t *testing.T) {
 			{Language: "Python", Bytes: 30000, RepoCount: 2},
 		}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -475,7 +475,7 @@ func TestGenerateAdvice_TechSuggestionFromTopLanguage(t *testing.T) {
 			{Language: "Go", Bytes: 80000, RepoCount: 5},
 		}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -496,7 +496,7 @@ func TestGenerateAdvice_TechSuggestionFromTopLanguage(t *testing.T) {
 			{Language: "Go", Bytes: 5000, RepoCount: 1},
 		}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -520,7 +520,7 @@ func TestGenerateAdvice_TechSuggestionTopLangNotFirst(t *testing.T) {
 			{Language: "Go", Bytes: 80000, RepoCount: 5},
 		}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -549,7 +549,7 @@ func TestGenerateAdvice_StalledRoadmapEdgeCases(t *testing.T) {
 		}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -571,7 +571,7 @@ func TestGenerateAdvice_StalledRoadmapEdgeCases(t *testing.T) {
 		}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}, {}, {}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -595,7 +595,7 @@ func TestGenerateAdvice_PrioritySorting(t *testing.T) {
 			{Language: "Go", Bytes: 20000},
 		}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{{}}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}}, int64(1), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
 		advices := svc.GenerateAdvice(1)
@@ -717,7 +717,7 @@ func TestGenerateAdvice_ContextCollectionError_Resources(t *testing.T) {
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, assert.AnError)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), assert.AnError)
 
 		advices := svc.GenerateAdvice(1)
 		assert.Empty(t, advices)
@@ -734,7 +734,7 @@ func TestGenerateAdvice_ContextCollectionError_User(t *testing.T) {
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
-		resourceRepo.On("FindByUserID", uint(1), true).Return([]model.LearningResource{}, nil)
+		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 		userRepo.On("FindByID", uint(1)).Return(nil, assert.AnError)
 
 		advices := svc.GenerateAdvice(1)

--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -53,11 +53,11 @@ func (s *LearningResourceService) HasSaved(userID, resourceID uint) (bool, error
 	return s.repo.HasSaved(userID, resourceID)
 }
 
-// GetByUserID は指定ユーザーの学習リソースを取得する。
+// GetByUserID は指定ユーザーの学習リソースをページネーション付きで取得する。
 // 自分のリソースの場合は非公開も含め、他ユーザーの場合は公開のみ返す。
-func (s *LearningResourceService) GetByUserID(targetUserID, currentUserID uint) ([]model.LearningResource, error) {
+func (s *LearningResourceService) GetByUserID(targetUserID, currentUserID uint, limit, offset int) ([]model.LearningResource, int64, error) {
 	includePrivate := currentUserID == targetUserID
-	return s.repo.FindByUserID(targetUserID, includePrivate)
+	return s.repo.FindByUserID(targetUserID, includePrivate, limit, offset)
 }
 
 // GetPublic は公開学習リソースをページネーション・フィルタ付きで取得する。

--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -87,11 +87,12 @@ func TestLearningResourceGetByUserID_Self(t *testing.T) {
 		{Title: "Private", IsPublic: false},
 	}
 	// 自分 → includePrivate=true
-	repo.On("FindByUserID", uint(1), true).Return(resources, nil)
+	repo.On("FindByUserID", uint(1), true, 20, 0).Return(resources, int64(2), nil)
 
-	result, err := svc.GetByUserID(1, 1)
+	result, total, err := svc.GetByUserID(1, 1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
 	repo.AssertExpectations(t)
 }
 
@@ -102,11 +103,24 @@ func TestLearningResourceGetByUserID_Other(t *testing.T) {
 		{Title: "Public Only", IsPublic: true},
 	}
 	// 他人 → includePrivate=false
-	repo.On("FindByUserID", uint(1), false).Return(resources, nil)
+	repo.On("FindByUserID", uint(1), false, 20, 0).Return(resources, int64(1), nil)
 
-	result, err := svc.GetByUserID(1, 999)
+	result, total, err := svc.GetByUserID(1, 999, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceGetByUserID_Page2(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("FindByUserID", uint(1), true, 10, 10).Return([]model.LearningResource{}, int64(15), nil)
+
+	result, total, err := svc.GetByUserID(1, 1, 10, 10)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(15), total)
 	repo.AssertExpectations(t)
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -699,9 +699,9 @@ func (m *MockLearningResourceRepository) FindByID(id uint) (*model.LearningResou
 	return args.Get(0).(*model.LearningResource), args.Error(1)
 }
 
-func (m *MockLearningResourceRepository) FindByUserID(userID uint, includePrivate bool) ([]model.LearningResource, error) {
-	args := m.Called(userID, includePrivate)
-	return args.Get(0).([]model.LearningResource), args.Error(1)
+func (m *MockLearningResourceRepository) FindByUserID(userID uint, includePrivate bool, limit, offset int) ([]model.LearningResource, int64, error) {
+	args := m.Called(userID, includePrivate, limit, offset)
+	return args.Get(0).([]model.LearningResource), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockLearningResourceRepository) FindPublic(limit, offset int, category string, difficulty string) ([]model.LearningResource, int64, error) {


### PR DESCRIPTION
## 概要
closes #1013

LearningResource.GetByUserIDにlimit/offsetページネーションを追加。

## 変更内容（10ファイル）
- `repository/interfaces.go`: FindByUserIDシグネチャ変更
- `repository/learning_resource.go`: Count+Limit+Offset追加
- `service/learning_resource.go`: GetByUserIDシグネチャ変更
- `service/ai_rule_engine.go`: 呼び出し元更新（limit=100）
- `handler/learning_resource.go`: parseLimitOffset + ResourceListResponse
- モック更新: service/mock_test.go, handler/testutil_test.go
- テスト更新: learning_resource_test.go, ai_rule_engine_test.go, ai_advice_test.go

## テスト結果
- Service層・Handler層全テストPASS