### PR TITLE
NoteTemplateService.Updateの空白バイパス脆弱性修正

### DIFF
--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -93,19 +95,19 @@ func (s *NoteTemplateService) Update(id, userID uint, name, description, default
 		return nil, err
 	}
 
-	if name != "" {
+	if strings.TrimSpace(name) != "" {
 		template.Name = name
 	}
-	if description != "" {
+	if strings.TrimSpace(description) != "" {
 		template.Description = description
 	}
-	if defaultTitle != "" {
+	if strings.TrimSpace(defaultTitle) != "" {
 		template.DefaultTitle = defaultTitle
 	}
-	if contentTemplate != "" {
+	if strings.TrimSpace(contentTemplate) != "" {
 		template.ContentTemplate = contentTemplate
 	}
-	if defaultTags != "" {
+	if strings.TrimSpace(defaultTags) != "" {
 		template.DefaultTags = defaultTags
 	}
 	if isDefault != nil {

--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -330,11 +330,12 @@ func TestNoteTemplateService_Update_ValidationContentTemplateError(t *testing.T)
 	existing := &model.NoteTemplate{ID: 1, UserID: 1, Name: "テンプレ"}
 
 	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
 
-	// 空白のみのcontentTemplate → TrimSpace後に空 → バリデーションエラー
+	// 空白のみのcontentTemplate → TrimSpace後に空 → フィールドスキップ（変更なし）
 	result, err := svc.Update(1, 1, "", "", "", "   ", "", nil)
-	assert.Error(t, err)
-	assert.Nil(t, result)
+	assert.NoError(t, err)
+	assert.Equal(t, "", result.ContentTemplate)
 }
 
 func TestNoteTemplateService_Update_ValidationDescriptionError(t *testing.T) {
@@ -538,4 +539,44 @@ func TestNoteTemplateService_Create_DefaultTitleValidationError(t *testing.T) {
 
 	err := svc.Create(template)
 	assert.Error(t, err)
+}
+
+// ============================================================
+// 空白バイパス脆弱性テスト
+// ============================================================
+
+func TestNoteTemplateUpdate_WhitespaceDescription(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+	existing := &model.NoteTemplate{Name: "Template", ContentTemplate: "Content", Description: "Original Desc", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, "", "   ", "", "", "", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "Original Desc", result.Description)
+}
+
+func TestNoteTemplateUpdate_WhitespaceDefaultTitle(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+	existing := &model.NoteTemplate{Name: "Template", ContentTemplate: "Content", DefaultTitle: "Original Title", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, "", "", "   ", "", "", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "Original Title", result.DefaultTitle)
+}
+
+func TestNoteTemplateUpdate_WhitespaceDefaultTags(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+	existing := &model.NoteTemplate{Name: "Template", ContentTemplate: "Content", DefaultTags: "go,rust", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, "", "", "", "", "   ", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "go,rust", result.DefaultTags)
 }


### PR DESCRIPTION
## 概要
closes #1019

NoteTemplateService.Updateで空白のみの入力が元の値を上書きする脆弱性を修正。

## 変更内容
- `note_template.go`: 5フィールド全て `strings.TrimSpace() != ""` に変更
- `note_template_test.go`: 空白バイパステスト3件追加 + 既存テスト1件の期待値修正

## テスト結果
- 全テストPASS