### PR TITLE
test: handler層テストカバレッジ向上（86.7%→88.9%）

### DIFF
--- a/backend/internal/handler/project_test.go
+++ b/backend/internal/handler/project_test.go
@@ -249,3 +249,129 @@ func TestProjectGetAll_ServiceError(t *testing.T) {
 	assertStatus(t, w, 500)
 	svc.AssertExpectations(t)
 }
+
+// ---------- Create (日付付き) ----------
+
+func TestProjectCreate_WithDates(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("Create", mock.AnythingOfType("*model.Project")).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/projects", h.Create)
+	w := doRequest(r, "POST", "/projects", map[string]interface{}{
+		"title":      "日付付きプロジェクト",
+		"start_date": "2024-01-15",
+		"end_date":   "2024-06-30",
+	})
+
+	assertStatus(t, w, 201)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetByUserID (エラーパス) ----------
+
+func TestProjectGetByUserID_InvalidID(t *testing.T) {
+	h, _ := setupProjectHandler()
+
+	r := newRouter(1)
+	r.GET("/users/:userId/projects", h.GetByUserID)
+	w := doRequest(r, "GET", "/users/abc/projects", nil)
+
+	assertStatus(t, w, 400)
+}
+
+func TestProjectGetByUserID_ServiceError(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("GetByUserID", uint(1), 20, 0).Return([]model.Project(nil), int64(0), fmt.Errorf("db error"))
+
+	r := newRouter(1)
+	r.GET("/users/:userId/projects", h.GetByUserID)
+	w := doRequest(r, "GET", "/users/1/projects", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetFeatured (エラーパス) ----------
+
+func TestProjectGetFeatured_InvalidID(t *testing.T) {
+	h, _ := setupProjectHandler()
+
+	r := newRouter(1)
+	r.GET("/users/:userId/projects/featured", h.GetFeatured)
+	w := doRequest(r, "GET", "/users/abc/projects/featured", nil)
+
+	assertStatus(t, w, 400)
+}
+
+func TestProjectGetFeatured_ServiceError(t *testing.T) {
+	h, svc := setupProjectHandler()
+	svc.On("GetFeaturedByUserID", uint(1)).Return([]model.Project(nil), fmt.Errorf("db error"))
+
+	r := newRouter(1)
+	r.GET("/users/:userId/projects/featured", h.GetFeatured)
+	w := doRequest(r, "GET", "/users/1/projects/featured", nil)
+
+	assertStatus(t, w, 500)
+	svc.AssertExpectations(t)
+}
+
+// ---------- Update (エラーパス) ----------
+
+func TestProjectUpdate_InvalidID(t *testing.T) {
+	h, _ := setupProjectHandler()
+
+	r := newRouter(1)
+	r.PUT("/projects/:id", h.Update)
+	w := doRequest(r, "PUT", "/projects/abc", map[string]interface{}{"title": "t"})
+
+	assertStatus(t, w, 400)
+}
+
+func TestProjectUpdate_FeaturedError(t *testing.T) {
+	h, svc := setupProjectHandler()
+	updated := &model.Project{Title: "Updated"}
+	updated.ID = 1
+	svc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.Project")).Return(updated, nil)
+	svc.On("UpdateFeatured", uint(1), uint(1), true).Return(nil, service.ErrForbidden)
+
+	r := newRouter(1)
+	r.PUT("/projects/:id", h.Update)
+	w := doRequest(r, "PUT", "/projects/1", map[string]interface{}{
+		"title":    "Updated",
+		"featured": true,
+	})
+
+	assertStatus(t, w, 403)
+	svc.AssertExpectations(t)
+}
+
+func TestProjectUpdate_WithDates(t *testing.T) {
+	h, svc := setupProjectHandler()
+	updated := &model.Project{Title: "Updated"}
+	updated.ID = 1
+	svc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.Project")).Return(updated, nil)
+
+	r := newRouter(1)
+	r.PUT("/projects/:id", h.Update)
+	w := doRequest(r, "PUT", "/projects/1", map[string]interface{}{
+		"title":      "Updated",
+		"start_date": "2024-01-01",
+		"end_date":   "2024-12-31",
+	})
+
+	assertStatus(t, w, 200)
+	svc.AssertExpectations(t)
+}
+
+// ---------- Delete (エラーパス) ----------
+
+func TestProjectDelete_InvalidID(t *testing.T) {
+	h, _ := setupProjectHandler()
+
+	r := newRouter(1)
+	r.DELETE("/projects/:id", h.Delete)
+	w := doRequest(r, "DELETE", "/projects/abc", nil)
+
+	assertStatus(t, w, 400)
+}

--- a/backend/internal/handler/roadmap_test.go
+++ b/backend/internal/handler/roadmap_test.go
@@ -467,3 +467,177 @@ func TestRoadmapReorderSteps_ValidationError(t *testing.T) {
 	w := doRequest(r, http.MethodPut, "/roadmaps/10/steps/reorder", map[string]string{})
 	assertStatus(t, w, http.StatusBadRequest)
 }
+
+// ---------- CreateFromTemplate ----------
+
+func TestRoadmapCreateFromTemplate_Success(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.POST("/roadmaps/templates/:id/create", h.CreateFromTemplate)
+
+	roadmap := &model.Roadmap{Title: "From Template"}
+	roadmap.ID = 10
+	svc.On("CreateFromTemplate", uint(5), uint(1)).Return(roadmap, nil)
+
+	w := doRequest(r, http.MethodPost, "/roadmaps/templates/5/create", nil)
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestRoadmapCreateFromTemplate_InvalidID(t *testing.T) {
+	h, _ := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.POST("/roadmaps/templates/:id/create", h.CreateFromTemplate)
+
+	w := doRequest(r, http.MethodPost, "/roadmaps/templates/abc/create", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestRoadmapCreateFromTemplate_ServiceError(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.POST("/roadmaps/templates/:id/create", h.CreateFromTemplate)
+
+	svc.On("CreateFromTemplate", uint(5), uint(1)).Return(nil, service.ErrNotFound)
+
+	w := doRequest(r, http.MethodPost, "/roadmaps/templates/5/create", nil)
+	assertStatus(t, w, http.StatusNotFound)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetTemplates エラーパス ----------
+
+func TestRoadmapGetTemplates_ServiceError(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps/templates", h.GetTemplates)
+
+	svc.On("GetTemplates").Return([]model.Roadmap(nil), assert.AnError)
+
+	w := doRequest(r, http.MethodGet, "/roadmaps/templates", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetMyRoadmaps エラーパス ----------
+
+func TestRoadmapGetMy_ServiceError(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps", h.GetMyRoadmaps)
+
+	svc.On("GetByUserID", uint(1), 20, 0).Return([]model.Roadmap(nil), int64(0), assert.AnError)
+
+	w := doRequest(r, http.MethodGet, "/roadmaps", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ---------- GetPublicRoadmaps エラーパス ----------
+
+func TestRoadmapGetPublic_ServiceError(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps/public", h.GetPublicRoadmaps)
+
+	svc.On("GetPublicRoadmaps", 20, 0).Return([]model.Roadmap(nil), int64(0), assert.AnError)
+
+	w := doRequest(r, http.MethodGet, "/roadmaps/public", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ---------- UpdateStep (完了ステータスのみ) ----------
+
+func TestRoadmapUpdateStep_CompletionOnly(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.PUT("/roadmaps/:id/steps/:stepId", h.UpdateStep)
+
+	completed := true
+	step := &model.RoadmapStep{Title: "Step1"}
+	step.ID = 2
+	svc.On("UpdateStepCompletion", uint(1), uint(2), uint(1), completed).Return(step, nil)
+
+	w := doRequest(r, http.MethodPut, "/roadmaps/1/steps/2", map[string]interface{}{
+		"is_completed": true,
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestRoadmapUpdateStep_CompletionError(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.PUT("/roadmaps/:id/steps/:stepId", h.UpdateStep)
+
+	svc.On("UpdateStepCompletion", uint(1), uint(2), uint(1), true).Return(nil, service.ErrForbidden)
+
+	w := doRequest(r, http.MethodPut, "/roadmaps/1/steps/2", map[string]interface{}{
+		"is_completed": true,
+	})
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+// ---------- UpdateStep InvalidStepID ----------
+
+func TestRoadmapUpdateStep_InvalidStepID(t *testing.T) {
+	h, _ := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.PUT("/roadmaps/:id/steps/:stepId", h.UpdateStep)
+
+	w := doRequest(r, http.MethodPut, "/roadmaps/1/steps/abc", map[string]interface{}{
+		"title": "test",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ---------- DeleteStep InvalidStepID ----------
+
+func TestRoadmapDeleteStep_InvalidStepID(t *testing.T) {
+	h, _ := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.DELETE("/roadmaps/:id/steps/:stepId", h.DeleteStep)
+
+	w := doRequest(r, http.MethodDelete, "/roadmaps/1/steps/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ---------- CopyRoadmap InvalidID ----------
+
+func TestRoadmapCopy_InvalidID(t *testing.T) {
+	h, _ := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.POST("/roadmaps/:id/copy", h.CopyRoadmap)
+
+	w := doRequest(r, http.MethodPost, "/roadmaps/abc/copy", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ---------- CopyRoadmap ServiceError ----------
+
+func TestRoadmapCopy_ServiceError(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.POST("/roadmaps/:id/copy", h.CopyRoadmap)
+
+	svc.On("CopyRoadmap", uint(5), uint(1)).Return(nil, assert.AnError)
+
+	w := doRequest(r, http.MethodPost, "/roadmaps/5/copy", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ---------- ReorderSteps InvalidID ----------
+
+func TestRoadmapReorderSteps_InvalidID(t *testing.T) {
+	h, _ := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.PUT("/roadmaps/:id/steps/reorder", h.ReorderSteps)
+
+	w := doRequest(r, http.MethodPut, "/roadmaps/abc/steps/reorder", map[string]interface{}{
+		"orders": []map[string]interface{}{{"step_id": 1, "order_index": 0}},
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/search_test.go
+++ b/backend/internal/handler/search_test.go
@@ -182,3 +182,49 @@ func TestSearchCircles_EmptyQuery(t *testing.T) {
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
+
+func TestSearchPosts_ServiceError(t *testing.T) {
+	mockSvc := new(MockPostSearchService)
+	mockSvc.On("SearchPosts", mock.MatchedBy(func(p model.PostSearchParams) bool {
+		return p.Query == "error"
+	})).Return(nil, assert.AnError)
+
+	h := NewSearchHandler(mockSvc, nil)
+	r := newRouter(1)
+	r.GET("/search/posts", h.SearchPosts)
+
+	w := doRequest(r, "GET", "/search/posts?q=error", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	mockSvc.AssertExpectations(t)
+}
+
+func TestSearchCircles_ServiceError(t *testing.T) {
+	mockCircleSvc := new(MockCircleSearchService)
+	mockCircleSvc.On("SearchCircles", "error", 20, 0).Return(nil, int64(0), assert.AnError)
+
+	h := NewSearchHandler(nil, mockCircleSvc)
+	r := newRouter(1)
+	r.GET("/search/circles", h.SearchCircles)
+
+	w := doRequest(r, "GET", "/search/circles?q=error", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	mockCircleSvc.AssertExpectations(t)
+}
+
+func TestSearchPosts_WithDateRange(t *testing.T) {
+	mockSvc := new(MockPostSearchService)
+	mockSvc.On("SearchPosts", mock.MatchedBy(func(p model.PostSearchParams) bool {
+		return p.Query == "Go" && p.DateFrom != nil && p.DateTo != nil
+	})).Return(
+		&model.PostSearchResult{Posts: []model.Post{}, Total: 0, Limit: 20},
+		nil,
+	)
+
+	h := NewSearchHandler(mockSvc, nil)
+	r := newRouter(1)
+	r.GET("/search/posts", h.SearchPosts)
+
+	w := doRequest(r, "GET", "/search/posts?q=Go&date_from=2024-01-01&date_to=2024-12-31", nil)
+	assertStatus(t, w, http.StatusOK)
+	mockSvc.AssertExpectations(t)
+}

--- a/backend/internal/handler/user_test.go
+++ b/backend/internal/handler/user_test.go
@@ -216,4 +216,70 @@ func TestUserHandler_Update(t *testing.T) {
 		assertStatus(t, w, http.StatusNotFound)
 		svc.AssertExpectations(t)
 	})
+
+	t.Run("無効なIDの場合400を返す", func(t *testing.T) {
+		h, _ := newTestUserHandler()
+		r := newRouter(1)
+		r.PUT("/users/:id", h.Update)
+
+		w := doRequest(r, "PUT", "/users/abc", map[string]interface{}{"name": "テスト"})
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("不正なJSONで400を返す", func(t *testing.T) {
+		h, svc := newTestUserHandler()
+		r := newRouter(1)
+		r.PUT("/users/:id", h.Update)
+
+		existing := &model.User{ID: 1, Name: "旧名前"}
+		svc.On("GetByID", uint(1)).Return(existing, nil)
+
+		w := doRequestRaw(r, "PUT", "/users/1", "invalid json")
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("サービスエラー時に500を返す", func(t *testing.T) {
+		h, svc := newTestUserHandler()
+		r := newRouter(1)
+		r.PUT("/users/:id", h.Update)
+
+		existing := &model.User{ID: 1, Name: "旧名前"}
+		svc.On("GetByID", uint(1)).Return(existing, nil)
+		svc.On("Update", mock.AnythingOfType("*model.User")).Return(errors.New("db error"))
+
+		w := doRequest(r, "PUT", "/users/1", map[string]interface{}{"name": "新名前"})
+		assertStatus(t, w, http.StatusInternalServerError)
+		svc.AssertExpectations(t)
+	})
+}
+
+// ============================================================
+// GetProfileCompleteness テスト
+// ============================================================
+
+func TestUserHandler_GetProfileCompleteness(t *testing.T) {
+	t.Run("正常にプロフィール完成度を取得", func(t *testing.T) {
+		h, svc := newTestUserHandler()
+		r := newRouter(1)
+		r.GET("/users/me/completeness", h.GetProfileCompleteness)
+
+		result := &service.ProfileCompleteness{Percentage: 80}
+		svc.On("GetProfileCompleteness", uint(1)).Return(result, nil)
+
+		w := doRequest(r, "GET", "/users/me/completeness", nil)
+		assertStatus(t, w, http.StatusOK)
+		svc.AssertExpectations(t)
+	})
+
+	t.Run("サービスエラー時に500を返す", func(t *testing.T) {
+		h, svc := newTestUserHandler()
+		r := newRouter(1)
+		r.GET("/users/me/completeness", h.GetProfileCompleteness)
+
+		svc.On("GetProfileCompleteness", uint(1)).Return(nil, errors.New("db error"))
+
+		w := doRequest(r, "GET", "/users/me/completeness", nil)
+		assertStatus(t, w, http.StatusInternalServerError)
+		svc.AssertExpectations(t)
+	})
 }


### PR DESCRIPTION
## 概要
Closes #1105

handler層のテストカバレッジを86.7%から88.9%に向上。

## 追加テスト（計28件）
- **user_test.go** (5件): GetProfileCompleteness・Update追加エラーパス
- **project_test.go** (9件): parseDate・GetByUserID・GetFeatured・Update・Delete追加エラーパス
- **search_test.go** (3件): ServiceError・日付範囲フィルター
- **roadmap_test.go** (11件): CreateFromTemplate・GetTemplates・UpdateStep完了・InvalidIDエラーパス

## テスト結果
- 全handlerテストPASS
- カバレッジ: 86.7% → 88.9%