### PR TITLE
refactor: 時間計算ヘルパー関数を domain 層に集約

### DIFF
--- a/backend/internal/domain/timeutil.go
+++ b/backend/internal/domain/timeutil.go
@@ -1,0 +1,24 @@
+package domain
+
+import "time"
+
+// StartOfMonth は指定時刻が属する月の1日 00:00:00 を返す。
+func StartOfMonth(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), 1, 0, 0, 0, 0, t.Location())
+}
+
+// StartOfWeek は指定時刻が属する週の月曜日 00:00:00 を返す。
+func StartOfWeek(t time.Time) time.Time {
+	weekday := t.Weekday()
+	if weekday == time.Sunday {
+		weekday = 7
+	}
+	daysBack := int(weekday) - int(time.Monday)
+	monday := t.AddDate(0, 0, -daysBack)
+	return time.Date(monday.Year(), monday.Month(), monday.Day(), 0, 0, 0, 0, t.Location())
+}
+
+// DaysAgo は指定時刻から n 日前の時刻を返す。
+func DaysAgo(t time.Time, n int) time.Time {
+	return t.AddDate(0, 0, -n)
+}

--- a/backend/internal/domain/timeutil_test.go
+++ b/backend/internal/domain/timeutil_test.go
@@ -1,0 +1,84 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStartOfMonth(t *testing.T) {
+	// 2024年3月15日のケース
+	input := time.Date(2024, 3, 15, 14, 30, 0, 0, time.UTC)
+	result := StartOfMonth(input)
+
+	assert.Equal(t, 2024, result.Year())
+	assert.Equal(t, time.March, result.Month())
+	assert.Equal(t, 1, result.Day())
+	assert.Equal(t, 0, result.Hour())
+	assert.Equal(t, 0, result.Minute())
+	assert.Equal(t, 0, result.Second())
+}
+
+func TestStartOfMonth_FirstDay(t *testing.T) {
+	// 月初の場合もそのまま月初を返す
+	input := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	result := StartOfMonth(input)
+
+	assert.Equal(t, 2024, result.Year())
+	assert.Equal(t, time.January, result.Month())
+	assert.Equal(t, 1, result.Day())
+}
+
+func TestStartOfMonth_LastDay(t *testing.T) {
+	// 月末の場合
+	input := time.Date(2024, 2, 29, 23, 59, 59, 0, time.UTC)
+	result := StartOfMonth(input)
+
+	assert.Equal(t, 2024, result.Year())
+	assert.Equal(t, time.February, result.Month())
+	assert.Equal(t, 1, result.Day())
+}
+
+func TestStartOfWeek_Wednesday(t *testing.T) {
+	// 水曜日の場合 → 月曜日を返す
+	wednesday := time.Date(2024, 3, 13, 14, 30, 0, 0, time.UTC) // 水曜
+	result := StartOfWeek(wednesday)
+
+	assert.Equal(t, 2024, result.Year())
+	assert.Equal(t, time.March, result.Month())
+	assert.Equal(t, 11, result.Day()) // 月曜
+	assert.Equal(t, 0, result.Hour())
+}
+
+func TestStartOfWeek_Monday(t *testing.T) {
+	// 月曜日の場合 → そのまま月曜を返す
+	monday := time.Date(2024, 3, 11, 10, 0, 0, 0, time.UTC) // 月曜
+	result := StartOfWeek(monday)
+
+	assert.Equal(t, 11, result.Day())
+}
+
+func TestStartOfWeek_Sunday(t *testing.T) {
+	// 日曜日の場合 → 前の月曜を返す
+	sunday := time.Date(2024, 3, 17, 10, 0, 0, 0, time.UTC) // 日曜
+	result := StartOfWeek(sunday)
+
+	assert.Equal(t, 11, result.Day()) // 前の月曜
+}
+
+func TestDaysAgo(t *testing.T) {
+	base := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+	result := DaysAgo(base, 7)
+
+	assert.Equal(t, 2024, result.Year())
+	assert.Equal(t, time.March, result.Month())
+	assert.Equal(t, 8, result.Day())
+}
+
+func TestDaysAgo_Zero(t *testing.T) {
+	base := time.Date(2024, 3, 15, 0, 0, 0, 0, time.UTC)
+	result := DaysAgo(base, 0)
+
+	assert.Equal(t, 15, result.Day())
+}

--- a/backend/internal/repository/bookmark_stats.go
+++ b/backend/internal/repository/bookmark_stats.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -35,8 +36,7 @@ func (r *BookmarkStatsRepository) GetBookmarkStats(userID uint) (*model.Bookmark
 	}
 
 	// 今月ブックマークした数
-	now := time.Now()
-	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfMonth := domain.StartOfMonth(time.Now())
 	if err := r.db.Model(&model.Bookmark{}).Where("user_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.BookmarksThisMonth).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/comment_stats.go
+++ b/backend/internal/repository/comment_stats.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -40,8 +41,7 @@ func (r *CommentStatsRepository) GetCommentStats(userID uint) (*model.CommentSta
 	}
 
 	// 今月のコメント数
-	now := time.Now()
-	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfMonth := domain.StartOfMonth(time.Now())
 	if err := r.db.Model(&model.Comment{}).Where("user_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.CommentsThisMonth).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/learning_log_stats.go
+++ b/backend/internal/repository/learning_log_stats.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -37,8 +38,7 @@ func (r *LearningLogStatsRepository) GetLearningLogStats(userID uint) (*model.Le
 	}
 
 	// 今月のログ数
-	now := time.Now()
-	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	monthStart := domain.StartOfMonth(time.Now())
 	if err := r.db.Model(&model.LearningLog{}).Where("user_id = ? AND created_at >= ?", userID, monthStart).Count(&stats.LogsThisMonth).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/mention_stats.go
+++ b/backend/internal/repository/mention_stats.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -32,8 +33,7 @@ func (r *MentionStatsRepository) GetMentionStats(userID uint) (*model.MentionSta
 	}
 
 	// 今月メンションされた回数
-	now := time.Now()
-	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfMonth := domain.StartOfMonth(time.Now())
 	if err := r.db.Model(&model.Mention{}).Where("user_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.MentionsThisMonth).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/message_stats.go
+++ b/backend/internal/repository/message_stats.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -40,8 +41,7 @@ func (r *MessageStatsRepository) GetMessageStats(userID uint) (*model.MessageSta
 	}
 
 	// 今月の送信メッセージ数
-	now := time.Now()
-	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfMonth := domain.StartOfMonth(time.Now())
 	if err := r.db.Model(&model.Message{}).Where("sender_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.MessagesThisMonth).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/note_stats.go
+++ b/backend/internal/repository/note_stats.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -42,7 +43,7 @@ func (r *NoteStatsRepository) GetNoteStats(userID uint) (*model.NoteStats, error
 	}
 
 	// 今週作成したノート数（過去7日間）
-	weekAgo := time.Now().AddDate(0, 0, -7)
+	weekAgo := domain.DaysAgo(time.Now(), 7)
 	if err := r.db.Model(&model.Note{}).Where("user_id = ? AND created_at >= ?", userID, weekAgo).Count(&stats.NotesThisWeek).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/notification_stats.go
+++ b/backend/internal/repository/notification_stats.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -32,8 +33,7 @@ func (r *NotificationStatsRepository) GetNotificationStats(userID uint) (*model.
 	}
 
 	// 今月の通知数
-	now := time.Now()
-	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfMonth := domain.StartOfMonth(time.Now())
 	if err := r.db.Model(&model.Notification{}).Where("user_id = ? AND created_at >= ?", userID, startOfMonth).Count(&stats.NotificationsThisMonth).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/post_stats.go
+++ b/backend/internal/repository/post_stats.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -55,8 +56,7 @@ func (r *PostStatsRepository) GetPostStats(userID uint) (*model.PostStats, error
 	}
 
 	// 今月の投稿数
-	now := time.Now()
-	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	monthStart := domain.StartOfMonth(time.Now())
 	if err := r.db.Model(&model.Post{}).Where("user_id = ? AND created_at >= ?", userID, monthStart).Count(&stats.PostsThisMonth).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/repository/reaction_stats.go
+++ b/backend/internal/repository/reaction_stats.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"gorm.io/gorm"
 )
@@ -39,8 +40,7 @@ func (r *ReactionStatsRepository) GetReactionStats(userID uint) (*model.Reaction
 	}
 
 	// 今月受け取ったリアクション数
-	now := time.Now()
-	startOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, now.Location())
+	startOfMonth := domain.StartOfMonth(time.Now())
 	if err := r.db.Model(&model.Reaction{}).
 		Joins("JOIN posts ON posts.id = reactions.post_id").
 		Where("posts.user_id = ? AND reactions.created_at >= ?", userID, startOfMonth).


### PR DESCRIPTION
## 概要
Closes #1119

9つのリポジトリファイルに散在していた月初・日数前計算の重複コードを
domain 層のヘルパー関数に統一。

## 変更内容
- `domain/timeutil.go` — `StartOfMonth`, `StartOfWeek`, `DaysAgo` 関数追加
- 9つの `*_stats.go` リポジトリを置換
- 8テストケース追加

## テスト
- `go test ./internal/...` 全テストPASS