### PR TITLE
fix: 検索ソートパラメータのバリデーション追加

### DIFF
--- a/backend/internal/model/search.go
+++ b/backend/internal/model/search.go
@@ -11,6 +11,13 @@ const (
 	SearchSortByViews   SearchSortBy = "views"   // 閲覧数順
 )
 
+// ValidSearchSortBy は有効なソート順の集合。
+var ValidSearchSortBy = map[SearchSortBy]bool{
+	SearchSortByLatest:  true,
+	SearchSortByPopular: true,
+	SearchSortByViews:   true,
+}
+
 // PostSearchParams は投稿検索のパラメータ。
 type PostSearchParams struct {
 	Query    string

--- a/backend/internal/service/search_service.go
+++ b/backend/internal/service/search_service.go
@@ -42,10 +42,12 @@ func (s *SearchService) SearchPosts(params model.PostSearchParams) (*model.PostS
 		limit = maxSearchLimit
 	}
 
-	// ソート順の正規化
+	// ソート順の正規化・バリデーション
 	sortBy := string(params.SortBy)
 	if sortBy == "" {
 		sortBy = string(model.SearchSortByLatest)
+	} else if !model.ValidSearchSortBy[params.SortBy] {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なソート順です", nil)
 	}
 
 	posts, total, err := s.postSearchRepo.SearchWithFilter(

--- a/backend/internal/service/search_service_test.go
+++ b/backend/internal/service/search_service_test.go
@@ -176,6 +176,41 @@ func TestSearchPosts_DefaultLimit_Success(t *testing.T) {
 	repo.AssertCalled(t, "SearchWithFilter", "Go", []string(nil), "latest", (*time.Time)(nil), (*time.Time)(nil), 20, 0)
 }
 
+// TestSearchPosts_InvalidSortBy_Error は無効なソート順が拒否されることを確認。
+func TestSearchPosts_InvalidSortBy_Error(t *testing.T) {
+	svc, _ := newTestSearchService()
+
+	params := model.PostSearchParams{
+		Query:  "Go",
+		SortBy: model.SearchSortBy("malicious"),
+		Limit:  20,
+	}
+	result, err := svc.SearchPosts(params)
+
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// TestSearchPosts_ViewsSortBy_Success は閲覧数順ソートが正常に動作することを確認。
+func TestSearchPosts_ViewsSortBy_Success(t *testing.T) {
+	svc, repo := newTestSearchService()
+
+	expected := []model.Post{{Title: "閲覧数多い記事"}}
+	repo.On("SearchWithFilter", "記事", []string(nil), "views", (*time.Time)(nil), (*time.Time)(nil), 20, 0).
+		Return(expected, int64(1), nil)
+
+	params := model.PostSearchParams{
+		Query:  "記事",
+		SortBy: model.SearchSortByViews,
+		Limit:  20,
+	}
+	result, err := svc.SearchPosts(params)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1), result.Total)
+	repo.AssertExpectations(t)
+}
+
 // TestSearchPosts_RepositoryError はリポジトリエラーが適切に伝播することを確認。
 func TestSearchPosts_RepositoryError(t *testing.T) {
 	svc, repo := newTestSearchService()


### PR DESCRIPTION
## Summary
- 検索APIのsortByパラメータにバリデーションを追加
- `ValidSearchSortBy`マップで有効値（latest/popular/views）を定義
- 無効な値は400エラーを返すよう修正
- TDDでテスト2件追加（InvalidSortBy, ViewsSortBy）

## Test plan
- [x] InvalidSortByテスト通過（無効値で400エラー）
- [x] ViewsSortByテスト通過（有効値で正常動作）
- [x] 既存テスト全件通過
- [x] `go build ./...` 成功

Closes #1139