### PR TITLE
feat: NoteFolder.GetByUserIDにページネーション対応

### DIFF
--- a/backend/internal/dto/note_folder_dto.go
+++ b/backend/internal/dto/note_folder_dto.go
@@ -1,5 +1,7 @@
 package dto
 
+import "github.com/norman6464/devsync/backend/internal/model"
+
 // CreateNoteFolderRequest はフォルダ作成リクエスト。
 type CreateNoteFolderRequest struct {
 	Name     string `json:"name" binding:"required"`
@@ -10,4 +12,12 @@ type CreateNoteFolderRequest struct {
 type UpdateNoteFolderRequest struct {
 	Name     string `json:"name"`
 	ParentID *uint  `json:"parent_id"`
+}
+
+// NoteFolderListResponse はフォルダ一覧レスポンス（ページネーション付き）。
+type NoteFolderListResponse struct {
+	Folders []model.NoteFolder `json:"folders"`
+	Total   int64              `json:"total"`
+	Limit   int                `json:"limit"`
+	Offset  int                `json:"offset"`
 }

--- a/backend/internal/handler/note_folder.go
+++ b/backend/internal/handler/note_folder.go
@@ -11,7 +11,7 @@ import (
 type NoteFolderServiceInterface interface {
 	Create(folder *model.NoteFolder) error
 	GetByID(id uint) (*model.NoteFolder, error)
-	GetByUserID(userID uint) ([]model.NoteFolder, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.NoteFolder, int64, error)
 	GetChildren(parentID uint) ([]model.NoteFolder, error)
 	GetRootFolders(userID uint) ([]model.NoteFolder, error)
 	Update(id, userID uint, name string, parentID *uint) (*model.NoteFolder, error)
@@ -67,17 +67,23 @@ func (h *NoteFolderHandler) GetByID(c *gin.Context) {
 	respondOK(c, folder)
 }
 
-// GetByUserID は現在のユーザーのフォルダ一覧を取得する。
+// GetByUserID は現在のユーザーのフォルダ一覧をページネーション付きで取得する。
 func (h *NoteFolderHandler) GetByUserID(c *gin.Context) {
 	userID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
 
-	folders, err := h.service.GetByUserID(userID)
+	folders, total, err := h.service.GetByUserID(userID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, ensureSlice(folders))
+	respondOK(c, dto.NoteFolderListResponse{
+		Folders: ensureSlice(folders),
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+	})
 }
 
 // GetChildren は指定フォルダの子フォルダ一覧を取得する。

--- a/backend/internal/handler/note_folder_test.go
+++ b/backend/internal/handler/note_folder_test.go
@@ -33,9 +33,9 @@ func (m *MockNoteFolderService) GetByID(id uint) (*model.NoteFolder, error) {
 	return nil, args.Error(1)
 }
 
-func (m *MockNoteFolderService) GetByUserID(userID uint) ([]model.NoteFolder, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.NoteFolder), args.Error(1)
+func (m *MockNoteFolderService) GetByUserID(userID uint, limit, offset int) ([]model.NoteFolder, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.NoteFolder), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockNoteFolderService) GetChildren(parentID uint) ([]model.NoteFolder, error) {
@@ -141,7 +141,7 @@ func TestNoteFolderHandler_GetByUserID(t *testing.T) {
 		{ID: 2, UserID: 1, Name: "フォルダ2"},
 	}
 
-	mockService.On("GetByUserID", uint(1)).Return(folders, nil)
+	mockService.On("GetByUserID", uint(1), 20, 0).Return(folders, int64(2), nil)
 
 	req, _ := http.NewRequest("GET", "/folders", nil)
 	w := httptest.NewRecorder()
@@ -303,7 +303,7 @@ func TestNoteFolderHandler_GetByUserID_ServiceError(t *testing.T) {
 	r := newRouter(1)
 	r.GET("/folders", h.GetByUserID)
 
-	svc.On("GetByUserID", uint(1)).Return([]model.NoteFolder(nil), errors.New("db error"))
+	svc.On("GetByUserID", uint(1), 20, 0).Return([]model.NoteFolder(nil), int64(0), errors.New("db error"))
 
 	w := doRequest(r, "GET", "/folders", nil)
 	assertStatus(t, w, http.StatusInternalServerError)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -461,7 +461,7 @@ type NoteRepositoryInterface interface {
 type NoteFolderRepositoryInterface interface {
 	Create(folder *model.NoteFolder) error
 	FindByID(id uint) (*model.NoteFolder, error)
-	FindByUserID(userID uint) ([]model.NoteFolder, error)
+	FindByUserID(userID uint, limit, offset int) ([]model.NoteFolder, int64, error)
 	FindByParentID(parentID uint) ([]model.NoteFolder, error)
 	GetRootFolders(userID uint) ([]model.NoteFolder, error)
 	Update(folder *model.NoteFolder) error

--- a/backend/internal/repository/note_folder.go
+++ b/backend/internal/repository/note_folder.go
@@ -30,11 +30,14 @@ func (r *NoteFolderRepository) FindByID(id uint) (*model.NoteFolder, error) {
 	return &folder, nil
 }
 
-// FindByUserID は指定ユーザーの全フォルダを取得する。
-func (r *NoteFolderRepository) FindByUserID(userID uint) ([]model.NoteFolder, error) {
+// FindByUserID は指定ユーザーのフォルダをページネーション付きで取得する。
+func (r *NoteFolderRepository) FindByUserID(userID uint, limit, offset int) ([]model.NoteFolder, int64, error) {
 	var folders []model.NoteFolder
-	err := r.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&folders).Error
-	return folders, err
+	var total int64
+	query := r.db.Where("user_id = ?", userID)
+	query.Model(&model.NoteFolder{}).Count(&total)
+	err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&folders).Error
+	return folders, total, err
 }
 
 // FindByParentID は指定親フォルダ配下のサブフォルダを取得する。

--- a/backend/internal/service/note_folder.go
+++ b/backend/internal/service/note_folder.go
@@ -35,9 +35,9 @@ func (s *NoteFolderService) GetByID(id uint) (*model.NoteFolder, error) {
 	return s.repo.FindByID(id)
 }
 
-// GetByUserID は指定ユーザーの全フォルダを取得する。
-func (s *NoteFolderService) GetByUserID(userID uint) ([]model.NoteFolder, error) {
-	return s.repo.FindByUserID(userID)
+// GetByUserID は指定ユーザーのフォルダをページネーション付きで取得する。
+func (s *NoteFolderService) GetByUserID(userID uint, limit, offset int) ([]model.NoteFolder, int64, error) {
+	return s.repo.FindByUserID(userID, limit, offset)
 }
 
 // GetChildren は指定フォルダの子フォルダを取得する。

--- a/backend/internal/service/note_folder_test.go
+++ b/backend/internal/service/note_folder_test.go
@@ -28,9 +28,9 @@ func (m *MockNoteFolderRepository) FindByID(id uint) (*model.NoteFolder, error) 
 	return args.Get(0).(*model.NoteFolder), args.Error(1)
 }
 
-func (m *MockNoteFolderRepository) FindByUserID(userID uint) ([]model.NoteFolder, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.NoteFolder), args.Error(1)
+func (m *MockNoteFolderRepository) FindByUserID(userID uint, limit, offset int) ([]model.NoteFolder, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.NoteFolder), args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockNoteFolderRepository) FindByParentID(parentID uint) ([]model.NoteFolder, error) {
@@ -96,11 +96,12 @@ func TestNoteFolderService_GetByUserID(t *testing.T) {
 		{ID: 2, UserID: 1, Name: "フォルダ2"},
 	}
 
-	mockRepo.On("FindByUserID", uint(1)).Return(expected, nil)
+	mockRepo.On("FindByUserID", uint(1), 20, 0).Return(expected, int64(2), nil)
 
-	result, err := service.GetByUserID(1)
+	folders, total, err := service.GetByUserID(1, 20, 0)
 	assert.NoError(t, err)
-	assert.Len(t, result, 2)
+	assert.Len(t, folders, 2)
+	assert.Equal(t, int64(2), total)
 	mockRepo.AssertExpectations(t)
 }
 
@@ -253,11 +254,12 @@ func TestNoteFolderService_GetByUserID_Error(t *testing.T) {
 	mockRepo := new(MockNoteFolderRepository)
 	service := NewNoteFolderService(mockRepo)
 
-	mockRepo.On("FindByUserID", uint(1)).Return([]model.NoteFolder(nil), errors.New("db error"))
+	mockRepo.On("FindByUserID", uint(1), 20, 0).Return([]model.NoteFolder(nil), int64(0), errors.New("db error"))
 
-	result, err := service.GetByUserID(1)
+	result, total, err := service.GetByUserID(1, 20, 0)
 	assert.Error(t, err)
 	assert.Nil(t, result)
+	assert.Equal(t, int64(0), total)
 	mockRepo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
NoteFolder.GetByUserIDエンドポイントにページネーション（limit/offset/total）を追加。

## 変更内容
- repository層: FindByUserIDにlimit/offsetパラメータ追加、Count+Limit+Offsetでページネーション
- service層: GetByUserIDシグネチャ変更（limit, offset, total対応）
- handler層: parseLimitOffset利用、NoteFolderListResponse DTOで返却
- dto層: NoteFolderListResponse追加（folders, total, limit, offset）
- テスト: service/handler両層のモック・テストケースを新シグネチャに更新

Closes #1093