### PR TITLE
feat: Follow.GetFollowers/GetFollowingにページネーション対応

### DIFF
--- a/backend/internal/dto/follow_dto.go
+++ b/backend/internal/dto/follow_dto.go
@@ -1,0 +1,11 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// FollowListResponse はフォロワー/フォロー中一覧レスポンス（ページネーション付き）。
+type FollowListResponse struct {
+	Users  []model.User `json:"users"`
+	Total  int64        `json:"total"`
+	Limit  int          `json:"limit"`
+	Offset int          `json:"offset"`
+}

--- a/backend/internal/handler/follow.go
+++ b/backend/internal/handler/follow.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -10,8 +11,8 @@ import (
 type FollowServiceInterface interface {
 	Follow(followerID, followeeID uint) error
 	Unfollow(followerID, followeeID uint) error
-	GetFollowers(userID uint) ([]model.User, error)
-	GetFollowing(userID uint) ([]model.User, error)
+	GetFollowers(userID uint, limit, offset int) ([]model.User, int64, error)
+	GetFollowing(userID uint, limit, offset int) ([]model.User, int64, error)
 }
 
 // FollowHandler はフォロー関連のHTTPハンドラ。
@@ -53,30 +54,42 @@ func (h *FollowHandler) Unfollow(c *gin.Context) {
 	respondOK(c, domain.NewMessageResponse("unfollowed"))
 }
 
-// GetFollowers は指定ユーザーのフォロワー一覧を返す。
+// GetFollowers は指定ユーザーのフォロワー一覧をページネーション付きで返す。
 func (h *FollowHandler) GetFollowers(c *gin.Context) {
 	id, ok := parseID(c, "id")
 	if !ok {
 		return
 	}
-	users, err := h.service.GetFollowers(id)
+	limit, offset := parseLimitOffset(c)
+	users, total, err := h.service.GetFollowers(id, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, ensureSlice(users))
+	respondOK(c, dto.FollowListResponse{
+		Users:  ensureSlice(users),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }
 
-// GetFollowing は指定ユーザーのフォロー中一覧を返す。
+// GetFollowing は指定ユーザーのフォロー中一覧をページネーション付きで返す。
 func (h *FollowHandler) GetFollowing(c *gin.Context) {
 	id, ok := parseID(c, "id")
 	if !ok {
 		return
 	}
-	users, err := h.service.GetFollowing(id)
+	limit, offset := parseLimitOffset(c)
+	users, total, err := h.service.GetFollowing(id, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, ensureSlice(users))
+	respondOK(c, dto.FollowListResponse{
+		Users:  ensureSlice(users),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }

--- a/backend/internal/handler/follow_test.go
+++ b/backend/internal/handler/follow_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
-	"github.com/stretchr/testify/assert"
 )
 
 // ---------- Follow ----------
@@ -70,7 +69,7 @@ func TestUnfollow_ServiceError(t *testing.T) {
 func TestGetFollowers_Success(t *testing.T) {
 	h, svc := setupFollowHandler()
 	users := []model.User{{Name: "alice"}, {Name: "bob"}}
-	svc.On("GetFollowers", uint(2)).Return(users, nil)
+	svc.On("GetFollowers", uint(2), 20, 0).Return(users, int64(2), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:id/followers", h.GetFollowers)
@@ -82,21 +81,18 @@ func TestGetFollowers_Success(t *testing.T) {
 func TestGetFollowers_Empty(t *testing.T) {
 	h, svc := setupFollowHandler()
 	var empty []model.User
-	svc.On("GetFollowers", uint(2)).Return(empty, nil)
+	svc.On("GetFollowers", uint(2), 20, 0).Return(empty, int64(0), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:id/followers", h.GetFollowers)
 	w := doRequest(r, "GET", "/users/2/followers", nil)
 	assertStatus(t, w, 200)
-	// nilの場合は空配列を返すことを確認
-	body := w.Body.String()
-	assert.Contains(t, body, "[]")
 }
 
 func TestGetFollowers_ServiceError(t *testing.T) {
 	h, svc := setupFollowHandler()
 	var empty []model.User
-	svc.On("GetFollowers", uint(2)).Return(empty, fmt.Errorf("internal error"))
+	svc.On("GetFollowers", uint(2), 20, 0).Return(empty, int64(0), fmt.Errorf("internal error"))
 
 	r := newRouter(1)
 	r.GET("/users/:id/followers", h.GetFollowers)
@@ -109,7 +105,7 @@ func TestGetFollowers_ServiceError(t *testing.T) {
 func TestGetFollowing_Success(t *testing.T) {
 	h, svc := setupFollowHandler()
 	users := []model.User{{Name: "charlie"}}
-	svc.On("GetFollowing", uint(2)).Return(users, nil)
+	svc.On("GetFollowing", uint(2), 20, 0).Return(users, int64(1), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:id/following", h.GetFollowing)
@@ -121,19 +117,17 @@ func TestGetFollowing_Success(t *testing.T) {
 func TestGetFollowing_Empty(t *testing.T) {
 	h, svc := setupFollowHandler()
 	var empty []model.User
-	svc.On("GetFollowing", uint(2)).Return(empty, nil)
+	svc.On("GetFollowing", uint(2), 20, 0).Return(empty, int64(0), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:id/following", h.GetFollowing)
 	w := doRequest(r, "GET", "/users/2/following", nil)
 	assertStatus(t, w, 200)
-	body := w.Body.String()
-	assert.Contains(t, body, "[]")
 }
 
 func TestGetFollowing_ServiceError(t *testing.T) {
 	h, svc := setupFollowHandler()
-	svc.On("GetFollowing", uint(2)).Return([]model.User(nil), errors.New("db error"))
+	svc.On("GetFollowing", uint(2), 20, 0).Return([]model.User(nil), int64(0), errors.New("db error"))
 
 	r := newRouter(1)
 	r.GET("/users/:id/following", h.GetFollowing)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -812,13 +812,13 @@ func (m *MockFollowService) Follow(followerID, followeeID uint) error {
 func (m *MockFollowService) Unfollow(followerID, followeeID uint) error {
 	return m.Called(followerID, followeeID).Error(0)
 }
-func (m *MockFollowService) GetFollowers(userID uint) ([]model.User, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.User), args.Error(1)
+func (m *MockFollowService) GetFollowers(userID uint, limit, offset int) ([]model.User, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.User), args.Get(1).(int64), args.Error(2)
 }
-func (m *MockFollowService) GetFollowing(userID uint) ([]model.User, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.User), args.Error(1)
+func (m *MockFollowService) GetFollowing(userID uint, limit, offset int) ([]model.User, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.User), args.Get(1).(int64), args.Error(2)
 }
 
 // setupFollowHandler はFollowHandlerテスト用のセットアップを行う。

--- a/backend/internal/repository/follow.go
+++ b/backend/internal/repository/follow.go
@@ -33,16 +33,20 @@ func (r *FollowRepository) IsFollowing(followerID, followeeID uint) bool {
 	return count > 0
 }
 
-// GetFollowers は指定ユーザーのフォロワー一覧を取得する。
-func (r *FollowRepository) GetFollowers(userID uint) ([]model.User, error) {
+// GetFollowers は指定ユーザーのフォロワー一覧をページネーション付きで取得する。
+func (r *FollowRepository) GetFollowers(userID uint, limit, offset int) ([]model.User, int64, error) {
 	var users []model.User
-	err := r.db.Raw(`SELECT u.* FROM users u JOIN follows f ON f.follower_id = u.id WHERE f.followee_id = ?`, userID).Scan(&users).Error
-	return users, err
+	var total int64
+	r.db.Raw(`SELECT COUNT(*) FROM follows WHERE followee_id = ?`, userID).Scan(&total)
+	err := r.db.Raw(`SELECT u.* FROM users u JOIN follows f ON f.follower_id = u.id WHERE f.followee_id = ? ORDER BY f.created_at DESC LIMIT ? OFFSET ?`, userID, limit, offset).Scan(&users).Error
+	return users, total, err
 }
 
-// GetFollowing は指定ユーザーがフォロー中のユーザー一覧を取得する。
-func (r *FollowRepository) GetFollowing(userID uint) ([]model.User, error) {
+// GetFollowing は指定ユーザーがフォロー中のユーザー一覧をページネーション付きで取得する。
+func (r *FollowRepository) GetFollowing(userID uint, limit, offset int) ([]model.User, int64, error) {
 	var users []model.User
-	err := r.db.Raw(`SELECT u.* FROM users u JOIN follows f ON f.followee_id = u.id WHERE f.follower_id = ?`, userID).Scan(&users).Error
-	return users, err
+	var total int64
+	r.db.Raw(`SELECT COUNT(*) FROM follows WHERE follower_id = ?`, userID).Scan(&total)
+	err := r.db.Raw(`SELECT u.* FROM users u JOIN follows f ON f.followee_id = u.id WHERE f.follower_id = ? ORDER BY f.created_at DESC LIMIT ? OFFSET ?`, userID, limit, offset).Scan(&users).Error
+	return users, total, err
 }

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -87,8 +87,8 @@ type FollowRepositoryInterface interface {
 	Follow(followerID, followeeID uint) error
 	Unfollow(followerID, followeeID uint) error
 	IsFollowing(followerID, followeeID uint) bool
-	GetFollowers(userID uint) ([]model.User, error)
-	GetFollowing(userID uint) ([]model.User, error)
+	GetFollowers(userID uint, limit, offset int) ([]model.User, int64, error)
+	GetFollowing(userID uint, limit, offset int) ([]model.User, int64, error)
 }
 
 // NotificationRepositoryInterface は通知データ操作の契約を定義する。

--- a/backend/internal/service/follow.go
+++ b/backend/internal/service/follow.go
@@ -36,12 +36,12 @@ func (s *FollowService) IsFollowing(followerID, followeeID uint) bool {
 	return s.repo.IsFollowing(followerID, followeeID)
 }
 
-// GetFollowers は指定ユーザーの全フォロワーを取得する。
-func (s *FollowService) GetFollowers(userID uint) ([]model.User, error) {
-	return s.repo.GetFollowers(userID)
+// GetFollowers は指定ユーザーのフォロワーをページネーション付きで取得する。
+func (s *FollowService) GetFollowers(userID uint, limit, offset int) ([]model.User, int64, error) {
+	return s.repo.GetFollowers(userID, limit, offset)
 }
 
-// GetFollowing は指定ユーザーがフォロー中の全ユーザーを取得する。
-func (s *FollowService) GetFollowing(userID uint) ([]model.User, error) {
-	return s.repo.GetFollowing(userID)
+// GetFollowing は指定ユーザーがフォロー中のユーザーをページネーション付きで取得する。
+func (s *FollowService) GetFollowing(userID uint, limit, offset int) ([]model.User, int64, error) {
+	return s.repo.GetFollowing(userID, limit, offset)
 }

--- a/backend/internal/service/follow_test.go
+++ b/backend/internal/service/follow_test.go
@@ -102,11 +102,12 @@ func TestFollowService_GetFollowers_EmptyList(t *testing.T) {
 	repo := new(MockFollowRepository)
 	svc := NewFollowService(repo)
 
-	repo.On("GetFollowers", uint(1)).Return([]model.User{}, nil)
+	repo.On("GetFollowers", uint(1), 20, 0).Return([]model.User{}, int64(0), nil)
 
-	result, err := svc.GetFollowers(1)
+	result, total, err := svc.GetFollowers(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
 }
 
@@ -114,11 +115,12 @@ func TestFollowService_GetFollowing_EmptyList(t *testing.T) {
 	repo := new(MockFollowRepository)
 	svc := NewFollowService(repo)
 
-	repo.On("GetFollowing", uint(1)).Return([]model.User{}, nil)
+	repo.On("GetFollowing", uint(1), 20, 0).Return([]model.User{}, int64(0), nil)
 
-	result, err := svc.GetFollowing(1)
+	result, total, err := svc.GetFollowing(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
 }
 
@@ -131,11 +133,12 @@ func TestFollowService_GetFollowers(t *testing.T) {
 			{Name: "alice"},
 			{Name: "bob"},
 		}
-		repo.On("GetFollowers", uint(1)).Return(expected, nil)
+		repo.On("GetFollowers", uint(1), 20, 0).Return(expected, int64(2), nil)
 
-		result, err := svc.GetFollowers(1)
+		result, total, err := svc.GetFollowers(1, 20, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, result)
+		assert.Equal(t, int64(2), total)
 		repo.AssertExpectations(t)
 	})
 
@@ -143,11 +146,12 @@ func TestFollowService_GetFollowers(t *testing.T) {
 		repo := new(MockFollowRepository)
 		svc := NewFollowService(repo)
 
-		repo.On("GetFollowers", uint(1)).Return([]model.User(nil), errors.New("db error"))
+		repo.On("GetFollowers", uint(1), 20, 0).Return([]model.User(nil), int64(0), errors.New("db error"))
 
-		result, err := svc.GetFollowers(1)
+		result, total, err := svc.GetFollowers(1, 20, 0)
 		assert.Error(t, err)
 		assert.Nil(t, result)
+		assert.Equal(t, int64(0), total)
 		repo.AssertExpectations(t)
 	})
 }
@@ -160,11 +164,12 @@ func TestFollowService_GetFollowing(t *testing.T) {
 		expected := []model.User{
 			{Name: "charlie"},
 		}
-		repo.On("GetFollowing", uint(1)).Return(expected, nil)
+		repo.On("GetFollowing", uint(1), 20, 0).Return(expected, int64(1), nil)
 
-		result, err := svc.GetFollowing(1)
+		result, total, err := svc.GetFollowing(1, 20, 0)
 		assert.NoError(t, err)
 		assert.Equal(t, expected, result)
+		assert.Equal(t, int64(1), total)
 		repo.AssertExpectations(t)
 	})
 
@@ -172,11 +177,12 @@ func TestFollowService_GetFollowing(t *testing.T) {
 		repo := new(MockFollowRepository)
 		svc := NewFollowService(repo)
 
-		repo.On("GetFollowing", uint(1)).Return([]model.User(nil), errors.New("db error"))
+		repo.On("GetFollowing", uint(1), 20, 0).Return([]model.User(nil), int64(0), errors.New("db error"))
 
-		result, err := svc.GetFollowing(1)
+		result, total, err := svc.GetFollowing(1, 20, 0)
 		assert.Error(t, err)
 		assert.Nil(t, result)
+		assert.Equal(t, int64(0), total)
 		repo.AssertExpectations(t)
 	})
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -245,14 +245,14 @@ func (m *MockFollowRepository) IsFollowing(followerID, followeeID uint) bool {
 	return args.Bool(0)
 }
 
-func (m *MockFollowRepository) GetFollowers(userID uint) ([]model.User, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.User), args.Error(1)
+func (m *MockFollowRepository) GetFollowers(userID uint, limit, offset int) ([]model.User, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.User), args.Get(1).(int64), args.Error(2)
 }
 
-func (m *MockFollowRepository) GetFollowing(userID uint) ([]model.User, error) {
-	args := m.Called(userID)
-	return args.Get(0).([]model.User), args.Error(1)
+func (m *MockFollowRepository) GetFollowing(userID uint, limit, offset int) ([]model.User, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.User), args.Get(1).(int64), args.Error(2)
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
Follow.GetFollowers/GetFollowingにページネーション（limit/offset/total）を追加。

## 変更内容
- repository層: GetFollowers/GetFollowingにlimit/offset追加、COUNT+LIMIT+OFFSETでページネーション
- service層: シグネチャ変更（limit, offset, total対応）
- handler層: parseLimitOffset利用、FollowListResponse DTOで返却
- dto層: FollowListResponse追加
- テスト: service/handler両層のモック・テストケースを更新

Closes #1101