### PR TITLE
refactor: クエリパラメータ整数パースをヘルパー関数に統一

### DIFF
--- a/backend/internal/handler/answer.go
+++ b/backend/internal/handler/answer.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
@@ -173,17 +171,12 @@ func (h *AnswerHandler) GetByVoteRange(c *gin.Context) {
 		return
 	}
 
-	minVoteStr := c.DefaultQuery("min_vote", "0")
-	maxVoteStr := c.DefaultQuery("max_vote", "100")
-
-	minVote, err := strconv.Atoi(minVoteStr)
-	if err != nil {
-		respondError(c, domain.NewError(domain.ErrCodeBadRequest, "min_voteは数値で指定してください", nil))
+	minVote, ok := parseQueryInt(c, "min_vote", "0")
+	if !ok {
 		return
 	}
-	maxVote, err := strconv.Atoi(maxVoteStr)
-	if err != nil {
-		respondError(c, domain.NewError(domain.ErrCodeBadRequest, "max_voteは数値で指定してください", nil))
+	maxVote, ok := parseQueryInt(c, "max_vote", "100")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -161,14 +159,12 @@ func (h *BookReviewHandler) Update(c *gin.Context) {
 func (h *BookReviewHandler) GetByRating(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	minRating, err := strconv.Atoi(c.Query("min_rating"))
-	if err != nil {
-		respondBadRequest(c, "min_ratingは数値で指定してください")
+	minRating, ok := parseQueryInt(c, "min_rating", "")
+	if !ok {
 		return
 	}
-	maxRating, err := strconv.Atoi(c.Query("max_rating"))
-	if err != nil {
-		respondBadRequest(c, "max_ratingは数値で指定してください")
+	maxRating, ok := parseQueryInt(c, "max_rating", "")
+	if !ok {
 		return
 	}
 

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -69,6 +69,31 @@ func parseSearchQuery(c *gin.Context) (string, bool) {
 	return strings.TrimSpace(query), true
 }
 
+// parseQueryInt はクエリパラメータを整数としてパースする。
+// 未指定時はdefaultValueを使用する。パース失敗時は400レスポンスを返しfalseを返す。
+func parseQueryInt(c *gin.Context, param, defaultValue string) (int, bool) {
+	raw := c.DefaultQuery(param, defaultValue)
+	val, err := strconv.Atoi(raw)
+	if err != nil {
+		respondBadRequest(c, param+"は数値で指定してください")
+		return 0, false
+	}
+	return val, true
+}
+
+// parseQueryIntSilent はクエリパラメータを整数としてパースする。
+// 未指定時やパース失敗時はデフォルト値を返す。
+func parseQueryIntSilent(c *gin.Context, param string, defaultValue int) int {
+	raw := c.Query(param)
+	if raw == "" {
+		return defaultValue
+	}
+	if val, err := strconv.Atoi(raw); err == nil && val > 0 {
+		return val
+	}
+	return defaultValue
+}
+
 // bindJSON はリクエストボディをJSON構造体にバインドする。
 // バインド失敗時は400レスポンスを返しnilを返す。
 func bindJSON[T any](c *gin.Context) *T {

--- a/backend/internal/handler/learning_analytics.go
+++ b/backend/internal/handler/learning_analytics.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"strconv"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -82,12 +80,7 @@ func (h *LearningAnalyticsHandler) GetWeeklyTrends(c *gin.Context) {
 		return
 	}
 
-	weeks := 12
-	if w := c.Query("weeks"); w != "" {
-		if parsed, err := strconv.Atoi(w); err == nil && parsed > 0 {
-			weeks = parsed
-		}
-	}
+	weeks := parseQueryIntSilent(c, "weeks", 12)
 
 	data, err := h.service.GetWeeklyTrends(userID, weeks)
 	if err != nil {


### PR DESCRIPTION
## 概要
handler層で strconv.Atoi を直接使用してクエリパラメータを解析するコードを共通ヘルパーに統一。

## 変更内容
- `helpers.go`: `parseQueryInt`（エラー時400応答）と `parseQueryIntSilent`（デフォルト値フォールバック）を追加
- `book_review.go`: min_rating/max_rating → parseQueryInt
- `answer.go`: min_vote/max_vote → parseQueryInt
- `learning_analytics.go`: weeks → parseQueryIntSilent
- 3ファイルから strconv インポート削除

Closes #1031