### PR TITLE
fix: LearningResource URL/ImageURLにhttp_urlバリデーション追加

### DIFF
--- a/backend/internal/dto/learning_resource_dto.go
+++ b/backend/internal/dto/learning_resource_dto.go
@@ -21,11 +21,11 @@ type ResourceListResponse struct {
 type CreateResourceRequest struct {
 	Title       string `json:"title" binding:"required,max=300"`
 	Description string `json:"description"`
-	URL         string `json:"url"`
+	URL         string `json:"url" binding:"omitempty,http_url,max=2000"`
 	Category    string `json:"category" binding:"required"`
 	Difficulty  string `json:"difficulty"`
 	Tags        string `json:"tags"`
-	ImageURL    string `json:"image_url"`
+	ImageURL    string `json:"image_url" binding:"omitempty,http_url,max=2000"`
 	IsPublic    *bool  `json:"is_public"`
 }
 
@@ -33,10 +33,10 @@ type CreateResourceRequest struct {
 type UpdateResourceRequest struct {
 	Title       string `json:"title" binding:"max=300"`
 	Description string `json:"description"`
-	URL         string `json:"url"`
+	URL         string `json:"url" binding:"omitempty,http_url,max=2000"`
 	Category    string `json:"category"`
 	Difficulty  string `json:"difficulty"`
 	Tags        string `json:"tags"`
-	ImageURL    string `json:"image_url"`
+	ImageURL    string `json:"image_url" binding:"omitempty,http_url,max=2000"`
 	IsPublic    *bool  `json:"is_public"`
 }

--- a/backend/internal/handler/learning_resource_test.go
+++ b/backend/internal/handler/learning_resource_test.go
@@ -554,3 +554,27 @@ func TestResourceGetByDifficulty_ServiceError(t *testing.T) {
 	w := doRequest(r, http.MethodGet, "/resources/difficulty/beginner", nil)
 	assertStatus(t, w, http.StatusInternalServerError)
 }
+
+func TestResourceCreate_InvalidURL(t *testing.T) {
+	h, _ := setupLearningResourceHandler()
+	r := newRouter(1)
+	r.POST("/resources", h.Create)
+
+	w := doRequest(r, http.MethodPost, "/resources", map[string]interface{}{
+		"title":    "悪意あるリソース",
+		"url":      "javascript:alert('xss')",
+		"category": "article",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestResourceUpdate_InvalidImageURL(t *testing.T) {
+	h, _ := setupLearningResourceHandler()
+	r := newRouter(1)
+	r.PUT("/resources/:id", h.Update)
+
+	w := doRequest(r, http.MethodPut, "/resources/1", map[string]interface{}{
+		"image_url": "data:text/html,<script>alert('xss')</script>",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}


### PR DESCRIPTION
## 概要
Closes #1163

LearningResourceのURL・ImageURLフィールドにhttp_urlバリデーションを追加し、`javascript:`や`data:`等の危険なURIスキームを拒否する。

## 変更内容
- `CreateResourceRequest`/`UpdateResourceRequest`のURL・ImageURLに`binding:"omitempty,http_url,max=2000"`を追加
- ハンドラーテスト2件追加（不正URL・不正ImageURL検証）

## テスト
- `TestResourceCreate_InvalidURL` — javascript:スキームのURL → 400
- `TestResourceUpdate_InvalidImageURL` — data:スキームのImageURL → 400
- 全ハンドラーテスト通過確認済み