### PR TITLE
test: GetByStatus/GetByUserLanguage/GetByUserIDのhandlerテスト追加

### DIFF
--- a/backend/internal/handler/code_snippet_test.go
+++ b/backend/internal/handler/code_snippet_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -233,5 +234,47 @@ func TestCodeSnippetDeleteComment_ServiceError(t *testing.T) {
 	w := doRequest(r, "DELETE", "/snippets/1/comments/1", nil)
 
 	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetByUserLanguage テスト
+// ============================================================
+
+func TestCodeSnippet_GetByUserLanguage_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	r := newRouter(1)
+	r.GET("/snippets/language/:language", h.GetByUserLanguage)
+
+	snippets := []model.CodeSnippet{{Language: "Go", FileName: "main.go"}}
+	svc.On("GetByUserLanguage", uint(1), "Go").Return(snippets, nil)
+
+	w := doRequest(r, http.MethodGet, "/snippets/language/Go", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippet_GetByUserLanguage_NilResult(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	r := newRouter(1)
+	r.GET("/snippets/language/:language", h.GetByUserLanguage)
+
+	svc.On("GetByUserLanguage", uint(1), "Rust").Return([]model.CodeSnippet(nil), nil)
+
+	w := doRequest(r, http.MethodGet, "/snippets/language/Rust", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Equal(t, "[]", w.Body.String())
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippet_GetByUserLanguage_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	r := newRouter(1)
+	r.GET("/snippets/language/:language", h.GetByUserLanguage)
+
+	svc.On("GetByUserLanguage", uint(1), "invalid").Return([]model.CodeSnippet(nil), service.ErrNotFound)
+
+	w := doRequest(r, http.MethodGet, "/snippets/language/invalid", nil)
+	assertStatus(t, w, http.StatusNotFound)
 	svc.AssertExpectations(t)
 }

--- a/backend/internal/handler/question_test.go
+++ b/backend/internal/handler/question_test.go
@@ -257,6 +257,44 @@ func TestQuestionVote_InvalidValue(t *testing.T) {
 	assertStatus(t, w, http.StatusBadRequest)
 }
 
+// ============================================================
+// GetByUserID テスト
+// ============================================================
+
+func TestQuestion_GetByUserID_Success(t *testing.T) {
+	h, repo := setupQuestionHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/questions", h.GetByUserID)
+
+	questions := []model.Question{{Title: "Go質問"}}
+	repo.On("FindByUserID", uint(5), 20, 0).Return(questions, int64(1), nil)
+
+	w := doRequest(r, http.MethodGet, "/users/5/questions", nil)
+	assertStatus(t, w, http.StatusOK)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestion_GetByUserID_Empty(t *testing.T) {
+	h, repo := setupQuestionHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/questions", h.GetByUserID)
+
+	repo.On("FindByUserID", uint(99), 20, 0).Return([]model.Question{}, int64(0), nil)
+
+	w := doRequest(r, http.MethodGet, "/users/99/questions", nil)
+	assertStatus(t, w, http.StatusOK)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestion_GetByUserID_InvalidID(t *testing.T) {
+	h, _ := setupQuestionHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/questions", h.GetByUserID)
+
+	w := doRequest(r, http.MethodGet, "/users/abc/questions", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
 func TestQuestionRemoveVote_Success(t *testing.T) {
 	h, repo := setupQuestionHandler()
 	r := newRouter(1)

--- a/backend/internal/handler/roadmap_test.go
+++ b/backend/internal/handler/roadmap_test.go
@@ -420,6 +420,48 @@ func TestRoadmapReorderSteps_Forbidden(t *testing.T) {
 	assertStatus(t, w, http.StatusForbidden)
 }
 
+// ============================================================
+// GetByStatus テスト
+// ============================================================
+
+func TestRoadmap_GetByStatus_Success(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps/status/:status", h.GetByStatus)
+
+	roadmaps := []model.Roadmap{{Title: "Go入門"}}
+	svc.On("GetByStatus", uint(1), "active").Return(roadmaps, nil)
+
+	w := doRequest(r, http.MethodGet, "/roadmaps/status/active", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestRoadmap_GetByStatus_NilResult(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps/status/:status", h.GetByStatus)
+
+	svc.On("GetByStatus", uint(1), "completed").Return([]model.Roadmap(nil), nil)
+
+	w := doRequest(r, http.MethodGet, "/roadmaps/status/completed", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Equal(t, "[]", w.Body.String())
+	svc.AssertExpectations(t)
+}
+
+func TestRoadmap_GetByStatus_ServiceError(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps/status/:status", h.GetByStatus)
+
+	svc.On("GetByStatus", uint(1), "invalid").Return([]model.Roadmap(nil), service.ErrNotFound)
+
+	w := doRequest(r, http.MethodGet, "/roadmaps/status/invalid", nil)
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
 func TestRoadmapReorderSteps_ValidationError(t *testing.T) {
 	h, _ := setupRoadmapHandler()
 	r := newRouter(1)

--- a/backend/internal/handler/study_circle_test.go
+++ b/backend/internal/handler/study_circle_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -543,4 +544,43 @@ func TestStudyCircleReorderSteps_Success(t *testing.T) {
 		},
 	})
 	assertStatus(t, w, http.StatusOK)
+}
+
+// ============================================================
+// GetByStatus テスト
+// ============================================================
+
+func TestStudyCircle_GetByStatus_Success(t *testing.T) {
+	h, repo := setupStudyCircleHandler()
+	r := newRouter(1)
+	r.GET("/study-circles/status/:status", h.GetByStatus)
+
+	circles := []model.StudyCircle{{Name: "Go勉強会"}}
+	repo.On("GetByStatus", uint(1), "active").Return(circles, nil)
+
+	w := doRequest(r, http.MethodGet, "/study-circles/status/active", nil)
+	assertStatus(t, w, http.StatusOK)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircle_GetByStatus_NilResult(t *testing.T) {
+	h, repo := setupStudyCircleHandler()
+	r := newRouter(1)
+	r.GET("/study-circles/status/:status", h.GetByStatus)
+
+	repo.On("GetByStatus", uint(1), "completed").Return([]model.StudyCircle(nil), nil)
+
+	w := doRequest(r, http.MethodGet, "/study-circles/status/completed", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Equal(t, "[]", w.Body.String())
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircle_GetByStatus_InvalidStatus(t *testing.T) {
+	h, _ := setupStudyCircleHandler()
+	r := newRouter(1)
+	r.GET("/study-circles/status/:status", h.GetByStatus)
+
+	w := doRequest(r, http.MethodGet, "/study-circles/status/invalid", nil)
+	assertStatus(t, w, http.StatusBadRequest)
 }


### PR DESCRIPTION
## 概要
Closes #1049

handler層の0%カバレッジ関数に12テストを追加。

## 変更内容
- **roadmap_test**: GetByStatus 3テスト（Success/NilResult/ServiceError）
- **study_circle_test**: GetByStatus 3テスト（Success/NilResult/InvalidStatus）
- **code_snippet_test**: GetByUserLanguage 3テスト（Success/NilResult/ServiceError）
- **question_test**: GetByUserID 3テスト（Success/Empty/InvalidID）

## テスト結果
- 12テスト全通過
- handler層カバレッジ: 81.3% → 82.2%