### PR TITLE
test: GetByRating/GetByVoteRange/GetUnreadAdviceのハンドラーテスト追加

### DIFF
--- a/backend/internal/handler/ai_advice_test.go
+++ b/backend/internal/handler/ai_advice_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAIAdvice_GetAdvice_Success(t *testing.T) {
@@ -165,6 +166,51 @@ func TestAIAdvice_GetConversation_ServiceError(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/conversations/99", nil)
 	r.ServeHTTP(w, req)
 
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetUnreadAdvice テスト
+// ============================================================
+
+func TestAIAdviceGetUnreadAdvice_Success(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	r := newRouter(1)
+	r.GET("/ai-advice/unread", h.GetUnreadAdvice)
+
+	advices := []model.AIAdvice{
+		{TitleKey: "advice.study_daily"},
+	}
+	svc.On("GetUnreadAdvice", uint(1)).Return(advices, nil)
+
+	w := doRequest(r, http.MethodGet, "/ai-advice/unread", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdviceGetUnreadAdvice_Empty(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	r := newRouter(1)
+	r.GET("/ai-advice/unread", h.GetUnreadAdvice)
+
+	svc.On("GetUnreadAdvice", uint(1)).Return([]model.AIAdvice(nil), nil)
+
+	w := doRequest(r, http.MethodGet, "/ai-advice/unread", nil)
+	assertStatus(t, w, http.StatusOK)
+	// nilの場合は空配列[]に変換されるべき
+	assert.Equal(t, "[]", w.Body.String())
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdviceGetUnreadAdvice_ServiceError(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	r := newRouter(1)
+	r.GET("/ai-advice/unread", h.GetUnreadAdvice)
+
+	svc.On("GetUnreadAdvice", uint(1)).Return([]model.AIAdvice(nil), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/ai-advice/unread", nil)
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }

--- a/backend/internal/handler/answer_test.go
+++ b/backend/internal/handler/answer_test.go
@@ -266,3 +266,64 @@ func TestAnswerRemoveVote_Success(t *testing.T) {
 	assertStatus(t, w, http.StatusOK)
 	svc.AssertExpectations(t)
 }
+
+// ============================================================
+// GetByVoteRange テスト
+// ============================================================
+
+func TestAnswerGetByVoteRange_Success(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.GET("/questions/:id/answers/vote-range", h.GetByVoteRange)
+
+	answers := []model.Answer{
+		{Body: "回答A"},
+	}
+	svc.On("GetByVoteRange", uint(1), 5, 10).Return(answers, nil)
+
+	w := doRequest(r, http.MethodGet, "/questions/1/answers/vote-range?min_vote=5&max_vote=10", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerGetByVoteRange_DefaultValues(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.GET("/questions/:id/answers/vote-range", h.GetByVoteRange)
+
+	svc.On("GetByVoteRange", uint(1), 0, 100).Return([]model.Answer{}, nil)
+
+	w := doRequest(r, http.MethodGet, "/questions/1/answers/vote-range", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerGetByVoteRange_InvalidMinVote(t *testing.T) {
+	h, _ := setupAnswerHandler()
+	r := newRouter(1)
+	r.GET("/questions/:id/answers/vote-range", h.GetByVoteRange)
+
+	w := doRequest(r, http.MethodGet, "/questions/1/answers/vote-range?min_vote=abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestAnswerGetByVoteRange_InvalidID(t *testing.T) {
+	h, _ := setupAnswerHandler()
+	r := newRouter(1)
+	r.GET("/questions/:id/answers/vote-range", h.GetByVoteRange)
+
+	w := doRequest(r, http.MethodGet, "/questions/abc/answers/vote-range", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestAnswerGetByVoteRange_ServiceError(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.GET("/questions/:id/answers/vote-range", h.GetByVoteRange)
+
+	svc.On("GetByVoteRange", uint(1), 0, 100).Return([]model.Answer(nil), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/questions/1/answers/vote-range", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/book_review_test.go
+++ b/backend/internal/handler/book_review_test.go
@@ -264,3 +264,52 @@ func TestBookReviewDelete_NotFound(t *testing.T) {
 	assertStatus(t, w, http.StatusNotFound)
 	svc.AssertExpectations(t)
 }
+
+// ============================================================
+// GetByRating テスト
+// ============================================================
+
+func TestBookReviewGetByRating_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/rating", h.GetByRating)
+
+	reviews := []model.BookReview{
+		{Title: "良書", Rating: 4},
+	}
+	svc.On("GetByRating", uint(1), 4, 5).Return(reviews, nil)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/rating?min_rating=4&max_rating=5", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewGetByRating_InvalidMinRating(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/rating", h.GetByRating)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/rating?min_rating=abc&max_rating=5", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookReviewGetByRating_InvalidMaxRating(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/rating", h.GetByRating)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/rating?min_rating=1&max_rating=abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookReviewGetByRating_ServiceError(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/rating", h.GetByRating)
+
+	svc.On("GetByRating", uint(1), 1, 5).Return([]model.BookReview(nil), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/rating?min_rating=1&max_rating=5", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
カバレッジ0%だった3関数に計12テストを追加し、handler層カバレッジを80%超に向上。

## 変更内容
- `book_review_test.go`: GetByRating 4テスト追加
- `answer_test.go`: GetByVoteRange 5テスト追加
- `ai_advice_test.go`: GetUnreadAdvice 3テスト追加

## 効果
handler層カバレッジ 78.9% → 80.1%

Closes #1033