### PR TITLE
fix: AvatarコンポーネントのURLサニタイズを追加

### DIFF
--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -1,3 +1,5 @@
+import { sanitizeUrl } from '../../utils/url';
+
 interface AvatarProps {
   name: string;
   avatarUrl?: string;
@@ -12,10 +14,11 @@ const sizeClasses = {
 };
 
 export default function Avatar({ name, avatarUrl, size = 'md' }: AvatarProps) {
-  if (avatarUrl) {
+  const safeUrl = sanitizeUrl(avatarUrl);
+  if (safeUrl) {
     return (
       <img
-        src={avatarUrl}
+        src={safeUrl}
         alt={name}
         className={`${sizeClasses[size]} rounded-full object-cover`}
       />

--- a/frontend/src/utils/__tests__/url.test.ts
+++ b/frontend/src/utils/__tests__/url.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { isHttpUrl, sanitizeUrl } from '../url';
+
+describe('isHttpUrl', () => {
+  it('https URLを許可する', () => {
+    expect(isHttpUrl('https://example.com')).toBe(true);
+    expect(isHttpUrl('https://example.com/path?q=1')).toBe(true);
+  });
+
+  it('http URLを許可する', () => {
+    expect(isHttpUrl('http://example.com')).toBe(true);
+  });
+
+  it('javascript: URLを拒否する', () => {
+    expect(isHttpUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('data: URLを拒否する', () => {
+    expect(isHttpUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+  });
+
+  it('vbscript: URLを拒否する', () => {
+    expect(isHttpUrl('vbscript:msgbox')).toBe(false);
+  });
+
+  it('空文字列を拒否する', () => {
+    expect(isHttpUrl('')).toBe(false);
+  });
+
+  it('不正なURLを拒否する', () => {
+    expect(isHttpUrl('not-a-url')).toBe(false);
+  });
+
+  it('ftp: URLを拒否する', () => {
+    expect(isHttpUrl('ftp://example.com')).toBe(false);
+  });
+});
+
+describe('sanitizeUrl', () => {
+  it('有効なhttps URLをそのまま返す', () => {
+    expect(sanitizeUrl('https://example.com/avatar.png')).toBe('https://example.com/avatar.png');
+  });
+
+  it('javascript: URLに対してundefinedを返す', () => {
+    expect(sanitizeUrl('javascript:alert(1)')).toBeUndefined();
+  });
+
+  it('undefinedに対してundefinedを返す', () => {
+    expect(sanitizeUrl(undefined)).toBeUndefined();
+  });
+
+  it('空文字列に対してundefinedを返す', () => {
+    expect(sanitizeUrl('')).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -1,0 +1,22 @@
+/**
+ * URLがHTTPまたはHTTPSプロトコルかを検証する。
+ * javascript:, data:, vbscript: 等の危険なプロトコルを拒否する。
+ */
+export function isHttpUrl(url: string): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * URLをサニタイズして返す。
+ * http/httpsでないURLの場合はundefinedを返す。
+ */
+export function sanitizeUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+  return isHttpUrl(url) ? url : undefined;
+}


### PR DESCRIPTION
## 概要
AvatarのURLサニタイズでXSS脆弱性を修正。

## 変更内容
- `utils/url.ts`: `isHttpUrl`/`sanitizeUrl`ユーティリティ追加（http/httpsのみ許可）
- `Avatar.tsx`: `sanitizeUrl`で危険なプロトコルのURLをフォールバック表示に変更
- テスト12件追加（isHttpUrl: 8件、sanitizeUrl: 4件）

Closes #1181