### PR TITLE
feat: 書籍レビューに読書状態（未読/読中/読了）を追加

### DIFF
--- a/backend/internal/dto/book_review_dto.go
+++ b/backend/internal/dto/book_review_dto.go
@@ -22,6 +22,11 @@ type UpdateBookReviewRequest struct {
 	ImageURL string `json:"image_url"`
 }
 
+// UpdateBookReviewStatusRequest は書籍レビューの読書状態更新リクエスト。
+type UpdateBookReviewStatusRequest struct {
+	Status string `json:"status" binding:"required"`
+}
+
 // BookReviewListResponse は書籍レビュー一覧レスポンス。
 type BookReviewListResponse struct {
 	Reviews []model.BookReview `json:"reviews"`

--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -17,6 +17,7 @@ type BookReviewServiceInterface interface {
 	GetByRating(userID uint, minRating, maxRating int) ([]model.BookReview, error)
 	ArchiveReview(id, userID uint) error
 	UnarchiveReview(id, userID uint) error
+	UpdateStatus(id, userID uint, status model.ReviewStatus) error
 }
 
 // BookReviewHandler は書籍レビュー関連のHTTPハンドラ。
@@ -209,6 +210,27 @@ func (h *BookReviewHandler) Unarchive(c *gin.Context) {
 	}
 
 	respondOK(c, gin.H{"message": "書籍レビューのアーカイブを解除しました"})
+}
+
+// UpdateStatus は書籍レビューの読書状態を更新する。
+func (h *BookReviewHandler) UpdateStatus(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	req := bindJSON[dto.UpdateBookReviewStatusRequest](c)
+	if req == nil {
+		return
+	}
+
+	if err := h.service.UpdateStatus(id, userID, model.ReviewStatus(req.Status)); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"message": "読書状態を更新しました"})
 }
 
 // Delete は指定IDの書籍レビューを削除する。

--- a/backend/internal/handler/book_review_test.go
+++ b/backend/internal/handler/book_review_test.go
@@ -434,3 +434,42 @@ func TestBookReviewUnarchive_InvalidID(t *testing.T) {
 	w := doRequest(r, http.MethodPut, "/book-reviews/abc/unarchive", nil)
 	assertStatus(t, w, http.StatusBadRequest)
 }
+
+func TestBookReviewUpdateStatus_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id/status", h.UpdateStatus)
+
+	svc.On("UpdateStatus", uint(5), uint(1), model.ReviewStatus("reading")).Return(nil)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/5/status", map[string]string{
+		"status": "reading",
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewUpdateStatus_Forbidden(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id/status", h.UpdateStatus)
+
+	svc.On("UpdateStatus", uint(5), uint(1), model.ReviewStatus("completed")).Return(service.ErrForbidden)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/5/status", map[string]string{
+		"status": "completed",
+	})
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewUpdateStatus_InvalidID(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id/status", h.UpdateStatus)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/abc/status", map[string]string{
+		"status": "reading",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -767,6 +767,10 @@ func (m *MockBookReviewService) UnarchiveReview(id, userID uint) error {
 	return m.Called(id, userID).Error(0)
 }
 
+func (m *MockBookReviewService) UpdateStatus(id, userID uint, status model.ReviewStatus) error {
+	return m.Called(id, userID, status).Error(0)
+}
+
 // setupBookReviewHandler はBookReviewHandlerテスト用のセットアップを行う。
 func setupBookReviewHandler() (*BookReviewHandler, *MockBookReviewService) {
 	mockService := new(MockBookReviewService)

--- a/backend/internal/model/book_review.go
+++ b/backend/internal/model/book_review.go
@@ -6,6 +6,22 @@ import (
 	"gorm.io/gorm"
 )
 
+// ReviewStatus は書籍レビューの読書状態を表す型。
+type ReviewStatus string
+
+const (
+	ReviewStatusNotStarted ReviewStatus = "not_started" // 未読
+	ReviewStatusReading    ReviewStatus = "reading"     // 読中
+	ReviewStatusCompleted  ReviewStatus = "completed"   // 読了
+)
+
+// ValidReviewStatuses は有効な読書ステータスのマップ。
+var ValidReviewStatuses = map[ReviewStatus]bool{
+	ReviewStatusNotStarted: true,
+	ReviewStatusReading:    true,
+	ReviewStatusCompleted:  true,
+}
+
 // BookReview はユーザーが投稿した書籍レビューを表す。
 // Rating は1〜5の整数で評価を表し、Review にレビュー本文を格納する。
 type BookReview struct {
@@ -18,6 +34,7 @@ type BookReview struct {
 	Rating    int            `json:"rating" gorm:"not null"`                  // 評価（1〜5の整数）
 	Review    string         `json:"review" gorm:"type:text"`                 // レビュー本文
 	ImageURL   string         `json:"image_url" gorm:"size:500"`               // 書籍カバー画像URL
+	Status     ReviewStatus   `json:"status" gorm:"default:'not_started'"`     // 読書状態
 	IsArchived bool           `json:"is_archived" gorm:"default:false"`        // アーカイブ済みフラグ
 	CreatedAt  time.Time      `json:"created_at"`
 	UpdatedAt time.Time      `json:"updated_at"`

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -520,6 +520,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		bookReviews.GET("/rating", c.BookReviewHandler.GetByRating)
 		bookReviews.PUT("/:id/archive", c.BookReviewHandler.Archive)
 		bookReviews.PUT("/:id/unarchive", c.BookReviewHandler.Unarchive)
+		bookReviews.PUT("/:id/status", c.BookReviewHandler.UpdateStatus)
 	}
 
 	// バッジ

--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -107,6 +107,19 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 	return review, nil
 }
 
+// UpdateStatus は所有権を検証した後、書籍レビューの読書状態を更新する。
+func (s *BookReviewService) UpdateStatus(id, userID uint, status model.ReviewStatus) error {
+	if !model.ValidReviewStatuses[status] {
+		return domain.NewError(domain.ErrCodeBadRequest, "無効なステータスです", nil)
+	}
+	review, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return err
+	}
+	review.Status = status
+	return s.repo.Update(review)
+}
+
 // ArchiveReview は所有権を検証した後、書籍レビューをアーカイブする。
 func (s *BookReviewService) ArchiveReview(id, userID uint) error {
 	review, err := s.findAndCheckOwnership(id, userID)

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // newTestBookReviewService はBookReviewServiceのテスト用インスタンスを生成するヘルパー。
@@ -485,5 +486,39 @@ func TestBookReviewUnarchive_Forbidden(t *testing.T) {
 	repo.On("FindByID", uint(1)).Return(existing, nil)
 
 	err := svc.UnarchiveReview(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+func TestBookReviewUpdateStatus_Success(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Go本"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.MatchedBy(func(r *model.BookReview) bool {
+		return r.ID == 1 && r.Status == model.ReviewStatusReading
+	})).Return(nil)
+
+	err := svc.UpdateStatus(1, 1, model.ReviewStatusReading)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewUpdateStatus_InvalidStatus(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	err := svc.UpdateStatus(1, 1, model.ReviewStatus("invalid"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "無効なステータス")
+}
+
+func TestBookReviewUpdateStatus_Forbidden(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 99, Title: "他人のレビュー"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	err := svc.UpdateStatus(1, 1, model.ReviewStatusCompleted)
 	assert.ErrorIs(t, err, ErrForbidden)
 }


### PR DESCRIPTION
## 概要
書籍レビューに読書進捗管理用のStatus機能を追加。

Closes #1157

## 変更内容
- `model/book_review.go`: ReviewStatus型 + Statusフィールド追加
- `dto/book_review_dto.go`: UpdateBookReviewStatusRequest追加
- `service/book_review.go`: UpdateStatusメソッド追加
- `handler/book_review.go`: UpdateStatusエンドポイント追加
- `router/router.go`: PUT /:id/status ルート追加
- サービステスト3件 + ハンドラーテスト3件追加