### PR TITLE
refactor: Bookmark/Save系ハンドラーのhandleToggleAction統合

### DIFF
--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -1,9 +1,7 @@
 package handler
 
 import (
-
 	"github.com/gin-gonic/gin"
-	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -245,34 +243,12 @@ func (h *LearningResourceHandler) Unlike(c *gin.Context) {
 
 // SaveResource は学習リソースを保存する。
 func (h *LearningResourceHandler) SaveResource(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Save(userID, id); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, domain.NewMessageResponse("Resource saved"))
+	handleToggleAction(c, h.service.Save, "Resource saved")
 }
 
 // UnsaveResource は学習リソースの保存を取り消す。
 func (h *LearningResourceHandler) UnsaveResource(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Unsave(userID, id); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, domain.NewMessageResponse("Resource unsaved"))
+	handleToggleAction(c, h.service.Unsave, "Resource unsaved")
 }
 
 // GetByDifficulty は難易度別の公開学習リソースを取得する。

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -382,32 +382,12 @@ func (h *PostHandler) Unpublish(c *gin.Context) {
 
 // Bookmark は投稿をブックマークする。
 func (h *PostHandler) Bookmark(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Bookmark(userID, id); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondOK(c, domain.NewMessageResponse("bookmarked"))
+	handleToggleAction(c, h.service.Bookmark, "bookmarked")
 }
 
 // Unbookmark は投稿のブックマークを解除する。
 func (h *PostHandler) Unbookmark(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Unbookmark(userID, id); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondOK(c, domain.NewMessageResponse("unbookmarked"))
+	handleToggleAction(c, h.service.Unbookmark, "unbookmarked")
 }
 
 // GetBookmarks は現在のユーザーのブックマーク済み投稿一覧を返す。


### PR DESCRIPTION
## 概要
handleToggleActionヘルパーをBookmark/Save系にも適用。

Closes #1159

## 変更内容
- `handler/post.go`: Bookmark/Unbookmark → handleToggleAction化
- `handler/learning_resource.go`: SaveResource/UnsaveResource → handleToggleAction化

## 効果
- 2ファイル変更、+4行/-48行（純減44行）
- 全既存テスト通過確認