### PR TITLE
fix: LearningGoalService.Updateの空白バイパス脆弱性を修正

### DIFF
--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"time"
 
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -96,13 +97,13 @@ func (s *LearningGoalService) Update(id, userID uint, updates *model.LearningGoa
 		return nil, err
 	}
 
-	if updates.Title != "" {
+	if strings.TrimSpace(updates.Title) != "" {
 		goal.Title = updates.Title
 	}
-	if updates.Description != "" {
+	if strings.TrimSpace(updates.Description) != "" {
 		goal.Description = updates.Description
 	}
-	if updates.Category != "" {
+	if strings.TrimSpace(string(updates.Category)) != "" {
 		goal.Category = updates.Category
 	}
 	if updates.TargetDate != nil {
@@ -122,7 +123,7 @@ func (s *LearningGoalService) Update(id, userID uint, updates *model.LearningGoa
 			goal.CompletedAt = &now
 		}
 	}
-	if updates.Status != "" {
+	if strings.TrimSpace(string(updates.Status)) != "" {
 		goal.Status = updates.Status
 		if goal.Status == model.GoalStatusCompleted && goal.CompletedAt == nil {
 			now := time.Now()

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -595,3 +595,55 @@ func TestLearningGoalGetByStatus_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// 空白バイパス脆弱性テスト
+// ============================================================
+
+func TestLearningGoalUpdate_WhitespaceTitle(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	existing := &model.LearningGoal{Title: "Original Title", Description: "Desc", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningGoal{Title: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "Original Title", result.Title)
+}
+
+func TestLearningGoalUpdate_WhitespaceDescription(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	existing := &model.LearningGoal{Title: "Title", Description: "Original Desc", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningGoal{Description: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "Original Desc", result.Description)
+}
+
+func TestLearningGoalUpdate_WhitespaceCategory(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	existing := &model.LearningGoal{Title: "Title", Category: model.GoalCategoryLanguage, UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningGoal{Category: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, model.GoalCategoryLanguage, result.Category)
+}
+
+func TestLearningGoalUpdate_WhitespaceStatus(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	existing := &model.LearningGoal{Title: "Title", Status: model.GoalStatusActive, UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningGoal{Status: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, model.GoalStatusActive, result.Status)
+}


### PR DESCRIPTION
## 概要
LearningGoalService.Updateで空白のみの入力が既存値を上書きする脆弱性を修正。

## 変更内容
- `learning_goal.go`: Title/Description/Category/Statusの4フィールドにstrings.TrimSpace適用
- `learning_goal_test.go`: 空白バイパステスト4件追加（TDD RED→GREEN）

Closes #1035