### PR TITLE
feat: 書籍レビューのステータス管理・アーカイブ機能（フロントエンド）

### DIFF
--- a/frontend/src/api/bookReviews.ts
+++ b/frontend/src/api/bookReviews.ts
@@ -1,5 +1,5 @@
 import client from './client';
-import type { BookReview, CreateBookReviewRequest, UpdateBookReviewRequest } from '../types/bookReview';
+import type { BookReview, CreateBookReviewRequest, UpdateBookReviewRequest, ReviewStatus } from '../types/bookReview';
 
 export const createBookReview = async (data: CreateBookReviewRequest): Promise<BookReview> => {
   const res = await client.post('/book-reviews', data);
@@ -28,4 +28,29 @@ export const updateBookReview = async (id: number, data: UpdateBookReviewRequest
 
 export const deleteBookReview = async (id: number): Promise<void> => {
   await client.delete(`/book-reviews/${id}`);
+};
+
+export const searchBookReviews = async (q: string, limit = 20, offset = 0): Promise<{ reviews: BookReview[]; total: number }> => {
+  const res = await client.get('/book-reviews/search', { params: { q, limit, offset } });
+  return res.data;
+};
+
+export const getBookReviewsByRating = async (minRating: number, maxRating: number): Promise<BookReview[]> => {
+  const res = await client.get('/book-reviews/rating', { params: { min_rating: minRating, max_rating: maxRating } });
+  return res.data;
+};
+
+export const archiveBookReview = async (id: number): Promise<BookReview> => {
+  const res = await client.put(`/book-reviews/${id}/archive`);
+  return res.data;
+};
+
+export const unarchiveBookReview = async (id: number): Promise<BookReview> => {
+  const res = await client.put(`/book-reviews/${id}/unarchive`);
+  return res.data;
+};
+
+export const updateBookReviewStatus = async (id: number, status: ReviewStatus): Promise<BookReview> => {
+  const res = await client.put(`/book-reviews/${id}/status`, { status });
+  return res.data;
 };

--- a/frontend/src/components/bookReviews/BookReviewCard.tsx
+++ b/frontend/src/components/bookReviews/BookReviewCard.tsx
@@ -1,13 +1,22 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import type { BookReview } from '../../types/bookReview';
+import type { BookReview, ReviewStatus } from '../../types/bookReview';
 import Avatar from '../common/Avatar';
 import { cardClass } from '../../constants/styles';
+
+const statusColors: Record<ReviewStatus, string> = {
+  not_started: 'bg-gray-600 text-gray-200',
+  reading: 'bg-blue-600 text-blue-100',
+  completed: 'bg-green-600 text-green-100',
+};
 
 interface BookReviewCardProps {
   review: BookReview;
   onEdit?: () => void;
   onDelete?: () => void;
+  onStatusChange?: (id: number, status: ReviewStatus) => void;
+  onArchive?: (id: number) => void;
+  onUnarchive?: (id: number) => void;
   isOwner?: boolean;
   showUser?: boolean;
 }
@@ -16,6 +25,9 @@ export default function BookReviewCard({
   review,
   onEdit,
   onDelete,
+  onStatusChange,
+  onArchive,
+  onUnarchive,
   isOwner = false,
   showUser = true,
 }: BookReviewCardProps) {
@@ -87,14 +99,57 @@ export default function BookReviewCard({
             )}
           </div>
 
-          {/* Rating */}
-          <div className="mt-2">
+          {/* Status & Rating */}
+          <div className="mt-2 flex items-center gap-3">
             {renderStars(review.rating)}
+            {review.status && (
+              <span className={`text-xs px-2 py-0.5 rounded-full ${statusColors[review.status]}`}>
+                {t(`bookReviews.status.${review.status}`)}
+              </span>
+            )}
+            {review.is_archived && (
+              <span className="text-xs px-2 py-0.5 rounded-full bg-yellow-700 text-yellow-200">
+                {t('bookReviews.archivedLabel')}
+              </span>
+            )}
           </div>
 
           {/* Review Text */}
           {review.review && (
             <p className="text-gray-300 text-sm mt-2 line-clamp-2">{review.review}</p>
+          )}
+
+          {/* Owner Actions */}
+          {isOwner && (onStatusChange || onArchive || onUnarchive) && (
+            <div className="flex items-center gap-2 mt-2">
+              {onStatusChange && (
+                <select
+                  value={review.status}
+                  onChange={(e) => onStatusChange(review.id, e.target.value as ReviewStatus)}
+                  className="text-xs bg-gray-700 text-gray-300 border border-gray-600 rounded px-2 py-1"
+                >
+                  <option value="not_started">{t('bookReviews.status.not_started')}</option>
+                  <option value="reading">{t('bookReviews.status.reading')}</option>
+                  <option value="completed">{t('bookReviews.status.completed')}</option>
+                </select>
+              )}
+              {onArchive && !review.is_archived && (
+                <button
+                  onClick={() => onArchive(review.id)}
+                  className="text-xs text-gray-400 hover:text-yellow-400 transition-colors"
+                >
+                  {t('bookReviews.archive')}
+                </button>
+              )}
+              {onUnarchive && review.is_archived && (
+                <button
+                  onClick={() => onUnarchive(review.id)}
+                  className="text-xs text-gray-400 hover:text-blue-400 transition-colors"
+                >
+                  {t('bookReviews.unarchive')}
+                </button>
+              )}
+            </div>
           )}
 
           {/* Footer */}

--- a/frontend/src/hooks/useBookReviews.ts
+++ b/frontend/src/hooks/useBookReviews.ts
@@ -1,14 +1,19 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
-import type { BookReview, CreateBookReviewRequest } from '../types/bookReview';
-import { getBookReviews, createBookReview, updateBookReview, deleteBookReview } from '../api/bookReviews';
+import type { BookReview, CreateBookReviewRequest, ReviewStatus } from '../types/bookReview';
+import {
+  getBookReviews, createBookReview, updateBookReview, deleteBookReview,
+  archiveBookReview, unarchiveBookReview, updateBookReviewStatus,
+} from '../api/bookReviews';
 import { useAsyncData } from './useAsyncData';
 
 export function useBookReviews() {
   const { t } = useTranslation();
   const [saving, setSaving] = useState(false);
   const [page, setPage] = useState(0);
+  const [statusFilter, setStatusFilter] = useState<ReviewStatus | 'all'>('all');
+  const [showArchived, setShowArchived] = useState(false);
   const limit = 20;
 
   const { data, loading, refetch } = useAsyncData(
@@ -22,7 +27,13 @@ export function useBookReviews() {
   const total = data?.total ?? 0;
 
   const [localReviews, setLocalReviews] = useState<BookReview[] | null>(null);
-  const currentReviews = localReviews ?? reviews;
+  const allReviews = localReviews ?? reviews;
+  const currentReviews = allReviews.filter(r => {
+    if (!showArchived && r.is_archived) return false;
+    if (showArchived && !r.is_archived) return false;
+    if (statusFilter !== 'all' && r.status !== statusFilter) return false;
+    return true;
+  });
 
   const handleCreate = useCallback(async (reqData: CreateBookReviewRequest) => {
     setSaving(true);
@@ -66,6 +77,42 @@ export function useBookReviews() {
     }
   }, [t, reviews]);
 
+  const handleUpdateStatus = useCallback(async (reviewId: number, status: ReviewStatus) => {
+    try {
+      const updated = await updateBookReviewStatus(reviewId, status);
+      setLocalReviews(prev => (prev ?? reviews).map(r => r.id === updated.id ? updated : r));
+      toast.success(t('bookReviews.statusUpdated'));
+      return updated;
+    } catch {
+      toast.error(t('bookReviews.statusUpdateFailed'));
+      return null;
+    }
+  }, [t, reviews]);
+
+  const handleArchive = useCallback(async (reviewId: number) => {
+    try {
+      const updated = await archiveBookReview(reviewId);
+      setLocalReviews(prev => (prev ?? reviews).map(r => r.id === updated.id ? updated : r));
+      toast.success(t('bookReviews.archived'));
+      return updated;
+    } catch {
+      toast.error(t('bookReviews.archiveFailed'));
+      return null;
+    }
+  }, [t, reviews]);
+
+  const handleUnarchive = useCallback(async (reviewId: number) => {
+    try {
+      const updated = await unarchiveBookReview(reviewId);
+      setLocalReviews(prev => (prev ?? reviews).map(r => r.id === updated.id ? updated : r));
+      toast.success(t('bookReviews.unarchived'));
+      return updated;
+    } catch {
+      toast.error(t('bookReviews.unarchiveFailed'));
+      return null;
+    }
+  }, [t, reviews]);
+
   return {
     reviews: currentReviews,
     total,
@@ -74,9 +121,16 @@ export function useBookReviews() {
     page,
     setPage,
     limit,
+    statusFilter,
+    setStatusFilter,
+    showArchived,
+    setShowArchived,
     createReview: handleCreate,
     updateReview: handleUpdate,
     deleteReview: handleDelete,
+    updateStatus: handleUpdateStatus,
+    archiveReview: handleArchive,
+    unarchiveReview: handleUnarchive,
     refetch,
   };
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -839,7 +839,22 @@
     "createFailed": "Rezension konnte nicht erstellt werden",
     "updateFailed": "Rezension konnte nicht aktualisiert werden",
     "deleteFailed": "Rezension konnte nicht gelöscht werden",
-    "confirmDelete": "Bist du sicher, dass du diese Rezension löschen möchtest?"
+    "confirmDelete": "Bist du sicher, dass du diese Rezension löschen möchtest?",
+    "status": {
+      "not_started": "Nicht begonnen",
+      "reading": "Wird gelesen",
+      "completed": "Abgeschlossen"
+    },
+    "statusAll": "Alle",
+    "archivedLabel": "Archiviert",
+    "archive": "Archivieren",
+    "unarchive": "Entarchivieren",
+    "archived": "Rezension archiviert",
+    "unarchived": "Rezension entarchiviert",
+    "archiveFailed": "Archivierung fehlgeschlagen",
+    "unarchiveFailed": "Entarchivierung fehlgeschlagen",
+    "statusUpdated": "Status aktualisiert",
+    "statusUpdateFailed": "Statusaktualisierung fehlgeschlagen"
   },
   "qa": {
     "pageTitle": "Tech Q&A",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -839,7 +839,22 @@
     "createFailed": "Failed to create review",
     "updateFailed": "Failed to update review",
     "deleteFailed": "Failed to delete review",
-    "confirmDelete": "Are you sure you want to delete this review?"
+    "confirmDelete": "Are you sure you want to delete this review?",
+    "status": {
+      "not_started": "Not Started",
+      "reading": "Reading",
+      "completed": "Completed"
+    },
+    "statusAll": "All",
+    "archivedLabel": "Archived",
+    "archive": "Archive",
+    "unarchive": "Unarchive",
+    "archived": "Review archived",
+    "unarchived": "Review unarchived",
+    "archiveFailed": "Failed to archive",
+    "unarchiveFailed": "Failed to unarchive",
+    "statusUpdated": "Status updated",
+    "statusUpdateFailed": "Failed to update status"
   },
   "qa": {
     "pageTitle": "Tech Q&A",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -839,7 +839,22 @@
     "createFailed": "Error al crear reseña",
     "updateFailed": "Error al actualizar reseña",
     "deleteFailed": "Error al eliminar reseña",
-    "confirmDelete": "¿Estás seguro de que deseas eliminar esta reseña?"
+    "confirmDelete": "¿Estás seguro de que deseas eliminar esta reseña?",
+    "status": {
+      "not_started": "No iniciado",
+      "reading": "Leyendo",
+      "completed": "Completado"
+    },
+    "statusAll": "Todos",
+    "archivedLabel": "Archivado",
+    "archive": "Archivar",
+    "unarchive": "Desarchivar",
+    "archived": "Reseña archivada",
+    "unarchived": "Reseña desarchivada",
+    "archiveFailed": "Error al archivar",
+    "unarchiveFailed": "Error al desarchivar",
+    "statusUpdated": "Estado actualizado",
+    "statusUpdateFailed": "Error al actualizar el estado"
   },
   "qa": {
     "pageTitle": "Q&A Técnico",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -839,7 +839,22 @@
     "createFailed": "Échec de la création de la critique",
     "updateFailed": "Échec de la mise à jour de la critique",
     "deleteFailed": "Échec de la suppression de la critique",
-    "confirmDelete": "Êtes-vous sûr de vouloir supprimer cette critique ?"
+    "confirmDelete": "Êtes-vous sûr de vouloir supprimer cette critique ?",
+    "status": {
+      "not_started": "Non commencé",
+      "reading": "En lecture",
+      "completed": "Terminé"
+    },
+    "statusAll": "Tous",
+    "archivedLabel": "Archivé",
+    "archive": "Archiver",
+    "unarchive": "Désarchiver",
+    "archived": "Avis archivé",
+    "unarchived": "Avis désarchivé",
+    "archiveFailed": "Échec de l'archivage",
+    "unarchiveFailed": "Échec du désarchivage",
+    "statusUpdated": "Statut mis à jour",
+    "statusUpdateFailed": "Échec de la mise à jour du statut"
   },
   "qa": {
     "pageTitle": "Q&A Technique",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -793,7 +793,22 @@
     "createFailed": "レビューの作成に失敗しました",
     "updateFailed": "レビューの更新に失敗しました",
     "deleteFailed": "レビューの削除に失敗しました",
-    "confirmDelete": "このレビューを削除してもよろしいですか？"
+    "confirmDelete": "このレビューを削除してもよろしいですか？",
+    "status": {
+      "not_started": "未読",
+      "reading": "読書中",
+      "completed": "読了"
+    },
+    "statusAll": "すべて",
+    "archivedLabel": "アーカイブ済み",
+    "archive": "アーカイブ",
+    "unarchive": "アーカイブ解除",
+    "archived": "アーカイブしました",
+    "unarchived": "アーカイブを解除しました",
+    "archiveFailed": "アーカイブに失敗しました",
+    "unarchiveFailed": "アーカイブ解除に失敗しました",
+    "statusUpdated": "ステータスを更新しました",
+    "statusUpdateFailed": "ステータスの更新に失敗しました"
   },
   "qa": {
     "pageTitle": "技術Q&A",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -839,7 +839,22 @@
     "createFailed": "리뷰 생성에 실패했습니다",
     "updateFailed": "리뷰 업데이트에 실패했습니다",
     "deleteFailed": "리뷰 삭제에 실패했습니다",
-    "confirmDelete": "이 리뷰를 삭제하시겠습니까?"
+    "confirmDelete": "이 리뷰를 삭제하시겠습니까?",
+    "status": {
+      "not_started": "미읽음",
+      "reading": "읽는 중",
+      "completed": "완독"
+    },
+    "statusAll": "전체",
+    "archivedLabel": "보관됨",
+    "archive": "보관",
+    "unarchive": "보관 해제",
+    "archived": "보관되었습니다",
+    "unarchived": "보관이 해제되었습니다",
+    "archiveFailed": "보관에 실패했습니다",
+    "unarchiveFailed": "보관 해제에 실패했습니다",
+    "statusUpdated": "상태가 업데이트되었습니다",
+    "statusUpdateFailed": "상태 업데이트에 실패했습니다"
   },
   "qa": {
     "pageTitle": "기술 Q&A",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -839,7 +839,22 @@
     "createFailed": "Falha ao criar resenha",
     "updateFailed": "Falha ao atualizar resenha",
     "deleteFailed": "Falha ao excluir resenha",
-    "confirmDelete": "Tem certeza de que deseja excluir esta resenha?"
+    "confirmDelete": "Tem certeza de que deseja excluir esta resenha?",
+    "status": {
+      "not_started": "Não iniciado",
+      "reading": "Lendo",
+      "completed": "Concluído"
+    },
+    "statusAll": "Todos",
+    "archivedLabel": "Arquivado",
+    "archive": "Arquivar",
+    "unarchive": "Desarquivar",
+    "archived": "Resenha arquivada",
+    "unarchived": "Resenha desarquivada",
+    "archiveFailed": "Falha ao arquivar",
+    "unarchiveFailed": "Falha ao desarquivar",
+    "statusUpdated": "Status atualizado",
+    "statusUpdateFailed": "Falha ao atualizar status"
   },
   "qa": {
     "pageTitle": "Q&A Técnico",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -839,7 +839,22 @@
     "createFailed": "Не удалось создать обзор",
     "updateFailed": "Не удалось обновить обзор",
     "deleteFailed": "Не удалось удалить обзор",
-    "confirmDelete": "Вы уверены, что хотите удалить этот обзор?"
+    "confirmDelete": "Вы уверены, что хотите удалить этот обзор?",
+    "status": {
+      "not_started": "Не начато",
+      "reading": "Читаю",
+      "completed": "Прочитано"
+    },
+    "statusAll": "Все",
+    "archivedLabel": "В архиве",
+    "archive": "Архивировать",
+    "unarchive": "Разархивировать",
+    "archived": "Отзыв архивирован",
+    "unarchived": "Отзыв разархивирован",
+    "archiveFailed": "Не удалось архивировать",
+    "unarchiveFailed": "Не удалось разархивировать",
+    "statusUpdated": "Статус обновлён",
+    "statusUpdateFailed": "Не удалось обновить статус"
   },
   "qa": {
     "pageTitle": "Технический Q&A",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -839,7 +839,22 @@
     "createFailed": "创建书评失败",
     "updateFailed": "更新书评失败",
     "deleteFailed": "删除书评失败",
-    "confirmDelete": "确定要删除这篇书评吗？"
+    "confirmDelete": "确定要删除这篇书评吗？",
+    "status": {
+      "not_started": "未开始",
+      "reading": "阅读中",
+      "completed": "已完成"
+    },
+    "statusAll": "全部",
+    "archivedLabel": "已归档",
+    "archive": "归档",
+    "unarchive": "取消归档",
+    "archived": "已归档",
+    "unarchived": "已取消归档",
+    "archiveFailed": "归档失败",
+    "unarchiveFailed": "取消归档失败",
+    "statusUpdated": "状态已更新",
+    "statusUpdateFailed": "状态更新失败"
   },
   "qa": {
     "pageTitle": "技术问答",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -839,7 +839,22 @@
     "createFailed": "建立書評失敗",
     "updateFailed": "更新書評失敗",
     "deleteFailed": "刪除書評失敗",
-    "confirmDelete": "確定要刪除這篇書評嗎？"
+    "confirmDelete": "確定要刪除這篇書評嗎？",
+    "status": {
+      "not_started": "未開始",
+      "reading": "閱讀中",
+      "completed": "已完成"
+    },
+    "statusAll": "全部",
+    "archivedLabel": "已封存",
+    "archive": "封存",
+    "unarchive": "取消封存",
+    "archived": "已封存",
+    "unarchived": "已取消封存",
+    "archiveFailed": "封存失敗",
+    "unarchiveFailed": "取消封存失敗",
+    "statusUpdated": "狀態已更新",
+    "statusUpdateFailed": "狀態更新失敗"
   },
   "qa": {
     "pageTitle": "技術問答",

--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { BookOpen } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
-import type { BookReview } from '../types/bookReview';
+import type { BookReview, ReviewStatus } from '../types/bookReview';
 import { useBookReviews, useConfirm } from '../hooks';
 import BookReviewCard from '../components/bookReviews/BookReviewCard';
 import BookReviewForm from '../components/bookReviews/BookReviewForm';
@@ -14,7 +14,9 @@ export default function BookReviewsPage() {
   const user = useAuthStore((s) => s.user);
   const {
     reviews, total, loading, saving, page, setPage, limit,
+    statusFilter, setStatusFilter, showArchived, setShowArchived,
     createReview, updateReview, deleteReview,
+    updateStatus, archiveReview, unarchiveReview,
   } = useBookReviews();
 
   const { confirm, dialogProps } = useConfirm();
@@ -50,6 +52,33 @@ export default function BookReviewsPage() {
         actionLabel={t('bookReviews.addReview')}
         onAction={() => setShowForm(true)}
       />
+
+      {/* Filter Bar */}
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        {(['all', 'not_started', 'reading', 'completed'] as const).map(status => (
+          <button
+            key={status}
+            onClick={() => setStatusFilter(status)}
+            className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
+              statusFilter === status
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+            }`}
+          >
+            {status === 'all' ? t('bookReviews.statusAll') : t(`bookReviews.status.${status}`)}
+          </button>
+        ))}
+        <button
+          onClick={() => setShowArchived(!showArchived)}
+          className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
+            showArchived
+              ? 'bg-yellow-700 text-yellow-200'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          {t('bookReviews.archivedLabel')}
+        </button>
+      </div>
 
       {/* Form Modal */}
       <Modal
@@ -87,6 +116,9 @@ export default function BookReviewsPage() {
                 showUser={true}
                 onEdit={() => setEditingReview(review)}
                 onDelete={() => handleDeleteReview(review)}
+                onStatusChange={updateStatus}
+                onArchive={archiveReview}
+                onUnarchive={unarchiveReview}
               />
             ))}
           </div>

--- a/frontend/src/types/bookReview.ts
+++ b/frontend/src/types/bookReview.ts
@@ -1,5 +1,7 @@
 import type { User } from './user';
 
+export type ReviewStatus = 'not_started' | 'reading' | 'completed';
+
 export interface BookReview {
   id: number;
   user_id: number;
@@ -10,6 +12,8 @@ export interface BookReview {
   rating: number; // 1-5
   review: string;
   image_url: string;
+  status: ReviewStatus;
+  is_archived: boolean;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## 概要
書籍レビューにステータス管理（未読/読書中/読了）とアーカイブ機能のフロントエンドUIを実装。

## 変更内容
- `BookReview`型に`status`（ReviewStatus）と`is_archived`フィールドを追加
- APIクライアントに`searchBookReviews`, `getBookReviewsByRating`, `archiveBookReview`, `unarchiveBookReview`, `updateBookReviewStatus`を追加
- `useBookReviews`フックにステータスフィルタ、アーカイブ表示切替、操作ハンドラを追加
- `BookReviewCard`にステータスバッジ、ドロップダウン変更UI、アーカイブ/解除ボタンを追加
- `BookReviewsPage`にステータスフィルタバー（すべて/未読/読書中/読了/アーカイブ済み）を追加
- 10言語のi18n対応（16キー × 10言語）

Closes #1183