### PR TITLE
refactor: Search メソッドの interface{} 型を具象型に変更

### DIFF
--- a/backend/internal/handler/search.go
+++ b/backend/internal/handler/search.go
@@ -16,7 +16,7 @@ type PostSearchService interface {
 // CircleSearchService はスタディサークル検索のサービスインターフェース。
 // Service 層を経由することでクリーンアーキテクチャを維持する。
 type CircleSearchService interface {
-	SearchCircles(query string, limit, offset int) (interface{}, int64, error)
+	SearchCircles(query string, limit, offset int) ([]model.StudyCircle, int64, error)
 }
 
 // SearchHandler is the handler for search operations

--- a/backend/internal/handler/search_test.go
+++ b/backend/internal/handler/search_test.go
@@ -30,9 +30,12 @@ type MockCircleSearchService struct {
 	mock.Mock
 }
 
-func (m *MockCircleSearchService) SearchCircles(query string, limit, offset int) (interface{}, int64, error) {
+func (m *MockCircleSearchService) SearchCircles(query string, limit, offset int) ([]model.StudyCircle, int64, error) {
 	args := m.Called(query, limit, offset)
-	return args.Get(0), args.Get(1).(int64), args.Error(2)
+	if v := args.Get(0); v != nil {
+		return v.([]model.StudyCircle), args.Get(1).(int64), args.Error(2)
+	}
+	return nil, args.Get(1).(int64), args.Error(2)
 }
 
 func TestSearchPosts_Success(t *testing.T) {

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -702,9 +702,12 @@ func (m *MockStudyCircleRepository) GetStreakRanking(circleID uint) ([]model.Cir
 	args := m.Called(circleID)
 	return args.Get(0).([]model.CircleMemberStreak), args.Error(1)
 }
-func (m *MockStudyCircleRepository) Search(query string, limit, offset int) (interface{}, int64, error) {
+func (m *MockStudyCircleRepository) Search(query string, limit, offset int) ([]model.StudyCircle, int64, error) {
 	args := m.Called(query, limit, offset)
-	return args.Get(0), args.Get(1).(int64), args.Error(2)
+	if v := args.Get(0); v != nil {
+		return v.([]model.StudyCircle), args.Get(1).(int64), args.Error(2)
+	}
+	return nil, args.Get(1).(int64), args.Error(2)
 }
 func (m *MockStudyCircleRepository) GetByStatus(userID uint, status string) ([]model.StudyCircle, error) {
 	args := m.Called(userID, status)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -393,7 +393,7 @@ type StudyCircleRepositoryInterface interface {
 	GetByStatus(userID uint, status string) ([]model.StudyCircle, error)
 
 	// 検索
-	Search(query string, limit, offset int) (interface{}, int64, error)
+	Search(query string, limit, offset int) ([]model.StudyCircle, int64, error)
 
 	// メンバー管理
 	AddMember(circleID, userID uint, role model.StudyCircleMemberRole) error

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -150,7 +150,7 @@ func (r *PostRepository) DeleteComment(id uint) error {
 }
 
 // Search はキーワードで投稿を検索する（タイトルまたは本文に部分一致）。下書きは除外。
-func (r *PostRepository) Search(query string, limit, offset int) (interface{}, int64, error) {
+func (r *PostRepository) Search(query string, limit, offset int) ([]model.Post, int64, error) {
 	var posts []model.Post
 	var total int64
 

--- a/backend/internal/repository/study_circle.go
+++ b/backend/internal/repository/study_circle.go
@@ -287,7 +287,7 @@ func calculateCheckinStreak(dates []string) int {
 }
 
 // Search はキーワードでスタディサークルを検索する（名前、トピック、説明に部分一致）。
-func (r *StudyCircleRepository) Search(query string, limit, offset int) (interface{}, int64, error) {
+func (r *StudyCircleRepository) Search(query string, limit, offset int) ([]model.StudyCircle, int64, error) {
 	var circles []model.StudyCircle
 	var total int64
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1481,9 +1481,12 @@ func (m *MockStudyCircleRepository) GetStreakRanking(circleID uint) ([]model.Cir
 	return args.Get(0).([]model.CircleMemberStreak), args.Error(1)
 }
 
-func (m *MockStudyCircleRepository) Search(query string, limit, offset int) (interface{}, int64, error) {
+func (m *MockStudyCircleRepository) Search(query string, limit, offset int) ([]model.StudyCircle, int64, error) {
 	args := m.Called(query, limit, offset)
-	return args.Get(0), args.Get(1).(int64), args.Error(2)
+	if v := args.Get(0); v != nil {
+		return v.([]model.StudyCircle), args.Get(1).(int64), args.Error(2)
+	}
+	return nil, args.Get(1).(int64), args.Error(2)
 }
 
 func (m *MockStudyCircleRepository) GetByStatus(userID uint, status string) ([]model.StudyCircle, error) {

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -351,6 +351,6 @@ func (s *StudyCircleService) GetStreakRanking(circleID, userID uint) ([]model.Ci
 }
 
 // SearchCircles はキーワードでスタディサークルを検索する。
-func (s *StudyCircleService) SearchCircles(query string, limit, offset int) (interface{}, int64, error) {
+func (s *StudyCircleService) SearchCircles(query string, limit, offset int) ([]model.StudyCircle, int64, error) {
 	return s.repo.Search(query, limit, offset)
 }

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -826,9 +826,7 @@ func TestSearchCircles_Success(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(2), total)
-	circles, ok := result.([]model.StudyCircle)
-	assert.True(t, ok)
-	assert.Len(t, circles, 2)
+	assert.Len(t, result, 2)
 	repo.AssertExpectations(t)
 }
 
@@ -841,9 +839,7 @@ func TestSearchCircles_EmptyResult(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, int64(0), total)
-	circles, ok := result.([]model.StudyCircle)
-	assert.True(t, ok)
-	assert.Len(t, circles, 0)
+	assert.Len(t, result, 0)
 }
 
 func TestSearchCircles_RepoError(t *testing.T) {


### PR DESCRIPTION
## 概要
Closes #1111

repository/service/handler 各層の Search メソッドの戻り値型を `interface{}` から具象型に変更し、型安全性を向上。

## 変更内容
- `PostRepository.Search` → `[]model.Post`
- `StudyCircleRepository.Search` → `[]model.StudyCircle`
- 対応するインターフェース・サービス・ハンドラーの戻り値型を統一
- モック・テストコード（5ファイル）を更新

## テスト
- `go test ./internal/... ` 全テストPASS