### PR TITLE
fix: Update系メソッドでTrimSpace後の値を代入するよう修正

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -58,7 +58,7 @@ func (s *AnswerService) Update(answerID, userID uint, body string) (*model.Answe
 	if err != nil {
 		return nil, err
 	}
-	answer.Body = body
+	answer.Body = strings.TrimSpace(body)
 	if err := s.answerRepo.Update(answer); err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -553,3 +553,15 @@ func TestAnswerGetByVoteRange_RepoError(t *testing.T) {
 	assert.Nil(t, result)
 	answerRepo.AssertExpectations(t)
 }
+
+func TestAnswerUpdate_TrimsPaddedBody(t *testing.T) {
+	svc, answerRepo, _ := newTestAnswerService()
+	existing := &model.Answer{UserID: 1, Body: "Original"}
+	existing.ID = 1
+	answerRepo.On("FindByID", uint(1)).Return(existing, nil)
+	answerRepo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, "  Updated Body  ")
+	assert.NoError(t, err)
+	assert.Equal(t, "Updated Body", result.Body)
+}

--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -80,13 +80,13 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		review.Title = updates.Title
+		review.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Author) != "" {
-		review.Author = updates.Author
+		review.Author = strings.TrimSpace(updates.Author)
 	}
 	if strings.TrimSpace(updates.ISBN) != "" {
-		review.ISBN = updates.ISBN
+		review.ISBN = strings.TrimSpace(updates.ISBN)
 	}
 	if updates.Rating != 0 {
 		if err := validateRating(updates.Rating); err != nil {
@@ -95,10 +95,10 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		review.Rating = updates.Rating
 	}
 	if strings.TrimSpace(updates.Review) != "" {
-		review.Review = updates.Review
+		review.Review = strings.TrimSpace(updates.Review)
 	}
 	if strings.TrimSpace(updates.ImageURL) != "" {
-		review.ImageURL = updates.ImageURL
+		review.ImageURL = strings.TrimSpace(updates.ImageURL)
 	}
 
 	if err := s.repo.Update(review); err != nil {

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -413,3 +413,15 @@ func TestBookReviewUpdate_WhitespaceReview(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "Original Review", result.Review)
 }
+
+func TestBookReviewUpdate_TrimsPaddedTitle(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+	existing := &model.BookReview{Title: "Original", Author: "Author", Rating: 4, Review: "Review", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.BookReview{Title: "  New Title  "})
+	assert.NoError(t, err)
+	assert.Equal(t, "New Title", result.Title)
+}

--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -73,25 +73,25 @@ func (s *ProjectService) Update(id, userID uint, updates *model.Project) (*model
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		project.Title = updates.Title
+		project.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		project.Description = updates.Description
+		project.Description = strings.TrimSpace(updates.Description)
 	}
 	if strings.TrimSpace(updates.TechStack) != "" {
-		project.TechStack = updates.TechStack
+		project.TechStack = strings.TrimSpace(updates.TechStack)
 	}
 	if strings.TrimSpace(updates.DemoURL) != "" {
-		project.DemoURL = updates.DemoURL
+		project.DemoURL = strings.TrimSpace(updates.DemoURL)
 	}
 	if strings.TrimSpace(updates.GithubURL) != "" {
-		project.GithubURL = updates.GithubURL
+		project.GithubURL = strings.TrimSpace(updates.GithubURL)
 	}
 	if strings.TrimSpace(updates.ImageURL) != "" {
-		project.ImageURL = updates.ImageURL
+		project.ImageURL = strings.TrimSpace(updates.ImageURL)
 	}
 	if strings.TrimSpace(updates.Role) != "" {
-		project.Role = updates.Role
+		project.Role = strings.TrimSpace(updates.Role)
 	}
 	if updates.StartDate != nil {
 		project.StartDate = updates.StartDate

--- a/backend/internal/service/project_test.go
+++ b/backend/internal/service/project_test.go
@@ -439,3 +439,15 @@ func TestProjectUpdate_WhitespaceRole(t *testing.T) {
 	assert.Equal(t, "Backend Engineer", result.Role)
 	repo.AssertExpectations(t)
 }
+
+func TestProjectUpdate_TrimsPaddedTitle(t *testing.T) {
+	svc, repo := newTestProjectService()
+	existing := &model.Project{Title: "Original", Description: "Desc", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.Project{Title: "  New Title  "})
+	assert.NoError(t, err)
+	assert.Equal(t, "New Title", result.Title)
+}

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -183,13 +183,13 @@ func (s *RoadmapService) UpdateStep(roadmapID, stepID, userID uint, updates *mod
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		step.Title = updates.Title
+		step.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		step.Description = updates.Description
+		step.Description = strings.TrimSpace(updates.Description)
 	}
 	if strings.TrimSpace(updates.ResourceURL) != "" {
-		step.ResourceURL = updates.ResourceURL
+		step.ResourceURL = strings.TrimSpace(updates.ResourceURL)
 	}
 
 	if err := s.repo.UpdateStep(step); err != nil {

--- a/backend/internal/service/roadmap_test.go
+++ b/backend/internal/service/roadmap_test.go
@@ -1233,3 +1233,18 @@ func TestRoadmapUpdateStep_WhitespaceResourceURL(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://example.com", result.ResourceURL)
 }
+
+func TestRoadmapUpdateStep_TrimsPaddedTitle(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 1
+	step := &model.RoadmapStep{RoadmapID: 1, Title: "Original"}
+	step.ID = 10
+	repo.On("FindByID", uint(1)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(10)).Return(step, nil)
+	repo.On("UpdateStep", step).Return(nil)
+
+	result, err := svc.UpdateStep(1, 10, 1, &model.RoadmapStep{Title: "  New Title  "})
+	assert.NoError(t, err)
+	assert.Equal(t, "New Title", result.Title)
+}


### PR DESCRIPTION
## 概要
BookReview/Project/Answer/RoadmapStepのUpdate系メソッドで空白パディングが保存される問題を修正。

## 変更内容
- BookReview.Update: 5フィールドの代入をTrimSpace後の値に変更
- Project.Update: 7フィールドの代入をTrimSpace後の値に変更
- Answer.Update: Bodyの代入をTrimSpace後の値に変更
- Roadmap.UpdateStep: 3フィールドの代入をTrimSpace後の値に変更
- TDDテスト4件追加

Closes #1099