### PR TITLE
handler層のServiceError/InvalidIDテスト追加（カバレッジ83.1%）

### DIFF
--- a/backend/internal/handler/follow_test.go
+++ b/backend/internal/handler/follow_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -128,4 +129,23 @@ func TestGetFollowing_Empty(t *testing.T) {
 	assertStatus(t, w, 200)
 	body := w.Body.String()
 	assert.Contains(t, body, "[]")
+}
+
+func TestGetFollowing_ServiceError(t *testing.T) {
+	h, svc := setupFollowHandler()
+	svc.On("GetFollowing", uint(2)).Return([]model.User(nil), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/users/:id/following", h.GetFollowing)
+	w := doRequest(r, "GET", "/users/2/following", nil)
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}
+
+func TestGetFollowing_InvalidID(t *testing.T) {
+	h, _ := setupFollowHandler()
+	r := newRouter(1)
+	r.GET("/users/:id/following", h.GetFollowing)
+	w := doRequest(r, "GET", "/users/abc/following", nil)
+	assertStatus(t, w, 400)
 }

--- a/backend/internal/handler/github_test.go
+++ b/backend/internal/handler/github_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 	"time"
@@ -134,6 +135,46 @@ func TestGitHubGetRepos_Success(t *testing.T) {
 
 	assertStatus(t, w, http.StatusOK)
 	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubGetLanguages_ServiceError(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	ghSvc.On("GetLanguages", uint(1)).Return([]model.GitHubLanguageStat(nil), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/github/:userId/languages", h.GetLanguages)
+	w := doRequest(r, "GET", "/github/1/languages", nil)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubGetLanguages_InvalidID(t *testing.T) {
+	h, _, _ := setupGitHubHandlerMock()
+	r := newRouter(1)
+	r.GET("/github/:userId/languages", h.GetLanguages)
+	w := doRequest(r, "GET", "/github/abc/languages", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestGitHubGetRepos_ServiceError(t *testing.T) {
+	h, ghSvc, _ := setupGitHubHandlerMock()
+	ghSvc.On("GetRepos", uint(1)).Return([]model.GitHubRepository(nil), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/github/:userId/repos", h.GetRepos)
+	w := doRequest(r, "GET", "/github/1/repos", nil)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	ghSvc.AssertExpectations(t)
+}
+
+func TestGitHubGetRepos_InvalidID(t *testing.T) {
+	h, _, _ := setupGitHubHandlerMock()
+	r := newRouter(1)
+	r.GET("/github/:userId/repos", h.GetRepos)
+	w := doRequest(r, "GET", "/github/abc/repos", nil)
+	assertStatus(t, w, http.StatusBadRequest)
 }
 
 func TestGitHubSync_Success(t *testing.T) {

--- a/backend/internal/handler/learning_goal_test.go
+++ b/backend/internal/handler/learning_goal_test.go
@@ -403,3 +403,23 @@ func TestLearningGoalGetStats_Success(t *testing.T) {
 	w := doRequest(r, http.MethodGet, "/users/1/goals/stats", nil)
 	assertStatus(t, w, http.StatusOK)
 }
+
+func TestLearningGoalGetStats_ServiceError(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/goals/stats", h.GetStats)
+
+	repo.On("GetStats", uint(1)).Return(nil, errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/users/1/goals/stats", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalGetStats_InvalidID(t *testing.T) {
+	h, _ := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/goals/stats", h.GetStats)
+	w := doRequest(r, http.MethodGet, "/users/abc/goals/stats", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -173,6 +173,26 @@ func TestLearningLog_GetStreakInfo_Success(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
+func TestLearningLog_GetStreakInfo_ServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	svc.On("GetStreakInfo", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/users/:userId/streak", h.GetStreakInfo)
+	w := doRequest(r, http.MethodGet, "/users/1/streak", nil)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_GetStreakInfo_InvalidID(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/streak", h.GetStreakInfo)
+	w := doRequest(r, http.MethodGet, "/users/abc/streak", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
 func TestLearningLog_GetCalendarData_Success(t *testing.T) {
 	h, svc := setupLearningLogHandler()
 	entries := []model.CalendarEntry{{Date: "2026-02-17", Count: 3}}


### PR DESCRIPTION
## 概要
handler層の低カバレッジ関数にテスト追加。82.7%→83.1%に向上。

## 変更内容
- github_test.go: GetLanguages/GetRepos（4テスト）
- learning_log_test.go: GetStreakInfo（2テスト）
- learning_goal_test.go: GetStats（2テスト）
- follow_test.go: GetFollowing（2テスト）

Closes #1065