### PR TITLE
fix: ProjectService.Updateの空白バイパス脆弱性を修正

### DIFF
--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -70,25 +72,25 @@ func (s *ProjectService) Update(id, userID uint, updates *model.Project) (*model
 		return nil, err
 	}
 
-	if updates.Title != "" {
+	if strings.TrimSpace(updates.Title) != "" {
 		project.Title = updates.Title
 	}
-	if updates.Description != "" {
+	if strings.TrimSpace(updates.Description) != "" {
 		project.Description = updates.Description
 	}
-	if updates.TechStack != "" {
+	if strings.TrimSpace(updates.TechStack) != "" {
 		project.TechStack = updates.TechStack
 	}
-	if updates.DemoURL != "" {
+	if strings.TrimSpace(updates.DemoURL) != "" {
 		project.DemoURL = updates.DemoURL
 	}
-	if updates.GithubURL != "" {
+	if strings.TrimSpace(updates.GithubURL) != "" {
 		project.GithubURL = updates.GithubURL
 	}
-	if updates.ImageURL != "" {
+	if strings.TrimSpace(updates.ImageURL) != "" {
 		project.ImageURL = updates.ImageURL
 	}
-	if updates.Role != "" {
+	if strings.TrimSpace(updates.Role) != "" {
 		project.Role = updates.Role
 	}
 	if updates.StartDate != nil {

--- a/backend/internal/service/project_test.go
+++ b/backend/internal/service/project_test.go
@@ -382,3 +382,46 @@ func TestProjectUpdateFeatured_UpdateError(t *testing.T) {
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// 空白バイパステスト
+// ============================================================
+
+func TestProjectUpdate_WhitespaceTechStack(t *testing.T) {
+	svc, repo := newTestProjectService()
+	existing := &model.Project{Title: "Project", Description: "Desc", TechStack: "Go, React", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.Project{TechStack: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "Go, React", result.TechStack)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectUpdate_WhitespaceImageURL(t *testing.T) {
+	svc, repo := newTestProjectService()
+	existing := &model.Project{Title: "Project", Description: "Desc", ImageURL: "https://example.com/img.png", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.Project{ImageURL: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/img.png", result.ImageURL)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectUpdate_WhitespaceRole(t *testing.T) {
+	svc, repo := newTestProjectService()
+	existing := &model.Project{Title: "Project", Description: "Desc", Role: "Backend Engineer", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.Project{Role: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "Backend Engineer", result.Role)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## Summary
- ProjectService.UpdateのTechStack/ImageURL/Roleの空白バイパス修正
- 全7フィールドをstrings.TrimSpaceチェックに統一
- TDD RED→GREEN確認済み

Closes #1027

## Test plan
- [x] 新規3テスト（WhitespaceTechStack/WhitespaceImageURL/WhitespaceRole）PASS
- [x] 既存27テスト全件PASS