### PR TITLE
feat: 週間学習時間合計API（GetWeeklyDuration）

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -21,6 +21,7 @@ type LearningLogServiceInterface interface {
 	ExportCSV(userID uint, days int) ([]byte, error)
 	GetByCategory(userID uint, category string) ([]model.LearningLog, error)
 	GetBySource(userID uint, source string) ([]model.LearningLog, error)
+	GetWeeklyDuration(userID uint) (int, error)
 }
 
 // LearningLogHandler は学習ログ関連のHTTPハンドラ。
@@ -257,4 +258,20 @@ func (h *LearningLogHandler) ExportLogs(c *gin.Context) {
 
 	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
 	c.Data(200, "text/csv; charset=utf-8", csvBytes)
+}
+
+// GetWeeklyDuration は指定ユーザーの過去7日間の学習時間合計を返す。
+func (h *LearningLogHandler) GetWeeklyDuration(c *gin.Context) {
+	userID, ok := parseID(c, "userId")
+	if !ok {
+		return
+	}
+
+	duration, err := h.service.GetWeeklyDuration(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"duration": duration})
 }

--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -348,3 +348,41 @@ func TestLearningLog_ExportLogs_ServiceError(t *testing.T) {
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }
+
+// ============================================================
+// GetWeeklyDuration テスト
+// ============================================================
+
+func TestLearningLog_GetWeeklyDuration_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/learning-logs/weekly-duration/:userId", h.GetWeeklyDuration)
+
+	svc.On("GetWeeklyDuration", uint(1)).Return(120, nil)
+
+	w := doRequest(r, http.MethodGet, "/learning-logs/weekly-duration/1", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Body.String(), "120")
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_GetWeeklyDuration_ServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/learning-logs/weekly-duration/:userId", h.GetWeeklyDuration)
+
+	svc.On("GetWeeklyDuration", uint(1)).Return(0, errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/learning-logs/weekly-duration/1", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_GetWeeklyDuration_InvalidID(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/learning-logs/weekly-duration/:userId", h.GetWeeklyDuration)
+
+	w := doRequest(r, http.MethodGet, "/learning-logs/weekly-duration/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1307,6 +1307,10 @@ func (m *MockLearningLogService) GetBySource(userID uint, source string) ([]mode
 	args := m.Called(userID, source)
 	return args.Get(0).([]model.LearningLog), args.Error(1)
 }
+func (m *MockLearningLogService) GetWeeklyDuration(userID uint) (int, error) {
+	args := m.Called(userID)
+	return args.Int(0), args.Error(1)
+}
 
 // setupLearningLogHandler はLearningLogHandlerテスト用のセットアップを行う。
 func setupLearningLogHandler() (*LearningLogHandler, *MockLearningLogService) {

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -156,6 +156,7 @@ type LearningLogRepositoryInterface interface {
 	GetByCategory(userID uint, category string) ([]model.LearningLog, error)
 	GetByPeriod(userID uint, days int) ([]model.LearningLog, error)
 	GetBySource(userID uint, source string) ([]model.LearningLog, error)
+	SumDurationByPeriod(userID uint, days int) (int, error)
 	GetStreakInfo(userID uint) (*model.StreakInfo, error)
 	GetCalendarData(userID uint) ([]model.CalendarEntry, error)
 }

--- a/backend/internal/repository/learning_log.go
+++ b/backend/internal/repository/learning_log.go
@@ -80,6 +80,17 @@ func (r *LearningLogRepository) GetByPeriod(userID uint, days int) ([]model.Lear
 	return logs, err
 }
 
+// SumDurationByPeriod は指定ユーザーの指定期間内の学習時間合計（分）を返す。
+func (r *LearningLogRepository) SumDurationByPeriod(userID uint, days int) (int, error) {
+	var total int
+	since := time.Now().AddDate(0, 0, -days)
+	err := r.db.Model(&model.LearningLog{}).
+		Where("user_id = ? AND created_at >= ?", userID, since).
+		Select("COALESCE(SUM(duration), 0)").
+		Scan(&total).Error
+	return total, err
+}
+
 // GetStreakInfo は学習ログから連続学習情報を算出する。
 // 現在の連続日数、最長連続日数、合計学習日数、最終ログ日を返す。
 func (r *LearningLogRepository) GetStreakInfo(userID uint) (*model.StreakInfo, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -391,6 +391,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 		learningLogs.GET("/user/:userId", c.LearningLogHandler.GetByUserID)
 		learningLogs.GET("/calendar/:userId", c.LearningLogHandler.GetCalendarData)
 		learningLogs.GET("/streak/:userId", c.LearningLogHandler.GetStreakInfo)
+		learningLogs.GET("/weekly-duration/:userId", c.LearningLogHandler.GetWeeklyDuration)
 		learningLogs.GET("/:id", c.LearningLogHandler.GetByID)
 		learningLogs.PUT("/:id", c.LearningLogHandler.Update)
 		learningLogs.DELETE("/:id", c.LearningLogHandler.Delete)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -123,6 +123,11 @@ func (s *LearningLogService) Delete(id, userID uint) error {
 	return s.repo.Delete(id, userID)
 }
 
+// GetWeeklyDuration は指定ユーザーの過去7日間の学習時間合計（分）を返す。
+func (s *LearningLogService) GetWeeklyDuration(userID uint) (int, error) {
+	return s.repo.SumDurationByPeriod(userID, 7)
+}
+
 // GetStreakInfo は指定ユーザーの学習ストリーク情報を取得する。
 func (s *LearningLogService) GetStreakInfo(userID uint) (*model.StreakInfo, error) {
 	return s.repo.GetStreakInfo(userID)

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -553,3 +553,38 @@ func TestLearningLogGetBySource_RepoError(t *testing.T) {
 	assert.Empty(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// 週間学習時間合計テスト
+// ============================================================
+
+func TestLearningLogGetWeeklyDuration_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("SumDurationByPeriod", uint(1), 7).Return(480, nil)
+
+	duration, err := svc.GetWeeklyDuration(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 480, duration)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogGetWeeklyDuration_ZeroLogs(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("SumDurationByPeriod", uint(1), 7).Return(0, nil)
+
+	duration, err := svc.GetWeeklyDuration(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, duration)
+}
+
+func TestLearningLogGetWeeklyDuration_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("SumDurationByPeriod", uint(1), 7).Return(0, errors.New("db error"))
+
+	duration, err := svc.GetWeeklyDuration(1)
+	assert.Error(t, err)
+	assert.Equal(t, 0, duration)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -518,6 +518,11 @@ func (m *MockLearningLogRepository) GetByPeriod(userID uint, days int) ([]model.
 	return args.Get(0).([]model.LearningLog), args.Error(1)
 }
 
+func (m *MockLearningLogRepository) SumDurationByPeriod(userID uint, days int) (int, error) {
+	args := m.Called(userID, days)
+	return args.Int(0), args.Error(1)
+}
+
 func (m *MockLearningLogRepository) GetStreakInfo(userID uint) (*model.StreakInfo, error) {
 	args := m.Called(userID)
 	if args.Get(0) == nil {


### PR DESCRIPTION
## Summary
- 指定ユーザーの過去7日間の学習時間合計を返す `GET /api/v1/learning-logs/weekly-duration/:userId` を追加
- リポジトリ・サービス・ハンドラーの全層をTDDで実装
- サービステスト3件・ハンドラーテスト3件を追加

## Test plan
- [x] サービステスト通過（Success / ZeroLogs / RepoError）
- [x] ハンドラーテスト通過（Success / ServiceError / InvalidID）
- [x] `go build ./...` 成功

Closes #1133