### PR TITLE
feat: 投稿コンテンツからのハッシュタグ自動抽出機能

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -251,6 +251,7 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	postTagRepo := repository.NewPostTagRepository(db)
 	postTagService := service.NewPostTagService(postTagRepo, postRepo)
 	c.PostTagHandler = handler.NewPostTagHandler(postTagService)
+	c.PostHandler.SetTagService(postTagService)
 
 	postPinRepo := repository.NewPostPinRepository(db)
 	postPinService := service.NewPostPinService(postPinRepo, postRepo)

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -47,11 +47,18 @@ type CodeSnippetServiceInterface interface {
 type PostHandler struct {
 	service        PostServiceInterface
 	snippetService CodeSnippetServiceInterface
+	tagService     PostTagServiceInterface
 }
 
 // NewPostHandler は新しいPostHandlerインスタンスを生成する。
 func NewPostHandler(s PostServiceInterface, snippetService CodeSnippetServiceInterface) *PostHandler {
 	return &PostHandler{service: s, snippetService: snippetService}
+}
+
+// SetTagService はオプショナルなタグサービスを設定する。
+// 設定すると、投稿の作成・更新時にコンテンツからハッシュタグを自動抽出してタグを設定する。
+func (h *PostHandler) SetTagService(tagService PostTagServiceInterface) {
+	h.tagService = tagService
 }
 
 // Create は新しい投稿を作成する。
@@ -94,6 +101,11 @@ func (h *PostHandler) Create(c *gin.Context) {
 		if updated, err := h.service.GetByID(created.ID); err == nil {
 			created = updated
 		}
+	}
+
+	// コンテンツからハッシュタグを自動抽出してタグを設定
+	if h.tagService != nil {
+		_ = h.tagService.SetAutoTags(created.ID, userID, input.Content)
 	}
 
 	respondCreated(c, created)
@@ -157,6 +169,12 @@ func (h *PostHandler) Update(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
+
+	// コンテンツ更新時にハッシュタグを自動再抽出
+	if h.tagService != nil && input.Content != "" {
+		_ = h.tagService.SetAutoTags(id, userID, input.Content)
+	}
+
 	respondOK(c, post)
 }
 

--- a/backend/internal/handler/post_tag.go
+++ b/backend/internal/handler/post_tag.go
@@ -10,6 +10,7 @@ import (
 // PostTagServiceInterface はPostTagHandlerが依存するサービスインターフェース。
 type PostTagServiceInterface interface {
 	SetTags(postID, userID uint, tags []string) error
+	SetAutoTags(postID, userID uint, content string) error
 	GetByPostID(postID uint) ([]string, error)
 	FindPostsByTag(tag string, limit, offset int) ([]model.Post, int64, error)
 	GetPopularTags(limit int) ([]model.TagCount, error)

--- a/backend/internal/handler/post_tag_test.go
+++ b/backend/internal/handler/post_tag_test.go
@@ -16,6 +16,9 @@ type MockPostTagService struct{ mock.Mock }
 func (m *MockPostTagService) SetTags(postID, userID uint, tags []string) error {
 	return m.Called(postID, userID, tags).Error(0)
 }
+func (m *MockPostTagService) SetAutoTags(postID, userID uint, content string) error {
+	return m.Called(postID, userID, content).Error(0)
+}
 func (m *MockPostTagService) GetByPostID(postID uint) ([]string, error) {
 	args := m.Called(postID)
 	if v := args.Get(0); v != nil {

--- a/backend/internal/service/hashtag.go
+++ b/backend/internal/service/hashtag.go
@@ -1,0 +1,55 @@
+package service
+
+import (
+	"regexp"
+	"strings"
+)
+
+// maxHashtags は1コンテンツから抽出するハッシュタグの最大数。
+const maxHashtags = 10
+
+// hashtagRegex はテキスト中の #hashtag パターンを抽出する正規表現。
+// 英数字・アンダースコア・CJK文字に対応。URL中のフラグメントを除外するため、
+// #の前が英数字・スラッシュ・ドットでないことを確認する。
+var hashtagRegex = regexp.MustCompile(`(?:^|[^\w/.])(#([\p{L}\p{N}_][\p{L}\p{N}_]*))`)
+
+// codeBlockRegex はMarkdownコードブロック（```...```）にマッチする正規表現。
+var codeBlockRegex = regexp.MustCompile("(?s)```.*?```")
+
+// inlineCodeRegex はMarkdownインラインコード（`...`）にマッチする正規表現。
+var inlineCodeRegex = regexp.MustCompile("`[^`]+`")
+
+// ExtractHashtags はテキストからハッシュタグ（#tag）を重複なしで抽出する。
+// コードブロック・インラインコード内のタグ、URLフラグメント、1文字タグは除外する。
+// 大文字小文字を区別せずに重複排除し、最初の出現形を保持する。最大10個まで。
+func ExtractHashtags(content string) []string {
+	if content == "" {
+		return nil
+	}
+
+	// コードブロックとインラインコードを除去
+	cleaned := codeBlockRegex.ReplaceAllString(content, "")
+	cleaned = inlineCodeRegex.ReplaceAllString(cleaned, "")
+
+	matches := hashtagRegex.FindAllStringSubmatch(cleaned, -1)
+	seen := make(map[string]bool)
+	var tags []string
+
+	for _, match := range matches {
+		tag := match[2]
+		// 1文字のタグは無視
+		if len([]rune(tag)) < 2 {
+			continue
+		}
+		lower := strings.ToLower(tag)
+		if !seen[lower] {
+			seen[lower] = true
+			tags = append(tags, tag)
+			if len(tags) >= maxHashtags {
+				break
+			}
+		}
+	}
+
+	return tags
+}

--- a/backend/internal/service/hashtag_test.go
+++ b/backend/internal/service/hashtag_test.go
@@ -1,0 +1,91 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractHashtags_SingleTag(t *testing.T) {
+	result := ExtractHashtags("今日は #golang を学んだ")
+	assert.Equal(t, []string{"golang"}, result)
+}
+
+func TestExtractHashtags_MultipleTags(t *testing.T) {
+	result := ExtractHashtags("#React と #TypeScript でアプリを作成")
+	assert.Equal(t, []string{"React", "TypeScript"}, result)
+}
+
+func TestExtractHashtags_JapaneseTags(t *testing.T) {
+	result := ExtractHashtags("#Go言語 を使って #Web開発 を学習中")
+	assert.Equal(t, []string{"Go言語", "Web開発"}, result)
+}
+
+func TestExtractHashtags_Deduplication(t *testing.T) {
+	result := ExtractHashtags("#golang は素晴らしい。#golang が好き")
+	assert.Equal(t, []string{"golang"}, result)
+}
+
+func TestExtractHashtags_CasePreserved(t *testing.T) {
+	result := ExtractHashtags("#TypeScript と #typescript")
+	// 大文字小文字を区別せず重複排除（最初の出現を保持）
+	assert.Len(t, result, 1)
+	assert.Equal(t, "TypeScript", result[0])
+}
+
+func TestExtractHashtags_IgnoreInCodeBlock(t *testing.T) {
+	content := "本文 #validTag\n```\n#notATag\nfmt.Println(\"hello\")\n```\n#anotherTag"
+	result := ExtractHashtags(content)
+	assert.Equal(t, []string{"validTag", "anotherTag"}, result)
+}
+
+func TestExtractHashtags_IgnoreInInlineCode(t *testing.T) {
+	content := "これは `#notATag` ではなく #realTag です"
+	result := ExtractHashtags(content)
+	assert.Equal(t, []string{"realTag"}, result)
+}
+
+func TestExtractHashtags_IgnoreURLFragments(t *testing.T) {
+	content := "https://example.com/page#section は参照です #validTag"
+	result := ExtractHashtags(content)
+	assert.Equal(t, []string{"validTag"}, result)
+}
+
+func TestExtractHashtags_EmptyContent(t *testing.T) {
+	result := ExtractHashtags("")
+	assert.Empty(t, result)
+}
+
+func TestExtractHashtags_NoHashtags(t *testing.T) {
+	result := ExtractHashtags("ハッシュタグなしの通常テキスト")
+	assert.Empty(t, result)
+}
+
+func TestExtractHashtags_MaxLimit(t *testing.T) {
+	// 最大10個まで抽出
+	content := "#a1 #a2 #a3 #a4 #a5 #a6 #a7 #a8 #a9 #a10 #a11 #a12"
+	result := ExtractHashtags(content)
+	assert.Len(t, result, 10)
+}
+
+func TestExtractHashtags_MinLength(t *testing.T) {
+	// 1文字のタグは無視
+	content := "#a #ab #abc"
+	result := ExtractHashtags(content)
+	assert.Equal(t, []string{"ab", "abc"}, result)
+}
+
+func TestExtractHashtags_HashOnly(t *testing.T) {
+	result := ExtractHashtags("# だけ")
+	assert.Empty(t, result)
+}
+
+func TestExtractHashtags_TagAtStartOfLine(t *testing.T) {
+	result := ExtractHashtags("#開発日記\n今日の成果")
+	assert.Equal(t, []string{"開発日記"}, result)
+}
+
+func TestExtractHashtags_TagWithNumbers(t *testing.T) {
+	result := ExtractHashtags("#100DaysOfCode チャレンジ中")
+	assert.Equal(t, []string{"100DaysOfCode"}, result)
+}

--- a/backend/internal/service/post_tag.go
+++ b/backend/internal/service/post_tag.go
@@ -56,6 +56,16 @@ func (s *PostTagService) GetPopularTags(limit int) ([]model.TagCount, error) {
 	return s.tagRepo.GetPopularTags(limit)
 }
 
+// SetAutoTags はコンテンツからハッシュタグを自動抽出し、投稿のタグとして設定する。
+// ハッシュタグが見つからない場合は何もしない。
+func (s *PostTagService) SetAutoTags(postID, userID uint, content string) error {
+	tags := ExtractHashtags(content)
+	if len(tags) == 0 {
+		return nil
+	}
+	return s.SetTags(postID, userID, tags)
+}
+
 // normalizeTags はタグを正規化する（小文字変換・トリム・空文字除外・重複除外）。
 func normalizeTags(tags []string) []string {
 	seen := make(map[string]bool)

--- a/backend/internal/service/post_tag_test.go
+++ b/backend/internal/service/post_tag_test.go
@@ -222,3 +222,66 @@ func TestPostTagGetPopularTags_Error(t *testing.T) {
 	assert.Empty(t, result)
 	tagRepo.AssertExpectations(t)
 }
+
+// ============================================================
+// SetAutoTags（コンテンツからハッシュタグ自動抽出・設定）
+// ============================================================
+
+func TestPostTagSetAutoTags_ExtractsAndSets(t *testing.T) {
+	svc, tagRepo, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+	tagRepo.On("SetTags", uint(10), []string{"golang", "react"}).Return(nil)
+
+	err := svc.SetAutoTags(10, 1, "今日は #golang と #React を学んだ")
+	assert.NoError(t, err)
+	tagRepo.AssertExpectations(t)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostTagSetAutoTags_NoHashtags(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	// ハッシュタグがない場合はSetTagsを呼ばない
+	err := svc.SetAutoTags(10, 1, "ハッシュタグなしの通常テキスト")
+	assert.NoError(t, err)
+	tagRepo.AssertNotCalled(t, "SetTags")
+}
+
+func TestPostTagSetAutoTags_IgnoresCodeBlocks(t *testing.T) {
+	svc, tagRepo, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+	tagRepo.On("SetTags", uint(10), []string{"validtag"}).Return(nil)
+
+	content := "#validTag を紹介\n```\n#notATag\n```"
+	err := svc.SetAutoTags(10, 1, content)
+	assert.NoError(t, err)
+	tagRepo.AssertExpectations(t)
+}
+
+func TestPostTagSetAutoTags_Forbidden(t *testing.T) {
+	svc, _, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	err := svc.SetAutoTags(10, 999, "#golang を学んだ")
+	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+func TestPostTagSetAutoTags_EmptyContent(t *testing.T) {
+	svc, tagRepo, _ := newTestPostTagService()
+
+	err := svc.SetAutoTags(10, 1, "")
+	assert.NoError(t, err)
+	tagRepo.AssertNotCalled(t, "SetTags")
+}


### PR DESCRIPTION
## Summary
- `ExtractHashtags` 純粋関数: 投稿本文から `#hashtag` を自動抽出（コードブロック・URL除外・日本語対応・最大10個）
- `PostTagService.SetAutoTags`: 抽出したタグをPostTagとして設定するサービスメソッド
- `PostHandler` のCreate/Updateで自動呼び出し（オプショナル依存）
- 20テストケース追加（ExtractHashtags: 15件、SetAutoTags: 5件）

## Test plan
- [x] ExtractHashtags全15テストPASS
- [x] SetAutoTags全5テストPASS
- [x] 全handler/serviceテストPASS
- [x] ビルド成功

Closes #1109