### PR TITLE
feat: ノートリンク統計（GetLinkStats）機能を追加

### DIFF
--- a/backend/internal/handler/note_link.go
+++ b/backend/internal/handler/note_link.go
@@ -13,6 +13,7 @@ type NoteLinkServiceInterface interface {
 	GetLinks(sourceNoteID uint) ([]model.NoteLink, error)
 	GetBacklinks(targetNoteID uint) ([]model.NoteLink, error)
 	DeleteLink(sourceNoteID, targetNoteID, userID uint) error
+	GetLinkStats(noteID, userID uint) (*model.NoteLinkStats, error)
 }
 
 // NoteLinkHandler はノート間リンク関連のHTTPハンドラ。
@@ -77,6 +78,24 @@ func (h *NoteLinkHandler) GetBacklinks(c *gin.Context) {
 	}
 
 	respondOK(c, ensureSlice(backlinks))
+}
+
+// GetLinkStats はノートのリンク統計を取得する。
+func (h *NoteLinkHandler) GetLinkStats(c *gin.Context) {
+	noteID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	userID := c.GetUint("userID")
+
+	stats, err := h.service.GetLinkStats(noteID, userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
 }
 
 // DeleteLink はリンクを削除する。

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1677,6 +1677,13 @@ func (m *MockNoteLinkService) GetBacklinks(targetNoteID uint) ([]model.NoteLink,
 func (m *MockNoteLinkService) DeleteLink(sourceNoteID, targetNoteID, userID uint) error {
 	return m.Called(sourceNoteID, targetNoteID, userID).Error(0)
 }
+func (m *MockNoteLinkService) GetLinkStats(noteID, userID uint) (*model.NoteLinkStats, error) {
+	args := m.Called(noteID, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.NoteLinkStats), args.Error(1)
+}
 
 func setupNoteLinkHandler() (*NoteLinkHandler, *MockNoteLinkService) {
 	svc := new(MockNoteLinkService)

--- a/backend/internal/model/note_link.go
+++ b/backend/internal/model/note_link.go
@@ -12,3 +12,10 @@ type NoteLink struct {
 	TargetNote   *Note     `gorm:"foreignKey:TargetNoteID" json:"target_note,omitempty"`
 	CreatedAt    time.Time `json:"created_at"`
 }
+
+// NoteLinkStats はノートのリンク統計情報を表す。
+type NoteLinkStats struct {
+	NoteID           uint  `json:"note_id"`
+	ForwardLinkCount int64 `json:"forward_link_count"`
+	BacklinkCount    int64 `json:"backlink_count"`
+}

--- a/backend/internal/repository/note_link.go
+++ b/backend/internal/repository/note_link.go
@@ -56,3 +56,17 @@ func (r *NoteLinkRepository) Exists(sourceNoteID, targetNoteID uint) (bool, erro
 		Count(&count).Error
 	return count > 0, err
 }
+
+// CountBySourceNoteID は指定ノートからのリンク数を返す。
+func (r *NoteLinkRepository) CountBySourceNoteID(noteID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.NoteLink{}).Where("source_note_id = ?", noteID).Count(&count).Error
+	return count, err
+}
+
+// CountByTargetNoteID は指定ノートへのリンク数（バックリンク数）を返す。
+func (r *NoteLinkRepository) CountByTargetNoteID(noteID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.NoteLink{}).Where("target_note_id = ?", noteID).Count(&count).Error
+	return count, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -409,6 +409,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		notes.POST("/:id/links", c.NoteLinkHandler.CreateLink)
 		notes.GET("/:id/links", c.NoteLinkHandler.GetLinks)
 		notes.GET("/:id/backlinks", c.NoteLinkHandler.GetBacklinks)
+		notes.GET("/:id/link-stats", c.NoteLinkHandler.GetLinkStats)
 		notes.DELETE("/:id/links/:targetId", c.NoteLinkHandler.DeleteLink)
 	}
 

--- a/backend/internal/service/note_link.go
+++ b/backend/internal/service/note_link.go
@@ -13,6 +13,8 @@ type NoteLinkRepositoryInterface interface {
 	FindByTargetNoteID(targetNoteID uint) ([]model.NoteLink, error)
 	Delete(sourceNoteID, targetNoteID uint) error
 	Exists(sourceNoteID, targetNoteID uint) (bool, error)
+	CountBySourceNoteID(noteID uint) (int64, error)
+	CountByTargetNoteID(noteID uint) (int64, error)
 }
 
 // NoteLinkService はノート間リンクのビジネスロジック。
@@ -92,4 +94,32 @@ func (s *NoteLinkService) DeleteLink(sourceNoteID, targetNoteID, userID uint) er
 		return err
 	}
 	return s.repo.Delete(sourceNoteID, targetNoteID)
+}
+
+// GetLinkStats はノートのリンク統計（フォワードリンク数・バックリンク数）を返す。
+// ノートの所有者のみ取得可能。
+func (s *NoteLinkService) GetLinkStats(noteID, userID uint) (*model.NoteLinkStats, error) {
+	note, err := s.noteRepo.FindByID(noteID)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+	if note.UserID != userID {
+		return nil, ErrForbidden
+	}
+
+	forwardCount, err := s.repo.CountBySourceNoteID(noteID)
+	if err != nil {
+		return nil, err
+	}
+
+	backlinkCount, err := s.repo.CountByTargetNoteID(noteID)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.NoteLinkStats{
+		NoteID:           noteID,
+		ForwardLinkCount: forwardCount,
+		BacklinkCount:    backlinkCount,
+	}, nil
 }

--- a/backend/internal/service/note_link_test.go
+++ b/backend/internal/service/note_link_test.go
@@ -37,6 +37,16 @@ func (m *MockNoteLinkRepository) Exists(sourceNoteID, targetNoteID uint) (bool, 
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockNoteLinkRepository) CountBySourceNoteID(noteID uint) (int64, error) {
+	args := m.Called(noteID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
+func (m *MockNoteLinkRepository) CountByTargetNoteID(noteID uint) (int64, error) {
+	args := m.Called(noteID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // newTestNoteLinkService はテスト用のNoteLinkServiceを生成する。
 func newTestNoteLinkService() (*NoteLinkService, *MockNoteLinkRepository, *MockNoteRepository) {
 	linkRepo := new(MockNoteLinkRepository)
@@ -279,4 +289,91 @@ func TestNoteLinkService_DeleteLink_Error(t *testing.T) {
 	assert.Error(t, err)
 	linkRepo.AssertExpectations(t)
 	noteRepo.AssertExpectations(t)
+}
+
+// ============================================================
+// GetLinkStats テスト
+// ============================================================
+
+func TestNoteLinkService_GetLinkStats_Success(t *testing.T) {
+	svc, linkRepo, noteRepo := newTestNoteLinkService()
+
+	note := &model.Note{ID: 1, UserID: 1, Title: "マイノート"}
+	noteRepo.On("FindByID", uint(1)).Return(note, nil)
+	linkRepo.On("CountBySourceNoteID", uint(1)).Return(int64(3), nil)
+	linkRepo.On("CountByTargetNoteID", uint(1)).Return(int64(5), nil)
+
+	stats, err := svc.GetLinkStats(1, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(1), stats.NoteID)
+	assert.Equal(t, int64(3), stats.ForwardLinkCount)
+	assert.Equal(t, int64(5), stats.BacklinkCount)
+	linkRepo.AssertExpectations(t)
+	noteRepo.AssertExpectations(t)
+}
+
+func TestNoteLinkService_GetLinkStats_ZeroLinks(t *testing.T) {
+	svc, linkRepo, noteRepo := newTestNoteLinkService()
+
+	note := &model.Note{ID: 1, UserID: 1, Title: "リンクなしノート"}
+	noteRepo.On("FindByID", uint(1)).Return(note, nil)
+	linkRepo.On("CountBySourceNoteID", uint(1)).Return(int64(0), nil)
+	linkRepo.On("CountByTargetNoteID", uint(1)).Return(int64(0), nil)
+
+	stats, err := svc.GetLinkStats(1, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), stats.ForwardLinkCount)
+	assert.Equal(t, int64(0), stats.BacklinkCount)
+	linkRepo.AssertExpectations(t)
+}
+
+func TestNoteLinkService_GetLinkStats_NoteNotFound(t *testing.T) {
+	svc, _, noteRepo := newTestNoteLinkService()
+
+	noteRepo.On("FindByID", uint(999)).Return((*model.Note)(nil), errors.New("not found"))
+
+	stats, err := svc.GetLinkStats(999, 1)
+	assert.Error(t, err)
+	assert.Nil(t, stats)
+	noteRepo.AssertExpectations(t)
+}
+
+func TestNoteLinkService_GetLinkStats_Forbidden(t *testing.T) {
+	svc, _, noteRepo := newTestNoteLinkService()
+
+	note := &model.Note{ID: 1, UserID: 99, Title: "他ユーザーのノート"}
+	noteRepo.On("FindByID", uint(1)).Return(note, nil)
+
+	stats, err := svc.GetLinkStats(1, 1)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrForbidden)
+	assert.Nil(t, stats)
+	noteRepo.AssertExpectations(t)
+}
+
+func TestNoteLinkService_GetLinkStats_CountForwardError(t *testing.T) {
+	svc, linkRepo, noteRepo := newTestNoteLinkService()
+
+	note := &model.Note{ID: 1, UserID: 1, Title: "マイノート"}
+	noteRepo.On("FindByID", uint(1)).Return(note, nil)
+	linkRepo.On("CountBySourceNoteID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	stats, err := svc.GetLinkStats(1, 1)
+	assert.Error(t, err)
+	assert.Nil(t, stats)
+	linkRepo.AssertExpectations(t)
+}
+
+func TestNoteLinkService_GetLinkStats_CountBacklinkError(t *testing.T) {
+	svc, linkRepo, noteRepo := newTestNoteLinkService()
+
+	note := &model.Note{ID: 1, UserID: 1, Title: "マイノート"}
+	noteRepo.On("FindByID", uint(1)).Return(note, nil)
+	linkRepo.On("CountBySourceNoteID", uint(1)).Return(int64(3), nil)
+	linkRepo.On("CountByTargetNoteID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	stats, err := svc.GetLinkStats(1, 1)
+	assert.Error(t, err)
+	assert.Nil(t, stats)
+	linkRepo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
Closes #1117

ノートのフォワードリンク数・バックリンク数を取得するAPIを追加。

## 変更内容
- `GET /api/v1/notes/:id/link-stats` エンドポイント新規追加
- model → repository → service → handler の全層実装
- TDDで6テストケース作成・全PASS

## レスポンス例
```json
{
  "note_id": 1,
  "forward_link_count": 3,
  "backlink_count": 5
}
```

## テスト
- `go test ./internal/...` 全テストPASS