### PR TITLE
feat: 学習目標の複製ボタンをフロントエンドに追加

### DIFF
--- a/frontend/src/api/goals.ts
+++ b/frontend/src/api/goals.ts
@@ -69,3 +69,6 @@ export const getGoalStats = (userId: number) =>
 
 export const getDeadlineAlerts = () =>
   client.get<GoalDeadlineAlert[]>('/goals/deadline-alerts');
+
+export const duplicateGoal = (id: number) =>
+  client.post<LearningGoal>(`/goals/${id}/duplicate`);

--- a/frontend/src/hooks/useGoalForm.ts
+++ b/frontend/src/hooks/useGoalForm.ts
@@ -69,6 +69,10 @@ export function useGoalForm() {
     if (ok) goalsData.deleteGoal(id);
   };
 
+  const handleDuplicateGoal = async (id: number) => {
+    await goalsData.duplicateGoal(id);
+  };
+
   return {
     ...goalsData,
     showForm,
@@ -88,6 +92,7 @@ export function useGoalForm() {
     handleProgressChange,
     handleStatusChange,
     handleDeleteGoal,
+    handleDuplicateGoal,
     dialogProps,
   };
 }

--- a/frontend/src/hooks/useGoals.ts
+++ b/frontend/src/hooks/useGoals.ts
@@ -6,6 +6,7 @@ import {
   createGoal,
   updateGoal,
   deleteGoal,
+  duplicateGoal,
   type LearningGoal,
   type GoalCategory,
   type GoalStatus,
@@ -90,6 +91,18 @@ export function useGoals() {
     }
   }, [t, setGoals]);
 
+  const handleDuplicate = useCallback(async (id: number) => {
+    try {
+      const { data: newGoal } = await duplicateGoal(id);
+      setGoals(prev => [newGoal, ...prev]);
+      toast.success(t('goals.duplicated'));
+      return newGoal;
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+      return null;
+    }
+  }, [t, setGoals]);
+
   const activeGoals = currentGoals.filter(g => g.status === 'active');
   const completedGoals = currentGoals.filter(g => g.status === 'completed');
   const pausedGoals = currentGoals.filter(g => g.status === 'paused');
@@ -104,6 +117,7 @@ export function useGoals() {
     createGoal: handleCreate,
     updateGoal: handleUpdate,
     deleteGoal: handleDelete,
+    duplicateGoal: handleDuplicate,
     refetch,
   };
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -584,6 +584,8 @@
     "created": "Ziel erstellt",
     "updated": "Ziel aktualisiert",
     "deleted": "Ziel gelöscht",
+    "duplicate": "Duplizieren",
+    "duplicated": "Ziel dupliziert",
     "totalGoals": "Gesamtziele",
     "activeGoals": "Aktiv",
     "completedGoals": "Abgeschlossen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -584,6 +584,8 @@
     "created": "Goal created",
     "updated": "Goal updated",
     "deleted": "Goal deleted",
+    "duplicate": "Duplicate",
+    "duplicated": "Goal duplicated",
     "totalGoals": "Total Goals",
     "activeGoals": "Active",
     "completedGoals": "Completed",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -584,6 +584,8 @@
     "created": "Objetivo creado",
     "updated": "Objetivo actualizado",
     "deleted": "Objetivo eliminado",
+    "duplicate": "Duplicar",
+    "duplicated": "Objetivo duplicado",
     "totalGoals": "Total de Objetivos",
     "activeGoals": "Activos",
     "completedGoals": "Completados",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -584,6 +584,8 @@
     "created": "Objectif créé",
     "updated": "Objectif mis à jour",
     "deleted": "Objectif supprimé",
+    "duplicate": "Dupliquer",
+    "duplicated": "Objectif dupliqué",
     "totalGoals": "Total des objectifs",
     "activeGoals": "Actifs",
     "completedGoals": "Terminés",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -566,6 +566,8 @@
     "created": "目標を作成しました",
     "updated": "目標を更新しました",
     "deleted": "目標を削除しました",
+    "duplicate": "複製",
+    "duplicated": "目標を複製しました",
     "createSuccess": "目標を作成しました",
     "updateSuccess": "目標を更新しました",
     "deleteSuccess": "目標を削除しました",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -584,6 +584,8 @@
     "created": "목표가 생성되었습니다",
     "updated": "목표가 업데이트되었습니다",
     "deleted": "목표가 삭제되었습니다",
+    "duplicate": "복제",
+    "duplicated": "목표가 복제되었습니다",
     "totalGoals": "총 목표",
     "activeGoals": "진행 중",
     "completedGoals": "완료",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -584,6 +584,8 @@
     "created": "Meta criada",
     "updated": "Meta atualizada",
     "deleted": "Meta excluída",
+    "duplicate": "Duplicar",
+    "duplicated": "Meta duplicada",
     "totalGoals": "Total de Metas",
     "activeGoals": "Ativas",
     "completedGoals": "Concluídas",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -584,6 +584,8 @@
     "created": "Цель создана",
     "updated": "Цель обновлена",
     "deleted": "Цель удалена",
+    "duplicate": "Дублировать",
+    "duplicated": "Цель дублирована",
     "totalGoals": "Всего целей",
     "activeGoals": "Активные",
     "completedGoals": "Завершённые",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -584,6 +584,8 @@
     "created": "目标已创建",
     "updated": "目标已更新",
     "deleted": "目标已删除",
+    "duplicate": "复制",
+    "duplicated": "目标已复制",
     "totalGoals": "总目标",
     "activeGoals": "进行中",
     "completedGoals": "已完成",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -584,6 +584,8 @@
     "created": "目標已建立",
     "updated": "目標已更新",
     "deleted": "目標已刪除",
+    "duplicate": "複製",
+    "duplicated": "目標已複製",
     "totalGoals": "總目標",
     "activeGoals": "進行中",
     "completedGoals": "已完成",

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Monitor, Rocket, Target, FolderOpen, FileText, type LucideIcon } from 'lucide-react';
+import { Monitor, Rocket, Target, FolderOpen, FileText, Copy, type LucideIcon } from 'lucide-react';
 import { type GoalCategory, type GoalStatus, type LearningGoal } from '../api/goals';
 import { useGoalForm } from '../hooks';
 import { Modal, PageLoader } from '../components/common';
@@ -51,6 +51,7 @@ export default function GoalsPage() {
     category, setCategory, targetDate, setTargetDate,
     resetForm, handleSubmit, handleEdit,
     handleProgressChange, handleStatusChange, handleDeleteGoal,
+    handleDuplicateGoal,
     dialogProps,
   } = useGoalForm();
 
@@ -195,6 +196,7 @@ export default function GoalsPage() {
                     goal={goal}
                     onEdit={handleEdit}
                     onDelete={handleDeleteGoal}
+                    onDuplicate={handleDuplicateGoal}
                     onProgressChange={handleProgressChange}
                     onStatusChange={handleStatusChange}
                     getCategoryInfo={getCategoryInfo}
@@ -218,6 +220,7 @@ export default function GoalsPage() {
                     goal={goal}
                     onEdit={handleEdit}
                     onDelete={handleDeleteGoal}
+                    onDuplicate={handleDuplicateGoal}
                     onProgressChange={handleProgressChange}
                     onStatusChange={handleStatusChange}
                     getCategoryInfo={getCategoryInfo}
@@ -241,6 +244,7 @@ export default function GoalsPage() {
                     goal={goal}
                     onEdit={handleEdit}
                     onDelete={handleDeleteGoal}
+                    onDuplicate={handleDuplicateGoal}
                     onProgressChange={handleProgressChange}
                     onStatusChange={handleStatusChange}
                     getCategoryInfo={getCategoryInfo}
@@ -263,6 +267,7 @@ interface GoalCardProps {
   goal: LearningGoal;
   onEdit: (goal: LearningGoal) => void;
   onDelete: (id: number) => void;
+  onDuplicate: (id: number) => void;
   onProgressChange: (goal: LearningGoal, progress: number) => void;
   onStatusChange: (goal: LearningGoal, status: GoalStatus) => void;
   getCategoryInfo: (cat: GoalCategory) => { value: GoalCategory; label: string; icon: string; Icon: LucideIcon };
@@ -274,6 +279,7 @@ const GoalCard = memo(function GoalCard({
   goal,
   onEdit,
   onDelete,
+  onDuplicate,
   onProgressChange,
   onStatusChange,
   getCategoryInfo,
@@ -377,6 +383,13 @@ const GoalCard = memo(function GoalCard({
               </svg>
             </button>
           )}
+          <button
+            onClick={() => onDuplicate(goal.id)}
+            className="p-2 text-gray-400 hover:text-purple-400 transition-colors"
+            aria-label={t('goals.duplicate')}
+          >
+            <Copy className="w-4 h-4" />
+          </button>
           <button
             onClick={() => onEdit(goal)}
             className="p-2 text-gray-400 hover:text-blue-400 transition-colors"


### PR DESCRIPTION
## 概要
Cycle 305で追加したDuplicate APIに対応するGoalCard複製ボタンを実装。

## 変更内容
- `api/goals.ts`: `duplicateGoal` API関数追加
- `hooks/useGoals.ts`: `handleDuplicate` 操作追加
- `hooks/useGoalForm.ts`: `handleDuplicateGoal` 追加
- `pages/GoalsPage.tsx`: GoalCardにCopyアイコンの複製ボタン追加
- 10言語i18nキー（`goals.duplicate`, `goals.duplicated`）追加

Closes #1175