### PR TITLE
feat: 書籍レビュー検索機能を追加

### DIFF
--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -18,6 +18,7 @@ type BookReviewServiceInterface interface {
 	ArchiveReview(id, userID uint) error
 	UnarchiveReview(id, userID uint) error
 	UpdateStatus(id, userID uint, status model.ReviewStatus) error
+	Search(query string, limit, offset int) ([]model.BookReview, int64, error)
 }
 
 // BookReviewHandler は書籍レビュー関連のHTTPハンドラ。
@@ -231,6 +232,25 @@ func (h *BookReviewHandler) UpdateStatus(c *gin.Context) {
 	}
 
 	respondOK(c, gin.H{"message": "読書状態を更新しました"})
+}
+
+// Search は書籍レビューをキーワード検索する。
+func (h *BookReviewHandler) Search(c *gin.Context) {
+	query := c.Query("q")
+	limit, offset := parseLimitOffset(c)
+
+	reviews, total, err := h.service.Search(query, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.BookReviewListResponse{
+		Reviews: reviews,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+	})
 }
 
 // Delete は指定IDの書籍レビューを削除する。

--- a/backend/internal/handler/book_review_test.go
+++ b/backend/internal/handler/book_review_test.go
@@ -473,3 +473,44 @@ func TestBookReviewUpdateStatus_InvalidID(t *testing.T) {
 	})
 	assertStatus(t, w, http.StatusBadRequest)
 }
+
+// ============================================================
+// Search テスト
+// ============================================================
+
+func TestBookReviewSearch_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/search", h.Search)
+
+	svc.On("Search", "Go", 20, 0).Return([]model.BookReview{
+		{Title: "Go言語入門", Author: "テスト著者"},
+	}, int64(1), nil)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/search?q=Go", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewSearch_EmptyQuery(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/search", h.Search)
+
+	svc.On("Search", "", 20, 0).Return([]model.BookReview(nil), int64(0), service.ErrBadRequest)
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/search?q=", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookReviewSearch_ServiceError(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.GET("/book-reviews/search", h.Search)
+
+	svc.On("Search", "test", 20, 0).Return([]model.BookReview(nil), int64(0), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/book-reviews/search?q=test", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -770,6 +770,10 @@ func (m *MockBookReviewService) UnarchiveReview(id, userID uint) error {
 func (m *MockBookReviewService) UpdateStatus(id, userID uint, status model.ReviewStatus) error {
 	return m.Called(id, userID, status).Error(0)
 }
+func (m *MockBookReviewService) Search(query string, limit, offset int) ([]model.BookReview, int64, error) {
+	args := m.Called(query, limit, offset)
+	return args.Get(0).([]model.BookReview), args.Get(1).(int64), args.Error(2)
+}
 
 // setupBookReviewHandler はBookReviewHandlerテスト用のセットアップを行う。
 func setupBookReviewHandler() (*BookReviewHandler, *MockBookReviewService) {

--- a/backend/internal/repository/book_review.go
+++ b/backend/internal/repository/book_review.go
@@ -64,6 +64,17 @@ func (r *BookReviewRepository) FindByRating(userID uint, minRating, maxRating in
 	return reviews, err
 }
 
+// Search は書籍レビューをタイトル・著者名・ISBNからキーワード検索する（新しい順）。
+func (r *BookReviewRepository) Search(query string, limit, offset int) ([]model.BookReview, int64, error) {
+	var reviews []model.BookReview
+	var total int64
+	like := "%" + query + "%"
+	q := r.db.Where("title ILIKE ? OR author ILIKE ? OR isbn ILIKE ?", like, like, like)
+	q.Model(&model.BookReview{}).Count(&total)
+	err := q.Preload("User").Order("created_at DESC").Limit(limit).Offset(offset).Find(&reviews).Error
+	return reviews, total, err
+}
+
 // Update は既存の書籍レビューを更新する。
 func (r *BookReviewRepository) Update(review *model.BookReview) error {
 	return r.db.Save(review).Error

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -202,6 +202,7 @@ type BookReviewRepositoryInterface interface {
 	FindByUserID(userID uint, limit, offset int) ([]model.BookReview, int64, error)
 	FindAll(limit, offset int) ([]model.BookReview, int64, error)
 	FindByRating(userID uint, minRating, maxRating int) ([]model.BookReview, error)
+	Search(query string, limit, offset int) ([]model.BookReview, int64, error)
 	Update(review *model.BookReview) error
 	Delete(id uint) error
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -517,6 +517,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		bookReviews.PUT("/:id", c.BookReviewHandler.Update)
 		bookReviews.DELETE("/:id", c.BookReviewHandler.Delete)
 		bookReviews.GET("/user/:userId", c.BookReviewHandler.GetByUserID)
+		bookReviews.GET("/search", c.BookReviewHandler.Search)
 		bookReviews.GET("/rating", c.BookReviewHandler.GetByRating)
 		bookReviews.PUT("/:id/archive", c.BookReviewHandler.Archive)
 		bookReviews.PUT("/:id/unarchive", c.BookReviewHandler.Unarchive)

--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -60,6 +60,14 @@ func (s *BookReviewService) GetByRating(userID uint, minRating, maxRating int) (
 	return s.repo.FindByRating(userID, minRating, maxRating)
 }
 
+// Search は書籍レビューをキーワード検索する。
+func (s *BookReviewService) Search(query string, limit, offset int) ([]model.BookReview, int64, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, 0, domain.NewError(domain.ErrCodeBadRequest, "検索キーワードは必須です", nil)
+	}
+	return s.repo.Search(strings.TrimSpace(query), limit, offset)
+}
+
 // findAndCheckOwnership は書籍レビューを取得し、指定ユーザーが所有者かを検証する。
 func (s *BookReviewService) findAndCheckOwnership(id, userID uint) (*model.BookReview, error) {
 	review, err := s.repo.FindByID(id)

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -522,3 +522,54 @@ func TestBookReviewUpdateStatus_Forbidden(t *testing.T) {
 	err := svc.UpdateStatus(1, 1, model.ReviewStatusCompleted)
 	assert.ErrorIs(t, err, ErrForbidden)
 }
+
+// ============================================================
+// 書籍レビュー検索テスト
+// ============================================================
+
+func TestBookReviewSearch_Success(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	expected := []model.BookReview{
+		{Title: "Go言語入門", Author: "テスト著者", Rating: 4, UserID: 1},
+	}
+	repo.On("Search", "Go", 20, 0).Return(expected, int64(1), nil)
+
+	result, total, err := svc.Search("Go", 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewSearch_EmptyQuery(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	result, total, err := svc.Search("", 20, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "検索キーワードは必須です")
+	assert.Nil(t, result)
+	assert.Equal(t, int64(0), total)
+}
+
+func TestBookReviewSearch_WhitespaceQuery(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	result, total, err := svc.Search("   ", 20, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "検索キーワードは必須です")
+	assert.Nil(t, result)
+	assert.Equal(t, int64(0), total)
+}
+
+func TestBookReviewSearch_RepoError(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	repo.On("Search", "Go", 20, 0).Return([]model.BookReview(nil), int64(0), errors.New("db error"))
+
+	result, total, err := svc.Search("Go", 20, 0)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -687,6 +687,11 @@ func (m *MockBookReviewRepository) FindByRating(userID uint, minRating, maxRatin
 	return args.Get(0).([]model.BookReview), args.Error(1)
 }
 
+func (m *MockBookReviewRepository) Search(query string, limit, offset int) ([]model.BookReview, int64, error) {
+	args := m.Called(query, limit, offset)
+	return args.Get(0).([]model.BookReview), args.Get(1).(int64), args.Error(2)
+}
+
 // ============================================================
 // MockLearningResourceRepository は repository.LearningResourceRepositoryInterface のテスト用モック実装。
 // ============================================================


### PR DESCRIPTION
## 概要
Closes #1165

書籍レビューをタイトル・著者名・ISBNからキーワード検索できる機能を追加。

## 変更内容
- `BookReviewRepository.Search` — ILIKE検索（タイトル・著者名・ISBN）、ページネーション付き
- `BookReviewService.Search` — 空クエリバリデーション + リポジトリ呼び出し
- `BookReviewHandler.Search` — `GET /book-reviews/search?q=xxx` エンドポイント
- ルーター登録

## テスト
- サービステスト4件（成功、空クエリ、空白クエリ、リポジトリエラー）
- ハンドラーテスト3件（成功、空クエリ、サービスエラー）
- 全テスト通過確認済み