### PR TITLE
fix: プロジェクトURLフィールドのバリデーション強化

### DIFF
--- a/backend/internal/dto/project_dto.go
+++ b/backend/internal/dto/project_dto.go
@@ -7,9 +7,9 @@ type CreateProjectRequest struct {
 	Title        string `json:"title" binding:"required,max=200" validate:"required,max=200"`
 	Description  string `json:"description" binding:"omitempty,max=5000"`
 	TechStack    string `json:"tech_stack" binding:"omitempty,max=500"`
-	DemoURL      string `json:"demo_url" binding:"omitempty,max=2000"`
-	GithubURL    string `json:"github_url" binding:"omitempty,max=2000"`
-	ImageURL     string `json:"image_url" binding:"omitempty,max=2000"`
+	DemoURL      string `json:"demo_url" binding:"omitempty,http_url,max=2000"`
+	GithubURL    string `json:"github_url" binding:"omitempty,http_url,max=2000"`
+	ImageURL     string `json:"image_url" binding:"omitempty,http_url,max=2000"`
 	Role         string `json:"role" binding:"omitempty,max=200"`
 	StartDate    string `json:"start_date" binding:"omitempty,max=20"`
 	EndDate      string `json:"end_date" binding:"omitempty,max=20"`
@@ -22,9 +22,9 @@ type UpdateProjectRequest struct {
 	Title        string `json:"title" binding:"omitempty,max=200" validate:"omitempty,max=200"`
 	Description  string `json:"description" binding:"omitempty,max=5000"`
 	TechStack    string `json:"tech_stack" binding:"omitempty,max=500"`
-	DemoURL      string `json:"demo_url" binding:"omitempty,max=2000"`
-	GithubURL    string `json:"github_url" binding:"omitempty,max=2000"`
-	ImageURL     string `json:"image_url" binding:"omitempty,max=2000"`
+	DemoURL      string `json:"demo_url" binding:"omitempty,http_url,max=2000"`
+	GithubURL    string `json:"github_url" binding:"omitempty,http_url,max=2000"`
+	ImageURL     string `json:"image_url" binding:"omitempty,http_url,max=2000"`
 	Role         string `json:"role" binding:"omitempty,max=200"`
 	StartDate    string `json:"start_date" binding:"omitempty,max=20"`
 	EndDate      string `json:"end_date" binding:"omitempty,max=20"`

--- a/backend/internal/handler/project_test.go
+++ b/backend/internal/handler/project_test.go
@@ -375,3 +375,28 @@ func TestProjectDelete_InvalidID(t *testing.T) {
 
 	assertStatus(t, w, 400)
 }
+
+func TestProjectCreate_InvalidDemoURL(t *testing.T) {
+	h, _ := setupProjectHandler()
+
+	r := newRouter(1)
+	r.POST("/projects", h.Create)
+	w := doRequest(r, "POST", "/projects", map[string]interface{}{
+		"title":    "Test Project",
+		"demo_url": "javascript:alert('xss')",
+	})
+
+	assertStatus(t, w, 400)
+}
+
+func TestProjectUpdate_InvalidGithubURL(t *testing.T) {
+	h, _ := setupProjectHandler()
+
+	r := newRouter(1)
+	r.PUT("/projects/:id", h.Update)
+	w := doRequest(r, "PUT", "/projects/1", map[string]interface{}{
+		"github_url": "data:text/html,<script>alert('xss')</script>",
+	})
+
+	assertStatus(t, w, 400)
+}


### PR DESCRIPTION
## 概要
プロジェクトURLフィールドにhttp_urlバリデーションを追加しXSSペイロードを防止。

Closes #1155

## 変更内容
- `dto/project_dto.go`: DemoURL/GithubURL/ImageURLに`http_url`バリデーション追加（Create/Update両方）
- `handler/project_test.go`: 不正URL拒否テスト2件追加

## セキュリティ改善
javascript:やdata:などの危険なURIスキームがDBに保存されるのを防止。