### PR TITLE
feat: LearningGoal.GetByUserIDにページネーション対応

### DIFF
--- a/backend/internal/dto/learning_goal_dto.go
+++ b/backend/internal/dto/learning_goal_dto.go
@@ -1,5 +1,15 @@
 package dto
 
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// GoalListResponse は学習目標一覧レスポンス。
+type GoalListResponse struct {
+	Goals  []model.LearningGoal `json:"goals"`
+	Total  int64                `json:"total"`
+	Limit  int                  `json:"limit"`
+	Offset int                  `json:"offset"`
+}
+
 // CreateGoalRequest は学習目標作成のリクエストボディ。
 type CreateGoalRequest struct {
 	Title       string `json:"title" binding:"required,max=200" validate:"required,max=200"`

--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -12,7 +12,7 @@ import (
 type LearningGoalServiceInterface interface {
 	Create(goal *model.LearningGoal) error
 	GetByID(id uint) (*model.LearningGoal, error)
-	GetByUserID(userID uint) ([]model.LearningGoal, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error)
 	GetByCategory(userID uint, category string) ([]model.LearningGoal, error)
 	GetByStatus(userID uint, status string) ([]model.LearningGoal, error)
 	GetStats(userID uint) (*model.LearningGoalStats, error)
@@ -159,26 +159,38 @@ func (h *LearningGoalHandler) GetByUserID(c *gin.Context) {
 		return
 	}
 
-	goals, err := h.service.GetByUserID(userID)
+	limit, offset := parseLimitOffset(c)
+	goals, total, err := h.service.GetByUserID(userID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, goals)
+	respondOK(c, dto.GoalListResponse{
+		Goals:  goals,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
 // GetMyGoals は認証ユーザー自身の学習目標一覧を取得する。
 func (h *LearningGoalHandler) GetMyGoals(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	goals, err := h.service.GetByUserID(userID)
+	limit, offset := parseLimitOffset(c)
+	goals, total, err := h.service.GetByUserID(userID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, goals)
+	respondOK(c, dto.GoalListResponse{
+		Goals:  goals,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
 // GetDeadlineAlerts は認証ユーザーのデッドラインアラートを取得する。

--- a/backend/internal/handler/learning_goal_test.go
+++ b/backend/internal/handler/learning_goal_test.go
@@ -24,9 +24,9 @@ func (m *MockLearningGoalRepository) FindByID(id uint) (*model.LearningGoal, err
 	return nil, args.Error(1)
 }
 
-func (m *MockLearningGoalRepository) GetByUserID(userID uint) ([]model.LearningGoal, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.LearningGoal), args.Error(1)
+func (m *MockLearningGoalRepository) GetByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.LearningGoal), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockLearningGoalRepository) GetActiveByUserID(userID uint) ([]model.LearningGoal, error) {
@@ -245,7 +245,7 @@ func TestLearningGoalGetMyGoals_Success(t *testing.T) {
 		{Title: "Goal 2"},
 	}
 
-	repo.On("GetByUserID", uint(1)).Return(goals, nil)
+	repo.On("GetByUserID", uint(1), 20, 0).Return(goals, int64(2), nil)
 
 	w := doRequest(r, http.MethodGet, "/goals/my", nil)
 	assertStatus(t, w, http.StatusOK)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -166,7 +166,7 @@ type LearningGoalRepositoryInterface interface {
 	Update(goal *model.LearningGoal) error
 	Delete(id uint) error
 	FindByID(id uint) (*model.LearningGoal, error)
-	GetByUserID(userID uint) ([]model.LearningGoal, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error)
 	GetActiveByUserID(userID uint) ([]model.LearningGoal, error)
 	GetByCategory(userID uint, category string) ([]model.LearningGoal, error)
 	GetByStatus(userID uint, status string) ([]model.LearningGoal, error)

--- a/backend/internal/repository/learning_goal.go
+++ b/backend/internal/repository/learning_goal.go
@@ -40,11 +40,14 @@ func (r *LearningGoalRepository) FindByID(id uint) (*model.LearningGoal, error) 
 	return &goal, nil
 }
 
-// GetByUserID は指定ユーザーの全学習目標を取得する（新しい順）。
-func (r *LearningGoalRepository) GetByUserID(userID uint) ([]model.LearningGoal, error) {
+// GetByUserID は指定ユーザーの学習目標をページネーション付きで取得する（新しい順）。
+func (r *LearningGoalRepository) GetByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error) {
 	var goals []model.LearningGoal
-	err := r.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&goals).Error
-	return goals, err
+	var total int64
+	query := r.db.Where("user_id = ?", userID)
+	query.Model(&model.LearningGoal{}).Count(&total)
+	err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&goals).Error
+	return goals, total, err
 }
 
 // GetActiveByUserID は指定ユーザーの進行中の学習目標を取得する（新しい順）。

--- a/backend/internal/service/ai_advice_test.go
+++ b/backend/internal/service/ai_advice_test.go
@@ -71,7 +71,7 @@ func TestRuleEngine_StreakBroken(t *testing.T) {
 		CurrentStreak: 0,
 		TotalDays:     10,
 	}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -97,7 +97,7 @@ func TestRuleEngine_RoadmapStalled(t *testing.T) {
 	// ロードマップのステップが7日以上未更新 → stalled_roadmap
 	stalledTime := time.Now().Add(-8 * 24 * time.Hour)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 3, TotalDays: 10}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{
 		{
@@ -132,9 +132,9 @@ func TestRuleEngine_GoalOverdue(t *testing.T) {
 	// 目標期限超過 → goal_overdue
 	pastDate := time.Now().Add(-3 * 24 * time.Hour)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 3, TotalDays: 10}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 		{Title: "React学習", Status: model.GoalStatusActive, TargetDate: &pastDate, Progress: 50},
-	}, nil)
+	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -159,9 +159,9 @@ func TestRuleEngine_TechGapReact(t *testing.T) {
 
 	// GitHub TypeScript多用 + React目標なし → React提案
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 3, TotalDays: 10}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 		{Title: "TypeScript基礎", Category: model.GoalCategoryLanguage, Status: model.GoalStatusActive},
-	}, nil)
+	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -189,7 +189,7 @@ func TestRuleEngine_NoGoalsWithGitHub(t *testing.T) {
 
 	// 目標0件 + GitHub活動あり → 目標設定提案
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 3, TotalDays: 10}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 0}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -216,12 +216,12 @@ func TestRuleEngine_HighCompletionRate(t *testing.T) {
 
 	// 達成率高い → 難易度UP提案
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 5, TotalDays: 30}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 		{Status: model.GoalStatusActive, Progress: 80},
 		{Status: model.GoalStatusCompleted, Progress: 100},
 		{Status: model.GoalStatusCompleted, Progress: 100},
 		{Status: model.GoalStatusCompleted, Progress: 100},
-	}, nil)
+	}, int64(4), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{
 		CompletedGoals: 3, ActiveGoals: 1, AverageProgress: 80,
 	}, nil)
@@ -252,9 +252,9 @@ func TestRuleEngine_ConsistentLearner(t *testing.T) {
 
 	// 7日平均60分/日以上 → 称賛
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 10, TotalDays: 30}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 		{Status: model.GoalStatusActive, Progress: 50},
-	}, nil)
+	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{
 		{ID: 1, Status: model.RoadmapStatusActive},
@@ -292,9 +292,9 @@ func TestRuleEngine_NoRoadmap(t *testing.T) {
 
 	// 目標あり + ロードマップなし → ロードマップ提案
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 3, TotalDays: 10}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 		{Title: "Go学習", Status: model.GoalStatusActive},
-	}, nil)
+	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -322,9 +322,9 @@ func TestRuleEngine_PriorityOrdering(t *testing.T) {
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{
 		CurrentStreak: 0, TotalDays: 10,
 	}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 		{Title: "React", Status: model.GoalStatusActive, TargetDate: &pastDate, Progress: 30},
-	}, nil)
+	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -348,7 +348,7 @@ func TestRuleEngine_NewUserNoData(t *testing.T) {
 
 	// データなし → 空または初期ウェルカム
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -375,9 +375,9 @@ func TestChat_Success(t *testing.T) {
 	// レート制限OK
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(2), nil)
 	// ユーザーコンテキスト収集
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 		{Title: "Go学習", Status: model.GoalStatusActive, Progress: 50},
-	}, nil)
+	}, int64(1), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 5}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -641,7 +641,7 @@ func TestChat_ExistingConversation(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(1), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -672,7 +672,7 @@ func TestChat_ForbiddenConversation(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(1), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -762,7 +762,7 @@ func TestChat_CreateConversationError(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -777,7 +777,7 @@ func TestChat_AddUserMessageError(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -793,7 +793,7 @@ func TestChat_LLMCompleteError(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -810,7 +810,7 @@ func TestChat_AddAssistantMessageError(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -836,7 +836,7 @@ func TestChat_ExistingConversationWithMessages(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -872,7 +872,7 @@ func TestChat_LongTitleTruncation(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -900,7 +900,7 @@ func TestChat_ExistingConversationNotFound(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -916,7 +916,7 @@ func TestChat_RefetchFallback(t *testing.T) {
 	svc, deps := newTestAIAdviceService(true)
 
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
-	deps.goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)

--- a/backend/internal/service/ai_chat.go
+++ b/backend/internal/service/ai_chat.go
@@ -28,7 +28,7 @@ func (s *AIAdviceService) Chat(userID uint, message string, conversationID uint)
 	}
 
 	// ユーザーコンテキスト収集（プロンプト用）
-	goals, _ := s.goalRepo.GetByUserID(userID)
+	goals, _, _ := s.goalRepo.GetByUserID(userID, 100, 0)
 	streak, _ := s.logRepo.GetStreakInfo(userID)
 	roadmaps, _ := s.roadmapRepo.GetByUserID(userID)
 	langStats, _ := s.githubRepo.GetLanguageStats(userID)

--- a/backend/internal/service/ai_rule_engine.go
+++ b/backend/internal/service/ai_rule_engine.go
@@ -32,7 +32,7 @@ func (s *AIAdviceService) collectContext(userID uint) (*userContext, error) {
 		return nil, err
 	}
 
-	ctx.goals, err = s.goalRepo.GetByUserID(userID)
+	ctx.goals, _, err = s.goalRepo.GetByUserID(userID, 100, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/ai_rule_engine_test.go
+++ b/backend/internal/service/ai_rule_engine_test.go
@@ -41,7 +41,7 @@ func setupDefaultMocks(
 	userRepo *MockUserRepository,
 ) {
 	logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 	roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -54,7 +54,7 @@ func TestGenerateAdvice_StreakBroken(t *testing.T) {
 	t.Run("ストリークが途切れた場合Criticalアドバイスを返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 0, TotalDays: 10, LongestStreak: 5}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -79,7 +79,7 @@ func TestGenerateAdvice_StreakBroken(t *testing.T) {
 	t.Run("ストリークが継続中の場合はアドバイスなし", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 3, TotalDays: 10}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -99,7 +99,7 @@ func TestGenerateAdvice_StalledRoadmap(t *testing.T) {
 	t.Run("7日以上更新のないアクティブロードマップにHighアドバイスを返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		staleTime := time.Now().Add(-10 * 24 * time.Hour)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{
@@ -129,9 +129,9 @@ func TestGenerateAdvice_GoalOverdue(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 		pastDate := time.Now().Add(-48 * time.Hour)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 			{Status: model.GoalStatusActive, TargetDate: &pastDate, Title: "Go学習"},
-		}, nil)
+		}, int64(1), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 1, ActiveGoals: 1}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -157,9 +157,9 @@ func TestGenerateAdvice_ReactSuggestion(t *testing.T) {
 	t.Run("TypeScript使用かつReact目標なしの場合React提案を返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 			{Title: "Go学習", Status: model.GoalStatusActive},
-		}, nil)
+		}, int64(1), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 1}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -185,9 +185,9 @@ func TestGenerateAdvice_ReactSuggestion(t *testing.T) {
 	t.Run("既にReact目標がある場合は提案なし", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 			{Title: "React学習", Status: model.GoalStatusActive},
-		}, nil)
+		}, int64(1), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 1}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -211,7 +211,7 @@ func TestGenerateAdvice_NoGoals(t *testing.T) {
 	t.Run("目標未設定かつGitHubデータありの場合目標提案を返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 0}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -239,9 +239,9 @@ func TestGenerateAdvice_NoRoadmap(t *testing.T) {
 	t.Run("目標ありロードマップなしの場合ロードマップ提案を返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 			{Title: "Go学習", Status: model.GoalStatusActive},
-		}, nil)
+		}, int64(1), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 1}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -267,7 +267,7 @@ func TestGenerateAdvice_DifficultyUp(t *testing.T) {
 	t.Run("完了目標3以上かつ平均進捗70超の場合難易度UPアドバイスを返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{CompletedGoals: 5, AverageProgress: 80}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -293,7 +293,7 @@ func TestGenerateAdvice_Praise(t *testing.T) {
 	t.Run("週平均60分以上の学習で称賛アドバイスを返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -326,7 +326,7 @@ func TestGenerateAdvice_ExploreResources(t *testing.T) {
 	t.Run("リソース3未満の場合探索アドバイスを返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -350,7 +350,7 @@ func TestGenerateAdvice_ExploreResources(t *testing.T) {
 	t.Run("リソース3以上の場合探索アドバイスなし", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -370,7 +370,7 @@ func TestGenerateAdvice_LowStudyTime(t *testing.T) {
 	t.Run("週平均15分未満の学習で学習時間増加アドバイスを返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -403,7 +403,7 @@ func TestGenerateAdvice_LowStudyTime(t *testing.T) {
 	t.Run("週平均15分以上60分未満の場合は学習時間アドバイスなし", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -436,9 +436,9 @@ func TestGenerateAdvice_TechSuggestionFromTopLanguage(t *testing.T) {
 	t.Run("TypeScript以外のトップ言語で目標なしの場合技術提案を返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 			{Title: "Docker学習", Status: model.GoalStatusActive},
-		}, nil)
+		}, int64(1), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 1}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -466,9 +466,9 @@ func TestGenerateAdvice_TechSuggestionFromTopLanguage(t *testing.T) {
 	t.Run("トップ言語に対応する目標がある場合は提案なし", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{
 			{Title: "Go言語マスター", Status: model.GoalStatusActive},
-		}, nil)
+		}, int64(1), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 1}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -489,7 +489,7 @@ func TestGenerateAdvice_TechSuggestionFromTopLanguage(t *testing.T) {
 	t.Run("トップ言語のバイト数が10000以下の場合は提案なし", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -512,7 +512,7 @@ func TestGenerateAdvice_TechSuggestionTopLangNotFirst(t *testing.T) {
 	t.Run("最初の要素が最大でない場合もトップ言語で技術提案を返す", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -541,7 +541,7 @@ func TestGenerateAdvice_StalledRoadmapEdgeCases(t *testing.T) {
 	t.Run("完了済みロードマップは停滞アドバイスを返さない", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		staleTime := time.Now().Add(-10 * 24 * time.Hour)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{
@@ -563,7 +563,7 @@ func TestGenerateAdvice_StalledRoadmapEdgeCases(t *testing.T) {
 	t.Run("全ステップ完了のアクティブロードマップは停滞アドバイスを返さない", func(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		staleTime := time.Now().Add(-10 * 24 * time.Hour)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{
@@ -588,7 +588,7 @@ func TestGenerateAdvice_PrioritySorting(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 		// ストリーク途切れ(Critical=1) + 目標未設定+GitHub有(Medium=3) + リソース少(Info=5)
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 0, TotalDays: 10, LongestStreak: 5}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 0}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
@@ -642,7 +642,7 @@ func TestGenerateAdvice_ContextCollectionError_Goals(t *testing.T) {
 		svc, logRepo, goalRepo, _, _, _, _ := setupRuleEngineService()
 
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, assert.AnError)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), assert.AnError)
 
 		advices := svc.GenerateAdvice(1)
 		assert.Empty(t, advices)
@@ -654,7 +654,7 @@ func TestGenerateAdvice_ContextCollectionError_GoalStats(t *testing.T) {
 		svc, logRepo, goalRepo, _, _, _, _ := setupRuleEngineService()
 
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(nil, assert.AnError)
 
 		advices := svc.GenerateAdvice(1)
@@ -667,7 +667,7 @@ func TestGenerateAdvice_ContextCollectionError_Roadmaps(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, _, _, _ := setupRuleEngineService()
 
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, assert.AnError)
 
@@ -681,7 +681,7 @@ func TestGenerateAdvice_ContextCollectionError_LanguageStats(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, _, _ := setupRuleEngineService()
 
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, assert.AnError)
@@ -696,7 +696,7 @@ func TestGenerateAdvice_ContextCollectionError_Logs(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, _, _ := setupRuleEngineService()
 
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -712,7 +712,7 @@ func TestGenerateAdvice_ContextCollectionError_Resources(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, _ := setupRuleEngineService()
 
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
@@ -729,7 +729,7 @@ func TestGenerateAdvice_ContextCollectionError_User(t *testing.T) {
 		svc, logRepo, goalRepo, roadmapRepo, githubRepo, resourceRepo, userRepo := setupRuleEngineService()
 
 		logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-		goalRepo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+		goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -29,9 +29,9 @@ func (s *LearningGoalService) GetByID(id uint) (*model.LearningGoal, error) {
 	return s.repo.FindByID(id)
 }
 
-// GetByUserID は指定ユーザーの全学習目標を取得する。
-func (s *LearningGoalService) GetByUserID(userID uint) ([]model.LearningGoal, error) {
-	return s.repo.GetByUserID(userID)
+// GetByUserID は指定ユーザーの学習目標をページネーション付きで取得する。
+func (s *LearningGoalService) GetByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error) {
+	return s.repo.GetByUserID(userID, limit, offset)
 }
 
 // GetActiveByUserID は指定ユーザーのアクティブな学習目標のみを取得する。

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -82,22 +82,35 @@ func TestLearningGoalGetByUserID_Success(t *testing.T) {
 		{Title: "Goal 1", UserID: 1},
 		{Title: "Goal 2", UserID: 1},
 	}
-	repo.On("GetByUserID", uint(1)).Return(goals, nil)
+	repo.On("GetByUserID", uint(1), 20, 0).Return(goals, int64(2), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
 	repo.AssertExpectations(t)
 }
 
 func TestLearningGoalGetByUserID_Error(t *testing.T) {
 	svc, repo := newTestLearningGoalService()
 
-	repo.On("GetByUserID", uint(1)).Return([]model.LearningGoal{}, errors.New("db error"))
+	repo.On("GetByUserID", uint(1), 20, 0).Return([]model.LearningGoal{}, int64(0), errors.New("db error"))
 
-	result, err := svc.GetByUserID(1)
+	result, _, err := svc.GetByUserID(1, 20, 0)
 	assert.Error(t, err)
 	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalGetByUserID_Page2(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	repo.On("GetByUserID", uint(1), 10, 10).Return([]model.LearningGoal{}, int64(15), nil)
+
+	result, total, err := svc.GetByUserID(1, 10, 10)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(15), total)
 	repo.AssertExpectations(t)
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -558,9 +558,9 @@ func (m *MockLearningGoalRepository) FindByID(id uint) (*model.LearningGoal, err
 	return args.Get(0).(*model.LearningGoal), args.Error(1)
 }
 
-func (m *MockLearningGoalRepository) GetByUserID(userID uint) ([]model.LearningGoal, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.LearningGoal), args.Error(1)
+func (m *MockLearningGoalRepository) GetByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.LearningGoal), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockLearningGoalRepository) GetActiveByUserID(userID uint) ([]model.LearningGoal, error) {


### PR DESCRIPTION
## Summary
- LearningGoal.GetByUserIDにlimit/offsetベースのページネーションを追加
- repository→service→handler全レイヤーのシグネチャ変更
- GoalListResponse DTOでtotal/limit/offset付きレスポンスを返す
- AI関連サービス（ai_chat, ai_rule_engine）の呼び出し元も更新

Closes #1021

## Test plan
- [x] Service層テスト全件PASS（Page2テスト追加含む）
- [x] Handler層テスト全件PASS
- [x] AI関連テスト（ai_rule_engine_test, ai_advice_test）全件PASS