### PR TITLE
test: handler層テストカバレッジ向上（83.1% → 84.1%）

### DIFF
--- a/backend/internal/handler/learning_resource_test.go
+++ b/backend/internal/handler/learning_resource_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -319,4 +320,77 @@ func TestResourceGetSaved_Success(t *testing.T) {
 
 	body := parseJSON(t, w)
 	assert.Equal(t, float64(1), body["total"])
+}
+
+// ---------- GetByUserID ----------
+
+func TestResourceGetByUserID_Success(t *testing.T) {
+	h, repo := setupLearningResourceHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/resources", h.GetByUserID)
+
+	repo.On("FindByUserID", uint(1), true, 20, 0).Return(
+		[]model.LearningResource{{Title: "My Resource"}},
+		int64(1), nil,
+	)
+
+	w := doRequest(r, http.MethodGet, "/users/1/resources", nil)
+	assertStatus(t, w, http.StatusOK)
+
+	body := parseJSON(t, w)
+	assert.Equal(t, float64(1), body["total"])
+}
+
+func TestResourceGetByUserID_InvalidID(t *testing.T) {
+	h, _ := setupLearningResourceHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/resources", h.GetByUserID)
+
+	w := doRequest(r, http.MethodGet, "/users/abc/resources", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestResourceGetByUserID_ServiceError(t *testing.T) {
+	h, repo := setupLearningResourceHandler()
+	r := newRouter(1)
+	r.GET("/users/:userId/resources", h.GetByUserID)
+
+	repo.On("FindByUserID", uint(1), true, 20, 0).Return(
+		[]model.LearningResource{}, int64(0), errors.New("db error"),
+	)
+
+	w := doRequest(r, http.MethodGet, "/users/1/resources", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+// ---------- GetByDifficulty ----------
+
+func TestResourceGetByDifficulty_Success(t *testing.T) {
+	h, repo := setupLearningResourceHandler()
+	r := newRouter(1)
+	r.GET("/resources/difficulty/:difficulty", h.GetByDifficulty)
+
+	repo.On("FindByDifficulty", "beginner", 20, 0).Return(
+		[]model.LearningResource{{Title: "Beginner Guide"}},
+		int64(1), nil,
+	)
+
+	w := doRequest(r, http.MethodGet, "/resources/difficulty/beginner", nil)
+	assertStatus(t, w, http.StatusOK)
+
+	body := parseJSON(t, w)
+	assert.Equal(t, float64(1), body["total"])
+}
+
+func TestResourceGetByDifficulty_ServiceError(t *testing.T) {
+	h, repo := setupLearningResourceHandler()
+	r := newRouter(1)
+	r.GET("/resources/difficulty/:difficulty", h.GetByDifficulty)
+
+	repo.On("FindByDifficulty", "beginner", 20, 0).Return(
+		[]model.LearningResource{}, int64(0), errors.New("db error"),
+	)
+
+	w := doRequest(r, http.MethodGet, "/resources/difficulty/beginner", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
 }

--- a/backend/internal/handler/question_test.go
+++ b/backend/internal/handler/question_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -293,6 +294,38 @@ func TestQuestion_GetByUserID_InvalidID(t *testing.T) {
 
 	w := doRequest(r, http.MethodGet, "/users/abc/questions", nil)
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ---------- GetSolved ----------
+
+func TestQuestionGetSolved_Success(t *testing.T) {
+	h, repo := setupQuestionHandler()
+	r := newRouter(1)
+	r.GET("/questions/solved", h.GetSolved)
+
+	repo.On("FindSolved", 20, 0).Return(
+		[]model.Question{{Title: "Solved Q"}},
+		int64(1), nil,
+	)
+
+	w := doRequest(r, http.MethodGet, "/questions/solved", nil)
+	assertStatus(t, w, http.StatusOK)
+
+	body := parseJSON(t, w)
+	assert.Equal(t, float64(1), body["total"])
+}
+
+func TestQuestionGetSolved_ServiceError(t *testing.T) {
+	h, repo := setupQuestionHandler()
+	r := newRouter(1)
+	r.GET("/questions/solved", h.GetSolved)
+
+	repo.On("FindSolved", 20, 0).Return(
+		[]model.Question{}, int64(0), errors.New("db error"),
+	)
+
+	w := doRequest(r, http.MethodGet, "/questions/solved", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
 }
 
 func TestQuestionRemoveVote_Success(t *testing.T) {

--- a/backend/internal/handler/ranking_test.go
+++ b/backend/internal/handler/ranking_test.go
@@ -77,6 +77,30 @@ func TestRankingLevel_Success(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
+func TestRankingLevel_ServiceError(t *testing.T) {
+	h, svc := setupRankingHandler()
+	svc.On("LevelRanking").Return([]model.RankingEntry{}, fmt.Errorf("internal error"))
+
+	r := newRouter(1)
+	r.GET("/rankings/levels", h.LevelRanking)
+	w := doRequest(r, "GET", "/rankings/levels", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}
+
+func TestRankingLanguage_ServiceError(t *testing.T) {
+	h, svc := setupRankingHandler()
+	svc.On("LanguageRanking", "Go", "weekly").Return([]model.RankingEntry{}, fmt.Errorf("db error"))
+
+	r := newRouter(1)
+	r.GET("/rankings/languages/:lang", h.LanguageRanking)
+	w := doRequest(r, "GET", "/rankings/languages/Go", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}
+
 // ---------- AvailableLanguages ----------
 
 func TestRankingAvailableLanguages_Success(t *testing.T) {

--- a/backend/internal/handler/recommendation_test.go
+++ b/backend/internal/handler/recommendation_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -128,6 +129,17 @@ func TestRecommendationGetTrendingResources_Success(t *testing.T) {
 	assert.Len(t, resources, 3)
 }
 
+func TestRecommendationGetTrendingPosts_ServiceError(t *testing.T) {
+	h, recRepo, _ := setupRecommendationHandlerRepo()
+	r := newRouter(1)
+	r.GET("/recommendations/posts", h.GetTrendingPosts)
+
+	recRepo.On("GetTrendingPosts", 10, 7).Return([]model.Post{}, errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/recommendations/posts", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
 func TestRecommendationGetTrendingResources_Empty(t *testing.T) {
 	h, recRepo, _ := setupRecommendationHandlerRepo()
 	r := newRouter(1)
@@ -141,4 +153,15 @@ func TestRecommendationGetTrendingResources_Empty(t *testing.T) {
 	var resources []map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &resources)
 	assert.Len(t, resources, 0)
+}
+
+func TestRecommendationGetTrendingResources_ServiceError(t *testing.T) {
+	h, recRepo, _ := setupRecommendationHandlerRepo()
+	r := newRouter(1)
+	r.GET("/recommendations/resources", h.GetTrendingResources)
+
+	recRepo.On("GetTrendingResources", 10, 30).Return([]model.LearningResource{}, errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/recommendations/resources", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
 }


### PR DESCRIPTION
## Summary
- handler層のテストカバレッジを83.1%→84.1%に向上
- 0%カバレッジだったGetByUserID, GetByDifficulty, GetSolvedに初テスト追加
- 60%台だったLevelRanking, TrendingPosts, TrendingResourcesのServiceErrorテスト追加
- 合計11テスト追加（4ファイル）

## Test plan
- [x] 新規11テスト全通過
- [x] 全テストスイート通過
- [x] handler層カバレッジ84.1%確認

Closes #1073