### PR TITLE
feat: 学習ログのお気に入り機能追加

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -22,6 +22,8 @@ type LearningLogServiceInterface interface {
 	GetByCategory(userID uint, category string) ([]model.LearningLog, error)
 	GetBySource(userID uint, source string) ([]model.LearningLog, error)
 	GetWeeklyDuration(userID uint) (int, error)
+	FavoriteLog(id, userID uint) error
+	UnfavoriteLog(id, userID uint) error
 }
 
 // LearningLogHandler は学習ログ関連のHTTPハンドラ。
@@ -274,4 +276,36 @@ func (h *LearningLogHandler) GetWeeklyDuration(c *gin.Context) {
 	}
 
 	respondOK(c, gin.H{"duration": duration})
+}
+
+// Favorite は学習ログをお気に入りに設定する。
+func (h *LearningLogHandler) Favorite(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.FavoriteLog(id, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"message": "学習ログをお気に入りに追加しました"})
+}
+
+// Unfavorite は学習ログのお気に入りを解除する。
+func (h *LearningLogHandler) Unfavorite(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.UnfavoriteLog(id, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"message": "学習ログのお気に入りを解除しました"})
 }

--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -447,5 +448,59 @@ func TestLearningLog_GetWeeklyDuration_InvalidID(t *testing.T) {
 	r.GET("/learning-logs/weekly-duration/:userId", h.GetWeeklyDuration)
 
 	w := doRequest(r, http.MethodGet, "/learning-logs/weekly-duration/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestLearningLog_Favorite_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.PUT("/logs/:id/favorite", h.Favorite)
+
+	svc.On("FavoriteLog", uint(10), uint(1)).Return(nil)
+
+	w := doRequest(r, http.MethodPut, "/logs/10/favorite", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_Favorite_Forbidden(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.PUT("/logs/:id/favorite", h.Favorite)
+
+	svc.On("FavoriteLog", uint(10), uint(1)).Return(service.ErrForbidden)
+
+	w := doRequest(r, http.MethodPut, "/logs/10/favorite", nil)
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_Favorite_InvalidID(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+	r := newRouter(1)
+	r.PUT("/logs/:id/favorite", h.Favorite)
+
+	w := doRequest(r, http.MethodPut, "/logs/abc/favorite", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestLearningLog_Unfavorite_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.PUT("/logs/:id/unfavorite", h.Unfavorite)
+
+	svc.On("UnfavoriteLog", uint(10), uint(1)).Return(nil)
+
+	w := doRequest(r, http.MethodPut, "/logs/10/unfavorite", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_Unfavorite_InvalidID(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+	r := newRouter(1)
+	r.PUT("/logs/:id/unfavorite", h.Unfavorite)
+
+	w := doRequest(r, http.MethodPut, "/logs/abc/unfavorite", nil)
 	assertStatus(t, w, http.StatusBadRequest)
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1318,6 +1318,16 @@ func (m *MockLearningLogService) GetWeeklyDuration(userID uint) (int, error) {
 	return args.Int(0), args.Error(1)
 }
 
+func (m *MockLearningLogService) FavoriteLog(id, userID uint) error {
+	args := m.Called(id, userID)
+	return args.Error(0)
+}
+
+func (m *MockLearningLogService) UnfavoriteLog(id, userID uint) error {
+	args := m.Called(id, userID)
+	return args.Error(0)
+}
+
 // setupLearningLogHandler はLearningLogHandlerテスト用のセットアップを行う。
 func setupLearningLogHandler() (*LearningLogHandler, *MockLearningLogService) {
 	svc := new(MockLearningLogService)

--- a/backend/internal/model/learning_log.go
+++ b/backend/internal/model/learning_log.go
@@ -46,9 +46,10 @@ type LearningLog struct {
 	Content   string      `json:"content" gorm:"type:text;not null"`
 	Category  LogCategory `json:"category" gorm:"default:'other'"`
 	Duration  int         `json:"duration" gorm:"default:0"`      // 学習時間（分単位）
-	Source    LogSource   `json:"source" gorm:"default:'manual'"` // 記録元（manual/pomodoro）
-	CreatedAt time.Time   `json:"created_at"`
-	UpdatedAt time.Time   `json:"updated_at"`
+	Source     LogSource `json:"source" gorm:"default:'manual'"` // 記録元（manual/pomodoro）
+	IsFavorite bool      `json:"is_favorite" gorm:"default:false"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
 }
 
 // CalendarEntry はカレンダービュー用の日別ログ件数を表す。

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -392,6 +392,8 @@ func registerLearningLogRoutes(g *gin.RouterGroup, c *di.Container) {
 		learningLogs.GET("/weekly-duration/:userId", c.LearningLogHandler.GetWeeklyDuration)
 		learningLogs.GET("/:id", c.LearningLogHandler.GetByID)
 		learningLogs.PUT("/:id", c.LearningLogHandler.Update)
+		learningLogs.PUT("/:id/favorite", c.LearningLogHandler.Favorite)
+		learningLogs.PUT("/:id/unfavorite", c.LearningLogHandler.Unfavorite)
 		learningLogs.DELETE("/:id", c.LearningLogHandler.Delete)
 	}
 }

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -115,6 +115,26 @@ func (s *LearningLogService) Update(id, userID uint, updates *model.LearningLog)
 	return log, nil
 }
 
+// FavoriteLog は所有権を検証した後、学習ログをお気に入りに設定する。
+func (s *LearningLogService) FavoriteLog(id, userID uint) error {
+	log, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return err
+	}
+	log.IsFavorite = true
+	return s.repo.Update(log)
+}
+
+// UnfavoriteLog は所有権を検証した後、学習ログのお気に入りを解除する。
+func (s *LearningLogService) UnfavoriteLog(id, userID uint) error {
+	log, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return err
+	}
+	log.IsFavorite = false
+	return s.repo.Update(log)
+}
+
 // Delete は所有権を検証した後、学習ログを削除する。
 func (s *LearningLogService) Delete(id, userID uint) error {
 	if _, err := s.findAndCheckOwnership(id, userID); err != nil {

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // newTestLearningLogService はLearningLogServiceのテスト用インスタンスを生成するヘルパー。
@@ -587,4 +588,65 @@ func TestLearningLogGetWeeklyDuration_RepoError(t *testing.T) {
 	duration, err := svc.GetWeeklyDuration(1)
 	assert.Error(t, err)
 	assert.Equal(t, 0, duration)
+}
+
+func TestLearningLogFavorite_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	log := &model.LearningLog{UserID: 1}
+	log.ID = 10
+	repo.On("FindByID", uint(10)).Return(log, nil)
+	repo.On("Update", mock.MatchedBy(func(l *model.LearningLog) bool {
+		return l.ID == 10 && l.IsFavorite
+	})).Return(nil)
+
+	err := svc.FavoriteLog(10, 1)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogFavorite_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	log := &model.LearningLog{UserID: 99}
+	log.ID = 10
+	repo.On("FindByID", uint(10)).Return(log, nil)
+
+	err := svc.FavoriteLog(10, 1)
+	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+func TestLearningLogFavorite_NotFound(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("FindByID", uint(99)).Return(nil, ErrNotFound)
+
+	err := svc.FavoriteLog(99, 1)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestLearningLogUnfavorite_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	log := &model.LearningLog{UserID: 1, IsFavorite: true}
+	log.ID = 10
+	repo.On("FindByID", uint(10)).Return(log, nil)
+	repo.On("Update", mock.MatchedBy(func(l *model.LearningLog) bool {
+		return l.ID == 10 && !l.IsFavorite
+	})).Return(nil)
+
+	err := svc.UnfavoriteLog(10, 1)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogUnfavorite_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	log := &model.LearningLog{UserID: 99}
+	log.ID = 10
+	repo.On("FindByID", uint(10)).Return(log, nil)
+
+	err := svc.UnfavoriteLog(10, 1)
+	assert.ErrorIs(t, err, ErrForbidden)
 }


### PR DESCRIPTION
## 概要
学習ログにお気に入り設定/解除機能を追加。

Closes #1149

## 変更内容
- `model/learning_log.go`: IsFavoriteフィールド追加
- `service/learning_log.go`: FavoriteLog / UnfavoriteLog メソッド追加
- `handler/learning_log.go`: Favorite / Unfavorite エンドポイント追加
- `router/router.go`: PUT /:id/favorite, /:id/unfavorite ルート追加
- サービステスト5件 + ハンドラーテスト5件追加