### PR TITLE
fix: アップロードファイル・ディレクトリのパーミッションを強化

### DIFF
--- a/backend/internal/handler/upload.go
+++ b/backend/internal/handler/upload.go
@@ -14,6 +14,11 @@ import (
 	"github.com/norman6464/devsync/backend/internal/dto"
 )
 
+const (
+	uploadDirPerm  os.FileMode = 0750 // rwxr-x---
+	uploadFilePerm os.FileMode = 0640 // rw-r-----
+)
+
 // allowedMIMETypes はアップロードを許可するMIMEタイプの一覧。
 // ファイルのマジックバイト（先頭512バイト）から検出したMIMEタイプで検証する。
 var allowedMIMETypes = map[string]bool{
@@ -52,7 +57,7 @@ func NewUploadHandler() *UploadHandler {
 	}
 
 	// アップロードディレクトリが存在しない場合は作成する
-	if err := os.MkdirAll(uploadDir, 0755); err != nil {
+	if err := os.MkdirAll(uploadDir, uploadDirPerm); err != nil {
 		panic(fmt.Sprintf("Failed to create upload directory: %v", err))
 	}
 
@@ -112,7 +117,7 @@ func (h *UploadHandler) UploadImage(c *gin.Context) {
 	// 日付ベースのサブディレクトリを作成する
 	dateDir := time.Now().Format("2006/01")
 	fullDir := filepath.Join(h.uploadDir, dateDir)
-	if err := os.MkdirAll(fullDir, 0755); err != nil {
+	if err := os.MkdirAll(fullDir, uploadDirPerm); err != nil {
 		respondInternalError(c, "Failed to create directory")
 		return
 	}
@@ -121,6 +126,12 @@ func (h *UploadHandler) UploadImage(c *gin.Context) {
 	filePath := filepath.Join(fullDir, filename)
 	if err := c.SaveUploadedFile(file, filePath); err != nil {
 		respondInternalError(c, "Failed to save file")
+		return
+	}
+
+	// ファイルパーミッションを制限する
+	if err := os.Chmod(filePath, uploadFilePerm); err != nil {
+		respondInternalError(c, "Failed to set file permissions")
 		return
 	}
 
@@ -163,7 +174,7 @@ func (h *UploadHandler) UploadMultipleImages(c *gin.Context) {
 
 	dateDir := time.Now().Format("2006/01")
 	fullDir := filepath.Join(h.uploadDir, dateDir)
-	if err := os.MkdirAll(fullDir, 0755); err != nil {
+	if err := os.MkdirAll(fullDir, uploadDirPerm); err != nil {
 		respondInternalError(c, "Failed to create directory")
 		return
 	}
@@ -205,6 +216,12 @@ func (h *UploadHandler) UploadMultipleImages(c *gin.Context) {
 
 		if err := c.SaveUploadedFile(file, filePath); err != nil {
 			respondInternalError(c, "Failed to save file")
+			return
+		}
+
+		// ファイルパーミッションを制限する
+		if err := os.Chmod(filePath, uploadFilePerm); err != nil {
+			respondInternalError(c, "Failed to set file permissions")
 			return
 		}
 

--- a/backend/internal/handler/upload_test.go
+++ b/backend/internal/handler/upload_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -250,4 +251,78 @@ func TestNewUploadHandler_DefaultDir(t *testing.T) {
 	// ディレクトリが作成されたことを確認
 	_, err := os.Stat(tmpDir + "/test_uploads")
 	assert.NoError(t, err)
+}
+
+// ---------- ファイルパーミッションテスト ----------
+
+func TestNewUploadHandler_DirPermissions(t *testing.T) {
+	orig := os.Getenv("UPLOAD_DIR")
+	defer os.Setenv("UPLOAD_DIR", orig)
+
+	tmpDir := t.TempDir()
+	os.Setenv("UPLOAD_DIR", tmpDir+"/secure_uploads")
+
+	NewUploadHandler()
+
+	info, err := os.Stat(tmpDir + "/secure_uploads")
+	assert.NoError(t, err)
+	// ディレクトリは0750（rwxr-x---）であること
+	assert.Equal(t, os.FileMode(0750), info.Mode().Perm())
+}
+
+func TestUploadImage_FilePermissions(t *testing.T) {
+	h := setupUploadHandler(t)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, _ := writer.CreateFormFile("image", "test.png")
+	part.Write(minimalPNG)
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/upload", body)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+
+	h.UploadImage(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// アップロードされたファイルのパーミッションを検証
+	files, _ := filepath.Glob(filepath.Join(h.uploadDir, "*", "*", "*.png"))
+	assert.NotEmpty(t, files)
+	info, err := os.Stat(files[0])
+	assert.NoError(t, err)
+	// ファイルは0640（rw-r-----）であること
+	assert.Equal(t, os.FileMode(0640), info.Mode().Perm())
+}
+
+func TestUploadMultipleImages_FilePermissions(t *testing.T) {
+	h := setupUploadHandler(t)
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	for i := 0; i < 2; i++ {
+		part, _ := writer.CreateFormFile("images", fmt.Sprintf("img%d.png", i))
+		part.Write(minimalPNG)
+	}
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/upload/multiple", body)
+	c.Request.Header.Set("Content-Type", writer.FormDataContentType())
+
+	h.UploadMultipleImages(c)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// アップロードされた全ファイルのパーミッションを検証
+	files, _ := filepath.Glob(filepath.Join(h.uploadDir, "*", "*", "*.png"))
+	assert.Len(t, files, 2)
+	for _, f := range files {
+		info, err := os.Stat(f)
+		assert.NoError(t, err)
+		assert.Equal(t, os.FileMode(0640), info.Mode().Perm())
+	}
 }


### PR DESCRIPTION
## 概要
アップロードファイルのファイルパーミッションをセキュリティ強化。

## 変更内容
- `upload.go`: ディレクトリ0755→0750、ファイル保存後chmod 0640を追加
- `upload_test.go`: パーミッション検証テスト3件追加

## テスト
- TestNewUploadHandler_DirPermissions（ディレクトリ0750検証）
- TestUploadImage_FilePermissions（単体アップロード0640検証）
- TestUploadMultipleImages_FilePermissions（複数アップロード0640検証）

Closes #1123