### PR TITLE
feat: BookReview.GetByUserIDにページネーション対応

### DIFF
--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -12,7 +12,7 @@ import (
 type BookReviewServiceInterface interface {
 	Create(review *model.BookReview) error
 	GetByID(id uint) (*model.BookReview, error)
-	GetByUserID(userID uint) ([]model.BookReview, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.BookReview, int64, error)
 	GetAll(limit, offset int) ([]model.BookReview, int64, error)
 	Update(id, userID uint, updates *model.BookReview) (*model.BookReview, error)
 	Delete(id, userID uint) error
@@ -73,20 +73,27 @@ func (h *BookReviewHandler) GetByID(c *gin.Context) {
 	respondOK(c, review)
 }
 
-// GetByUserID は指定ユーザーの書籍レビュー一覧を取得する。
+// GetByUserID は指定ユーザーの書籍レビュー一覧をページネーション付きで取得する。
 func (h *BookReviewHandler) GetByUserID(c *gin.Context) {
 	userID, ok := parseID(c, "userId")
 	if !ok {
 		return
 	}
 
-	reviews, err := h.service.GetByUserID(userID)
+	limit, offset := parseLimitOffset(c)
+
+	reviews, total, err := h.service.GetByUserID(userID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, reviews)
+	respondOK(c, dto.BookReviewListResponse{
+		Reviews: reviews,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+	})
 }
 
 // GetAll は書籍レビューの一覧をページネーション付きで取得する。

--- a/backend/internal/handler/book_review_test.go
+++ b/backend/internal/handler/book_review_test.go
@@ -170,7 +170,7 @@ func TestBookReviewGetByUserID_Success(t *testing.T) {
 	reviews := []model.BookReview{
 		{Title: "Go言語入門", Rating: 5},
 	}
-	svc.On("GetByUserID", uint(1)).Return(reviews, nil)
+	svc.On("GetByUserID", uint(1), 20, 0).Return(reviews, int64(1), nil)
 
 	w := doRequest(r, http.MethodGet, "/users/1/book-reviews", nil)
 	assertStatus(t, w, http.StatusOK)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -732,9 +732,9 @@ func (m *MockBookReviewService) GetByID(id uint) (*model.BookReview, error) {
 	}
 	return nil, args.Error(1)
 }
-func (m *MockBookReviewService) GetByUserID(userID uint) ([]model.BookReview, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.BookReview), args.Error(1)
+func (m *MockBookReviewService) GetByUserID(userID uint, limit, offset int) ([]model.BookReview, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.BookReview), args.Get(1).(int64), args.Error(2)
 }
 func (m *MockBookReviewService) GetAll(limit, offset int) ([]model.BookReview, int64, error) {
 	args := m.Called(limit, offset)

--- a/backend/internal/repository/book_review.go
+++ b/backend/internal/repository/book_review.go
@@ -30,13 +30,14 @@ func (r *BookReviewRepository) FindByID(id uint) (*model.BookReview, error) {
 	return &review, nil
 }
 
-// FindByUserID は指定ユーザーの全書籍レビューを取得する（新しい順）。
-func (r *BookReviewRepository) FindByUserID(userID uint) ([]model.BookReview, error) {
+// FindByUserID は指定ユーザーの書籍レビューをページネーション付きで取得する（新しい順）。
+func (r *BookReviewRepository) FindByUserID(userID uint, limit, offset int) ([]model.BookReview, int64, error) {
 	var reviews []model.BookReview
-	err := r.db.Where("user_id = ?", userID).
-		Order("created_at DESC").
-		Find(&reviews).Error
-	return reviews, err
+	var total int64
+	query := r.db.Where("user_id = ?", userID)
+	query.Model(&model.BookReview{}).Count(&total)
+	err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&reviews).Error
+	return reviews, total, err
 }
 
 // FindAll は全書籍レビューをページネーション付きで取得する。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -197,7 +197,7 @@ type ProjectRepositoryInterface interface {
 type BookReviewRepositoryInterface interface {
 	Create(review *model.BookReview) error
 	FindByID(id uint) (*model.BookReview, error)
-	FindByUserID(userID uint) ([]model.BookReview, error)
+	FindByUserID(userID uint, limit, offset int) ([]model.BookReview, int64, error)
 	FindAll(limit, offset int) ([]model.BookReview, int64, error)
 	FindByRating(userID uint, minRating, maxRating int) ([]model.BookReview, error)
 	Update(review *model.BookReview) error

--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -39,9 +39,9 @@ func (s *BookReviewService) GetByID(id uint) (*model.BookReview, error) {
 	return s.repo.FindByID(id)
 }
 
-// GetByUserID は指定ユーザーの全書籍レビューを取得する。
-func (s *BookReviewService) GetByUserID(userID uint) ([]model.BookReview, error) {
-	return s.repo.FindByUserID(userID)
+// GetByUserID は指定ユーザーの書籍レビューをページネーション付きで取得する。
+func (s *BookReviewService) GetByUserID(userID uint, limit, offset int) ([]model.BookReview, int64, error) {
+	return s.repo.FindByUserID(userID, limit, offset)
 }
 
 // GetAll は書籍レビュー一覧をページネーション付きで取得する。

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -86,11 +86,24 @@ func TestBookReviewGetByUserID_Success(t *testing.T) {
 		{Title: "本B", UserID: 1, Rating: 5},
 	}
 
-	repo.On("FindByUserID", uint(1)).Return(reviews, nil)
+	repo.On("FindByUserID", uint(1), 20, 0).Return(reviews, int64(2), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewGetByUserID_Page2(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	repo.On("FindByUserID", uint(1), 10, 10).Return([]model.BookReview{}, int64(15), nil)
+
+	result, total, err := svc.GetByUserID(1, 10, 10)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(15), total)
 	repo.AssertExpectations(t)
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -653,9 +653,9 @@ func (m *MockBookReviewRepository) FindByID(id uint) (*model.BookReview, error) 
 	return args.Get(0).(*model.BookReview), args.Error(1)
 }
 
-func (m *MockBookReviewRepository) FindByUserID(userID uint) ([]model.BookReview, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.BookReview), args.Error(1)
+func (m *MockBookReviewRepository) FindByUserID(userID uint, limit, offset int) ([]model.BookReview, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.BookReview), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockBookReviewRepository) FindAll(limit, offset int) ([]model.BookReview, int64, error) {


### PR DESCRIPTION
## 概要
BookReviewService.GetByUserIDにページネーション（limit/offset/total）を追加。

## 変更内容
- `repository/interfaces.go`: FindByUserIDシグネチャに limit, offset, total 追加
- `repository/book_review.go`: Count + Limit + Offset 実装
- `service/book_review.go`: GetByUserIDシグネチャ変更
- `handler/book_review.go`: parseLimitOffset + BookReviewListResponse適用
- モック・テスト全更新

Closes #1029