### PR TITLE
feat: コメント非表示/表示切替機能を追加

### DIFF
--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -25,6 +25,8 @@ type PostServiceInterface interface {
 	GetComments(postID uint) ([]model.Comment, error)
 	GetReplies(parentID uint) ([]model.Comment, error)
 	DeleteComment(id, userID uint) error
+	HideComment(id, userID uint) error
+	UnhideComment(id, userID uint) error
 	Publish(id, userID uint) (*model.Post, error)
 	Unpublish(id, userID uint) (*model.Post, error)
 	Bookmark(userID, postID uint) error
@@ -322,6 +324,36 @@ func (h *PostHandler) DeleteComment(c *gin.Context) {
 		return
 	}
 	respondDeleted(c)
+}
+
+// HideComment はコメントを非表示にする。
+func (h *PostHandler) HideComment(c *gin.Context) {
+	commentID, ok := parseID(c, "commentId")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	if err := h.service.HideComment(commentID, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, domain.NewMessageResponse("コメントを非表示にしました"))
+}
+
+// UnhideComment はコメントの非表示を解除する。
+func (h *PostHandler) UnhideComment(c *gin.Context) {
+	commentID, ok := parseID(c, "commentId")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	if err := h.service.UnhideComment(commentID, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, domain.NewMessageResponse("コメントの非表示を解除しました"))
 }
 
 // GetDrafts は現在のユーザーの下書き投稿一覧を返す。

--- a/backend/internal/handler/post_test.go
+++ b/backend/internal/handler/post_test.go
@@ -1090,3 +1090,74 @@ func TestPostCreate_WithTagService(t *testing.T) {
 	assertStatus(t, w, http.StatusCreated)
 	tagSvc.AssertCalled(t, "SetAutoTags", uint(12), uint(1), "Hello #golang")
 }
+
+// ---------- HideComment / UnhideComment ----------
+
+func TestPostHideComment_Success(t *testing.T) {
+	h, postRepo, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/:id/comments/:commentId/hide", h.HideComment)
+
+	comment := &model.Comment{PostID: 5, Content: "test"}
+	comment.ID = 10
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(10)).Return(comment, nil)
+	postRepo.On("UpdateComment", mock.AnythingOfType("*model.Comment")).Return(nil)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/comments/10/hide", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostHideComment_Forbidden(t *testing.T) {
+	h, postRepo, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/:id/comments/:commentId/hide", h.HideComment)
+
+	comment := &model.Comment{PostID: 5, Content: "test"}
+	comment.ID = 10
+	comment.UserID = 999 // 別ユーザー
+	postRepo.On("FindCommentByID", uint(10)).Return(comment, nil)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/comments/10/hide", nil)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+func TestPostHideComment_InvalidID(t *testing.T) {
+	h, _, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/:id/comments/:commentId/hide", h.HideComment)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/comments/abc/hide", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostUnhideComment_Success(t *testing.T) {
+	h, postRepo, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/:id/comments/:commentId/unhide", h.UnhideComment)
+
+	comment := &model.Comment{PostID: 5, Content: "test", IsHidden: true}
+	comment.ID = 10
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(10)).Return(comment, nil)
+	postRepo.On("UpdateComment", mock.AnythingOfType("*model.Comment")).Return(nil)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/comments/10/unhide", nil)
+
+	assertStatus(t, w, http.StatusOK)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostUnhideComment_InvalidID(t *testing.T) {
+	h, _, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/:id/comments/:commentId/unhide", h.UnhideComment)
+
+	w := doRequest(r, http.MethodPost, "/posts/5/comments/abc/unhide", nil)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -111,6 +111,9 @@ func (m *MockPostRepository) GetComments(postID uint) ([]model.Comment, error) {
 	args := m.Called(postID)
 	return args.Get(0).([]model.Comment), args.Error(1)
 }
+func (m *MockPostRepository) UpdateComment(comment *model.Comment) error {
+	return m.Called(comment).Error(0)
+}
 func (m *MockPostRepository) DeleteComment(id uint) error {
 	return m.Called(id).Error(0)
 }

--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -152,6 +152,7 @@ type Comment struct {
 	ParentID  *uint      `json:"parent_id,omitempty" gorm:"index"`
 	Content   string     `json:"content" gorm:"type:text;not null"`
 	LikeCount int        `json:"like_count" gorm:"default:0"`
+	IsHidden  bool       `json:"is_hidden" gorm:"default:false"`
 	Replies   []Comment  `json:"replies,omitempty" gorm:"foreignKey:ParentID"`
 	CreatedAt time.Time  `json:"created_at"`
 	UpdatedAt time.Time  `json:"updated_at"`

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -71,6 +71,7 @@ type PostRepositoryInterface interface {
 	FindCommentByID(id uint) (*model.Comment, error)
 	GetComments(postID uint) ([]model.Comment, error)
 	GetReplies(parentID uint) ([]model.Comment, error)
+	UpdateComment(comment *model.Comment) error
 	DeleteComment(id uint) error
 	Bookmark(userID, postID uint) error
 	Unbookmark(userID, postID uint) error

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -123,6 +123,11 @@ func (r *PostRepository) FindCommentByID(id uint) (*model.Comment, error) {
 	return &comment, nil
 }
 
+// UpdateComment はコメントを更新する。
+func (r *PostRepository) UpdateComment(comment *model.Comment) error {
+	return r.db.Save(comment).Error
+}
+
 // GetComments は指定投稿の全コメントをユーザー情報付きで取得する（古い順）。
 func (r *PostRepository) GetComments(postID uint) ([]model.Comment, error) {
 	var comments []model.Comment

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -171,6 +171,8 @@ func registerPostRoutes(g *gin.RouterGroup, c *di.Container) {
 		posts.POST("/:id/comments", c.PostHandler.CreateComment)
 		posts.GET("/:id/comments/:commentId/replies", c.PostHandler.GetReplies)
 		posts.DELETE("/:id/comments/:commentId", c.PostHandler.DeleteComment)
+		posts.POST("/:id/comments/:commentId/hide", c.PostHandler.HideComment)
+		posts.POST("/:id/comments/:commentId/unhide", c.PostHandler.UnhideComment)
 		posts.GET("/:id/reactions", c.PostHandler.GetReactions)
 		posts.POST("/:id/reactions", c.PostHandler.AddReaction)
 		posts.DELETE("/:id/reactions", c.PostHandler.RemoveReaction)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -179,6 +179,10 @@ func (m *MockPostRepository) GetReplies(parentID uint) ([]model.Comment, error) 
 	return args.Get(0).([]model.Comment), args.Error(1)
 }
 
+func (m *MockPostRepository) UpdateComment(comment *model.Comment) error {
+	return m.Called(comment).Error(0)
+}
+
 func (m *MockPostRepository) DeleteComment(id uint) error {
 	args := m.Called(id)
 	return args.Error(0)

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -242,6 +242,36 @@ func (s *PostService) DeleteComment(id, userID uint) error {
 	return s.repo.DeleteComment(id)
 }
 
+// HideComment は所有権を検証した後、コメントを非表示にする。
+func (s *PostService) HideComment(id, userID uint) error {
+	comment, err := s.repo.FindCommentByID(id)
+	if err != nil {
+		return err
+	}
+
+	if comment.UserID != userID {
+		return ErrForbidden
+	}
+
+	comment.IsHidden = true
+	return s.repo.UpdateComment(comment)
+}
+
+// UnhideComment は所有権を検証した後、コメントの非表示を解除する。
+func (s *PostService) UnhideComment(id, userID uint) error {
+	comment, err := s.repo.FindCommentByID(id)
+	if err != nil {
+		return err
+	}
+
+	if comment.UserID != userID {
+		return ErrForbidden
+	}
+
+	comment.IsHidden = false
+	return s.repo.UpdateComment(comment)
+}
+
 // Bookmark は投稿をブックマークする。
 // 自分の投稿へのブックマークは禁止する。
 func (s *PostService) Bookmark(userID, postID uint) error {

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -1227,6 +1227,81 @@ func TestPostDeleteComment_RepoError(t *testing.T) {
 	postRepo.AssertExpectations(t)
 }
 
+// ============================================================
+// コメント非表示テスト
+// ============================================================
+
+func TestPostHideComment_Success(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	comment := &model.Comment{PostID: 10, Content: "test"}
+	comment.ID = 5
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(5)).Return(comment, nil)
+	postRepo.On("UpdateComment", mock.MatchedBy(func(c *model.Comment) bool {
+		return c.ID == 5 && c.IsHidden
+	})).Return(nil)
+
+	err := svc.HideComment(5, 1)
+	assert.NoError(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostHideComment_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	comment := &model.Comment{PostID: 10, Content: "test"}
+	comment.ID = 5
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(5)).Return(comment, nil)
+
+	err := svc.HideComment(5, 999)
+	assert.Error(t, err)
+	var domainErr *domain.DomainError
+	assert.ErrorAs(t, err, &domainErr)
+	assert.Equal(t, domain.ErrCodeForbidden, domainErr.Code)
+}
+
+func TestPostHideComment_NotFound(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("FindCommentByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.HideComment(99, 1)
+	assert.Error(t, err)
+}
+
+func TestPostUnhideComment_Success(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	comment := &model.Comment{PostID: 10, Content: "test", IsHidden: true}
+	comment.ID = 5
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(5)).Return(comment, nil)
+	postRepo.On("UpdateComment", mock.MatchedBy(func(c *model.Comment) bool {
+		return c.ID == 5 && !c.IsHidden
+	})).Return(nil)
+
+	err := svc.UnhideComment(5, 1)
+	assert.NoError(t, err)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostUnhideComment_Forbidden(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	comment := &model.Comment{PostID: 10, Content: "test", IsHidden: true}
+	comment.ID = 5
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(5)).Return(comment, nil)
+
+	err := svc.UnhideComment(5, 999)
+	assert.Error(t, err)
+	var domainErr *domain.DomainError
+	assert.ErrorAs(t, err, &domainErr)
+	assert.Equal(t, domain.ErrCodeForbidden, domainErr.Code)
+}
+
 func TestPostCreateComment_RepoError(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 


### PR DESCRIPTION
## 概要
コメント所有者がコメントを非表示にできる機能をTDDで実装。

## 変更内容
- `model/post.go`: Comment に `IsHidden` フィールド追加
- `repository/interfaces.go`: `UpdateComment` メソッド追加
- `repository/post.go`: `UpdateComment` 実装
- `service/post.go`: `HideComment` / `UnhideComment`（所有権チェック付き）
- `handler/post.go`: ハンドラーメソッド・インターフェース拡張
- `router/router.go`: エンドポイント追加

## テスト
- Service層: 5テスト（成功・Forbidden・NotFound × hide/unhide）
- Handler層: 5テスト（成功・Forbidden・InvalidID × hide/unhide）

Closes #1125