### PR TITLE
AnswerService/LearningGoalServiceのCreateで空白バイパス脆弱性を修正

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -28,6 +28,9 @@ func (s *AnswerService) GetByQuestionID(questionID uint) ([]model.Answer, error)
 
 // Create は質問の存在を確認した後、新しい回答を作成する。
 func (s *AnswerService) Create(answer *model.Answer) error {
+	if strings.TrimSpace(answer.Body) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "回答内容は必須です", nil)
+	}
 	if _, err := s.questionRepo.FindByID(answer.QuestionID); err != nil {
 		return ErrNotFound
 	}

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -47,6 +47,32 @@ func TestAnswerCreate_QuestionNotFound(t *testing.T) {
 	questionRepo.AssertExpectations(t)
 }
 
+func TestAnswerCreate_WhitespaceOnlyBody(t *testing.T) {
+	svc, _, questionRepo := newTestAnswerService()
+
+	question := &model.Question{UserID: 1}
+	question.ID = 10
+	questionRepo.On("FindByID", uint(10)).Return(question, nil)
+
+	// 空白のみの回答 → エラーになるべき
+	answer := &model.Answer{QuestionID: 10, UserID: 2, Body: "   "}
+	err := svc.Create(answer)
+	assert.Error(t, err)
+}
+
+func TestAnswerCreate_EmptyBody(t *testing.T) {
+	svc, _, questionRepo := newTestAnswerService()
+
+	question := &model.Question{UserID: 1}
+	question.ID = 10
+	questionRepo.On("FindByID", uint(10)).Return(question, nil)
+
+	// 空の回答 → エラーになるべき
+	answer := &model.Answer{QuestionID: 10, UserID: 2, Body: ""}
+	err := svc.Create(answer)
+	assert.Error(t, err)
+}
+
 // ============================================================
 // 回答更新テスト
 // ============================================================

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -22,6 +22,9 @@ func NewLearningGoalService(repo repository.LearningGoalRepositoryInterface) *Le
 
 // Create は新しい学習目標を作成する。
 func (s *LearningGoalService) Create(goal *model.LearningGoal) error {
+	if strings.TrimSpace(goal.Title) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "タイトルは必須です", nil)
+	}
 	return s.repo.Create(goal)
 }
 

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -47,6 +47,24 @@ func TestLearningGoalCreate_Error(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestLearningGoalCreate_WhitespaceOnlyTitle(t *testing.T) {
+	svc, _ := newTestLearningGoalService()
+
+	// 空白のみのタイトル → エラーになるべき
+	goal := &model.LearningGoal{UserID: 1, Title: "   "}
+	err := svc.Create(goal)
+	assert.Error(t, err)
+}
+
+func TestLearningGoalCreate_EmptyTitle(t *testing.T) {
+	svc, _ := newTestLearningGoalService()
+
+	// 空のタイトル → エラーになるべき
+	goal := &model.LearningGoal{UserID: 1, Title: ""}
+	err := svc.Create(goal)
+	assert.Error(t, err)
+}
+
 // ============================================================
 // 学習目標取得テスト
 // ============================================================


### PR DESCRIPTION
## 概要
Createメソッドで空白のみ入力が通ってしまう脆弱性を修正。

## 変更内容
- AnswerService.Create: Body空白チェック追加
- LearningGoalService.Create: Title空白チェック追加
- 4テスト追加

Closes #1067