### PR TITLE
PostService.GetByUserIDにページネーション対応

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -45,6 +45,14 @@ type BookmarkedPostsResponse struct {
 	Total int64        `json:"total"`
 }
 
+// PostListResponse は投稿一覧レスポンス（ページネーション付き）。
+type PostListResponse struct {
+	Posts  []model.Post `json:"posts"`
+	Total  int64        `json:"total"`
+	Limit  int          `json:"limit"`
+	Offset int          `json:"offset"`
+}
+
 // ReactionRequest はリアクション追加/削除リクエスト。
 type ReactionRequest struct {
 	Emoji string `json:"emoji" binding:"required"`

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -13,7 +13,7 @@ type PostServiceInterface interface {
 	GetByID(id uint) (*model.Post, error)
 	GetAll(page, limit int) ([]model.Post, error)
 	CountAll() (int64, error)
-	GetByUserID(userID uint) ([]model.Post, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.Post, int64, error)
 	GetDrafts(userID uint) ([]model.Post, error)
 	Timeline(userID uint, page, limit int) ([]model.Post, error)
 	Update(id, userID uint, title, content, imageUrls string) (*model.Post, error)
@@ -188,18 +188,26 @@ func (h *PostHandler) Timeline(c *gin.Context) {
 	respondOK(c, posts)
 }
 
-// GetUserPosts は指定ユーザーの投稿一覧を返す。
+// GetUserPosts は指定ユーザーの投稿一覧をページネーション付きで返す。
 func (h *PostHandler) GetUserPosts(c *gin.Context) {
 	id, ok := parseID(c, "id")
 	if !ok {
 		return
 	}
-	posts, err := h.service.GetByUserID(id)
+	limit, offset := parseLimitOffset(c)
+
+	posts, total, err := h.service.GetByUserID(id, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, posts)
+
+	respondOK(c, dto.PostListResponse{
+		Posts:  ensureSlice(posts),
+		Total: total,
+		Limit: limit,
+		Offset: offset,
+	})
 }
 
 // Like は投稿にいいねする。

--- a/backend/internal/handler/post_test.go
+++ b/backend/internal/handler/post_test.go
@@ -496,9 +496,9 @@ func TestPostGetUserPosts_Success(t *testing.T) {
 	r := newRouter(1)
 	r.GET("/users/:id/posts", h.GetUserPosts)
 
-	postRepo.On("FindByUserID", uint(2)).Return([]model.Post{
+	postRepo.On("FindByUserID", uint(2), 20, 0).Return([]model.Post{
 		{Title: "User Post 1"}, {Title: "User Post 2"},
-	}, nil)
+	}, int64(2), nil)
 
 	w := doRequest(r, http.MethodGet, "/users/2/posts", nil)
 	assertStatus(t, w, http.StatusOK)
@@ -518,7 +518,7 @@ func TestPostGetUserPosts_ServiceError(t *testing.T) {
 	r := newRouter(1)
 	r.GET("/users/:id/posts", h.GetUserPosts)
 
-	postRepo.On("FindByUserID", uint(2)).Return([]model.Post(nil), service.ErrNotFound)
+	postRepo.On("FindByUserID", uint(2), 20, 0).Return([]model.Post(nil), int64(0), service.ErrNotFound)
 
 	w := doRequest(r, http.MethodGet, "/users/2/posts", nil)
 	assertStatus(t, w, http.StatusNotFound)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -74,9 +74,9 @@ func (m *MockPostRepository) CountAll() (int64, error) {
 	args := m.Called()
 	return args.Get(0).(int64), args.Error(1)
 }
-func (m *MockPostRepository) FindByUserID(userID uint) ([]model.Post, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.Post), args.Error(1)
+func (m *MockPostRepository) FindByUserID(userID uint, limit, offset int) ([]model.Post, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
 }
 func (m *MockPostRepository) Timeline(userID uint, page, limit int) ([]model.Post, error) {
 	args := m.Called(userID, page, limit)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -59,7 +59,7 @@ type PostRepositoryInterface interface {
 	FindByID(id uint) (*model.Post, error)
 	FindAll(page, limit int) ([]model.Post, error)
 	CountAll() (int64, error)
-	FindByUserID(userID uint) ([]model.Post, error)
+	FindByUserID(userID uint, limit, offset int) ([]model.Post, int64, error)
 	FindDraftsByUserID(userID uint) ([]model.Post, error)
 	Timeline(userID uint, page, limit int) ([]model.Post, error)
 	Update(post *model.Post) error

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -46,13 +46,15 @@ func (r *PostRepository) CountAll() (int64, error) {
 	return count, err
 }
 
-// FindByUserID は指定ユーザーの全投稿を取得する（新しい順）。下書きは除外。
-func (r *PostRepository) FindByUserID(userID uint) ([]model.Post, error) {
+// FindByUserID は指定ユーザーの投稿をページネーション付きで取得する（新しい順）。下書きは除外。
+func (r *PostRepository) FindByUserID(userID uint, limit, offset int) ([]model.Post, int64, error) {
 	var posts []model.Post
-	err := r.db.Preload("User").Preload("CodeSnippets").
-		Where("user_id = ? AND is_draft = ?", userID, false).
-		Order("created_at DESC").Find(&posts).Error
-	return posts, err
+	var total int64
+	query := r.db.Where("user_id = ? AND is_draft = ?", userID, false)
+	query.Model(&model.Post{}).Count(&total)
+	err := query.Preload("User").Preload("CodeSnippets").
+		Order("created_at DESC").Limit(limit).Offset(offset).Find(&posts).Error
+	return posts, total, err
 }
 
 // Timeline はフォロー中ユーザーと自分の投稿をタイムライン形式で取得する。下書きは除外。

--- a/backend/internal/service/ai_advice_test.go
+++ b/backend/internal/service/ai_advice_test.go
@@ -73,9 +73,9 @@ func TestRuleEngine_StreakBroken(t *testing.T) {
 	}, nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -99,7 +99,7 @@ func TestRuleEngine_RoadmapStalled(t *testing.T) {
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 3, TotalDays: 10}, nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{
 		{
 			ID: 1, Title: "Go学習", Status: model.RoadmapStatusActive,
 			StepCount: 5, CompletedStepCount: 2, Progress: 40,
@@ -108,9 +108,9 @@ func TestRuleEngine_RoadmapStalled(t *testing.T) {
 			},
 			UpdatedAt: stalledTime,
 		},
-	}, nil)
+	}, int64(1), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -136,9 +136,9 @@ func TestRuleEngine_GoalOverdue(t *testing.T) {
 		{Title: "React学習", Status: model.GoalStatusActive, TargetDate: &pastDate, Progress: 50},
 	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -163,12 +163,12 @@ func TestRuleEngine_TechGapReact(t *testing.T) {
 		{Title: "TypeScript基礎", Category: model.GoalCategoryLanguage, Status: model.GoalStatusActive},
 	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
 		{Language: "TypeScript", Bytes: 100000, RepoCount: 5},
 		{Language: "JavaScript", Bytes: 50000, RepoCount: 3},
 	}, nil)
-	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -191,11 +191,11 @@ func TestRuleEngine_NoGoalsWithGitHub(t *testing.T) {
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 3, TotalDays: 10}, nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{TotalGoals: 0}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
 		{Language: "Go", Bytes: 80000, RepoCount: 3},
 	}, nil)
-	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -225,11 +225,11 @@ func TestRuleEngine_HighCompletionRate(t *testing.T) {
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{
 		CompletedGoals: 3, ActiveGoals: 1, AverageProgress: 80,
 	}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{
 		{ID: 1, Status: model.RoadmapStatusActive},
-	}, nil)
+	}, int64(1), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{
 		{}, {}, {},
 	}, int64(3), nil)
@@ -256,9 +256,9 @@ func TestRuleEngine_ConsistentLearner(t *testing.T) {
 		{Status: model.GoalStatusActive, Progress: 50},
 	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{
 		{ID: 1, Status: model.RoadmapStatusActive},
-	}, nil)
+	}, int64(1), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 
 	// 直近7日間に毎日90分の学習ログ
@@ -269,7 +269,7 @@ func TestRuleEngine_ConsistentLearner(t *testing.T) {
 			CreatedAt: time.Now().Add(-time.Duration(i) * 24 * time.Hour),
 		}
 	}
-	deps.logRepo.On("GetByUserID", uint(1)).Return(logs, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return(logs, int64(7), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{
 		{}, {}, {},
 	}, int64(3), nil)
@@ -296,9 +296,9 @@ func TestRuleEngine_NoRoadmap(t *testing.T) {
 		{Title: "Go学習", Status: model.GoalStatusActive},
 	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -326,9 +326,9 @@ func TestRuleEngine_PriorityOrdering(t *testing.T) {
 		{Title: "React", Status: model.GoalStatusActive, TargetDate: &pastDate, Progress: 30},
 	}, int64(1), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{ActiveGoals: 1}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -350,9 +350,9 @@ func TestRuleEngine_NewUserNoData(t *testing.T) {
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.goalRepo.On("GetStats", uint(1)).Return(&model.LearningGoalStats{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-	deps.logRepo.On("GetByUserID", uint(1)).Return([]model.LearningLog{}, nil)
+	deps.logRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningLog{}, int64(0), nil)
 	deps.resourceRepo.On("FindByUserID", uint(1), true, 100, 0).Return([]model.LearningResource{}, int64(0), nil)
 	deps.userRepo.On("FindByID", uint(1)).Return(&model.User{}, nil)
 
@@ -379,7 +379,7 @@ func TestChat_Success(t *testing.T) {
 		{Title: "Go学習", Status: model.GoalStatusActive, Progress: 50},
 	}, int64(1), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{CurrentStreak: 5}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{
 		{Language: "Go", Bytes: 50000},
 	}, nil)
@@ -643,7 +643,7 @@ func TestChat_ExistingConversation(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(1), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 
 	// 既存会話を返す（所有者一致）
@@ -674,7 +674,7 @@ func TestChat_ForbiddenConversation(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(1), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 
 	// 他人の会話
@@ -764,7 +764,7 @@ func TestChat_CreateConversationError(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.convRepo.On("CreateConversation", mock.AnythingOfType("*model.AIConversation")).Return(ErrNotFound)
 
@@ -779,7 +779,7 @@ func TestChat_AddUserMessageError(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.convRepo.On("CreateConversation", mock.AnythingOfType("*model.AIConversation")).Return(nil)
 	deps.convRepo.On("AddMessage", mock.AnythingOfType("*model.AIMessage")).Return(ErrNotFound).Once()
@@ -795,7 +795,7 @@ func TestChat_LLMCompleteError(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.convRepo.On("CreateConversation", mock.AnythingOfType("*model.AIConversation")).Return(nil)
 	deps.convRepo.On("AddMessage", mock.AnythingOfType("*model.AIMessage")).Return(nil)
@@ -812,7 +812,7 @@ func TestChat_AddAssistantMessageError(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.convRepo.On("CreateConversation", mock.AnythingOfType("*model.AIConversation")).Return(nil)
 	// ユーザーメッセージ成功、アシスタントメッセージ失敗
@@ -838,7 +838,7 @@ func TestChat_ExistingConversationWithMessages(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	// 既存会話にメッセージ履歴あり（systemメッセージはスキップされること）
 	deps.convRepo.On("FindConversationByID", uint(10)).Return(&model.AIConversation{
@@ -874,7 +874,7 @@ func TestChat_LongTitleTruncation(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	// 会話作成時にタイトルが50文字+...に切り詰められることを検証
 	deps.convRepo.On("CreateConversation", mock.MatchedBy(func(c *model.AIConversation) bool {
@@ -902,7 +902,7 @@ func TestChat_ExistingConversationNotFound(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	// 既存会話が見つからない
 	deps.convRepo.On("FindConversationByID", uint(999)).Return((*model.AIConversation)(nil), ErrNotFound)
@@ -918,7 +918,7 @@ func TestChat_RefetchFallback(t *testing.T) {
 	deps.convRepo.On("CountTodayMessages", uint(1)).Return(int64(0), nil)
 	deps.goalRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.LearningGoal{}, int64(0), nil)
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
-	deps.roadmapRepo.On("GetByUserID", uint(1)).Return([]model.Roadmap{}, nil)
+	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
 	deps.convRepo.On("CreateConversation", mock.AnythingOfType("*model.AIConversation")).Return(nil)
 	deps.convRepo.On("AddMessage", mock.AnythingOfType("*model.AIMessage")).Return(nil)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -116,9 +116,9 @@ func (m *MockPostRepository) CountAll() (int64, error) {
 	return args.Get(0).(int64), args.Error(1)
 }
 
-func (m *MockPostRepository) FindByUserID(userID uint) ([]model.Post, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.Post), args.Error(1)
+func (m *MockPostRepository) FindByUserID(userID uint, limit, offset int) ([]model.Post, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockPostRepository) FindDraftsByUserID(userID uint) ([]model.Post, error) {

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -86,9 +86,9 @@ func (s *PostService) CountAll() (int64, error) {
 	return s.repo.CountAll()
 }
 
-// GetByUserID は指定ユーザーの全投稿を取得する。
-func (s *PostService) GetByUserID(userID uint) ([]model.Post, error) {
-	return s.repo.FindByUserID(userID)
+// GetByUserID は指定ユーザーの投稿をページネーション付きで取得する。
+func (s *PostService) GetByUserID(userID uint, limit, offset int) ([]model.Post, int64, error) {
+	return s.repo.FindByUserID(userID, limit, offset)
 }
 
 // GetDrafts は指定ユーザーの下書き投稿を取得する。

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -182,11 +182,12 @@ func TestPostGetByUserID_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
 	posts := []model.Post{{Title: "My Post", UserID: 1}}
-	postRepo.On("FindByUserID", uint(1)).Return(posts, nil)
+	postRepo.On("FindByUserID", uint(1), 20, 0).Return(posts, int64(1), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
 }
 
 func TestPostGetDrafts_Success(t *testing.T) {
@@ -1202,11 +1203,12 @@ func TestPostGetAll_RepoError(t *testing.T) {
 func TestPostGetByUserID_RepoError(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 
-	postRepo.On("FindByUserID", uint(1)).Return([]model.Post{}, errors.New("db error"))
+	postRepo.On("FindByUserID", uint(1), 20, 0).Return([]model.Post{}, int64(0), errors.New("db error"))
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.Error(t, err)
 	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
 	postRepo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
PostService.GetByUserIDにページネーション（limit/offset + total件数）を追加。

## 変更内容
- repository/service/handler全レイヤーでシグネチャ変更
- PostListResponse DTO追加
- 全モック・テスト更新（ai_advice_test.goの未更新分も含む）

Closes #1061