### PR TITLE
feat: ChatRoomService.GetByUserIDにページネーション対応

### DIFF
--- a/backend/internal/dto/chat_room_dto.go
+++ b/backend/internal/dto/chat_room_dto.go
@@ -1,5 +1,15 @@
 package dto
 
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// ChatRoomListResponse はチャットルーム一覧レスポンス（ページネーション付き）。
+type ChatRoomListResponse struct {
+	Rooms  []model.ChatRoom `json:"rooms"`
+	Total  int64            `json:"total"`
+	Limit  int              `json:"limit"`
+	Offset int              `json:"offset"`
+}
+
 // CreateChatRoomRequest はチャットルーム作成リクエスト。
 type CreateChatRoomRequest struct {
 	Name        string `json:"name" binding:"required,max=200" validate:"required,max=200"`

--- a/backend/internal/handler/chat_room.go
+++ b/backend/internal/handler/chat_room.go
@@ -10,7 +10,7 @@ import (
 // ChatRoomServiceInterface はChatRoomHandlerが依存するサービスのインターフェース。
 type ChatRoomServiceInterface interface {
 	Create(room *model.ChatRoom, memberIDs []uint) (*model.ChatRoom, error)
-	GetByUserID(userID uint) ([]model.ChatRoom, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.ChatRoom, int64, error)
 	GetByID(roomID, userID uint) (*model.ChatRoom, error)
 	Update(roomID, userID uint, name, description string) (*model.ChatRoom, error)
 	Delete(roomID, userID uint) error
@@ -59,12 +59,18 @@ func (h *ChatRoomHandler) Create(c *gin.Context) {
 // GetMyRooms は現在のユーザーが参加しているチャットルーム一覧を取得する。
 func (h *ChatRoomHandler) GetMyRooms(c *gin.Context) {
 	userID := c.GetUint("userID")
-	rooms, err := h.service.GetByUserID(userID)
+	limit, offset := parseLimitOffset(c)
+	rooms, total, err := h.service.GetByUserID(userID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, ensureSlice(rooms))
+	respondOK(c, dto.ChatRoomListResponse{
+		Rooms:  ensureSlice(rooms),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
 // GetByID は指定IDのチャットルーム詳細を取得する。

--- a/backend/internal/handler/chat_room_test.go
+++ b/backend/internal/handler/chat_room_test.go
@@ -56,16 +56,20 @@ func TestChatRoomGetMyRooms_Success(t *testing.T) {
 	r := newRouter(1)
 	r.GET("/rooms", h.GetMyRooms)
 
-	roomRepo.On("FindByUserID", uint(1)).Return([]model.ChatRoom{
+	roomRepo.On("FindByUserID", uint(1), 20, 0).Return([]model.ChatRoom{
 		{Name: "Room A"}, {Name: "Room B"},
-	}, nil)
+	}, int64(2), nil)
 
 	w := doRequest(r, http.MethodGet, "/rooms", nil)
 	assertStatus(t, w, http.StatusOK)
 
-	var rooms []map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &rooms)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	rooms := resp["rooms"].([]interface{})
 	assert.Len(t, rooms, 2)
+	assert.Equal(t, float64(2), resp["total"])
+	assert.Equal(t, float64(20), resp["limit"])
+	assert.Equal(t, float64(0), resp["offset"])
 }
 
 // ---------- GetByID ----------

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -415,9 +415,9 @@ func (m *MockChatRoomRepository) FindByID(id uint) (*model.ChatRoom, error) {
 	}
 	return nil, args.Error(1)
 }
-func (m *MockChatRoomRepository) FindByUserID(userID uint) ([]model.ChatRoom, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.ChatRoom), args.Error(1)
+func (m *MockChatRoomRepository) FindByUserID(userID uint, limit, offset int) ([]model.ChatRoom, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.ChatRoom), args.Get(1).(int64), args.Error(2)
 }
 func (m *MockChatRoomRepository) Update(room *model.ChatRoom) error {
 	return m.Called(room).Error(0)
@@ -1197,9 +1197,9 @@ func (m *MockChatRoomService) Create(room *model.ChatRoom, memberIDs []uint) (*m
 	}
 	return nil, args.Error(1)
 }
-func (m *MockChatRoomService) GetByUserID(userID uint) ([]model.ChatRoom, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.ChatRoom), args.Error(1)
+func (m *MockChatRoomService) GetByUserID(userID uint, limit, offset int) ([]model.ChatRoom, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.ChatRoom), args.Get(1).(int64), args.Error(2)
 }
 func (m *MockChatRoomService) GetByID(roomID, userID uint) (*model.ChatRoom, error) {
 	args := m.Called(roomID, userID)

--- a/backend/internal/repository/chat_room.go
+++ b/backend/internal/repository/chat_room.go
@@ -29,16 +29,19 @@ func (r *ChatRoomRepository) FindByID(id uint) (*model.ChatRoom, error) {
 	return &room, err
 }
 
-// FindByUserID は指定ユーザーが参加している全チャットルームを取得する。
+// FindByUserID は指定ユーザーが参加しているチャットルームをページネーション付きで取得する。
 // chat_room_membersテーブルをJOINし、更新日時の降順でソートされる。
-func (r *ChatRoomRepository) FindByUserID(userID uint) ([]model.ChatRoom, error) {
+func (r *ChatRoomRepository) FindByUserID(userID uint, limit, offset int) ([]model.ChatRoom, int64, error) {
 	var rooms []model.ChatRoom
-	err := r.db.Joins("JOIN chat_room_members ON chat_room_members.chat_room_id = chat_rooms.id").
-		Where("chat_room_members.user_id = ?", userID).
-		Preload("Owner").
+	var total int64
+	query := r.db.Joins("JOIN chat_room_members ON chat_room_members.chat_room_id = chat_rooms.id").
+		Where("chat_room_members.user_id = ?", userID)
+	query.Model(&model.ChatRoom{}).Count(&total)
+	err := query.Preload("Owner").
 		Order("chat_rooms.updated_at DESC").
+		Limit(limit).Offset(offset).
 		Find(&rooms).Error
-	return rooms, err
+	return rooms, total, err
 }
 
 // Update は既存のチャットルーム情報を更新する。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -249,7 +249,7 @@ type RoadmapRepositoryInterface interface {
 type ChatRoomRepositoryInterface interface {
 	Create(room *model.ChatRoom) error
 	FindByID(id uint) (*model.ChatRoom, error)
-	FindByUserID(userID uint) ([]model.ChatRoom, error)
+	FindByUserID(userID uint, limit, offset int) ([]model.ChatRoom, int64, error)
 	Update(room *model.ChatRoom) error
 	Delete(roomID uint) error
 	AddMember(roomID, userID uint) error

--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -60,9 +60,9 @@ func (s *ChatRoomService) checkMembership(roomID, userID uint) error {
 	return nil
 }
 
-// GetByUserID は指定ユーザーが参加している全チャットルームを取得する。
-func (s *ChatRoomService) GetByUserID(userID uint) ([]model.ChatRoom, error) {
-	return s.roomRepo.FindByUserID(userID)
+// GetByUserID は指定ユーザーが参加しているチャットルームをページネーション付きで取得する。
+func (s *ChatRoomService) GetByUserID(userID uint, limit, offset int) ([]model.ChatRoom, int64, error) {
+	return s.roomRepo.FindByUserID(userID, limit, offset)
 }
 
 // GetByID はメンバーシップを検証した後、チャットルームを取得する。

--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -360,11 +360,12 @@ func TestChatRoomGetByUserID_Success(t *testing.T) {
 		{Name: "Room A", OwnerID: 1},
 		{Name: "Room B", OwnerID: 2},
 	}
-	roomRepo.On("FindByUserID", uint(1)).Return(rooms, nil)
+	roomRepo.On("FindByUserID", uint(1), 20, 0).Return(rooms, int64(2), nil)
 
-	result, err := svc.GetByUserID(1)
+	result, total, err := svc.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
 	assert.Equal(t, "Room A", result[0].Name)
 	roomRepo.AssertExpectations(t)
 }
@@ -372,20 +373,21 @@ func TestChatRoomGetByUserID_Success(t *testing.T) {
 func TestChatRoomGetByUserID_Empty(t *testing.T) {
 	svc, roomRepo, _ := newTestChatRoomService()
 
-	roomRepo.On("FindByUserID", uint(999)).Return([]model.ChatRoom{}, nil)
+	roomRepo.On("FindByUserID", uint(999), 20, 0).Return([]model.ChatRoom{}, int64(0), nil)
 
-	result, err := svc.GetByUserID(999)
+	result, total, err := svc.GetByUserID(999, 20, 0)
 	assert.NoError(t, err)
 	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
 	roomRepo.AssertExpectations(t)
 }
 
 func TestChatRoomGetByUserID_RepoError(t *testing.T) {
 	svc, roomRepo, _ := newTestChatRoomService()
 
-	roomRepo.On("FindByUserID", uint(1)).Return([]model.ChatRoom{}, assert.AnError)
+	roomRepo.On("FindByUserID", uint(1), 20, 0).Return([]model.ChatRoom{}, int64(0), assert.AnError)
 
-	result, err := svc.GetByUserID(1)
+	result, _, err := svc.GetByUserID(1, 20, 0)
 	assert.Error(t, err)
 	assert.Empty(t, result)
 	roomRepo.AssertExpectations(t)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -916,9 +916,9 @@ func (m *MockChatRoomRepository) FindByID(id uint) (*model.ChatRoom, error) {
 	return args.Get(0).(*model.ChatRoom), args.Error(1)
 }
 
-func (m *MockChatRoomRepository) FindByUserID(userID uint) ([]model.ChatRoom, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.ChatRoom), args.Error(1)
+func (m *MockChatRoomRepository) FindByUserID(userID uint, limit, offset int) ([]model.ChatRoom, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.ChatRoom), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockChatRoomRepository) Update(room *model.ChatRoom) error {


### PR DESCRIPTION
## 概要
ChatRoomService.GetByUserIDメソッドにページネーション（limit/offset）を追加。

## 変更内容
- repository層: FindByUserIDにlimit/offsetパラメータ追加、Count+Limit+Offsetで結果返却
- service層: GetByUserIDシグネチャ変更（limit, offset追加、total返却）
- handler層: parseLimitOffset使用、ChatRoomListResponse DTOで応答
- dto: ChatRoomListResponse追加（rooms, total, limit, offset）
- テスト: service/handler両層のモック・テスト更新

Closes #1077