### PR TITLE
BookmarkedPostsResponseをPostListResponseに統合

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -39,12 +39,6 @@ type PostDetailResponse struct {
 	Bookmarked bool `json:"bookmarked"`
 }
 
-// BookmarkedPostsResponse はブックマーク済み投稿一覧レスポンス。
-type BookmarkedPostsResponse struct {
-	Posts []model.Post `json:"posts"`
-	Total int64        `json:"total"`
-}
-
 // PostListResponse は投稿一覧レスポンス（ページネーション付き）。
 type PostListResponse struct {
 	Posts  []model.Post `json:"posts"`

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -390,7 +390,12 @@ func (h *PostHandler) GetBookmarks(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, dto.BookmarkedPostsResponse{Posts: posts, Total: total})
+	respondOK(c, dto.PostListResponse{
+		Posts:  ensureSlice(posts),
+		Total:  total,
+		Limit:  limit,
+		Offset: (page - 1) * limit,
+	})
 }
 
 // AddReaction は投稿にリアクション（絵文字）を追加する。


### PR DESCRIPTION
## 概要
BookmarkedPostsResponseにLimit/Offsetが欠けていた問題を修正。PostListResponseに統合。

## 変更内容
- BookmarkedPostsResponse削除、PostListResponse使用に変更
- GetBookmarksにLimit/Offset情報を追加

Closes #1063