### PR TITLE
fix: BookReview ImageURLにhttp_urlバリデーション追加

### DIFF
--- a/backend/internal/dto/book_review_dto.go
+++ b/backend/internal/dto/book_review_dto.go
@@ -9,7 +9,7 @@ type CreateBookReviewRequest struct {
 	ISBN     string `json:"isbn" binding:"max=20" validate:"max=20"`
 	Rating   int    `json:"rating" binding:"required,min=1,max=5" validate:"required,min=1,max=5"`
 	Review   string `json:"review"`
-	ImageURL string `json:"image_url"`
+	ImageURL string `json:"image_url" binding:"omitempty,http_url,max=2000"`
 }
 
 // UpdateBookReviewRequest は書籍レビュー更新のリクエストボディ。
@@ -19,7 +19,7 @@ type UpdateBookReviewRequest struct {
 	ISBN     string `json:"isbn" binding:"omitempty,max=20" validate:"omitempty,max=20"`
 	Rating   *int   `json:"rating" binding:"omitempty,min=1,max=5" validate:"omitempty,min=1,max=5"`
 	Review   string `json:"review" binding:"omitempty,max=5000"`
-	ImageURL string `json:"image_url"`
+	ImageURL string `json:"image_url" binding:"omitempty,http_url,max=2000"`
 }
 
 // UpdateBookReviewStatusRequest は書籍レビューの読書状態更新リクエスト。

--- a/backend/internal/handler/book_review_test.go
+++ b/backend/internal/handler/book_review_test.go
@@ -514,3 +514,31 @@ func TestBookReviewSearch_ServiceError(t *testing.T) {
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }
+
+// ============================================================
+// ImageURL バリデーションテスト
+// ============================================================
+
+func TestBookReviewCreate_InvalidImageURL(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.POST("/book-reviews", h.Create)
+
+	w := doRequest(r, http.MethodPost, "/book-reviews", map[string]interface{}{
+		"title":     "テスト本",
+		"rating":    4,
+		"image_url": "javascript:alert('xss')",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookReviewUpdate_InvalidImageURL(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id", h.Update)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/1", map[string]interface{}{
+		"image_url": "data:text/html,<script>alert('xss')</script>",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}


### PR DESCRIPTION
## 概要
Closes #1171

書籍レビューのImageURLフィールドにhttp_urlバリデーションを追加し、XSS攻撃を防止。

## 変更内容
- `CreateBookReviewRequest.ImageURL` — `binding:"omitempty,http_url,max=2000"` 追加
- `UpdateBookReviewRequest.ImageURL` — `binding:"omitempty,http_url,max=2000"` 追加

## テスト
- `TestBookReviewCreate_InvalidImageURL` — javascript:スキーム → 400
- `TestBookReviewUpdate_InvalidImageURL` — data:スキーム → 400
- 全テスト通過確認済み