### PR TITLE
fix: RemoveReactionの絵文字バリデーション追加

### DIFF
--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -313,6 +313,9 @@ func (s *PostService) AddReaction(userID, postID uint, emoji string) error {
 // RemoveReaction は投稿のリアクションを削除する。
 // 自分の投稿へのリアクション削除は禁止する（そもそもリアクションできないため）。
 func (s *PostService) RemoveReaction(userID, postID uint, emoji string) error {
+	if !allowedEmojis[emoji] {
+		return domain.NewError(domain.ErrCodeBadRequest, "許可されていない絵文字です: "+emoji, nil)
+	}
 	if err := s.findAndPreventSelfAction(userID, postID); err != nil {
 		return err
 	}

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -896,6 +896,16 @@ func TestPostRemoveReaction_PostNotFound(t *testing.T) {
 	postRepo.AssertNotCalled(t, "RemoveReaction")
 }
 
+func TestPostRemoveReaction_InvalidEmoji_Error(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	err := svc.RemoveReaction(1, 10, "malicious")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "許可されていない絵文字です")
+	postRepo.AssertNotCalled(t, "FindByID")
+	postRepo.AssertNotCalled(t, "RemoveReaction")
+}
+
 func TestPostGetReactionsByPostID_Success(t *testing.T) {
 	svc, postRepo, _ := newTestPostService()
 


### PR DESCRIPTION
## 概要
RemoveReactionにAddReactionと同等の絵文字バリデーションを追加。

Closes #1147

## 変更内容
- `service/post.go`: RemoveReactionにallowedEmojisチェック追加
- `service/post_test.go`: 不許可絵文字テスト追加（TestPostRemoveReaction_InvalidEmoji_Error）

## セキュリティ改善
不正な絵文字文字列がリポジトリ層・DB操作に渡るのを防止。