### PR TITLE
fix: LearningResourceService.Updateの空白バイパス脆弱性を修正

### DIFF
--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -104,8 +106,17 @@ func (s *LearningResourceService) Update(id, userID uint, updates *model.Learnin
 		return nil, err
 	}
 
+	// 空白のみの値を空文字列に正規化（空白バイパス防止）
+	updates.Title = strings.TrimSpace(updates.Title)
+	updates.Description = strings.TrimSpace(updates.Description)
+	updates.URL = strings.TrimSpace(updates.URL)
+	updates.Tags = strings.TrimSpace(updates.Tags)
+	updates.ImageURL = strings.TrimSpace(updates.ImageURL)
+	trimmedCategory := strings.TrimSpace(string(updates.Category))
+	trimmedDifficulty := strings.TrimSpace(string(updates.Difficulty))
+
 	v := validator.NewResourceValidator()
-	if err := v.ValidateUpdateResource(updates.Title, updates.Description, updates.URL, string(updates.Category), string(updates.Difficulty)); err != nil {
+	if err := v.ValidateUpdateResource(updates.Title, updates.Description, updates.URL, trimmedCategory, trimmedDifficulty); err != nil {
 		return nil, err
 	}
 
@@ -118,10 +129,12 @@ func (s *LearningResourceService) Update(id, userID uint, updates *model.Learnin
 	if updates.URL != "" {
 		resource.URL = updates.URL
 	}
-	if updates.Category != "" {
+	if trimmedCategory != "" {
+		updates.Category = model.ResourceCategory(trimmedCategory)
 		resource.Category = updates.Category
 	}
-	if updates.Difficulty != "" {
+	if trimmedDifficulty != "" {
+		updates.Difficulty = model.ResourceDifficulty(trimmedDifficulty)
 		resource.Difficulty = updates.Difficulty
 	}
 	if updates.Tags != "" {

--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -770,6 +770,94 @@ func TestLearningResourceGetByDifficulty_Empty(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+// ============================================================
+// Update 空白バイパステスト
+// ============================================================
+
+func TestLearningResourceUpdate_WhitespaceTitle(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	existing := &model.LearningResource{Title: "Original", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningResource{Title: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "Original", result.Title)
+}
+
+func TestLearningResourceUpdate_WhitespaceDescription(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	existing := &model.LearningResource{Description: "Original", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningResource{Description: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "Original", result.Description)
+}
+
+func TestLearningResourceUpdate_WhitespaceURL(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	existing := &model.LearningResource{URL: "https://example.com", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningResource{URL: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com", result.URL)
+}
+
+func TestLearningResourceUpdate_WhitespaceCategory(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	existing := &model.LearningResource{Category: "article", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningResource{Category: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, model.ResourceCategory("article"), result.Category)
+}
+
+func TestLearningResourceUpdate_WhitespaceDifficulty(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	existing := &model.LearningResource{Difficulty: "beginner", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningResource{Difficulty: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, model.ResourceDifficulty("beginner"), result.Difficulty)
+}
+
+func TestLearningResourceUpdate_WhitespaceTags(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	existing := &model.LearningResource{Tags: "go,test", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningResource{Tags: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "go,test", result.Tags)
+}
+
+func TestLearningResourceUpdate_WhitespaceImageURL(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+	existing := &model.LearningResource{ImageURL: "https://img.example.com/1.png", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.LearningResource{ImageURL: "   "})
+	assert.NoError(t, err)
+	assert.Equal(t, "https://img.example.com/1.png", result.ImageURL)
+}
+
 func TestLearningResourceGetByDifficulty_RepoError(t *testing.T) {
 	svc, repo := newTestLearningResourceService()
 


### PR DESCRIPTION
## 概要
Closes #1051

LearningResourceService.Updateの空白バイパス脆弱性を修正。

## 変更内容
- **learning_resource.go**: バリデーター呼び出し前に7フィールドをTrimSpaceで正規化
  - Title, Description, URL: 直接TrimSpace
  - Category, Difficulty: string()キャスト後にTrimSpace
  - Tags, ImageURL: 直接TrimSpace
- **learning_resource_test.go**: 7テスト追加（空白のみ→元値保持を検証）

## テスト結果
- 7テスト全通過（RED→GREEN確認済み）
- 既存テスト全通過