### PR TITLE
test: handler層テストカバレッジ向上（84.1%→84.9%）

### DIFF
--- a/backend/internal/handler/message_test.go
+++ b/backend/internal/handler/message_test.go
@@ -99,3 +99,25 @@ func TestMessage_SendMessage_ServiceError(t *testing.T) {
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }
+
+func TestMessage_GetMessages_InvalidID(t *testing.T) {
+	h, _ := setupMessageHandler()
+
+	r := newRouter(1)
+	r.GET("/messages/:userId", h.GetMessages)
+
+	w := doRequest(r, http.MethodGet, "/messages/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestMessage_GetMessages_ServiceError(t *testing.T) {
+	h, svc := setupMessageHandler()
+	svc.On("GetConversation", uint(1), uint(5), 1, 20).Return([]model.Message(nil), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/messages/:userId", h.GetMessages)
+
+	w := doRequest(r, http.MethodGet, "/messages/5", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/note_folder_test.go
+++ b/backend/internal/handler/note_folder_test.go
@@ -3,12 +3,14 @@ package handler
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -258,4 +260,121 @@ func TestNoteFolderHandler_Delete(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	mockService.AssertExpectations(t)
+}
+
+// ============================================================
+// ServiceError / InvalidID テスト
+// ============================================================
+
+func TestNoteFolderHandler_Create_ServiceError(t *testing.T) {
+	h, svc := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.POST("/folders", h.Create)
+
+	svc.On("Create", mock.AnythingOfType("*model.NoteFolder")).Return(errors.New("db error"))
+
+	w := doRequest(r, "POST", "/folders", map[string]interface{}{"name": "テスト"})
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestNoteFolderHandler_GetByID_InvalidID(t *testing.T) {
+	h, _ := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.GET("/folders/:id", h.GetByID)
+
+	w := doRequest(r, "GET", "/folders/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteFolderHandler_GetByID_ServiceError(t *testing.T) {
+	h, svc := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.GET("/folders/:id", h.GetByID)
+
+	svc.On("GetByID", uint(1)).Return(nil, service.ErrNotFound)
+
+	w := doRequest(r, "GET", "/folders/1", nil)
+	assertStatus(t, w, http.StatusNotFound)
+}
+
+func TestNoteFolderHandler_GetByUserID_ServiceError(t *testing.T) {
+	h, svc := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.GET("/folders", h.GetByUserID)
+
+	svc.On("GetByUserID", uint(1)).Return([]model.NoteFolder(nil), errors.New("db error"))
+
+	w := doRequest(r, "GET", "/folders", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestNoteFolderHandler_GetChildren_InvalidID(t *testing.T) {
+	h, _ := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.GET("/folders/:id/children", h.GetChildren)
+
+	w := doRequest(r, "GET", "/folders/abc/children", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteFolderHandler_GetChildren_ServiceError(t *testing.T) {
+	h, svc := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.GET("/folders/:id/children", h.GetChildren)
+
+	svc.On("GetChildren", uint(1)).Return([]model.NoteFolder(nil), errors.New("db error"))
+
+	w := doRequest(r, "GET", "/folders/1/children", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestNoteFolderHandler_GetRootFolders_ServiceError(t *testing.T) {
+	h, svc := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.GET("/folders/root", h.GetRootFolders)
+
+	svc.On("GetRootFolders", uint(1)).Return([]model.NoteFolder(nil), errors.New("db error"))
+
+	w := doRequest(r, "GET", "/folders/root", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestNoteFolderHandler_Update_InvalidID(t *testing.T) {
+	h, _ := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.PUT("/folders/:id", h.Update)
+
+	w := doRequest(r, "PUT", "/folders/abc", map[string]interface{}{"name": "テスト"})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteFolderHandler_Update_ServiceError(t *testing.T) {
+	h, svc := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.PUT("/folders/:id", h.Update)
+
+	svc.On("Update", uint(1), uint(1), "変更", (*uint)(nil)).Return(nil, service.ErrForbidden)
+
+	w := doRequest(r, "PUT", "/folders/1", map[string]interface{}{"name": "変更"})
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+func TestNoteFolderHandler_Delete_InvalidID(t *testing.T) {
+	h, _ := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.DELETE("/folders/:id", h.Delete)
+
+	w := doRequest(r, "DELETE", "/folders/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteFolderHandler_Delete_ServiceError(t *testing.T) {
+	h, svc := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.DELETE("/folders/:id", h.Delete)
+
+	svc.On("Delete", uint(1), uint(1)).Return(service.ErrForbidden)
+
+	w := doRequest(r, "DELETE", "/folders/1", nil)
+	assertStatus(t, w, http.StatusForbidden)
 }

--- a/backend/internal/handler/note_template_test.go
+++ b/backend/internal/handler/note_template_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -178,4 +179,26 @@ func TestNoteTemplateUseTemplate_NotFound(t *testing.T) {
 
 	assertStatus(t, w, http.StatusNotFound)
 	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateGetByUserID_ServiceError(t *testing.T) {
+	h, svc := setupNoteTemplateHandler()
+	svc.On("GetByUserID", uint(1)).Return([]model.NoteTemplate(nil), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/note-templates", h.GetByUserID)
+	w := doRequest(r, "GET", "/note-templates", nil)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestNoteTemplateGetDefault_ServiceError(t *testing.T) {
+	h, svc := setupNoteTemplateHandler()
+	svc.On("GetDefaultByUserID", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/note-templates/default", h.GetDefault)
+	w := doRequest(r, "GET", "/note-templates/default", nil)
+
+	assertStatus(t, w, http.StatusInternalServerError)
 }


### PR DESCRIPTION
## 概要
handler層のテストカバレッジを84.1%から84.9%に向上。

## 追加テスト（15件）
- note_folder: ServiceError/InvalidIDテスト11件追加
- note_template: ServiceErrorテスト2件追加
- message: InvalidID/ServiceErrorテスト2件追加

## テスト
全handler層テストPASS

Closes #1081