### PR TITLE
fix: LIKE/ILIKEクエリのSQLワイルドカード注入対策

### DIFF
--- a/backend/internal/repository/learning_resource.go
+++ b/backend/internal/repository/learning_resource.go
@@ -84,7 +84,7 @@ func (r *LearningResourceRepository) Search(query string, limit, offset int) ([]
 	var resources []model.LearningResource
 	var total int64
 
-	searchQuery := "%" + query + "%"
+	searchQuery := EscapeLikePattern(query)
 	dbQuery := r.db.Model(&model.LearningResource{}).
 		Where("is_public = ?", true).
 		Where("title ILIKE ? OR description ILIKE ? OR tags ILIKE ?", searchQuery, searchQuery, searchQuery)

--- a/backend/internal/repository/note.go
+++ b/backend/internal/repository/note.go
@@ -65,7 +65,7 @@ func (r *NoteRepository) Search(userID uint, query string, limit, offset int) ([
 	var notes []model.Note
 	var total int64
 
-	searchPattern := "%" + query + "%"
+	searchPattern := EscapeLikePattern(query)
 	db := r.db.Model(&model.Note{}).Preload("Folder").
 		Where("user_id = ? AND is_archived = ? AND (title LIKE ? OR content LIKE ?)", userID, false, searchPattern, searchPattern).
 		Order("updated_at DESC")

--- a/backend/internal/repository/note_folder_test.go
+++ b/backend/internal/repository/note_folder_test.go
@@ -80,9 +80,10 @@ func TestNoteFolderRepository_FindByUserID(t *testing.T) {
 	}
 
 	// 取得テスト
-	results, err := repo.FindByUserID(1)
+	results, total, err := repo.FindByUserID(1, 20, 0)
 	assert.NoError(t, err)
 	assert.Len(t, results, 2)
+	assert.Equal(t, int64(2), total)
 }
 
 func TestNoteFolderRepository_FindByParentID(t *testing.T) {

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -154,7 +154,7 @@ func (r *PostRepository) Search(query string, limit, offset int) (interface{}, i
 	var posts []model.Post
 	var total int64
 
-	searchPattern := "%" + query + "%"
+	searchPattern := EscapeLikePattern(query)
 	db := r.db.Preload("User").Preload("CodeSnippets").
 		Where("(title LIKE ? OR content LIKE ?) AND is_draft = ?", searchPattern, searchPattern, false).
 		Order("created_at DESC")
@@ -265,7 +265,7 @@ func (r *PostRepository) SearchWithFilter(
 	var posts []model.Post
 	var total int64
 
-	searchPattern := "%" + query + "%"
+	searchPattern := EscapeLikePattern(query)
 	db := r.db.Preload("User").Preload("CodeSnippets").
 		Where("(title LIKE ? OR content LIKE ?) AND is_draft = ?", searchPattern, searchPattern, false)
 

--- a/backend/internal/repository/question.go
+++ b/backend/internal/repository/question.go
@@ -40,7 +40,7 @@ func (r *QuestionRepository) FindAll(limit, offset int, tag string, sort string)
 	query := r.db.Model(&model.Question{})
 
 	if tag != "" {
-		query = query.Where("tags ILIKE ?", "%\""+tag+"\"%")
+		query = query.Where("tags ILIKE ?", "%\""+EscapeLikeChars(tag)+"\"%")
 	}
 
 	query.Count(&total)
@@ -67,7 +67,7 @@ func (r *QuestionRepository) Search(q string, limit, offset int) ([]model.Questi
 	var questions []model.Question
 	var total int64
 
-	searchQuery := "%" + q + "%"
+	searchQuery := EscapeLikePattern(q)
 	dbQuery := r.db.Model(&model.Question{}).
 		Where("title ILIKE ? OR body ILIKE ? OR tags ILIKE ?", searchQuery, searchQuery, searchQuery)
 

--- a/backend/internal/repository/search_helper.go
+++ b/backend/internal/repository/search_helper.go
@@ -1,0 +1,19 @@
+package repository
+
+import "strings"
+
+// EscapeLikeChars はLIKE/ILIKEクエリのワイルドカード文字（%, _, \）をエスケープする。
+// ラッピングなしのエスケープのみ。タグ検索など独自パターンを組み立てる場合に使用する。
+func EscapeLikeChars(query string) string {
+	query = strings.ReplaceAll(query, "\\", "\\\\")
+	query = strings.ReplaceAll(query, "%", "\\%")
+	query = strings.ReplaceAll(query, "_", "\\_")
+	return query
+}
+
+// EscapeLikePattern はLIKE/ILIKEクエリのワイルドカード文字（%, _, \）をエスケープし、
+// 部分一致検索パターンを生成する。ユーザー入力をそのままLIKEに渡すと
+// ワイルドカード注入のリスクがあるため、この関数でエスケープする。
+func EscapeLikePattern(query string) string {
+	return "%" + EscapeLikeChars(query) + "%"
+}

--- a/backend/internal/repository/search_helper_test.go
+++ b/backend/internal/repository/search_helper_test.go
@@ -1,0 +1,50 @@
+package repository
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEscapeLikeChars(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"通常の文字列", "Go言語", "Go言語"},
+		{"パーセント記号をエスケープ", "100%完了", "100\\%完了"},
+		{"アンダースコアをエスケープ", "user_name", "user\\_name"},
+		{"バックスラッシュをエスケープ", "path\\to", "path\\\\to"},
+		{"空文字列", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EscapeLikeChars(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestEscapeLikePattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"通常の検索クエリ", "Go言語", "%Go言語%"},
+		{"パーセント記号をエスケープ", "100%完了", "%100\\%完了%"},
+		{"アンダースコアをエスケープ", "user_name", "%user\\_name%"},
+		{"バックスラッシュをエスケープ", "path\\to", "%path\\\\to%"},
+		{"複数のワイルドカード", "%test_100%", "%\\%test\\_100\\%%"},
+		{"空文字列", "", "%%"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EscapeLikePattern(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/backend/internal/repository/study_circle.go
+++ b/backend/internal/repository/study_circle.go
@@ -291,7 +291,7 @@ func (r *StudyCircleRepository) Search(query string, limit, offset int) (interfa
 	var circles []model.StudyCircle
 	var total int64
 
-	searchPattern := "%" + query + "%"
+	searchPattern := EscapeLikePattern(query)
 	db := r.db.Preload("Owner").Preload("Members").Preload("Members.User").
 		Where("name LIKE ? OR topic LIKE ? OR description LIKE ?", searchPattern, searchPattern, searchPattern).
 		Order("created_at DESC")

--- a/backend/internal/repository/user.go
+++ b/backend/internal/repository/user.go
@@ -55,7 +55,8 @@ func (r *UserRepository) FindByUsername(username string) (*model.User, error) {
 // Search は名前またはメールアドレスでユーザーを検索する（最大50件）。
 func (r *UserRepository) Search(query string) ([]model.User, error) {
 	var users []model.User
-	result := r.db.Where("name ILIKE ? OR email ILIKE ?", "%"+query+"%", "%"+query+"%").Limit(50).Find(&users)
+	searchPattern := EscapeLikePattern(query)
+	result := r.db.Where("name ILIKE ? OR email ILIKE ?", searchPattern, searchPattern).Limit(50).Find(&users)
 	return users, result.Error
 }
 


### PR DESCRIPTION
## Summary
- `EscapeLikeChars`/`EscapeLikePattern`関数を作成し、LIKE/ILIKEクエリのワイルドカード文字をエスケープ
- 全9箇所（post, note, user, question, study_circle, learning_resource）に適用
- 11テストケース追加（EscapeLikeChars: 5件、EscapeLikePattern: 6件）

## Test plan
- [x] EscapeLikeChars/EscapeLikePatternユニットテスト全PASS
- [x] 全repository/handler/serviceテストPASS
- [x] ビルド成功

Closes #1107