### PR TITLE
refactor: ensureSliceジェネリックヘルパーでnilスライス初期化を共通化

### DIFF
--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -152,9 +152,5 @@ func (h *AIAdviceHandler) GetUnreadAdvice(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if advices == nil {
-		advices = []model.AIAdvice{}
-	}
-
-	respondOK(c, advices)
+	respondOK(c, ensureSlice(advices))
 }

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -188,9 +188,5 @@ func (h *CodeSnippetHandler) GetByUserLanguage(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if snippets == nil {
-		snippets = []model.CodeSnippet{}
-	}
-
-	respondOK(c, snippets)
+	respondOK(c, ensureSlice(snippets))
 }

--- a/backend/internal/handler/follow.go
+++ b/backend/internal/handler/follow.go
@@ -64,10 +64,7 @@ func (h *FollowHandler) GetFollowers(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if users == nil {
-		users = []model.User{}
-	}
-	respondOK(c, users)
+	respondOK(c, ensureSlice(users))
 }
 
 // GetFollowing は指定ユーザーのフォロー中一覧を返す。
@@ -81,8 +78,5 @@ func (h *FollowHandler) GetFollowing(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if users == nil {
-		users = []model.User{}
-	}
-	respondOK(c, users)
+	respondOK(c, ensureSlice(users))
 }

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -112,6 +112,15 @@ func parseExportPeriod(c *gin.Context) (int, bool) {
 	return n, true
 }
 
+// ensureSlice はnilスライスを空スライスに変換する。
+// JSONレスポンスでnullの代わりに[]を返すために使用する。
+func ensureSlice[T any](s []T) []T {
+	if s == nil {
+		return []T{}
+	}
+	return s
+}
+
 // bindJSON はリクエストボディをJSON構造体にバインドする。
 // バインド失敗時は400レスポンスを返しnilを返す。
 func bindJSON[T any](c *gin.Context) *T {

--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -202,11 +202,7 @@ func (h *LearningGoalHandler) GetDeadlineAlerts(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if alerts == nil {
-		alerts = []model.GoalDeadlineAlert{}
-	}
-
-	respondOK(c, alerts)
+	respondOK(c, ensureSlice(alerts))
 }
 
 // GetByCategory は認証ユーザーの学習目標をカテゴリでフィルタリングして取得する。
@@ -219,11 +215,8 @@ func (h *LearningGoalHandler) GetByCategory(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if goals == nil {
-		goals = []model.LearningGoal{}
-	}
 
-	respondOK(c, goals)
+	respondOK(c, ensureSlice(goals))
 }
 
 // GetByStatus は認証ユーザーの学習目標をステータスでフィルタリングして取得する。
@@ -236,11 +229,8 @@ func (h *LearningGoalHandler) GetByStatus(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if goals == nil {
-		goals = []model.LearningGoal{}
-	}
 
-	respondOK(c, goals)
+	respondOK(c, ensureSlice(goals))
 }
 
 // GetStats は指定されたユーザーの学習目標統計情報を取得する。

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -216,11 +216,8 @@ func (h *LearningLogHandler) GetByCategory(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if logs == nil {
-		logs = []model.LearningLog{}
-	}
 
-	respondOK(c, logs)
+	respondOK(c, ensureSlice(logs))
 }
 
 // GetBySource はソース（manual/pomodoro）で学習ログをフィルタリングして取得する。
@@ -233,11 +230,8 @@ func (h *LearningLogHandler) GetBySource(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if logs == nil {
-		logs = []model.LearningLog{}
-	}
 
-	respondOK(c, logs)
+	respondOK(c, ensureSlice(logs))
 }
 
 // ExportLogs は学習ログをCSV形式でダウンロードする。

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -93,11 +93,7 @@ func (h *RoadmapHandler) GetByStatus(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if roadmaps == nil {
-		roadmaps = []model.Roadmap{}
-	}
-
-	respondOK(c, roadmaps)
+	respondOK(c, ensureSlice(roadmaps))
 }
 
 // GetPublicRoadmaps は公開ロードマップの一覧をページネーション付きで取得する。

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -352,9 +352,5 @@ func (h *StudyCircleHandler) GetByStatus(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	if circles == nil {
-		circles = []model.StudyCircle{}
-	}
-
-	respondOK(c, circles)
+	respondOK(c, ensureSlice(circles))
 }

--- a/backend/internal/handler/youtube.go
+++ b/backend/internal/handler/youtube.go
@@ -39,12 +39,8 @@ func (h *YouTubeHandler) Search(c *gin.Context) {
 		return
 	}
 
-	if videos == nil {
-		videos = []model.YouTubeVideo{}
-	}
-
 	respondOK(c, dto.YouTubeSearchResponse{
-		Videos: videos,
+		Videos: ensureSlice(videos),
 		Query:  query,
 		Cached: cached,
 		Total:  len(videos),
@@ -61,12 +57,8 @@ func (h *YouTubeHandler) Recommend(c *gin.Context) {
 		return
 	}
 
-	if videos == nil {
-		videos = []model.YouTubeVideo{}
-	}
-	if skills == nil {
-		skills = []string{}
-	}
+	videos = ensureSlice(videos)
+	skills = ensureSlice(skills)
 
 	respondOK(c, dto.YouTubeRecommendResponse{
 		Videos:    videos,


### PR DESCRIPTION
## 概要
Closes #1047

handler層のnilスライス→空スライス初期化パターンをジェネリックヘルパーに共通化。

## 変更内容
- **helpers.go**: `ensureSlice[T any](s []T) []T` ヘルパー追加
- **8ファイル**: 13箇所の `if x == nil { x = []model.X{} }` を `ensureSlice(x)` に置換
  - learning_goal.go（3箇所）, follow.go（2箇所）, learning_log.go（2箇所）
  - youtube.go（2箇所）, code_snippet.go, ai_advice.go, study_circle.go, roadmap.go（各1箇所）
- 合計 -60行 / +23行（37行削減）

## テスト結果
- handler層全テスト通過