### PR TITLE
refactor: handler層のInput構造体をdto層に移動 (#1087)

### DIFF
--- a/backend/internal/dto/note_dto.go
+++ b/backend/internal/dto/note_dto.go
@@ -1,0 +1,17 @@
+package dto
+
+// CreateNoteRequest はノート作成リクエスト。
+type CreateNoteRequest struct {
+	Title    string `json:"title" binding:"required"`
+	Content  string `json:"content" binding:"required"`
+	Tags     string `json:"tags"`
+	FolderID *uint  `json:"folder_id"`
+}
+
+// UpdateNoteRequest はノート更新リクエスト。
+type UpdateNoteRequest struct {
+	Title    string `json:"title"`
+	Content  string `json:"content"`
+	Tags     string `json:"tags"`
+	FolderID *uint  `json:"folder_id"`
+}

--- a/backend/internal/dto/note_folder_dto.go
+++ b/backend/internal/dto/note_folder_dto.go
@@ -1,0 +1,13 @@
+package dto
+
+// CreateNoteFolderRequest はフォルダ作成リクエスト。
+type CreateNoteFolderRequest struct {
+	Name     string `json:"name" binding:"required"`
+	ParentID *uint  `json:"parent_id"`
+}
+
+// UpdateNoteFolderRequest はフォルダ更新リクエスト。
+type UpdateNoteFolderRequest struct {
+	Name     string `json:"name"`
+	ParentID *uint  `json:"parent_id"`
+}

--- a/backend/internal/dto/note_link_dto.go
+++ b/backend/internal/dto/note_link_dto.go
@@ -1,0 +1,6 @@
+package dto
+
+// CreateNoteLinkRequest はノートリンク作成リクエスト。
+type CreateNoteLinkRequest struct {
+	TargetNoteID uint `json:"target_note_id" binding:"required"`
+}

--- a/backend/internal/dto/note_template_dto.go
+++ b/backend/internal/dto/note_template_dto.go
@@ -1,0 +1,21 @@
+package dto
+
+// CreateNoteTemplateRequest はテンプレート作成リクエスト。
+type CreateNoteTemplateRequest struct {
+	Name            string `json:"name" binding:"required"`
+	Description     string `json:"description"`
+	DefaultTitle    string `json:"default_title"`
+	ContentTemplate string `json:"content_template" binding:"required"`
+	DefaultTags     string `json:"default_tags"`
+	IsDefault       bool   `json:"is_default"`
+}
+
+// UpdateNoteTemplateRequest はテンプレート更新リクエスト。
+type UpdateNoteTemplateRequest struct {
+	Name            string `json:"name"`
+	Description     string `json:"description"`
+	DefaultTitle    string `json:"default_title"`
+	ContentTemplate string `json:"content_template"`
+	DefaultTags     string `json:"default_tags"`
+	IsDefault       *bool  `json:"is_default"`
+}

--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -38,18 +39,10 @@ func NewNoteHandler(s NoteServiceInterface) *NoteHandler {
 	return &NoteHandler{service: s}
 }
 
-// CreateNoteInput はノート作成のリクエストボディ。
-type CreateNoteInput struct {
-	Title    string `json:"title" binding:"required"`
-	Content  string `json:"content" binding:"required"`
-	Tags     string `json:"tags"`
-	FolderID *uint  `json:"folder_id"`
-}
-
 // Create は新しいノートを作成する。
 func (h *NoteHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
-	input := bindJSON[CreateNoteInput](c)
+	input := bindJSON[dto.CreateNoteRequest](c)
 	if input == nil {
 		return
 	}
@@ -122,14 +115,6 @@ func (h *NoteHandler) GetByFolderID(c *gin.Context) {
 	respondOK(c, ensureSlice(notes))
 }
 
-// UpdateNoteInput はノート更新のリクエストボディ。
-type UpdateNoteInput struct {
-	Title    string `json:"title"`
-	Content  string `json:"content"`
-	Tags     string `json:"tags"`
-	FolderID *uint  `json:"folder_id"`
-}
-
 // Update はノートを更新する。
 func (h *NoteHandler) Update(c *gin.Context) {
 	id, ok := parseID(c, "id")
@@ -138,7 +123,7 @@ func (h *NoteHandler) Update(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	input := bindJSON[UpdateNoteInput](c)
+	input := bindJSON[dto.UpdateNoteRequest](c)
 	if input == nil {
 		return
 	}

--- a/backend/internal/handler/note_folder.go
+++ b/backend/internal/handler/note_folder.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -28,16 +29,10 @@ func NewNoteFolderHandler(s NoteFolderServiceInterface) *NoteFolderHandler {
 	return &NoteFolderHandler{service: s}
 }
 
-// CreateNoteFolderInput はフォルダ作成のリクエストボディ。
-type CreateNoteFolderInput struct {
-	Name     string `json:"name" binding:"required"`
-	ParentID *uint  `json:"parent_id"`
-}
-
 // Create は新しいノートフォルダを作成する。
 func (h *NoteFolderHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
-	input := bindJSON[CreateNoteFolderInput](c)
+	input := bindJSON[dto.CreateNoteFolderRequest](c)
 	if input == nil {
 		return
 	}
@@ -114,12 +109,6 @@ func (h *NoteFolderHandler) GetRootFolders(c *gin.Context) {
 	respondOK(c, ensureSlice(folders))
 }
 
-// UpdateNoteFolderInput はフォルダ更新のリクエストボディ。
-type UpdateNoteFolderInput struct {
-	Name     string `json:"name"`
-	ParentID *uint  `json:"parent_id"`
-}
-
 // Update はフォルダを更新する。
 func (h *NoteFolderHandler) Update(c *gin.Context) {
 	id, ok := parseID(c, "id")
@@ -128,7 +117,7 @@ func (h *NoteFolderHandler) Update(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	input := bindJSON[UpdateNoteFolderInput](c)
+	input := bindJSON[dto.UpdateNoteFolderRequest](c)
 	if input == nil {
 		return
 	}

--- a/backend/internal/handler/note_folder_test.go
+++ b/backend/internal/handler/note_folder_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
 	"github.com/stretchr/testify/assert"
@@ -79,7 +80,7 @@ func TestNoteFolderHandler_Create(t *testing.T) {
 		handler.Create(c)
 	})
 
-	input := CreateNoteFolderInput{
+	input := dto.CreateNoteFolderRequest{
 		Name:     "新規フォルダ",
 		ParentID: nil,
 	}
@@ -217,7 +218,7 @@ func TestNoteFolderHandler_Update(t *testing.T) {
 		handler.Update(c)
 	})
 
-	input := UpdateNoteFolderInput{
+	input := dto.UpdateNoteFolderRequest{
 		Name: "更新後フォルダ名",
 	}
 	body, _ := json.Marshal(input)

--- a/backend/internal/handler/note_link.go
+++ b/backend/internal/handler/note_link.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -24,11 +25,6 @@ func NewNoteLinkHandler(s NoteLinkServiceInterface) *NoteLinkHandler {
 	return &NoteLinkHandler{service: s}
 }
 
-// CreateLinkInput はリンク作成のリクエストボディ。
-type CreateLinkInput struct {
-	TargetNoteID uint `json:"target_note_id" binding:"required"`
-}
-
 // CreateLink は新しいリンクを作成する。
 func (h *NoteLinkHandler) CreateLink(c *gin.Context) {
 	sourceNoteID, ok := parseID(c, "id")
@@ -38,7 +34,7 @@ func (h *NoteLinkHandler) CreateLink(c *gin.Context) {
 
 	userID := c.GetUint("userID")
 
-	input := bindJSON[CreateLinkInput](c)
+	input := bindJSON[dto.CreateNoteLinkRequest](c)
 	if input == nil {
 		return
 	}

--- a/backend/internal/handler/note_template.go
+++ b/backend/internal/handler/note_template.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -26,20 +27,10 @@ func NewNoteTemplateHandler(s NoteTemplateServiceInterface) *NoteTemplateHandler
 	return &NoteTemplateHandler{service: s}
 }
 
-// CreateTemplateInput はテンプレート作成のリクエストボディ。
-type CreateTemplateInput struct {
-	Name            string `json:"name" binding:"required"`
-	Description     string `json:"description"`
-	DefaultTitle    string `json:"default_title"`
-	ContentTemplate string `json:"content_template" binding:"required"`
-	DefaultTags     string `json:"default_tags"`
-	IsDefault       bool   `json:"is_default"`
-}
-
 // Create は新しいテンプレートを作成する。
 func (h *NoteTemplateHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
-	input := bindJSON[CreateTemplateInput](c)
+	input := bindJSON[dto.CreateNoteTemplateRequest](c)
 	if input == nil {
 		return
 	}
@@ -104,16 +95,6 @@ func (h *NoteTemplateHandler) GetDefault(c *gin.Context) {
 	respondOK(c, template)
 }
 
-// UpdateTemplateInput はテンプレート更新のリクエストボディ。
-type UpdateTemplateInput struct {
-	Name            string `json:"name"`
-	Description     string `json:"description"`
-	DefaultTitle    string `json:"default_title"`
-	ContentTemplate string `json:"content_template"`
-	DefaultTags     string `json:"default_tags"`
-	IsDefault       *bool  `json:"is_default"`
-}
-
 // Update はテンプレートを更新する。
 func (h *NoteTemplateHandler) Update(c *gin.Context) {
 	id, ok := parseID(c, "id")
@@ -122,7 +103,7 @@ func (h *NoteTemplateHandler) Update(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	input := bindJSON[UpdateTemplateInput](c)
+	input := bindJSON[dto.UpdateNoteTemplateRequest](c)
 	if input == nil {
 		return
 	}

--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -128,7 +129,7 @@ func TestNoteHandler_Create(t *testing.T) {
 		handler.Create(c)
 	})
 
-	input := CreateNoteInput{
+	input := dto.CreateNoteRequest{
 		Title:    "テストノート",
 		Content:  "これはテスト内容です",
 		Tags:     "Go,TDD",
@@ -216,7 +217,7 @@ func TestNoteHandler_Update(t *testing.T) {
 		handler.Update(c)
 	})
 
-	input := UpdateNoteInput{
+	input := dto.UpdateNoteRequest{
 		Title:   "更新後タイトル",
 		Content: "更新後内容",
 	}
@@ -653,7 +654,7 @@ func TestNoteHandler_Create_ServiceError(t *testing.T) {
 		handler.Create(c)
 	})
 
-	input := CreateNoteInput{Title: "テスト", Content: "内容"}
+	input := dto.CreateNoteRequest{Title: "テスト", Content: "内容"}
 	body, _ := json.Marshal(input)
 
 	mockService.On("Create", mock.AnythingOfType("*model.Note")).Return(assert.AnError)
@@ -790,7 +791,7 @@ func TestNoteHandler_Update_ServiceError(t *testing.T) {
 		handler.Update(c)
 	})
 
-	input := UpdateNoteInput{Title: "更新"}
+	input := dto.UpdateNoteRequest{Title: "更新"}
 	body, _ := json.Marshal(input)
 
 	mockService.On("Update", uint(1), uint(1), "更新", "", "", (*uint)(nil)).Return(nil, assert.AnError)


### PR DESCRIPTION
## 概要
handler層に直接定義されていた7つのInput構造体をdto層のRequest構造体に移動。

## 変更内容
- 4つの新規DTOファイル作成（note_dto.go, note_folder_dto.go, note_template_dto.go, note_link_dto.go）
- 4つのhandlerファイルから構造体定義を削除し、dto参照に切替
- 2つのテストファイルの型参照を更新

Closes #1087