### PR TITLE
UserDashboardHandler テストカバレッジ100%達成

### DIFF
--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1781,3 +1781,22 @@ func setupYouTubeHandler() (*YouTubeHandler, *MockYouTubeService) {
 	h := NewYouTubeHandler(svc)
 	return h, svc
 }
+
+// ---------- UserDashboardHandler モック ----------
+
+// MockUserDashboardService は UserDashboardServiceInterface のモック実装。
+type MockUserDashboardService struct{ mock.Mock }
+
+func (m *MockUserDashboardService) GetStats(userID uint) (*model.UserDashboardStats, error) {
+	args := m.Called(userID)
+	if s := args.Get(0); s != nil {
+		return s.(*model.UserDashboardStats), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func setupUserDashboardHandler() (*UserDashboardHandler, *MockUserDashboardService) {
+	svc := new(MockUserDashboardService)
+	h := NewUserDashboardHandler(svc)
+	return h, svc
+}

--- a/backend/internal/handler/user_dashboard_test.go
+++ b/backend/internal/handler/user_dashboard_test.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+func TestUserDashboard_GetStats_Success(t *testing.T) {
+	h, svc := setupUserDashboardHandler()
+	stats := &model.UserDashboardStats{
+		PostCount:     10,
+		LikesReceived: 50,
+		FollowerCount: 20,
+	}
+	svc.On("GetStats", uint(5)).Return(stats, nil)
+
+	r := newRouter(1)
+	r.GET("/users/:id/dashboard-stats", h.GetStats)
+	w := doRequest(r, http.MethodGet, "/users/5/dashboard-stats", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	if body["post_count"] != float64(10) {
+		t.Errorf("expected post_count=10, got %v", body["post_count"])
+	}
+	svc.AssertExpectations(t)
+}
+
+func TestUserDashboard_GetStats_InvalidID(t *testing.T) {
+	h, _ := setupUserDashboardHandler()
+
+	r := newRouter(1)
+	r.GET("/users/:id/dashboard-stats", h.GetStats)
+	w := doRequest(r, http.MethodGet, "/users/abc/dashboard-stats", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestUserDashboard_GetStats_ServiceError(t *testing.T) {
+	h, svc := setupUserDashboardHandler()
+	svc.On("GetStats", uint(5)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/users/:id/dashboard-stats", h.GetStats)
+	w := doRequest(r, http.MethodGet, "/users/5/dashboard-stats", nil)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
closes #1017

UserDashboardHandler全2関数のテストカバレッジを0%→100%に向上。

## 変更内容
- `testutil_test.go`: MockUserDashboardService + setupUserDashboardHandler 追加
- `user_dashboard_test.go`: 新規作成（3テスト: Success/InvalidID/ServiceError）

## テスト結果
- 全3テストPASS
- handler全体カバレッジ 77.5% → 77.7%