### PR TITLE
fix: CodeSnippetService.Createの空白バイパス対策 (#1091)

### DIFF
--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -25,6 +25,13 @@ func NewCodeSnippetService(
 // Create は新しいコードスニペットを作成する。
 // 投稿の存在を確認してからスニペットを作成する。
 func (s *CodeSnippetService) Create(snippet *model.CodeSnippet) (*model.CodeSnippet, error) {
+	if strings.TrimSpace(snippet.Language) == "" {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "言語は空白のみでは入力できません", nil)
+	}
+	if strings.TrimSpace(snippet.Code) == "" {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "コードは空白のみでは入力できません", nil)
+	}
+
 	// 投稿の存在確認
 	if _, err := s.postRepo.FindByID(snippet.PostID); err != nil {
 		return nil, err

--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -418,3 +418,27 @@ func TestCodeSnippetGetByUserLanguage_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	snippetRepo.AssertExpectations(t)
 }
+
+func TestSnippetCreate_WhitespaceCode(t *testing.T) {
+	svc, _, postRepo := newTestCodeSnippetService()
+	post := &model.Post{Title: "Test", Content: "Content", UserID: 1}
+	post.ID = 5
+	postRepo.On("FindByID", uint(5)).Return(post, nil)
+
+	snippet := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", Code: "   "}
+	_, err := svc.Create(snippet)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "コードは空白のみでは入力できません")
+}
+
+func TestSnippetCreate_WhitespaceLanguage(t *testing.T) {
+	svc, _, postRepo := newTestCodeSnippetService()
+	post := &model.Post{Title: "Test", Content: "Content", UserID: 1}
+	post.ID = 5
+	postRepo.On("FindByID", uint(5)).Return(post, nil)
+
+	snippet := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "   ", Code: "package main"}
+	_, err := svc.Create(snippet)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "言語は空白のみでは入力できません")
+}


### PR DESCRIPTION
## 概要
CodeSnippetService.Createにlanguage/codeフィールドの空白バイパス対策を追加。

## 変更内容
- code_snippet.go: Create()にTrimSpaceチェック追加
- code_snippet_test.go: WhitespaceCode/WhitespaceLanguageテスト追加

Closes #1091