### PR TITLE
fix: 認証エンドポイントにIPベースのレート制限を追加

### DIFF
--- a/backend/internal/middleware/rate_limit.go
+++ b/backend/internal/middleware/rate_limit.go
@@ -1,0 +1,85 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// RateLimitStore はIPごとのリクエスト履歴をインメモリで管理する。
+type RateLimitStore struct {
+	mu       sync.RWMutex
+	requests map[string][]time.Time
+}
+
+// NewRateLimitStore は新しいRateLimitStoreを生成する。
+func NewRateLimitStore() *RateLimitStore {
+	return &RateLimitStore{
+		requests: make(map[string][]time.Time),
+	}
+}
+
+// IsAllowed は指定キーがレート制限内か判定する。
+// windowSeconds秒以内にmaxRequests回以下のリクエストを許可する。
+func (s *RateLimitStore) IsAllowed(key string, maxRequests int, windowSeconds int) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := time.Now()
+	windowStart := now.Add(time.Duration(-windowSeconds) * time.Second)
+
+	// ウィンドウ内のリクエストのみ保持
+	var filtered []time.Time
+	for _, t := range s.requests[key] {
+		if t.After(windowStart) {
+			filtered = append(filtered, t)
+		}
+	}
+
+	if len(filtered) >= maxRequests {
+		s.requests[key] = filtered
+		return false
+	}
+
+	s.requests[key] = append(filtered, now)
+	return true
+}
+
+// Cleanup は古いエントリを削除してメモリを解放する。
+func (s *RateLimitStore) Cleanup(windowSeconds int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	cutoff := time.Now().Add(time.Duration(-windowSeconds) * time.Second)
+	for key, times := range s.requests {
+		var filtered []time.Time
+		for _, t := range times {
+			if t.After(cutoff) {
+				filtered = append(filtered, t)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(s.requests, key)
+		} else {
+			s.requests[key] = filtered
+		}
+	}
+}
+
+// RateLimit はIPごとのレート制限ミドルウェアを返す。
+func RateLimit(store *RateLimitStore, maxRequests int, windowSeconds int) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientIP := c.ClientIP()
+
+		if !store.IsAllowed(clientIP, maxRequests, windowSeconds) {
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error": "リクエストが多すぎます。しばらく待ってからお試しください",
+			})
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/backend/internal/middleware/rate_limit_test.go
+++ b/backend/internal/middleware/rate_limit_test.go
@@ -1,0 +1,102 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRateLimitStore_AllowsWithinLimit(t *testing.T) {
+	store := NewRateLimitStore()
+	for i := 0; i < 5; i++ {
+		assert.True(t, store.IsAllowed("ip:127.0.0.1", 5, 60))
+	}
+}
+
+func TestRateLimitStore_DeniesOverLimit(t *testing.T) {
+	store := NewRateLimitStore()
+	for i := 0; i < 5; i++ {
+		store.IsAllowed("ip:127.0.0.1", 5, 60)
+	}
+	assert.False(t, store.IsAllowed("ip:127.0.0.1", 5, 60))
+}
+
+func TestRateLimitStore_DifferentKeysIndependent(t *testing.T) {
+	store := NewRateLimitStore()
+	store.IsAllowed("ip:1.1.1.1", 1, 60)
+	assert.False(t, store.IsAllowed("ip:1.1.1.1", 1, 60))
+	assert.True(t, store.IsAllowed("ip:2.2.2.2", 1, 60))
+}
+
+func TestRateLimitStore_ResetsAfterWindow(t *testing.T) {
+	store := NewRateLimitStore()
+	assert.True(t, store.IsAllowed("test", 1, 1))
+	assert.False(t, store.IsAllowed("test", 1, 1))
+
+	time.Sleep(1100 * time.Millisecond)
+	assert.True(t, store.IsAllowed("test", 1, 1))
+}
+
+func TestRateLimitStore_Cleanup(t *testing.T) {
+	store := NewRateLimitStore()
+	store.IsAllowed("old", 10, 1)
+
+	time.Sleep(1100 * time.Millisecond)
+	store.Cleanup(1)
+
+	// クリーンアップ後はキーが削除されている
+	store.mu.RLock()
+	_, exists := store.requests["old"]
+	store.mu.RUnlock()
+	assert.False(t, exists)
+}
+
+func TestRateLimit_AllowsRequest(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewRateLimitStore()
+
+	r := gin.New()
+	r.Use(RateLimit(store, 5, 60))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "127.0.0.1:12345"
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestRateLimit_BlocksExceedingRequests(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	store := NewRateLimitStore()
+
+	r := gin.New()
+	r.Use(RateLimit(store, 2, 60))
+	r.GET("/test", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	for i := 0; i < 2; i++ {
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/test", nil)
+		req.RemoteAddr = "10.0.0.1:1234"
+		r.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+	}
+
+	// 3回目はブロック
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/test", nil)
+	req.RemoteAddr = "10.0.0.1:1234"
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusTooManyRequests, w.Code)
+	assert.Contains(t, w.Body.String(), "リクエストが多すぎます")
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -54,8 +54,12 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 
 	api := r.Group("/api/v1")
 
+	// レート制限（認証エンドポイント: 10リクエスト/60秒）
+	authRateLimitStore := middleware.NewRateLimitStore()
+
 	// 認証ルート（公開）
 	auth := api.Group("/auth")
+	auth.Use(middleware.RateLimit(authRateLimitStore, 10, 60))
 	{
 		auth.POST("/register", c.AuthHandler.Register)
 		auth.POST("/login", c.AuthHandler.Login)


### PR DESCRIPTION
## 概要
ブルートフォース攻撃対策として認証APIにレート制限を追加。

## 変更内容
- `middleware/rate_limit.go`: インメモリRateLimitStore + RateLimitミドルウェア
- `middleware/rate_limit_test.go`: 7テスト
- `router/router.go`: 認証エンドポイントに10req/60秒の制限を適用

## 実装詳細
- IPごとにスライディングウィンドウでリクエスト頻度を管理
- 制限超過時は429 Too Many Requestsを返却
- Cleanupメソッドでメモリリーク防止

Closes #1131