### PR TITLE
refactor: handler層のリスト返却にensureSlice一貫適用

### DIFF
--- a/backend/internal/handler/answer.go
+++ b/backend/internal/handler/answer.go
@@ -43,7 +43,7 @@ func (h *AnswerHandler) GetByQuestionID(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, answers)
+	respondOK(c, ensureSlice(answers))
 }
 
 // CreateAnswerRequest は回答作成のリクエストボディ。
@@ -186,7 +186,7 @@ func (h *AnswerHandler) GetByVoteRange(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, answers)
+	respondOK(c, ensureSlice(answers))
 }
 
 // RemoveVote は回答への投票を取り消す。

--- a/backend/internal/handler/chat_room.go
+++ b/backend/internal/handler/chat_room.go
@@ -64,7 +64,7 @@ func (h *ChatRoomHandler) GetMyRooms(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, rooms)
+	respondOK(c, ensureSlice(rooms))
 }
 
 // GetByID は指定IDのチャットルーム詳細を取得する。
@@ -189,7 +189,7 @@ func (h *ChatRoomHandler) GetMessages(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, messages)
+	respondOK(c, ensureSlice(messages))
 }
 
 // SendMessage は指定チャットルームにメッセージを送信する。

--- a/backend/internal/handler/ranking.go
+++ b/backend/internal/handler/ranking.go
@@ -32,7 +32,7 @@ func (h *RankingHandler) ContributionRanking(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, entries)
+	respondOK(c, ensureSlice(entries))
 }
 
 // LanguageRanking は指定言語のランキングを返す。
@@ -44,7 +44,7 @@ func (h *RankingHandler) LanguageRanking(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, entries)
+	respondOK(c, ensureSlice(entries))
 }
 
 // LevelRanking はXP合計に基づくレベルランキングを返す。
@@ -54,7 +54,7 @@ func (h *RankingHandler) LevelRanking(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, entries)
+	respondOK(c, ensureSlice(entries))
 }
 
 // AvailableLanguages はランキング対象の利用可能な言語一覧を返す。
@@ -64,5 +64,5 @@ func (h *RankingHandler) AvailableLanguages(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, languages)
+	respondOK(c, ensureSlice(languages))
 }

--- a/backend/internal/handler/recommendation.go
+++ b/backend/internal/handler/recommendation.go
@@ -30,7 +30,7 @@ func (h *RecommendationHandler) GetRecommendedUsers(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, users)
+	respondOK(c, ensureSlice(users))
 }
 
 // GetTrendingPosts は直近7日間の人気投稿を返す。
@@ -40,7 +40,7 @@ func (h *RecommendationHandler) GetTrendingPosts(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, posts)
+	respondOK(c, ensureSlice(posts))
 }
 
 // GetTrendingResources は直近30日間の人気学習リソースを返す。
@@ -50,5 +50,5 @@ func (h *RecommendationHandler) GetTrendingResources(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, resources)
+	respondOK(c, ensureSlice(resources))
 }

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -70,7 +70,7 @@ func (h *StudyCircleHandler) GetMyCircles(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, circles)
+	respondOK(c, ensureSlice(circles))
 }
 
 // GetByID はサークル詳細を返す。
@@ -133,7 +133,7 @@ func (h *StudyCircleHandler) GetMembers(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, members)
+	respondOK(c, ensureSlice(members))
 }
 
 // AddMember はメンバーを追加する。


### PR DESCRIPTION
## Summary
- nilスライスがJSONで`null`として返却される問題を防止
- answer, chat_room, study_circle, ranking, recommendationの全リスト返却にensureSlice適用
- 計13箇所を修正（5ファイル）

## Test plan
- [x] 全handler層テスト通過
- [x] 全service層テスト通過
- [x] ビルド成功

Closes #1071