### PR TITLE
refactor: Like/Unlikeハンドラーの共通化

### DIFF
--- a/backend/internal/handler/comment_like.go
+++ b/backend/internal/handler/comment_like.go
@@ -2,7 +2,6 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 )
 
@@ -25,32 +24,12 @@ func NewCommentLikeHandler(service CommentLikeServiceInterface) *CommentLikeHand
 
 // Like はコメントにいいねする。
 func (h *CommentLikeHandler) Like(c *gin.Context) {
-	commentID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Like(userID, commentID); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondOK(c, domain.NewMessageResponse("いいねしました"))
+	handleToggleAction(c, h.service.Like, "いいねしました")
 }
 
 // Unlike はコメントのいいねを取り消す。
 func (h *CommentLikeHandler) Unlike(c *gin.Context) {
-	commentID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Unlike(userID, commentID); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondOK(c, domain.NewMessageResponse("いいねを取り消しました"))
+	handleToggleAction(c, h.service.Unlike, "いいねを取り消しました")
 }
 
 // GetStatus はコメントのいいね状態（いいねしているか・いいね数）を返す。

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -198,3 +198,19 @@ func respondPaginated(c *gin.Context, data interface{}, total int64, page, limit
 	response := domain.NewPaginatedResponse(data, total, page, limit)
 	c.JSON(http.StatusOK, response)
 }
+
+// handleToggleAction はLike/Unlikeなどのトグル操作を共通化するヘルパー。
+// parseID → サービス呼び出し → レスポンス返却のパターンを統一する。
+func handleToggleAction(c *gin.Context, action func(userID, id uint) error, message string) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	if err := action(userID, id); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, domain.NewMessageResponse(message))
+}

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -235,34 +235,12 @@ func (h *LearningResourceHandler) Delete(c *gin.Context) {
 
 // Like は学習リソースにいいねする。
 func (h *LearningResourceHandler) Like(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Like(userID, id); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, domain.NewMessageResponse("Resource liked"))
+	handleToggleAction(c, h.service.Like, "Resource liked")
 }
 
 // Unlike は学習リソースのいいねを取り消す。
 func (h *LearningResourceHandler) Unlike(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Unlike(userID, id); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, domain.NewMessageResponse("Resource unliked"))
+	handleToggleAction(c, h.service.Unlike, "Resource unliked")
 }
 
 // SaveResource は学習リソースを保存する。

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -232,32 +232,12 @@ func (h *PostHandler) GetUserPosts(c *gin.Context) {
 
 // Like は投稿にいいねする。
 func (h *PostHandler) Like(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Like(userID, id); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondOK(c, domain.NewMessageResponse("liked"))
+	handleToggleAction(c, h.service.Like, "liked")
 }
 
 // Unlike は投稿のいいねを取り消す。
 func (h *PostHandler) Unlike(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Unlike(userID, id); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondOK(c, domain.NewMessageResponse("unliked"))
+	handleToggleAction(c, h.service.Unlike, "unliked")
 }
 
 // GetComments は投稿のコメント一覧を返す。


### PR DESCRIPTION
## 概要
Like/Unlikeの重複パターンをhandleToggleActionヘルパーに統合。

Closes #1151

## 変更内容
- `handler/helpers.go`: handleToggleAction関数追加
- `handler/post.go`: Like/Unlike → handleToggleAction呼び出しに変更
- `handler/learning_resource.go`: 同上
- `handler/comment_like.go`: 同上

## 効果
- 4ファイル変更、+22行/-69行（純減47行）
- 全既存テスト通過確認