### PR TITLE
handler層のServiceError/InvalidIDテスト追加（カバレッジ82.7%）

### DIFF
--- a/backend/internal/handler/activity_report_test.go
+++ b/backend/internal/handler/activity_report_test.go
@@ -118,6 +118,59 @@ func TestActivityReport_GetComparison_Success(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
+// ============================================================
+// GetMonthlyReport テスト
+// ============================================================
+
+func TestActivityReport_GetMonthlyReport_ServiceError(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	svc.On("GetMonthlyReport", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/users/:userId/reports/monthly", h.GetMonthlyReport)
+
+	w := doRequest(r, http.MethodGet, "/users/1/reports/monthly", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestActivityReport_GetMonthlyReport_InvalidID(t *testing.T) {
+	h, _ := setupActivityReportHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/reports/monthly", h.GetMonthlyReport)
+
+	w := doRequest(r, http.MethodGet, "/users/abc/reports/monthly", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// GetMyWeeklyReport / GetMyMonthlyReport テスト
+// ============================================================
+
+func TestActivityReport_GetMyWeeklyReport_ServiceError(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	svc.On("GetWeeklyReport", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/me/reports/weekly", h.GetMyWeeklyReport)
+
+	w := doRequest(r, http.MethodGet, "/me/reports/weekly", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestActivityReport_GetMyMonthlyReport_ServiceError(t *testing.T) {
+	h, svc := setupActivityReportHandler()
+	svc.On("GetMonthlyReport", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/me/reports/monthly", h.GetMyMonthlyReport)
+
+	w := doRequest(r, http.MethodGet, "/me/reports/monthly", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
 func TestActivityReport_GetComparison_Monthly(t *testing.T) {
 	h, svc := setupActivityReportHandler()
 	comp := &model.ReportComparison{ContributionsDiff: -2}

--- a/backend/internal/handler/ai_advice_test.go
+++ b/backend/internal/handler/ai_advice_test.go
@@ -203,6 +203,43 @@ func TestAIAdviceGetUnreadAdvice_Empty(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
+// ============================================================
+// DeleteConversation テスト
+// ============================================================
+
+func TestAIAdviceDeleteConversation_Success(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	r := newRouter(1)
+	r.DELETE("/ai-advice/conversations/:id", h.DeleteConversation)
+
+	svc.On("DeleteConversation", uint(5), uint(1)).Return(nil)
+
+	w := doRequest(r, http.MethodDelete, "/ai-advice/conversations/5", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdviceDeleteConversation_ServiceError(t *testing.T) {
+	h, svc := setupAIAdviceHandler()
+	r := newRouter(1)
+	r.DELETE("/ai-advice/conversations/:id", h.DeleteConversation)
+
+	svc.On("DeleteConversation", uint(99), uint(1)).Return(errors.New("not found"))
+
+	w := doRequest(r, http.MethodDelete, "/ai-advice/conversations/99", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestAIAdviceDeleteConversation_InvalidID(t *testing.T) {
+	h, _ := setupAIAdviceHandler()
+	r := newRouter(1)
+	r.DELETE("/ai-advice/conversations/:id", h.DeleteConversation)
+
+	w := doRequest(r, http.MethodDelete, "/ai-advice/conversations/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
 func TestAIAdviceGetUnreadAdvice_ServiceError(t *testing.T) {
 	h, svc := setupAIAdviceHandler()
 	r := newRouter(1)

--- a/backend/internal/handler/answer_test.go
+++ b/backend/internal/handler/answer_test.go
@@ -316,6 +316,31 @@ func TestAnswerGetByVoteRange_InvalidID(t *testing.T) {
 	assertStatus(t, w, http.StatusBadRequest)
 }
 
+// ============================================================
+// RemoveVote テスト
+// ============================================================
+
+func TestAnswerRemoveVote_ServiceError(t *testing.T) {
+	h, svc := setupAnswerHandler()
+	r := newRouter(1)
+	r.DELETE("/answers/:answerId/vote", h.RemoveVote)
+
+	svc.On("RemoveVote", uint(1), uint(5)).Return(errors.New("not found"))
+
+	w := doRequest(r, http.MethodDelete, "/answers/5/vote", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestAnswerRemoveVote_InvalidID(t *testing.T) {
+	h, _ := setupAnswerHandler()
+	r := newRouter(1)
+	r.DELETE("/answers/:answerId/vote", h.RemoveVote)
+
+	w := doRequest(r, http.MethodDelete, "/answers/abc/vote", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
 func TestAnswerGetByVoteRange_ServiceError(t *testing.T) {
 	h, svc := setupAnswerHandler()
 	r := newRouter(1)


### PR DESCRIPTION
## 概要
handler層の低カバレッジ関数にServiceError/InvalidIDテストを追加し、カバレッジを82.2%→82.7%に向上。

## 変更内容
- activity_report_test.go: GetMonthlyReport ServiceError/InvalidID + GetMyWeeklyReport/GetMyMonthlyReport ServiceError（4テスト）
- answer_test.go: RemoveVote ServiceError/InvalidID（2テスト）
- ai_advice_test.go: DeleteConversation Success/ServiceError/InvalidID（3テスト）

Closes #1057