### PR TITLE
feat: 学習目標の複製（Duplicate）機能を追加

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -19,6 +19,7 @@ type LearningGoalServiceInterface interface {
 	Update(id, userID uint, updates *model.LearningGoal) (*model.LearningGoal, error)
 	Delete(id, userID uint) error
 	GetDeadlineAlerts(userID uint) ([]model.GoalDeadlineAlert, error)
+	Duplicate(id, userID uint) (*model.LearningGoal, error)
 }
 
 // LearningGoalHandler は学習目標関連のHTTPハンドラ。
@@ -231,6 +232,23 @@ func (h *LearningGoalHandler) GetByStatus(c *gin.Context) {
 	}
 
 	respondOK(c, ensureSlice(goals))
+}
+
+// Duplicate は学習目標を複製する。所有者のみ複製可能。
+func (h *LearningGoalHandler) Duplicate(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	goal, err := h.service.Duplicate(id, userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, goal)
 }
 
 // GetStats は指定されたユーザーの学習目標統計情報を取得する。

--- a/backend/internal/handler/learning_goal_test.go
+++ b/backend/internal/handler/learning_goal_test.go
@@ -561,3 +561,53 @@ func TestLearningGoalGetMyGoals_ServiceError(t *testing.T) {
 	w := doRequest(r, http.MethodGet, "/goals/me", nil)
 	assertStatus(t, w, http.StatusNotFound)
 }
+
+// ========== Duplicate ==========
+
+func TestLearningGoalDuplicate_Success(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.POST("/goals/:id/duplicate", h.Duplicate)
+
+	existing := &model.LearningGoal{Title: "Goマスター", Description: "Go習得", Category: model.GoalCategoryLanguage, UserID: 1}
+	existing.ID = 10
+	repo.On("FindByID", uint(10)).Return(existing, nil)
+	repo.On("Create", mock.AnythingOfType("*model.LearningGoal")).Return(nil)
+
+	w := doRequest(r, http.MethodPost, "/goals/10/duplicate", nil)
+	assertStatus(t, w, http.StatusCreated)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalDuplicate_Forbidden(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.POST("/goals/:id/duplicate", h.Duplicate)
+
+	existing := &model.LearningGoal{Title: "他人の目標", UserID: 999}
+	existing.ID = 10
+	repo.On("FindByID", uint(10)).Return(existing, nil)
+
+	w := doRequest(r, http.MethodPost, "/goals/10/duplicate", nil)
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+func TestLearningGoalDuplicate_NotFound(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.POST("/goals/:id/duplicate", h.Duplicate)
+
+	repo.On("FindByID", uint(99)).Return(nil, service.ErrNotFound)
+
+	w := doRequest(r, http.MethodPost, "/goals/99/duplicate", nil)
+	assertStatus(t, w, http.StatusNotFound)
+}
+
+func TestLearningGoalDuplicate_InvalidID(t *testing.T) {
+	h, _ := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.POST("/goals/:id/duplicate", h.Duplicate)
+
+	w := doRequest(r, http.MethodPost, "/goals/abc/duplicate", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -332,6 +332,7 @@ func registerGoalRoutes(g *gin.RouterGroup, c *di.Container) {
 		goals.GET("/deadline-alerts", c.LearningGoalHandler.GetDeadlineAlerts)
 		goals.GET("/category/:category", c.LearningGoalHandler.GetByCategory)
 		goals.GET("/status/:status", c.LearningGoalHandler.GetByStatus)
+		goals.POST("/:id/duplicate", c.LearningGoalHandler.Duplicate)
 	}
 }
 

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -191,6 +191,30 @@ func (s *LearningGoalService) GetDeadlineAlerts(userID uint) ([]model.GoalDeadli
 	return alerts, nil
 }
 
+// Duplicate は所有権を検証した後、学習目標を複製する。
+// 進捗は0%にリセットし、ステータスはactiveに戻す。タイトルに「(コピー)」を付与する。
+func (s *LearningGoalService) Duplicate(id, userID uint) (*model.LearningGoal, error) {
+	goal, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	newGoal := &model.LearningGoal{
+		UserID:      goal.UserID,
+		Title:       goal.Title + " (コピー)",
+		Description: goal.Description,
+		Category:    goal.Category,
+		TargetDate:  goal.TargetDate,
+		Progress:    0,
+		Status:      model.GoalStatusActive,
+	}
+
+	if err := s.repo.Create(newGoal); err != nil {
+		return nil, err
+	}
+	return newGoal, nil
+}
+
 // Delete は所有権を検証した後、学習目標を削除する。
 func (s *LearningGoalService) Delete(id, userID uint) error {
 	if _, err := s.findAndCheckOwnership(id, userID); err != nil {

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // newTestLearningGoalService はLearningGoalServiceのテスト用インスタンスを生成するヘルパー。
@@ -664,4 +665,77 @@ func TestLearningGoalUpdate_WhitespaceStatus(t *testing.T) {
 	result, err := svc.Update(1, 1, &model.LearningGoal{Status: "   "})
 	assert.NoError(t, err)
 	assert.Equal(t, model.GoalStatusActive, result.Status)
+}
+
+// ============================================================
+// 学習目標 複製テスト
+// ============================================================
+
+func TestLearningGoalDuplicate_Success(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	existing := &model.LearningGoal{
+		UserID:      1,
+		Title:       "Goマスター",
+		Description: "Go言語を完全習得する",
+		Category:    model.GoalCategoryLanguage,
+		Progress:    80,
+		Status:      model.GoalStatusCompleted,
+	}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Create", mock.MatchedBy(func(g *model.LearningGoal) bool {
+		return g.Title == "Goマスター (コピー)" &&
+			g.Description == "Go言語を完全習得する" &&
+			g.Category == model.GoalCategoryLanguage &&
+			g.Progress == 0 &&
+			g.Status == model.GoalStatusActive &&
+			g.UserID == 1 &&
+			g.CompletedAt == nil
+	})).Return(nil)
+
+	result, err := svc.Duplicate(1, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "Goマスター (コピー)", result.Title)
+	assert.Equal(t, 0, result.Progress)
+	assert.Equal(t, model.GoalStatusActive, result.Status)
+	assert.Nil(t, result.CompletedAt)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalDuplicate_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	existing := &model.LearningGoal{UserID: 99, Title: "他人の目標"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	result, err := svc.Duplicate(1, 1)
+	assert.ErrorIs(t, err, ErrForbidden)
+	assert.Nil(t, result)
+}
+
+func TestLearningGoalDuplicate_NotFound(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	result, err := svc.Duplicate(99, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestLearningGoalDuplicate_CreateError(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	existing := &model.LearningGoal{UserID: 1, Title: "目標"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Create", mock.AnythingOfType("*model.LearningGoal")).Return(errors.New("db error"))
+
+	result, err := svc.Duplicate(1, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
学習目標を複製するAPIエンドポイントを追加。

## 変更内容
- `POST /api/goals/:id/duplicate` エンドポイント追加
- Service層: `Duplicate` メソッド追加（所有権チェック・進捗リセット・タイトル「(コピー)」付与）
- Handler層: `Duplicate` ハンドラー追加・インターフェース拡張
- サービステスト4件 + ハンドラーテスト4件

Closes #1173