### PR TITLE
fix: StudyCircle Update/UpdateStepの空白バイパス修正

### DIFF
--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -117,9 +117,15 @@ func (s *StudyCircleService) Update(id, userID uint, name, topic, description *s
 	}
 
 	if name != nil {
+		if strings.TrimSpace(*name) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "サークル名は空白のみでは入力できません", nil)
+		}
 		circle.Name = *name
 	}
 	if topic != nil {
+		if strings.TrimSpace(*topic) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "トピックは空白のみでは入力できません", nil)
+		}
 		circle.Topic = *topic
 	}
 	if description != nil {
@@ -223,6 +229,9 @@ func (s *StudyCircleService) UpdateStep(circleID, userID, stepID uint, title, de
 	}
 
 	if title != nil {
+		if strings.TrimSpace(*title) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみでは入力できません", nil)
+		}
 		step.Title = *title
 	}
 	if description != nil {

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -924,6 +924,49 @@ func TestStudyCircleUpdateStep_CircleNotFound(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+// --- Update 空白バイパス ---
+
+func TestStudyCircleUpdate_WhitespaceName(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	circle := &model.StudyCircle{ID: 1, Name: "旧名", OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+
+	name := "   "
+	result, err := svc.Update(1, 1, &name, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "サークル名")
+}
+
+func TestStudyCircleUpdate_WhitespaceTopic(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	circle := &model.StudyCircle{ID: 1, Name: "旧名", Topic: "Go", OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+
+	topic := "  \t  "
+	result, err := svc.Update(1, 1, nil, &topic, nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "トピック")
+}
+
+func TestStudyCircleUpdateStep_WhitespaceTitle(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	step := &model.StudyCircleStep{ID: 5, CircleID: 1, Title: "旧タイトル"}
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+
+	title := "   "
+	result, err := svc.UpdateStep(1, 1, 5, &title, nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトル")
+}
+
 func TestStudyCircleCreateCheckin_IsMemberError(t *testing.T) {
 	svc, repo := newTestStudyCircleService()
 


### PR DESCRIPTION
## 概要
StudyCircle.Update()とUpdateStep()で空白のみの入力がバリデーションをバイパスできる脆弱性を修正。

## 変更内容
- Update(): name/topicにTrimSpaceチェック追加
- UpdateStep(): titleにTrimSpaceチェック追加
- TDDテスト3件追加（RED→GREEN確認済み）

Closes #1083