### PR TITLE
fix: Roadmap/StudyCircle/BookReview Createの空白タイトルバイパス修正

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -28,6 +28,9 @@ func validateRating(rating int) error {
 
 // Create は新しい書籍レビューを作成する。
 func (s *BookReviewService) Create(review *model.BookReview) error {
+	if strings.TrimSpace(review.Title) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "タイトルは必須です", nil)
+	}
 	if err := validateRating(review.Rating); err != nil {
 		return err
 	}

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -37,6 +37,23 @@ func TestBookReviewCreate_Success(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestBookReviewCreate_WhitespaceTitle(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{UserID: 1, Title: "   \t  ", Rating: 4}
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "タイトルは必須です")
+}
+
+func TestBookReviewCreate_EmptyTitle(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{UserID: 1, Title: "", Rating: 4}
+	err := svc.Create(review)
+	assert.Error(t, err)
+}
+
 func TestBookReviewCreate_RepoError(t *testing.T) {
 	svc, repo := newTestBookReviewService()
 

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -29,6 +29,9 @@ func NewRoadmapService(repo repository.RoadmapRepositoryInterface) *RoadmapServi
 
 // Create は新しいロードマップを作成する。
 func (s *RoadmapService) Create(roadmap *model.Roadmap) error {
+	if strings.TrimSpace(roadmap.Title) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "タイトルは必須です", nil)
+	}
 	return s.repo.Create(roadmap)
 }
 

--- a/backend/internal/service/roadmap_test.go
+++ b/backend/internal/service/roadmap_test.go
@@ -584,6 +584,23 @@ func TestRoadmapCreate_Success(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestRoadmapCreate_WhitespaceTitle(t *testing.T) {
+	svc, _ := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{Title: "   \t\n  ", UserID: 1}
+	err := svc.Create(roadmap)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "タイトルは必須です")
+}
+
+func TestRoadmapCreate_EmptyTitle(t *testing.T) {
+	svc, _ := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{Title: "", UserID: 1}
+	err := svc.Create(roadmap)
+	assert.Error(t, err)
+}
+
 // ============================================================
 // GetByUserID テスト
 // ============================================================

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"time"
 
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -45,6 +46,9 @@ func (s *StudyCircleService) findAndCheckStepOwnership(circleID, stepID, userID 
 
 // Create はサークルを作成し、オーナーをメンバーとして自動追加する。
 func (s *StudyCircleService) Create(circle *model.StudyCircle, memberIDs []uint) error {
+	if strings.TrimSpace(circle.Name) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "サークル名は必須です", nil)
+	}
 	if circle.MaxMembers < 3 || circle.MaxMembers > 10 {
 		circle.MaxMembers = 5
 	}

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -31,6 +31,23 @@ func TestStudyCircleCreate_Success(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestStudyCircleCreate_WhitespaceName(t *testing.T) {
+	svc, _ := newTestStudyCircleService()
+
+	circle := &model.StudyCircle{Name: "   \t  ", Topic: "Go", OwnerID: 1, MaxMembers: 5}
+	err := svc.Create(circle, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "サークル名は必須です")
+}
+
+func TestStudyCircleCreate_EmptyName(t *testing.T) {
+	svc, _ := newTestStudyCircleService()
+
+	circle := &model.StudyCircle{Name: "", Topic: "Go", OwnerID: 1, MaxMembers: 5}
+	err := svc.Create(circle, nil)
+	assert.Error(t, err)
+}
+
 func TestStudyCircleCreate_WithMembers(t *testing.T) {
 	svc, repo := newTestStudyCircleService()
 


### PR DESCRIPTION
## Summary
- Roadmap/StudyCircle/BookReviewのCreateメソッドに空白タイトルバリデーション追加
- 空白のみの入力でリソース作成を許可する脆弱性を修正
- TDD RED→GREEN: 6テスト追加（各サービス Whitespace + Empty）

## Test plan
- [x] 新規6テスト全通過
- [x] 全テストスイート（service + handler）通過
- [x] ビルド成功

Closes #1075