### PR TITLE
test: 検索コンポーネントのテスト23件追加

### DIFF
--- a/frontend/src/components/search/__tests__/CircleSearchCard.test.tsx
+++ b/frontend/src/components/search/__tests__/CircleSearchCard.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import CircleSearchCard from '../CircleSearchCard';
+import type { StudyCircle } from '../../../types/studyCircle';
+
+const mockCircle: StudyCircle = {
+  id: 1,
+  name: 'React Study Group',
+  topic: 'React & TypeScript',
+  description: 'A study group for React developers.',
+  max_members: 20,
+  member_count: 8,
+  owner_id: 1,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('CircleSearchCard', () => {
+  it('サークル名が表示される', () => {
+    renderWithRouter(<CircleSearchCard circle={mockCircle} />);
+    expect(screen.getByText('React Study Group')).toBeInTheDocument();
+  });
+
+  it('トピックが表示される', () => {
+    renderWithRouter(<CircleSearchCard circle={mockCircle} />);
+    expect(screen.getByText('React & TypeScript')).toBeInTheDocument();
+  });
+
+  it('説明が表示される', () => {
+    renderWithRouter(<CircleSearchCard circle={mockCircle} />);
+    expect(screen.getByText('A study group for React developers.')).toBeInTheDocument();
+  });
+
+  it('メンバー数と上限が表示される', () => {
+    renderWithRouter(<CircleSearchCard circle={mockCircle} />);
+    expect(screen.getByText('8 / 20')).toBeInTheDocument();
+  });
+
+  it('説明が空の場合は表示されない', () => {
+    const circleNoDesc = { ...mockCircle, description: '' };
+    renderWithRouter(<CircleSearchCard circle={circleNoDesc} />);
+    expect(screen.queryByText('A study group for React developers.')).not.toBeInTheDocument();
+  });
+
+  it('サークルへのリンクが正しいパスを持つ', () => {
+    renderWithRouter(<CircleSearchCard circle={mockCircle} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/study-circles/1');
+  });
+});

--- a/frontend/src/components/search/__tests__/PostFilterPanel.test.tsx
+++ b/frontend/src/components/search/__tests__/PostFilterPanel.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PostFilterPanel from '../PostFilterPanel';
+import type { PostSearchFilters } from '../../../api/posts';
+
+const defaultFilters: PostSearchFilters = {
+  sortBy: 'latest',
+  tags: [],
+};
+
+describe('PostFilterPanel', () => {
+  it('ソートボタンが3つ表示される', () => {
+    const onChange = vi.fn();
+    render(<PostFilterPanel filters={defaultFilters} onFiltersChange={onChange} />);
+
+    expect(screen.getByText('最新順')).toBeInTheDocument();
+    expect(screen.getByText('人気順')).toBeInTheDocument();
+    expect(screen.getByText('閲覧数順')).toBeInTheDocument();
+  });
+
+  it('ソートボタンクリックでフィルターが変更される', () => {
+    const onChange = vi.fn();
+    render(<PostFilterPanel filters={defaultFilters} onFiltersChange={onChange} />);
+
+    fireEvent.click(screen.getByText('人気順'));
+    expect(onChange).toHaveBeenCalledWith({ ...defaultFilters, sortBy: 'popular' });
+  });
+
+  it('タグを追加できる', () => {
+    const onChange = vi.fn();
+    render(<PostFilterPanel filters={defaultFilters} onFiltersChange={onChange} />);
+
+    const input = screen.getByPlaceholderText('タグを入力...');
+    fireEvent.change(input, { target: { value: 'React' } });
+    fireEvent.click(screen.getByText('追加'));
+
+    expect(onChange).toHaveBeenCalledWith({ ...defaultFilters, tags: ['React'] });
+  });
+
+  it('Enterキーでタグを追加できる', () => {
+    const onChange = vi.fn();
+    render(<PostFilterPanel filters={defaultFilters} onFiltersChange={onChange} />);
+
+    const input = screen.getByPlaceholderText('タグを入力...');
+    fireEvent.change(input, { target: { value: 'TypeScript' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(onChange).toHaveBeenCalledWith({ ...defaultFilters, tags: ['TypeScript'] });
+  });
+
+  it('既存タグが表示される', () => {
+    const onChange = vi.fn();
+    const filters = { ...defaultFilters, tags: ['React', 'Vue'] };
+    render(<PostFilterPanel filters={filters} onFiltersChange={onChange} />);
+
+    expect(screen.getByText('#React')).toBeInTheDocument();
+    expect(screen.getByText('#Vue')).toBeInTheDocument();
+  });
+
+  it('タグの削除ボタンでタグが除去される', () => {
+    const onChange = vi.fn();
+    const filters = { ...defaultFilters, tags: ['React', 'Vue'] };
+    render(<PostFilterPanel filters={filters} onFiltersChange={onChange} />);
+
+    const removeButtons = screen.getAllByText('×');
+    fireEvent.click(removeButtons[0]);
+
+    expect(onChange).toHaveBeenCalledWith({ ...defaultFilters, tags: ['Vue'] });
+  });
+
+  it('日付フィルターが変更される', () => {
+    const onChange = vi.fn();
+    const { container } = render(<PostFilterPanel filters={defaultFilters} onFiltersChange={onChange} />);
+
+    const dateInputs = container.querySelectorAll('input[type="date"]');
+    fireEvent.change(dateInputs[0], { target: { value: '2026-01-01' } });
+
+    expect(onChange).toHaveBeenCalledWith({ ...defaultFilters, dateFrom: '2026-01-01' });
+  });
+});

--- a/frontend/src/components/search/__tests__/PostSearchCard.test.tsx
+++ b/frontend/src/components/search/__tests__/PostSearchCard.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import PostSearchCard from '../PostSearchCard';
+import type { Post } from '../../../types/post';
+
+const mockPost: Post = {
+  id: 1,
+  user_id: 1,
+  title: 'Test Post Title',
+  content: 'This is the post content for testing.',
+  status: 'published',
+  like_count: 5,
+  comment_count: 3,
+  view_count: 100,
+  created_at: '2026-01-15T10:00:00Z',
+  updated_at: '2026-01-15T10:00:00Z',
+  user: {
+    id: 1,
+    name: 'Author Name',
+    username: 'author',
+    email: 'author@example.com',
+    bio: '',
+    avatar_url: '',
+    github_username: '',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  },
+};
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('PostSearchCard', () => {
+  it('投稿タイトルが表示される', () => {
+    renderWithRouter(<PostSearchCard post={mockPost} />);
+    expect(screen.getByText('Test Post Title')).toBeInTheDocument();
+  });
+
+  it('投稿内容が表示される', () => {
+    renderWithRouter(<PostSearchCard post={mockPost} />);
+    expect(screen.getByText('This is the post content for testing.')).toBeInTheDocument();
+  });
+
+  it('著者名が表示される', () => {
+    renderWithRouter(<PostSearchCard post={mockPost} />);
+    expect(screen.getByText('Author Name')).toBeInTheDocument();
+  });
+
+  it('いいね数が表示される', () => {
+    renderWithRouter(<PostSearchCard post={mockPost} />);
+    expect(screen.getByText('5件のいいね')).toBeInTheDocument();
+  });
+
+  it('投稿へのリンクが正しいパスを持つ', () => {
+    renderWithRouter(<PostSearchCard post={mockPost} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/posts/1');
+  });
+});

--- a/frontend/src/components/search/__tests__/UserSearchCard.test.tsx
+++ b/frontend/src/components/search/__tests__/UserSearchCard.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import UserSearchCard from '../UserSearchCard';
+import type { User } from '../../../types/user';
+
+const mockUser: User = {
+  id: 1,
+  name: 'Test User',
+  username: 'testuser',
+  email: 'test@example.com',
+  bio: 'This is a test bio',
+  avatar_url: '',
+  github_username: '',
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+};
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('UserSearchCard', () => {
+  it('ユーザー名が表示される', () => {
+    renderWithRouter(<UserSearchCard user={mockUser} />);
+    expect(screen.getByText('Test User')).toBeInTheDocument();
+  });
+
+  it('bioが表示される', () => {
+    renderWithRouter(<UserSearchCard user={mockUser} />);
+    expect(screen.getByText('This is a test bio')).toBeInTheDocument();
+  });
+
+  it('bioが空の場合は表示されない', () => {
+    const userNoBio = { ...mockUser, bio: '' };
+    renderWithRouter(<UserSearchCard user={userNoBio} />);
+    expect(screen.queryByText('This is a test bio')).not.toBeInTheDocument();
+  });
+
+  it('プロフィールリンクが正しいパスを持つ', () => {
+    renderWithRouter(<UserSearchCard user={mockUser} />);
+    const links = screen.getAllByRole('link');
+    const profileLinks = links.filter(link => link.getAttribute('href') === '/profile/testuser');
+    expect(profileLinks.length).toBeGreaterThan(0);
+  });
+
+  it('プロフィール表示ボタンが表示される', () => {
+    renderWithRouter(<UserSearchCard user={mockUser} />);
+    expect(screen.getByText('プロフィール')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
Cycle 307で分離した4つの検索コンポーネントのユニットテストを追加。

## 変更内容
- `PostFilterPanel.test.tsx`: 7テスト
- `UserSearchCard.test.tsx`: 5テスト
- `PostSearchCard.test.tsx`: 5テスト
- `CircleSearchCard.test.tsx`: 6テスト
- 計23テスト、全て通過

Closes #1179