### PR TITLE
PostService/QuestionServiceのUpdate空白バイパス脆弱性を修正

### DIFF
--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"unicode/utf8"
 
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -106,6 +107,11 @@ func (s *PostService) Update(id, userID uint, title, content, imageUrls string) 
 	if err != nil {
 		return nil, err
 	}
+
+	// 空白のみの入力を正規化（空白のみ→変更なしとして扱う）
+	title = strings.TrimSpace(title)
+	content = strings.TrimSpace(content)
+	imageUrls = strings.TrimSpace(imageUrls)
 
 	// バリデーション
 	v := validator.NewPostValidator()

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -1099,6 +1099,38 @@ func TestPostUpdate_ValidationError(t *testing.T) {
 	postRepo.AssertExpectations(t)
 }
 
+func TestPostUpdate_WhitespaceOnlyTitle(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	existing := &model.Post{Title: "Old Title", Content: "Old Content", UserID: 1}
+	existing.ID = 1
+
+	postRepo.On("FindByID", uint(1)).Return(existing, nil)
+	postRepo.On("Update", existing).Return(nil)
+
+	// 空白のみのタイトル → 変更なし（エラーにならない）
+	result, err := svc.Update(1, 1, "   ", "", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "Old Title", result.Title) // 元のタイトルが維持される
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostUpdate_WhitespaceOnlyContent(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	existing := &model.Post{Title: "Old Title", Content: "Old Content", UserID: 1}
+	existing.ID = 1
+
+	postRepo.On("FindByID", uint(1)).Return(existing, nil)
+	postRepo.On("Update", existing).Return(nil)
+
+	// 空白のみの本文 → 変更なし（エラーにならない）
+	result, err := svc.Update(1, 1, "", "   ", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "Old Content", result.Content) // 元の本文が維持される
+	postRepo.AssertExpectations(t)
+}
+
 // ============================================================
 // 投稿非公開化（Unpublish）追加テスト
 // ============================================================

--- a/backend/internal/service/question.go
+++ b/backend/internal/service/question.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -69,6 +71,11 @@ func (s *QuestionService) Update(id, userID uint, title, body, tags string) (*mo
 	if err != nil {
 		return nil, err
 	}
+
+	// 空白のみの入力を正規化（空白のみ→変更なしとして扱う）
+	title = strings.TrimSpace(title)
+	body = strings.TrimSpace(body)
+	tags = strings.TrimSpace(tags)
 
 	v := validator.NewQuestionValidator()
 	if err := v.ValidateUpdateQuestion(title, body, tags); err != nil {

--- a/backend/internal/service/question_test.go
+++ b/backend/internal/service/question_test.go
@@ -480,6 +480,54 @@ func TestQuestionUpdate_TagsTooLong(t *testing.T) {
 	assert.Nil(t, result)
 }
 
+func TestQuestionUpdate_WhitespaceOnlyTitle(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	existing := &model.Question{Title: "Old Title", Body: "Old Body", Tags: "go", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	// 空白のみのタイトル → 変更なし（エラーにならない）
+	result, err := svc.Update(1, 1, "   ", "", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "Old Title", result.Title) // 元のタイトルが維持される
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionUpdate_WhitespaceOnlyBody(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	existing := &model.Question{Title: "Old Title", Body: "Old Body", Tags: "go", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	// 空白のみの本文 → 変更なし
+	result, err := svc.Update(1, 1, "", "   ", "")
+	assert.NoError(t, err)
+	assert.Equal(t, "Old Body", result.Body)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionUpdate_WhitespaceOnlyTags(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	existing := &model.Question{Title: "Old Title", Body: "Old Body", Tags: "go", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	// 空白のみのタグ → 変更なし
+	result, err := svc.Update(1, 1, "", "", "   ")
+	assert.NoError(t, err)
+	assert.Equal(t, "go", result.Tags)
+	repo.AssertExpectations(t)
+}
+
 // ============================================================
 // GetSolved テスト
 // ============================================================


### PR DESCRIPTION
## 概要
PostService.UpdateとQuestionService.Updateで空白のみの入力がバリデーションエラー＋パニックを引き起こす脆弱性を修正。

## 変更内容
- PostService.Update: title/content/imageUrlsをバリデーター呼び出し前にTrimSpace
- QuestionService.Update: title/body/tagsをバリデーター呼び出し前にTrimSpace
- 5テスト追加（空白のみ入力が「変更なし」として扱われることを検証）

Closes #1059