### PR TITLE
PostTag/PostPinのgin.Hレスポンスを型付きDTOに置換

### DIFF
--- a/backend/internal/dto/response.go
+++ b/backend/internal/dto/response.go
@@ -43,3 +43,13 @@ type AvailabilityResponse struct {
 	Available bool `json:"available"`
 }
 
+// TagsResponse はタグ一覧レスポンス
+type TagsResponse struct {
+	Tags interface{} `json:"tags"`
+}
+
+// PinsResponse はピン留め一覧レスポンス
+type PinsResponse struct {
+	Pins interface{} `json:"pins"`
+}
+

--- a/backend/internal/handler/post_pin.go
+++ b/backend/internal/handler/post_pin.go
@@ -68,7 +68,7 @@ func (h *PostPinHandler) GetByUserID(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"pins": pins})
+	respondOK(c, dto.PinsResponse{Pins: pins})
 }
 
 // Reorder はピン留めの表示順序を変更する。

--- a/backend/internal/handler/post_tag.go
+++ b/backend/internal/handler/post_tag.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -58,7 +59,7 @@ func (h *PostTagHandler) GetByPostID(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"tags": tags})
+	respondOK(c, dto.TagsResponse{Tags: tags})
 }
 
 // FindPostsByTag はタグで投稿を検索する。
@@ -87,5 +88,5 @@ func (h *PostTagHandler) GetPopularTags(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, gin.H{"tags": tags})
+	respondOK(c, dto.TagsResponse{Tags: tags})
 }


### PR DESCRIPTION
## 概要
closes #1015

ハンドラー内の最後のgin.Hデータレスポンス3箇所を型付きDTOに置換。

## 変更内容
- `dto/response.go`: TagsResponse, PinsResponse 追加
- `post_tag.go`: gin.H → dto.TagsResponse（2箇所）
- `post_pin.go`: gin.H → dto.PinsResponse（1箇所）

## テスト結果
- PostTag/PostPin全20テストPASS