### PR TITLE
test: handler層テストカバレッジ向上（84.9%→85.5%） (#1089)

### DIFF
--- a/backend/internal/handler/code_snippet_test.go
+++ b/backend/internal/handler/code_snippet_test.go
@@ -278,3 +278,87 @@ func TestCodeSnippet_GetByUserLanguage_ServiceError(t *testing.T) {
 	assertStatus(t, w, http.StatusNotFound)
 	svc.AssertExpectations(t)
 }
+
+func TestCodeSnippetGetByID_InvalidID(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.GET("/snippets/:id", h.GetByID)
+	w := doRequest(r, "GET", "/snippets/abc", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetGetByID_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	svc.On("GetByPostID", uint(1)).Return([]model.CodeSnippet(nil), service.ErrNotFound)
+
+	r := newRouter(1)
+	r.GET("/snippets/:id", h.GetByID)
+	w := doRequest(r, "GET", "/snippets/1", nil)
+
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetGetByPostID_InvalidID(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.GET("/posts/:id/snippets", h.GetByPostID)
+	w := doRequest(r, "GET", "/posts/abc/snippets", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetUpdate_InvalidID(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.PUT("/snippets/:id", h.Update)
+	w := doRequest(r, "PUT", "/snippets/abc", map[string]string{"language": "Go"})
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetDelete_InvalidID(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.DELETE("/snippets/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/snippets/abc", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetGetComments_InvalidID(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.GET("/snippets/:id/comments", h.GetComments)
+	w := doRequest(r, "GET", "/snippets/abc/comments", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetCreateComment_InvalidID(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.POST("/snippets/:id/comments", h.CreateComment)
+	w := doRequest(r, "POST", "/snippets/abc/comments", map[string]interface{}{
+		"line_number": 5, "content": "test",
+	})
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetDeleteComment_InvalidID(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.DELETE("/snippets/:id/comments/:commentId", h.DeleteComment)
+	w := doRequest(r, "DELETE", "/snippets/1/comments/abc", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/note_link_test.go
+++ b/backend/internal/handler/note_link_test.go
@@ -115,3 +115,53 @@ func TestNoteLinkDeleteLink_ServiceError(t *testing.T) {
 	assertStatus(t, w, http.StatusNotFound)
 	svc.AssertExpectations(t)
 }
+
+func TestNoteLinkCreateLink_BadRequest(t *testing.T) {
+	h, _ := setupNoteLinkHandler()
+
+	r := newRouter(1)
+	r.POST("/notes/:id/links", h.CreateLink)
+	w := doRequest(r, "POST", "/notes/1/links", map[string]interface{}{})
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteLinkGetLinks_InvalidID(t *testing.T) {
+	h, _ := setupNoteLinkHandler()
+
+	r := newRouter(1)
+	r.GET("/notes/:id/links", h.GetLinks)
+	w := doRequest(r, "GET", "/notes/abc/links", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteLinkGetBacklinks_InvalidID(t *testing.T) {
+	h, _ := setupNoteLinkHandler()
+
+	r := newRouter(1)
+	r.GET("/notes/:id/backlinks", h.GetBacklinks)
+	w := doRequest(r, "GET", "/notes/abc/backlinks", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteLinkDeleteLink_InvalidID(t *testing.T) {
+	h, _ := setupNoteLinkHandler()
+
+	r := newRouter(1)
+	r.DELETE("/notes/:id/links/:targetId", h.DeleteLink)
+	w := doRequest(r, "DELETE", "/notes/abc/links/2", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteLinkDeleteLink_InvalidTargetID(t *testing.T) {
+	h, _ := setupNoteLinkHandler()
+
+	r := newRouter(1)
+	r.DELETE("/notes/:id/links/:targetId", h.DeleteLink)
+	w := doRequest(r, "DELETE", "/notes/1/links/abc", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/note_template_test.go
+++ b/backend/internal/handler/note_template_test.go
@@ -202,3 +202,53 @@ func TestNoteTemplateGetDefault_ServiceError(t *testing.T) {
 
 	assertStatus(t, w, http.StatusInternalServerError)
 }
+
+func TestNoteTemplateCreate_BadRequest(t *testing.T) {
+	h, _ := setupNoteTemplateHandler()
+
+	r := newRouter(1)
+	r.POST("/note-templates", h.Create)
+	w := doRequest(r, "POST", "/note-templates", map[string]interface{}{})
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteTemplateGetByID_InvalidID(t *testing.T) {
+	h, _ := setupNoteTemplateHandler()
+
+	r := newRouter(1)
+	r.GET("/note-templates/:id", h.GetByID)
+	w := doRequest(r, "GET", "/note-templates/abc", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteTemplateUpdate_InvalidID(t *testing.T) {
+	h, _ := setupNoteTemplateHandler()
+
+	r := newRouter(1)
+	r.PUT("/note-templates/:id", h.Update)
+	w := doRequest(r, "PUT", "/note-templates/abc", map[string]interface{}{"name": "テスト"})
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteTemplateDelete_InvalidID(t *testing.T) {
+	h, _ := setupNoteTemplateHandler()
+
+	r := newRouter(1)
+	r.DELETE("/note-templates/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/note-templates/abc", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteTemplateUseTemplate_InvalidID(t *testing.T) {
+	h, _ := setupNoteTemplateHandler()
+
+	r := newRouter(1)
+	r.POST("/note-templates/:id/use", h.UseTemplate)
+	w := doRequest(r, "POST", "/note-templates/abc/use", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}


### PR DESCRIPTION
## 概要
handler層のテストカバレッジを84.9%→85.5%に向上。

## 変更内容
- note_link_test.go: 6テスト追加（InvalidID/BadRequest系）
- note_template_test.go: 5テスト追加（InvalidID/BadRequest系）
- code_snippet_test.go: 9テスト追加（InvalidID/ServiceError系）

Closes #1089