### PR TITLE
refactor: 残存するRequest構造体をhandler層からdto層に移動

### DIFF
--- a/backend/internal/dto/answer_dto.go
+++ b/backend/internal/dto/answer_dto.go
@@ -1,0 +1,11 @@
+package dto
+
+// CreateAnswerRequest は回答作成のリクエストボディ。
+type CreateAnswerRequest struct {
+	Body string `json:"body" binding:"required"`
+}
+
+// UpdateAnswerRequest は回答更新のリクエストボディ。
+type UpdateAnswerRequest struct {
+	Body string `json:"body" binding:"required"`
+}

--- a/backend/internal/dto/learning_resource_dto.go
+++ b/backend/internal/dto/learning_resource_dto.go
@@ -16,3 +16,27 @@ type ResourceListResponse struct {
 	Limit     int                      `json:"limit"`
 	Offset    int                      `json:"offset"`
 }
+
+// CreateResourceRequest は学習リソース作成のリクエストボディ。
+type CreateResourceRequest struct {
+	Title       string `json:"title" binding:"required,max=300"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	Category    string `json:"category" binding:"required"`
+	Difficulty  string `json:"difficulty"`
+	Tags        string `json:"tags"`
+	ImageURL    string `json:"image_url"`
+	IsPublic    *bool  `json:"is_public"`
+}
+
+// UpdateResourceRequest は学習リソース更新のリクエストボディ。
+type UpdateResourceRequest struct {
+	Title       string `json:"title" binding:"max=300"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+	Category    string `json:"category"`
+	Difficulty  string `json:"difficulty"`
+	Tags        string `json:"tags"`
+	ImageURL    string `json:"image_url"`
+	IsPublic    *bool  `json:"is_public"`
+}

--- a/backend/internal/dto/post_tag_dto.go
+++ b/backend/internal/dto/post_tag_dto.go
@@ -1,0 +1,6 @@
+package dto
+
+// SetTagsRequest はタグ設定のリクエストボディ。
+type SetTagsRequest struct {
+	Tags []string `json:"tags"`
+}

--- a/backend/internal/handler/answer.go
+++ b/backend/internal/handler/answer.go
@@ -46,16 +46,6 @@ func (h *AnswerHandler) GetByQuestionID(c *gin.Context) {
 	respondOK(c, ensureSlice(answers))
 }
 
-// CreateAnswerRequest は回答作成のリクエストボディ。
-type CreateAnswerRequest struct {
-	Body string `json:"body" binding:"required"`
-}
-
-// UpdateAnswerRequest は回答更新のリクエストボディ。
-type UpdateAnswerRequest struct {
-	Body string `json:"body" binding:"required"`
-}
-
 // Create は質問に対して新しい回答を作成する。
 func (h *AnswerHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
@@ -64,7 +54,7 @@ func (h *AnswerHandler) Create(c *gin.Context) {
 		return
 	}
 
-	req := bindJSON[CreateAnswerRequest](c)
+	req := bindJSON[dto.CreateAnswerRequest](c)
 	if req == nil {
 		return
 	}
@@ -91,7 +81,7 @@ func (h *AnswerHandler) Update(c *gin.Context) {
 		return
 	}
 
-	req := bindJSON[UpdateAnswerRequest](c)
+	req := bindJSON[dto.UpdateAnswerRequest](c)
 	if req == nil {
 		return
 	}

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -39,35 +39,11 @@ func NewLearningResourceHandler(s LearningResourceServiceInterface) *LearningRes
 	return &LearningResourceHandler{service: s}
 }
 
-// CreateResourceRequest は学習リソース作成のリクエストボディ。
-type CreateResourceRequest struct {
-	Title       string `json:"title" binding:"required,max=300"`
-	Description string `json:"description"`
-	URL         string `json:"url"`
-	Category    string `json:"category" binding:"required"`
-	Difficulty  string `json:"difficulty"`
-	Tags        string `json:"tags"`
-	ImageURL    string `json:"image_url"`
-	IsPublic    *bool  `json:"is_public"`
-}
-
-// UpdateResourceRequest は学習リソース更新のリクエストボディ。
-type UpdateResourceRequest struct {
-	Title       string `json:"title" binding:"max=300"`
-	Description string `json:"description"`
-	URL         string `json:"url"`
-	Category    string `json:"category"`
-	Difficulty  string `json:"difficulty"`
-	Tags        string `json:"tags"`
-	ImageURL    string `json:"image_url"`
-	IsPublic    *bool  `json:"is_public"`
-}
-
 // Create は新しい学習リソースを作成する。
 func (h *LearningResourceHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	req := bindJSON[CreateResourceRequest](c)
+	req := bindJSON[dto.CreateResourceRequest](c)
 	if req == nil {
 		return
 	}
@@ -195,7 +171,7 @@ func (h *LearningResourceHandler) Update(c *gin.Context) {
 		return
 	}
 
-	req := bindJSON[UpdateResourceRequest](c)
+	req := bindJSON[dto.UpdateResourceRequest](c)
 	if req == nil {
 		return
 	}

--- a/backend/internal/handler/post_tag.go
+++ b/backend/internal/handler/post_tag.go
@@ -33,9 +33,7 @@ func (h *PostTagHandler) SetTags(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	req := bindJSON[struct {
-		Tags []string `json:"tags"`
-	}](c)
+	req := bindJSON[dto.SetTagsRequest](c)
 	if req == nil {
 		return
 	}


### PR DESCRIPTION
## 概要
handler層に残っていたRequest構造体をdto層に移動し、一貫性を確保。

## 変更内容
- `CreateResourceRequest` / `UpdateResourceRequest` → `dto/learning_resource_dto.go`
- `CreateAnswerRequest` / `UpdateAnswerRequest` → 新規 `dto/answer_dto.go`
- `post_tag.go`のインライン構造体 → 新規 `dto/post_tag_dto.go`（`SetTagsRequest`）
- handler側の参照を`dto.XxxRequest`に変更

Closes #1095