### PR TITLE
refactor: handler層の残りスライス返却にensureSlice適用（第2弾）

### DIFF
--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -174,7 +174,7 @@ func (h *BookReviewHandler) GetByRating(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, reviews)
+	respondOK(c, ensureSlice(reviews))
 }
 
 // Delete は指定IDの書籍レビューを削除する。

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -68,7 +68,7 @@ func (h *CodeSnippetHandler) GetByPostID(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, snippets)
+	respondOK(c, ensureSlice(snippets))
 }
 
 // GetByID は指定IDのスニペットを返す。
@@ -83,7 +83,7 @@ func (h *CodeSnippetHandler) GetByID(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, snippets)
+	respondOK(c, ensureSlice(snippets))
 }
 
 // Update はスニペットを更新する。所有者のみ更新可能。
@@ -134,7 +134,7 @@ func (h *CodeSnippetHandler) GetComments(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, comments)
+	respondOK(c, ensureSlice(comments))
 }
 
 // CreateComment はスニペットにインラインコメントを作成する。

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -203,7 +203,7 @@ func (h *LearningLogHandler) GetCalendarData(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, entries)
+	respondOK(c, ensureSlice(entries))
 }
 
 // GetByCategory はカテゴリで学習ログをフィルタリングして取得する。

--- a/backend/internal/handler/mention.go
+++ b/backend/internal/handler/mention.go
@@ -34,7 +34,7 @@ func (h *MentionHandler) GetMyMentions(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, mentions)
+	respondOK(c, ensureSlice(mentions))
 }
 
 // GetPostMentions は投稿に関連するメンション一覧を取得する。
@@ -49,5 +49,5 @@ func (h *MentionHandler) GetPostMentions(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, mentions)
+	respondOK(c, ensureSlice(mentions))
 }

--- a/backend/internal/handler/message.go
+++ b/backend/internal/handler/message.go
@@ -32,7 +32,7 @@ func (h *MessageHandler) GetConversations(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, conversations)
+	respondOK(c, ensureSlice(conversations))
 }
 
 // GetMessages は指定ユーザーとの会話メッセージをページネーション付きで返す。
@@ -50,7 +50,7 @@ func (h *MessageHandler) GetMessages(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, messages)
+	respondOK(c, ensureSlice(messages))
 }
 
 // SendMessage は指定ユーザーにDMを送信する。

--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -119,7 +119,7 @@ func (h *NoteHandler) GetByFolderID(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, notes)
+	respondOK(c, ensureSlice(notes))
 }
 
 // UpdateNoteInput はノート更新のリクエストボディ。

--- a/backend/internal/handler/note_folder.go
+++ b/backend/internal/handler/note_folder.go
@@ -82,7 +82,7 @@ func (h *NoteFolderHandler) GetByUserID(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, folders)
+	respondOK(c, ensureSlice(folders))
 }
 
 // GetChildren は指定フォルダの子フォルダ一覧を取得する。
@@ -98,7 +98,7 @@ func (h *NoteFolderHandler) GetChildren(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, children)
+	respondOK(c, ensureSlice(children))
 }
 
 // GetRootFolders は現在のユーザーのルートフォルダ（親なし）一覧を取得する。
@@ -111,7 +111,7 @@ func (h *NoteFolderHandler) GetRootFolders(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, folders)
+	respondOK(c, ensureSlice(folders))
 }
 
 // UpdateNoteFolderInput はフォルダ更新のリクエストボディ。

--- a/backend/internal/handler/note_link.go
+++ b/backend/internal/handler/note_link.go
@@ -64,7 +64,7 @@ func (h *NoteLinkHandler) GetLinks(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, links)
+	respondOK(c, ensureSlice(links))
 }
 
 // GetBacklinks は指定ノートへのリンク一覧（バックリンク）を取得する。
@@ -80,7 +80,7 @@ func (h *NoteLinkHandler) GetBacklinks(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, backlinks)
+	respondOK(c, ensureSlice(backlinks))
 }
 
 // DeleteLink はリンクを削除する。

--- a/backend/internal/handler/note_template.go
+++ b/backend/internal/handler/note_template.go
@@ -88,7 +88,7 @@ func (h *NoteTemplateHandler) GetByUserID(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, templates)
+	respondOK(c, ensureSlice(templates))
 }
 
 // GetDefault は現在のユーザーのデフォルトテンプレートを取得する。

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -185,7 +185,7 @@ func (h *PostHandler) Timeline(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, posts)
+	respondOK(c, ensureSlice(posts))
 }
 
 // GetUserPosts は指定ユーザーの投稿一覧をページネーション付きで返す。
@@ -252,7 +252,7 @@ func (h *PostHandler) GetComments(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, comments)
+	respondOK(c, ensureSlice(comments))
 }
 
 // CreateComment は投稿にコメントを作成する。
@@ -288,7 +288,7 @@ func (h *PostHandler) GetReplies(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, replies)
+	respondOK(c, ensureSlice(replies))
 }
 
 // DeleteComment はコメントを削除する。所有者のみ削除可能。
@@ -315,7 +315,7 @@ func (h *PostHandler) GetDrafts(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, drafts)
+	respondOK(c, ensureSlice(drafts))
 }
 
 // Publish は下書き投稿を公開する。所有者のみ公開可能。

--- a/backend/internal/handler/post_collection.go
+++ b/backend/internal/handler/post_collection.go
@@ -101,7 +101,7 @@ func (h *PostCollectionHandler) GetByUserID(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, collections)
+	respondOK(c, ensureSlice(collections))
 }
 
 // Update は指定IDのコレクションを更新する。
@@ -155,7 +155,7 @@ func (h *PostCollectionHandler) GetPosts(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, items)
+	respondOK(c, ensureSlice(items))
 }
 
 // AddPost はコレクションに投稿を追加する。

--- a/backend/internal/handler/post_series.go
+++ b/backend/internal/handler/post_series.go
@@ -148,7 +148,7 @@ func (h *PostSeriesHandler) GetPosts(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, items)
+	respondOK(c, ensureSlice(items))
 }
 
 // AddPost はシリーズに投稿を追加する。


### PR DESCRIPTION
## 概要
Cycle 254の続きとして、handler層の残り23箇所にensureSliceを適用し、nilスライスがJSONでnullではなく[]として返却されるよう統一。

## 変更内容
12ファイル23箇所を修正：
- post, message, note, code_snippet, note_folder, note_link, note_template, mention, post_collection, post_series, learning_log, book_review

## テスト
既存handler層テスト全件PASS

Closes #1079