### PR TITLE
feat: ProjectService.GetByUserIDにページネーション対応

### DIFF
--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -17,7 +17,7 @@ func parseDate(dateStr string) (time.Time, error) {
 type ProjectServiceInterface interface {
 	Create(project *model.Project) error
 	GetByID(id uint) (*model.Project, error)
-	GetByUserID(userID uint) ([]model.Project, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.Project, int64, error)
 	GetFeaturedByUserID(userID uint) ([]model.Project, error)
 	GetAll(limit, offset int) ([]model.Project, int64, error)
 	Update(id, userID uint, updates *model.Project) (*model.Project, error)
@@ -95,20 +95,27 @@ func (h *ProjectHandler) GetByID(c *gin.Context) {
 	respondOK(c, project)
 }
 
-// GetByUserID は指定ユーザーのプロジェクト一覧を取得する。
+// GetByUserID は指定ユーザーのプロジェクト一覧をページネーション付きで取得する。
 func (h *ProjectHandler) GetByUserID(c *gin.Context) {
 	userID, ok := parseID(c, "userId")
 	if !ok {
 		return
 	}
 
-	projects, err := h.service.GetByUserID(userID)
+	limit, offset := parseLimitOffset(c)
+
+	projects, total, err := h.service.GetByUserID(userID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, projects)
+	respondOK(c, dto.ProjectListResponse{
+		Projects: projects,
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
+	})
 }
 
 // GetFeatured は指定ユーザーの注目プロジェクト一覧を取得する。

--- a/backend/internal/handler/project_test.go
+++ b/backend/internal/handler/project_test.go
@@ -97,7 +97,7 @@ func TestProjectGetByID_NotFound(t *testing.T) {
 func TestProjectGetByUserID_Success(t *testing.T) {
 	h, svc := setupProjectHandler()
 	projects := []model.Project{{Title: "P1"}, {Title: "P2"}}
-	svc.On("GetByUserID", uint(1)).Return(projects, nil)
+	svc.On("GetByUserID", uint(1), 20, 0).Return(projects, int64(2), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:userId/projects", h.GetByUserID)
@@ -109,7 +109,7 @@ func TestProjectGetByUserID_Success(t *testing.T) {
 
 func TestProjectGetByUserID_Empty(t *testing.T) {
 	h, svc := setupProjectHandler()
-	svc.On("GetByUserID", uint(1)).Return([]model.Project{}, nil)
+	svc.On("GetByUserID", uint(1), 20, 0).Return([]model.Project{}, int64(0), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:userId/projects", h.GetByUserID)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -873,9 +873,9 @@ func (m *MockProjectService) GetByID(id uint) (*model.Project, error) {
 	}
 	return nil, args.Error(1)
 }
-func (m *MockProjectService) GetByUserID(userID uint) ([]model.Project, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.Project), args.Error(1)
+func (m *MockProjectService) GetByUserID(userID uint, limit, offset int) ([]model.Project, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.Project), args.Get(1).(int64), args.Error(2)
 }
 func (m *MockProjectService) GetFeaturedByUserID(userID uint) ([]model.Project, error) {
 	args := m.Called(userID)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -186,7 +186,7 @@ type RankingRepositoryInterface interface {
 type ProjectRepositoryInterface interface {
 	Create(project *model.Project) error
 	FindByID(id uint) (*model.Project, error)
-	FindByUserID(userID uint) ([]model.Project, error)
+	FindByUserID(userID uint, limit, offset int) ([]model.Project, int64, error)
 	FindFeaturedByUserID(userID uint) ([]model.Project, error)
 	Update(project *model.Project) error
 	Delete(id uint) error

--- a/backend/internal/repository/project.go
+++ b/backend/internal/repository/project.go
@@ -32,13 +32,16 @@ func (r *ProjectRepository) FindByID(id uint) (*model.Project, error) {
 
 // FindByUserID は指定ユーザーの全プロジェクトをGitHubリポジトリ情報付きで取得する。
 // featured（注目）プロジェクトが先に、その後作成日降順でソートされる。
-func (r *ProjectRepository) FindByUserID(userID uint) ([]model.Project, error) {
+func (r *ProjectRepository) FindByUserID(userID uint, limit, offset int) ([]model.Project, int64, error) {
 	var projects []model.Project
-	err := r.db.Preload("GithubRepo").
-		Where("user_id = ?", userID).
+	var total int64
+	query := r.db.Where("user_id = ?", userID)
+	query.Model(&model.Project{}).Count(&total)
+	err := query.Preload("GithubRepo").
 		Order("featured DESC, created_at DESC").
+		Limit(limit).Offset(offset).
 		Find(&projects).Error
-	return projects, err
+	return projects, total, err
 }
 
 // FindFeaturedByUserID は指定ユーザーの注目プロジェクトのみを取得する。

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -607,9 +607,9 @@ func (m *MockProjectRepository) FindByID(id uint) (*model.Project, error) {
 	return args.Get(0).(*model.Project), args.Error(1)
 }
 
-func (m *MockProjectRepository) FindByUserID(userID uint) ([]model.Project, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.Project), args.Error(1)
+func (m *MockProjectRepository) FindByUserID(userID uint, limit, offset int) ([]model.Project, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.Project), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockProjectRepository) FindFeaturedByUserID(userID uint) ([]model.Project, error) {

--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -33,9 +33,9 @@ func (s *ProjectService) GetByID(id uint) (*model.Project, error) {
 	return s.repo.FindByID(id)
 }
 
-// GetByUserID は指定ユーザーの全プロジェクトを取得する。
-func (s *ProjectService) GetByUserID(userID uint) ([]model.Project, error) {
-	return s.repo.FindByUserID(userID)
+// GetByUserID は指定ユーザーのプロジェクトをページネーション付きで取得する。
+func (s *ProjectService) GetByUserID(userID uint, limit, offset int) ([]model.Project, int64, error) {
+	return s.repo.FindByUserID(userID, limit, offset)
 }
 
 // GetFeaturedByUserID は指定ユーザーの注目プロジェクトのみを取得する。

--- a/backend/internal/service/project_test.go
+++ b/backend/internal/service/project_test.go
@@ -239,22 +239,36 @@ func TestProjectGetByUserID_Success(t *testing.T) {
 		{Title: "Project 2", UserID: 1},
 	}
 
-	repo.On("FindByUserID", uint(1)).Return(expected, nil)
+	repo.On("FindByUserID", uint(1), 20, 0).Return(expected, int64(2), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
 	repo.AssertExpectations(t)
 }
 
 func TestProjectGetByUserID_Empty(t *testing.T) {
 	svc, repo := newTestProjectService()
 
-	repo.On("FindByUserID", uint(1)).Return([]model.Project{}, nil)
+	repo.On("FindByUserID", uint(1), 20, 0).Return([]model.Project{}, int64(0), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectGetByUserID_Page2(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	repo.On("FindByUserID", uint(1), 10, 10).Return([]model.Project{}, int64(15), nil)
+
+	result, total, err := svc.GetByUserID(1, 10, 10)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(15), total)
 	repo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
ProjectService.GetByUserIDにページネーション（limit/offset/total）を追加。

## 変更内容
- `repository/interfaces.go`: FindByUserIDシグネチャにlimit, offset, total追加
- `repository/project.go`: Count + Limit + Offset実装
- `service/project.go`: GetByUserIDシグネチャ変更
- `handler/project.go`: parseLimitOffset + ProjectListResponse適用
- モック・テスト全更新 + Page2テスト追加

Closes #1037