### PR TITLE
test: StudyCircleタブコンポーネントのテスト追加（19テスト）

### DIFF
--- a/frontend/src/components/studyCircles/__tests__/CircleCheckinTab.test.tsx
+++ b/frontend/src/components/studyCircles/__tests__/CircleCheckinTab.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CircleCheckinTab from '../CircleCheckinTab';
+import type { StudyCircleCheckin } from '../../../types/studyCircle';
+
+const mockCheckins: StudyCircleCheckin[] = [
+  {
+    id: 1, circle_id: 1, user_id: 1,
+    user: { id: 1, name: 'Alice', avatar_url: '' },
+    date: '2026-02-18', content: 'Reactの基礎を学んだ',
+    created_at: '2026-02-18T10:00:00Z',
+  },
+  {
+    id: 2, circle_id: 1, user_id: 2,
+    user: { id: 2, name: 'Bob', avatar_url: '' },
+    date: '2026-02-18', content: 'TypeScriptの型を復習した',
+    created_at: '2026-02-18T11:00:00Z',
+  },
+];
+
+describe('CircleCheckinTab', () => {
+  it('チェックインフォームが表示される', () => {
+    const onCheckin = vi.fn();
+    render(<CircleCheckinTab checkins={[]} onCheckin={onCheckin} />);
+    expect(screen.getByText('日次チェックイン')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('今日やったことを一言で...')).toBeInTheDocument();
+  });
+
+  it('チェックイン履歴が表示される', () => {
+    const onCheckin = vi.fn();
+    render(<CircleCheckinTab checkins={mockCheckins} onCheckin={onCheckin} />);
+    expect(screen.getByText('Reactの基礎を学んだ')).toBeInTheDocument();
+    expect(screen.getByText('TypeScriptの型を復習した')).toBeInTheDocument();
+  });
+
+  it('ユーザー名が表示される', () => {
+    const onCheckin = vi.fn();
+    render(<CircleCheckinTab checkins={mockCheckins} onCheckin={onCheckin} />);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('送信ボタンが空入力で無効化される', () => {
+    const onCheckin = vi.fn();
+    render(<CircleCheckinTab checkins={[]} onCheckin={onCheckin} />);
+    const submitButton = screen.getByText('チェックイン');
+    expect(submitButton).toBeDisabled();
+  });
+
+  it('テキスト入力後に送信ボタンが有効になる', () => {
+    const onCheckin = vi.fn();
+    render(<CircleCheckinTab checkins={[]} onCheckin={onCheckin} />);
+    const input = screen.getByPlaceholderText('今日やったことを一言で...');
+    fireEvent.change(input, { target: { value: 'テスト内容' } });
+    const submitButton = screen.getByText('チェックイン');
+    expect(submitButton).not.toBeDisabled();
+  });
+
+  it('チェックインが空の場合は空状態メッセージが表示される', () => {
+    const onCheckin = vi.fn();
+    render(<CircleCheckinTab checkins={[]} onCheckin={onCheckin} />);
+    expect(screen.getByText('チェックインがまだありません')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/studyCircles/__tests__/CircleRankingTab.test.tsx
+++ b/frontend/src/components/studyCircles/__tests__/CircleRankingTab.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CircleRankingTab from '../CircleRankingTab';
+import type { CircleMemberStreak } from '../../../types/studyCircle';
+
+const mockStreaks: CircleMemberStreak[] = [
+  { user_id: 1, user_name: 'Alice', avatar_url: '', current_streak: 10, total_checkins: 30 },
+  { user_id: 2, user_name: 'Bob', avatar_url: '', current_streak: 5, total_checkins: 15 },
+  { user_id: 3, user_name: 'Charlie', avatar_url: '', current_streak: 3, total_checkins: 8 },
+];
+
+describe('CircleRankingTab', () => {
+  it('ストリークランキングのタイトルが表示される', () => {
+    render(<CircleRankingTab streaks={mockStreaks} />);
+    expect(screen.getByText('ストリークランキング')).toBeInTheDocument();
+  });
+
+  it('メンバー名が表示される', () => {
+    render(<CircleRankingTab streaks={mockStreaks} />);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Charlie')).toBeInTheDocument();
+  });
+
+  it('連続日数が表示される', () => {
+    render(<CircleRankingTab streaks={mockStreaks} />);
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('順位番号が表示される', () => {
+    render(<CircleRankingTab streaks={mockStreaks} />);
+    const rankings = screen.getAllByText(/^[123]$/);
+    expect(rankings.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('ストリークが空の場合は空状態メッセージが表示される', () => {
+    render(<CircleRankingTab streaks={[]} />);
+    expect(screen.getByText('データがまだありません')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/studyCircles/__tests__/CircleRoadmapTab.test.tsx
+++ b/frontend/src/components/studyCircles/__tests__/CircleRoadmapTab.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import CircleRoadmapTab from '../CircleRoadmapTab';
+import type { StudyCircle, StudyCircleMemberProgress } from '../../../types/studyCircle';
+
+const mockCircle: StudyCircle = {
+  id: 1,
+  name: 'React学習会',
+  topic: 'React',
+  description: '',
+  owner_id: 1,
+  max_members: 10,
+  status: 'active',
+  steps: [
+    { id: 1, circle_id: 1, title: 'JSX基礎', description: 'JSXの書き方を学ぶ', order_index: 0, resource_url: 'https://example.com', created_at: '', updated_at: '' },
+    { id: 2, circle_id: 1, title: 'Hooks入門', description: '', order_index: 1, resource_url: '', created_at: '', updated_at: '' },
+  ],
+  members: [
+    { id: 1, circle_id: 1, user_id: 1, user: { id: 1, name: 'Alice', avatar_url: '' }, role: 'owner', joined_at: '' },
+  ],
+  created_at: '',
+  updated_at: '',
+};
+
+const mockProgress: StudyCircleMemberProgress[] = [
+  { id: 1, circle_id: 1, step_id: 1, user_id: 1, is_completed: true, completed_at: '2026-02-18T10:00:00Z' },
+];
+
+const mockUser = { id: 1, name: 'Alice', username: 'alice', email: 'a@e.com', bio: '', avatar_url: '', github_username: '', created_at: '', updated_at: '' };
+
+describe('CircleRoadmapTab', () => {
+  const defaultProps = {
+    circle: mockCircle,
+    progress: mockProgress,
+    currentUser: mockUser,
+    isOwner: true,
+    saving: false,
+    onCreateStep: vi.fn(),
+    onDeleteStep: vi.fn(),
+    onToggleProgress: vi.fn(),
+  };
+
+  it('ステップタイトルが表示される', () => {
+    render(<CircleRoadmapTab {...defaultProps} />);
+    expect(screen.getByText('JSX基礎')).toBeInTheDocument();
+    expect(screen.getByText('Hooks入門')).toBeInTheDocument();
+  });
+
+  it('ステップの説明が表示される', () => {
+    render(<CircleRoadmapTab {...defaultProps} />);
+    expect(screen.getByText('JSXの書き方を学ぶ')).toBeInTheDocument();
+  });
+
+  it('完了済みステップに取り消し線が適用される', () => {
+    render(<CircleRoadmapTab {...defaultProps} />);
+    const completedStep = screen.getByText('JSX基礎');
+    expect(completedStep).toHaveClass('line-through');
+  });
+
+  it('リソースURLリンクが表示される', () => {
+    render(<CircleRoadmapTab {...defaultProps} />);
+    expect(screen.getByText('参考URL')).toBeInTheDocument();
+  });
+
+  it('オーナーにステップ追加ボタンが表示される', () => {
+    render(<CircleRoadmapTab {...defaultProps} />);
+    expect(screen.getByText('ステップを追加')).toBeInTheDocument();
+  });
+
+  it('非オーナーにステップ追加ボタンが非表示', () => {
+    render(<CircleRoadmapTab {...defaultProps} isOwner={false} />);
+    expect(screen.queryByText('ステップを追加')).not.toBeInTheDocument();
+  });
+
+  it('ステップ追加ボタンクリックでフォームが表示される', () => {
+    render(<CircleRoadmapTab {...defaultProps} />);
+    fireEvent.click(screen.getByText('ステップを追加'));
+    expect(screen.getByPlaceholderText('ステップ')).toBeInTheDocument();
+  });
+
+  it('ステップがない場合は空状態メッセージが表示される', () => {
+    const emptyCircle = { ...mockCircle, steps: [] };
+    render(<CircleRoadmapTab {...defaultProps} circle={emptyCircle} />);
+    expect(screen.getByText('ステップがまだありません')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
Cycle 311で抽出した3つのStudyCircleタブコンポーネントのユニットテストを追加。

## テスト内容
- **CircleRoadmapTab** (8テスト): ステップ表示、完了状態の取り消し線、リソースURL表示、オーナー権限でのステップ追加ボタン、フォーム表示、空状態
- **CircleCheckinTab** (6テスト): フォーム表示、履歴表示、ユーザー名表示、送信ボタン無効化/有効化、空状態
- **CircleRankingTab** (5テスト): タイトル表示、メンバー名、連続日数、順位番号、空状態

Closes #1187