### PR TITLE
fix: リクエストボディサイズ制限ミドルウェアを追加

### DIFF
--- a/backend/internal/middleware/body_limit.go
+++ b/backend/internal/middleware/body_limit.go
@@ -1,0 +1,32 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// BodyLimit はリクエストボディのサイズを制限するミドルウェアを返す。
+// maxBytes を超えるボディを持つリクエストは 413 Request Entity Too Large で拒否される。
+// GET/HEAD/OPTIONS などボディを持たないメソッドはスキップする。
+func BodyLimit(maxBytes int64) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if c.Request.Body == nil || c.Request.Method == "GET" ||
+			c.Request.Method == "HEAD" || c.Request.Method == "OPTIONS" {
+			c.Next()
+			return
+		}
+
+		// Content-Lengthヘッダーによる早期チェック
+		if c.Request.ContentLength > maxBytes {
+			c.AbortWithStatusJSON(http.StatusRequestEntityTooLarge, gin.H{
+				"error": "リクエストボディが大きすぎます",
+			})
+			return
+		}
+
+		// ボディを制限付きリーダーで置き換え
+		c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxBytes)
+		c.Next()
+	}
+}

--- a/backend/internal/middleware/body_limit_test.go
+++ b/backend/internal/middleware/body_limit_test.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	gin.SetMode(gin.TestMode)
+}
+
+func setupBodyLimitRouter(limit int64) *gin.Engine {
+	r := gin.New()
+	r.Use(BodyLimit(limit))
+	r.POST("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+	return r
+}
+
+func TestBodyLimit_AllowsSmallBody(t *testing.T) {
+	r := setupBodyLimitRouter(1024) // 1KB
+
+	body := bytes.NewBufferString(`{"name":"test"}`)
+	req := httptest.NewRequest("POST", "/test", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestBodyLimit_RejectsLargeBody(t *testing.T) {
+	r := setupBodyLimitRouter(100) // 100バイト制限
+
+	// 200バイトのボディを送信
+	body := bytes.NewBufferString(strings.Repeat("a", 200))
+	req := httptest.NewRequest("POST", "/test", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}
+
+func TestBodyLimit_AllowsExactLimitSize(t *testing.T) {
+	r := setupBodyLimitRouter(50)
+
+	body := bytes.NewBufferString(strings.Repeat("a", 50))
+	req := httptest.NewRequest("POST", "/test", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestBodyLimit_AllowsGetRequests(t *testing.T) {
+	r := gin.New()
+	r.Use(BodyLimit(10)) // 極小制限
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
+	req := httptest.NewRequest("GET", "/test", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestBodyLimit_AllowsEmptyBody(t *testing.T) {
+	r := setupBodyLimitRouter(100)
+
+	req := httptest.NewRequest("POST", "/test", nil)
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestBodyLimit_RejectsBasedOnContentLength(t *testing.T) {
+	r := setupBodyLimitRouter(100)
+
+	body := bytes.NewBufferString(`{"data":"test"}`)
+	req := httptest.NewRequest("POST", "/test", body)
+	req.Header.Set("Content-Type", "application/json")
+	req.ContentLength = 200 // 実際のボディより大きいContent-Lengthヘッダー
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusRequestEntityTooLarge, w.Code)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -32,6 +32,9 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		AllowCredentials: true,
 	}))
 
+	// リクエストボディサイズ制限（1MB: JSON API用）
+	r.Use(middleware.BodyLimit(1 << 20))
+
 	// セキュリティヘッダー（全エンドポイント）
 	r.Use(func(ctx *gin.Context) {
 		ctx.Header("X-Content-Type-Options", "nosniff")
@@ -267,6 +270,7 @@ func registerMessageRoutes(g *gin.RouterGroup, c *di.Container) {
 
 func registerUploadRoutes(g *gin.RouterGroup, c *di.Container) {
 	upload := g.Group("/upload")
+	upload.Use(middleware.BodyLimit(10 << 20)) // 10MB: ファイルアップロード用
 	{
 		upload.POST("/image", c.UploadHandler.UploadImage)
 		upload.POST("/images", c.UploadHandler.UploadMultipleImages)


### PR DESCRIPTION
## 概要
Closes #1115

DoS攻撃対策としてリクエストボディサイズ制限ミドルウェアを導入。

## 変更内容
- `middleware/body_limit.go` — BodyLimit ミドルウェア新規作成
- `router/router.go` — 全エンドポイントに1MB制限、アップロードに10MB制限
- `middleware/body_limit_test.go` — 6テスト追加

## テスト
- `go test ./internal/...` 全テストPASS