### PR TITLE
feat: PostCollectionService.GetByUserIDにページネーション対応

### DIFF
--- a/backend/internal/dto/post_collection_dto.go
+++ b/backend/internal/dto/post_collection_dto.go
@@ -1,5 +1,15 @@
 package dto
 
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// PostCollectionListResponse はコレクション一覧レスポンス（ページネーション付き）。
+type PostCollectionListResponse struct {
+	Collections []model.PostCollection `json:"collections"`
+	Total       int64                  `json:"total"`
+	Limit       int                    `json:"limit"`
+	Offset      int                    `json:"offset"`
+}
+
 // CreatePostCollectionRequest はコレクション作成のリクエストボディ。
 type CreatePostCollectionRequest struct {
 	Title       string `json:"title" binding:"required,max=200"`

--- a/backend/internal/handler/post_collection.go
+++ b/backend/internal/handler/post_collection.go
@@ -10,7 +10,7 @@ import (
 type PostCollectionServiceInterface interface {
 	Create(collection *model.PostCollection) (*model.PostCollection, error)
 	GetByID(id uint) (*model.PostCollection, error)
-	GetByUserID(userID uint) ([]model.PostCollection, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.PostCollection, int64, error)
 	GetPublicByUserID(userID uint) ([]model.PostCollection, error)
 	Update(id, userID uint, title, description string, isPublic bool) (*model.PostCollection, error)
 	Delete(id, userID uint) error
@@ -71,7 +71,7 @@ func (h *PostCollectionHandler) GetByID(c *gin.Context) {
 }
 
 // GetByUserID は指定ユーザーのコレクション一覧を取得する。
-// 自分のコレクションは全件、他人のコレクションは公開のみ返す。
+// 自分のコレクションはページネーション付きで全件、他人のコレクションは公開のみ返す。
 func (h *PostCollectionHandler) GetByUserID(c *gin.Context) {
 	currentUserID := c.GetUint("userID")
 	targetUserID, ok := parseID(c, "userId")
@@ -79,15 +79,23 @@ func (h *PostCollectionHandler) GetByUserID(c *gin.Context) {
 		return
 	}
 
-	var collections []model.PostCollection
-	var err error
-
 	if currentUserID == targetUserID {
-		collections, err = h.service.GetByUserID(targetUserID)
-	} else {
-		collections, err = h.service.GetPublicByUserID(targetUserID)
+		limit, offset := parseLimitOffset(c)
+		collections, total, err := h.service.GetByUserID(targetUserID, limit, offset)
+		if err != nil {
+			respondError(c, err)
+			return
+		}
+		respondOK(c, dto.PostCollectionListResponse{
+			Collections: ensureSlice(collections),
+			Total:       total,
+			Limit:       limit,
+			Offset:      offset,
+		})
+		return
 	}
 
+	collections, err := h.service.GetPublicByUserID(targetUserID)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/post_collection_test.go
+++ b/backend/internal/handler/post_collection_test.go
@@ -27,12 +27,12 @@ func (m *MockPostCollectionService) GetByID(id uint) (*model.PostCollection, err
 	}
 	return nil, args.Error(1)
 }
-func (m *MockPostCollectionService) GetByUserID(userID uint) ([]model.PostCollection, error) {
-	args := m.Called(userID)
+func (m *MockPostCollectionService) GetByUserID(userID uint, limit, offset int) ([]model.PostCollection, int64, error) {
+	args := m.Called(userID, limit, offset)
 	if v := args.Get(0); v != nil {
-		return v.([]model.PostCollection), args.Error(1)
+		return v.([]model.PostCollection), args.Get(1).(int64), args.Error(2)
 	}
-	return nil, args.Error(1)
+	return nil, args.Get(1).(int64), args.Error(2)
 }
 func (m *MockPostCollectionService) GetPublicByUserID(userID uint) ([]model.PostCollection, error) {
 	args := m.Called(userID)
@@ -162,7 +162,7 @@ func TestPostCollectionGetByID_ServiceError(t *testing.T) {
 func TestPostCollectionGetByUserID_OwnCollections(t *testing.T) {
 	h, svc := setupPostCollectionHandler()
 	collections := []model.PostCollection{{Title: "My Collection", UserID: 1}}
-	svc.On("GetByUserID", uint(1)).Return(collections, nil)
+	svc.On("GetByUserID", uint(1), 20, 0).Return(collections, int64(1), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:userId/collections", h.GetByUserID)
@@ -197,7 +197,7 @@ func TestPostCollectionGetByUserID_InvalidID(t *testing.T) {
 
 func TestPostCollectionGetByUserID_ServiceError(t *testing.T) {
 	h, svc := setupPostCollectionHandler()
-	svc.On("GetByUserID", uint(1)).Return(nil, errors.New("db error"))
+	svc.On("GetByUserID", uint(1), 20, 0).Return(nil, int64(0), errors.New("db error"))
 
 	r := newRouter(1)
 	r.GET("/users/:userId/collections", h.GetByUserID)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -472,7 +472,7 @@ type NoteFolderRepositoryInterface interface {
 type PostCollectionRepositoryInterface interface {
 	Create(collection *model.PostCollection) error
 	FindByID(id uint) (*model.PostCollection, error)
-	FindByUserID(userID uint) ([]model.PostCollection, error)
+	FindByUserID(userID uint, limit, offset int) ([]model.PostCollection, int64, error)
 	FindPublicByUserID(userID uint) ([]model.PostCollection, error)
 	Update(collection *model.PostCollection) error
 	Delete(id uint) error

--- a/backend/internal/repository/post_collection.go
+++ b/backend/internal/repository/post_collection.go
@@ -30,13 +30,14 @@ func (r *PostCollectionRepository) FindByID(id uint) (*model.PostCollection, err
 	return &collection, nil
 }
 
-// FindByUserID は指定ユーザーの全コレクションを取得する（新しい順）。
-func (r *PostCollectionRepository) FindByUserID(userID uint) ([]model.PostCollection, error) {
+// FindByUserID は指定ユーザーの全コレクションをページネーション付きで取得する（新しい順）。
+func (r *PostCollectionRepository) FindByUserID(userID uint, limit, offset int) ([]model.PostCollection, int64, error) {
 	var collections []model.PostCollection
-	err := r.db.Where("user_id = ?", userID).
-		Order("created_at DESC").
-		Find(&collections).Error
-	return collections, err
+	var total int64
+	query := r.db.Where("user_id = ?", userID)
+	query.Model(&model.PostCollection{}).Count(&total)
+	err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&collections).Error
+	return collections, total, err
 }
 
 // FindPublicByUserID は指定ユーザーの公開コレクションを取得する（新しい順）。

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1646,9 +1646,9 @@ func (m *MockPostCollectionRepository) FindByID(id uint) (*model.PostCollection,
 	return args.Get(0).(*model.PostCollection), args.Error(1)
 }
 
-func (m *MockPostCollectionRepository) FindByUserID(userID uint) ([]model.PostCollection, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.PostCollection), args.Error(1)
+func (m *MockPostCollectionRepository) FindByUserID(userID uint, limit, offset int) ([]model.PostCollection, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.PostCollection), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockPostCollectionRepository) FindPublicByUserID(userID uint) ([]model.PostCollection, error) {

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -35,9 +35,9 @@ func (s *PostCollectionService) GetByID(id uint) (*model.PostCollection, error) 
 	return s.repo.FindByID(id)
 }
 
-// GetByUserID は指定ユーザーの全コレクションを取得する。
-func (s *PostCollectionService) GetByUserID(userID uint) ([]model.PostCollection, error) {
-	return s.repo.FindByUserID(userID)
+// GetByUserID は指定ユーザーの全コレクションをページネーション付きで取得する。
+func (s *PostCollectionService) GetByUserID(userID uint, limit, offset int) ([]model.PostCollection, int64, error) {
+	return s.repo.FindByUserID(userID, limit, offset)
 }
 
 // GetPublicByUserID は指定ユーザーの公開コレクションを取得する。

--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -125,22 +125,24 @@ func TestPostCollectionGetByUserID_Success(t *testing.T) {
 		{Title: "Go Tips", UserID: 1},
 		{Title: "React集", UserID: 1},
 	}
-	repo.On("FindByUserID", uint(1)).Return(collections, nil)
+	repo.On("FindByUserID", uint(1), 20, 0).Return(collections, int64(2), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
 	repo.AssertExpectations(t)
 }
 
 func TestPostCollectionGetByUserID_Empty(t *testing.T) {
 	svc, repo := newTestPostCollectionService()
 
-	repo.On("FindByUserID", uint(999)).Return([]model.PostCollection{}, nil)
+	repo.On("FindByUserID", uint(999), 20, 0).Return([]model.PostCollection{}, int64(0), nil)
 
-	result, err := svc.GetByUserID(999)
+	result, total, err := svc.GetByUserID(999, 20, 0)
 	assert.NoError(t, err)
 	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## Summary
- PostCollectionService.GetByUserIDにlimit/offsetパラメータとtotalカウントを追加
- 全レイヤー（repository → service → handler → DTO → テスト）を一貫して更新
- PostCollectionListResponse DTOを追加

## Test plan
- [x] service層テスト（GetByUserID Success/Empty）通過
- [x] handler層テスト（OwnCollections/OtherUserPublicOnly/ServiceError）通過
- [x] 全テストスイート通過

Closes #1069