### PR TITLE
feat: LearningLog.GetByUserIDにページネーション対応

### DIFF
--- a/backend/internal/dto/learning_log_dto.go
+++ b/backend/internal/dto/learning_log_dto.go
@@ -1,5 +1,7 @@
 package dto
 
+import "github.com/norman6464/devsync/backend/internal/model"
+
 // CreateLearningLogRequest は学習ログ作成リクエスト。
 type CreateLearningLogRequest struct {
 	Title    string `json:"title" binding:"required,max=200" validate:"required,max=200"`
@@ -7,6 +9,14 @@ type CreateLearningLogRequest struct {
 	Category string `json:"category" binding:"omitempty,max=100"`
 	Duration int    `json:"duration" binding:"omitempty,min=0,max=1440"`
 	Source   string `json:"source" binding:"omitempty,max=500"`
+}
+
+// LearningLogListResponse は学習ログ一覧レスポンス（ページネーション付き）。
+type LearningLogListResponse struct {
+	Logs   []model.LearningLog `json:"logs"`
+	Total  int64               `json:"total"`
+	Limit  int                 `json:"limit"`
+	Offset int                 `json:"offset"`
 }
 
 // UpdateLearningLogRequest は学習ログ更新リクエスト。

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -13,7 +13,7 @@ import (
 type LearningLogServiceInterface interface {
 	Create(log *model.LearningLog) error
 	GetByID(id uint) (*model.LearningLog, error)
-	GetByUserID(userID uint) ([]model.LearningLog, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	Update(id, userID uint, updates *model.LearningLog) (*model.LearningLog, error)
 	Delete(id, userID uint) error
 	GetStreakInfo(userID uint) (*model.StreakInfo, error)
@@ -136,14 +136,20 @@ func (h *LearningLogHandler) GetByID(c *gin.Context) {
 // GetMyLogs は認証ユーザー自身の学習ログ一覧を取得する。
 func (h *LearningLogHandler) GetMyLogs(c *gin.Context) {
 	userID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
 
-	logs, err := h.service.GetByUserID(userID)
+	logs, total, err := h.service.GetByUserID(userID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, logs)
+	respondOK(c, dto.LearningLogListResponse{
+		Logs:   logs,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
 // GetByUserID は指定されたユーザーの学習ログ一覧を取得する。
@@ -152,14 +158,20 @@ func (h *LearningLogHandler) GetByUserID(c *gin.Context) {
 	if !ok {
 		return
 	}
+	limit, offset := parseLimitOffset(c)
 
-	logs, err := h.service.GetByUserID(userID)
+	logs, total, err := h.service.GetByUserID(userID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, logs)
+	respondOK(c, dto.LearningLogListResponse{
+		Logs:   logs,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
 // GetStreakInfo は指定されたユーザーのストリーク情報を取得する。

--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -79,7 +79,7 @@ func TestLearningLog_GetByID_ServiceError(t *testing.T) {
 func TestLearningLog_GetMyLogs_Success(t *testing.T) {
 	h, svc := setupLearningLogHandler()
 	logs := []model.LearningLog{{Title: "Log1"}, {Title: "Log2"}}
-	svc.On("GetByUserID", uint(1)).Return(logs, nil)
+	svc.On("GetByUserID", uint(1), 20, 0).Return(logs, int64(2), nil)
 
 	r := gin.New()
 	r.GET("/me/logs", authMiddleware(1), h.GetMyLogs)
@@ -95,7 +95,7 @@ func TestLearningLog_GetMyLogs_Success(t *testing.T) {
 func TestLearningLog_GetByUserID_Success(t *testing.T) {
 	h, svc := setupLearningLogHandler()
 	logs := []model.LearningLog{{Title: "Log1"}}
-	svc.On("GetByUserID", uint(5)).Return(logs, nil)
+	svc.On("GetByUserID", uint(5), 20, 0).Return(logs, int64(1), nil)
 
 	r := gin.New()
 	r.GET("/users/:userId/logs", h.GetByUserID)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1260,9 +1260,9 @@ func (m *MockLearningLogService) GetByID(id uint) (*model.LearningLog, error) {
 	}
 	return nil, args.Error(1)
 }
-func (m *MockLearningLogService) GetByUserID(userID uint) ([]model.LearningLog, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.LearningLog), args.Error(1)
+func (m *MockLearningLogService) GetByUserID(userID uint, limit, offset int) ([]model.LearningLog, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.LearningLog), args.Get(1).(int64), args.Error(2)
 }
 func (m *MockLearningLogService) Update(id, userID uint, updates *model.LearningLog) (*model.LearningLog, error) {
 	args := m.Called(id, userID, updates)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -151,7 +151,7 @@ type LearningLogRepositoryInterface interface {
 	Update(log *model.LearningLog) error
 	Delete(id, userID uint) error
 	FindByID(id uint) (*model.LearningLog, error)
-	GetByUserID(userID uint) ([]model.LearningLog, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	GetByCategory(userID uint, category string) ([]model.LearningLog, error)
 	GetByPeriod(userID uint, days int) ([]model.LearningLog, error)
 	GetBySource(userID uint, source string) ([]model.LearningLog, error)

--- a/backend/internal/repository/learning_log.go
+++ b/backend/internal/repository/learning_log.go
@@ -43,11 +43,14 @@ func (r *LearningLogRepository) FindByID(id uint) (*model.LearningLog, error) {
 	return &log, nil
 }
 
-// GetByUserID は指定ユーザーの全学習ログを取得する（新しい順）。
-func (r *LearningLogRepository) GetByUserID(userID uint) ([]model.LearningLog, error) {
+// GetByUserID は指定ユーザーの学習ログをページネーション付きで取得する（新しい順）。
+func (r *LearningLogRepository) GetByUserID(userID uint, limit, offset int) ([]model.LearningLog, int64, error) {
 	var logs []model.LearningLog
-	err := r.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&logs).Error
-	return logs, err
+	var total int64
+	query := r.db.Where("user_id = ?", userID)
+	query.Model(&model.LearningLog{}).Count(&total)
+	err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&logs).Error
+	return logs, total, err
 }
 
 // GetByCategory は指定ユーザーの学習ログをカテゴリでフィルタリングして取得する（新しい順）。

--- a/backend/internal/service/ai_rule_engine.go
+++ b/backend/internal/service/ai_rule_engine.go
@@ -52,7 +52,7 @@ func (s *AIAdviceService) collectContext(userID uint) (*userContext, error) {
 		return nil, err
 	}
 
-	ctx.logs, err = s.logRepo.GetByUserID(userID)
+	ctx.logs, _, err = s.logRepo.GetByUserID(userID, 100, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/ai_rule_engine_test.go
+++ b/backend/internal/service/ai_rule_engine_test.go
@@ -45,7 +45,7 @@ func setupDefaultMocks(
 	goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 	roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 	githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-	logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 }
@@ -58,7 +58,7 @@ func TestGenerateAdvice_StreakBroken(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -83,7 +83,7 @@ func TestGenerateAdvice_StreakBroken(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -106,7 +106,7 @@ func TestGenerateAdvice_StalledRoadmap(t *testing.T) {
 			{Status: model.RoadmapStatusActive, StepCount: 5, CompletedStepCount: 2, UpdatedAt: staleTime},
 		}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -135,7 +135,7 @@ func TestGenerateAdvice_GoalOverdue(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 1, ActiveGoals: 1}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -165,7 +165,7 @@ func TestGenerateAdvice_ReactSuggestion(t *testing.T) {
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
 			{Language: "TypeScript", Bytes: 50000},
 		}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -193,7 +193,7 @@ func TestGenerateAdvice_ReactSuggestion(t *testing.T) {
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
 			{Language: "TypeScript", Bytes: 50000},
 		}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -217,7 +217,7 @@ func TestGenerateAdvice_NoGoals(t *testing.T) {
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
 			{Language: "Go", Bytes: 20000},
 		}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -245,7 +245,7 @@ func TestGenerateAdvice_NoRoadmap(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 1}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -271,7 +271,7 @@ func TestGenerateAdvice_DifficultyUp(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{CompletedGoals: 5, AverageProgress: 80}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -304,7 +304,7 @@ func TestGenerateAdvice_Praise(t *testing.T) {
 			logs[i] = model.LearningLog{Duration: 90}
 			logs[i].CreatedAt = now.Add(-time.Duration(i) * 24 * time.Hour)
 		}
-		logRepo.On("GetByUserID", uint(1)).Return(logs, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return(logs, int64(len(logs)), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -330,7 +330,7 @@ func TestGenerateAdvice_ExploreResources(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}}, int64(2), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -354,7 +354,7 @@ func TestGenerateAdvice_ExploreResources(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -382,7 +382,7 @@ func TestGenerateAdvice_LowStudyTime(t *testing.T) {
 		}
 		logs[0].CreatedAt = now.Add(-1 * 24 * time.Hour)
 		logs[1].CreatedAt = now.Add(-3 * 24 * time.Hour)
-		logRepo.On("GetByUserID", uint(1)).Return(logs, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return(logs, int64(len(logs)), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -417,7 +417,7 @@ func TestGenerateAdvice_LowStudyTime(t *testing.T) {
 		logs[0].CreatedAt = now.Add(-1 * 24 * time.Hour)
 		logs[1].CreatedAt = now.Add(-3 * 24 * time.Hour)
 		logs[2].CreatedAt = now.Add(-5 * 24 * time.Hour)
-		logRepo.On("GetByUserID", uint(1)).Return(logs, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return(logs, int64(len(logs)), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -445,7 +445,7 @@ func TestGenerateAdvice_TechSuggestionFromTopLanguage(t *testing.T) {
 			{Language: "Go", Bytes: 80000, RepoCount: 5},
 			{Language: "Python", Bytes: 30000, RepoCount: 2},
 		}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -474,7 +474,7 @@ func TestGenerateAdvice_TechSuggestionFromTopLanguage(t *testing.T) {
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
 			{Language: "Go", Bytes: 80000, RepoCount: 5},
 		}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -495,7 +495,7 @@ func TestGenerateAdvice_TechSuggestionFromTopLanguage(t *testing.T) {
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
 			{Language: "Go", Bytes: 5000, RepoCount: 1},
 		}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -519,7 +519,7 @@ func TestGenerateAdvice_TechSuggestionTopLangNotFirst(t *testing.T) {
 			{Language: "Python", Bytes: 5000, RepoCount: 1},
 			{Language: "Go", Bytes: 80000, RepoCount: 5},
 		}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -548,7 +548,7 @@ func TestGenerateAdvice_StalledRoadmapEdgeCases(t *testing.T) {
 			{Status: model.RoadmapStatusCompleted, StepCount: 5, CompletedStepCount: 5, UpdatedAt: staleTime},
 		}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -570,7 +570,7 @@ func TestGenerateAdvice_StalledRoadmapEdgeCases(t *testing.T) {
 			{Status: model.RoadmapStatusActive, StepCount: 5, CompletedStepCount: 5, UpdatedAt: staleTime},
 		}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}, {}, {}}, int64(3), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -594,7 +594,7 @@ func TestGenerateAdvice_PrioritySorting(t *testing.T) {
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
 			{Language: "Go", Bytes: 20000},
 		}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{{}}, int64(1), nil)
 		userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -700,7 +700,7 @@ func TestGenerateAdvice_ContextCollectionError_Logs(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, assert.AnError)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), assert.AnError)
 
 		advices := svc.GenerateAdvice(1)
 		assert.Empty(t, advices)
@@ -716,7 +716,7 @@ func TestGenerateAdvice_ContextCollectionError_Resources(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), assert.AnError)
 
 		advices := svc.GenerateAdvice(1)
@@ -733,7 +733,7 @@ func TestGenerateAdvice_ContextCollectionError_User(t *testing.T) {
 		goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
 		roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
 		githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-		logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+		logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 		resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 		userRepo.On("FindByID", uint(1)).Return(nil, assert.AnError)
 

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -45,9 +45,9 @@ func (s *LearningLogService) GetByID(id uint) (*model.LearningLog, error) {
 	return s.repo.FindByID(id)
 }
 
-// GetByUserID は指定ユーザーの全学習ログを取得する。
-func (s *LearningLogService) GetByUserID(userID uint) ([]model.LearningLog, error) {
-	return s.repo.GetByUserID(userID)
+// GetByUserID は指定ユーザーの学習ログをページネーション付きで取得する。
+func (s *LearningLogService) GetByUserID(userID uint, limit, offset int) ([]model.LearningLog, int64, error) {
+	return s.repo.GetByUserID(userID, limit, offset)
 }
 
 // GetByCategory は指定ユーザーの学習ログをカテゴリでフィルタリングして取得する。

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -253,22 +253,36 @@ func TestLearningLogGetByUserID_Success(t *testing.T) {
 	svc, repo := newTestLearningLogService()
 
 	logs := []model.LearningLog{{Title: "Go Study"}, {Title: "React Study"}}
-	repo.On("GetByUserID", uint(1)).Return(logs, nil)
+	repo.On("GetByUserID", uint(1), 20, 0).Return(logs, int64(2), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
 	repo.AssertExpectations(t)
 }
 
 func TestLearningLogGetByUserID_Empty(t *testing.T) {
 	svc, repo := newTestLearningLogService()
 
-	repo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	repo.On("GetByUserID", uint(1), 20, 0).Return([]model.LearningLog{}, int64(0), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+}
+
+func TestLearningLogGetByUserID_Page2(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetByUserID", uint(1), 10, 10).Return([]model.LearningLog{}, int64(15), nil)
+
+	result, total, err := svc.GetByUserID(1, 10, 10)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(15), total)
+	repo.AssertExpectations(t)
 }
 
 func TestLearningLogUpdate_RepoError(t *testing.T) {

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -494,9 +494,9 @@ func (m *MockLearningLogRepository) FindByID(id uint) (*model.LearningLog, error
 	return args.Get(0).(*model.LearningLog), args.Error(1)
 }
 
-func (m *MockLearningLogRepository) GetByUserID(userID uint) ([]model.LearningLog, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.LearningLog), args.Error(1)
+func (m *MockLearningLogRepository) GetByUserID(userID uint, limit, offset int) ([]model.LearningLog, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.LearningLog), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockLearningLogRepository) GetByCategory(userID uint, category string) ([]model.LearningLog, error) {


### PR DESCRIPTION
## 概要
Closes #1045

LearningLogService.GetByUserIDにページネーション（limit/offset）を追加。

## 変更内容
- **repository層**: GetByUserIDにCount + Limit + Offset実装
- **service層**: GetByUserIDシグネチャ変更（total返却追加）
- **handler層**: GetMyLogs/GetByUserID両メソッドにparseLimitOffset + LearningLogListResponse適用
- **dto**: LearningLogListResponse追加
- **ai_rule_engine.go**: logRepo.GetByUserID呼び出しを`(userID, 100, 0)`に更新
- **テスト**: service/handler/ai_rule_engine全テストのモック更新

## テスト結果
- service層: 全テスト通過（GetByUserID Success/Empty/Page2含む）
- handler層: 全テスト通過