### PR TITLE
fix: ユーザー入力URLにsanitizeUrlを適用しXSS脆弱性を防止

### DIFF
--- a/frontend/src/components/profile/ShareableProfileCard.tsx
+++ b/frontend/src/components/profile/ShareableProfileCard.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import type { User } from '../../types/user';
 import type { GitHubLanguageStat } from '../../types/github';
+import { sanitizeUrl } from '../../utils/url';
 
 interface ShareableProfileCardProps {
   user: User;
@@ -49,7 +50,7 @@ const ShareableProfileCard = forwardRef<HTMLDivElement, ShareableProfileCardProp
           {/* Left side - Avatar and basic info */}
           <div className="flex flex-col items-center justify-center w-48">
             <img
-              src={user.avatar_url || `https://ui-avatars.com/api/?name=${encodeURIComponent(user.name || 'User')}&background=7c3aed&color=fff&size=128`}
+              src={sanitizeUrl(user.avatar_url) || `https://ui-avatars.com/api/?name=${encodeURIComponent(user.name || 'User')}&background=7c3aed&color=fff&size=128`}
               alt={user.name}
               className="w-24 h-24 rounded-full border-4 border-purple-500/50"
             />

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import type { Project } from '../../types/project';
 import { cardClass } from '../../constants/styles';
+import { sanitizeUrl } from '../../utils/url';
 
 interface ProjectCardProps {
   project: Project;
@@ -100,9 +101,9 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
         )}
 
         <div className="flex gap-2 mt-4">
-          {project.demo_url && (
+          {sanitizeUrl(project.demo_url) && (
             <a
-              href={project.demo_url}
+              href={sanitizeUrl(project.demo_url)!}
               target="_blank"
               rel="noopener noreferrer"
               className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded-lg transition-colors"
@@ -113,9 +114,9 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
               {t('projects.liveDemo')}
             </a>
           )}
-          {project.github_url && (
+          {sanitizeUrl(project.github_url) && (
             <a
-              href={project.github_url}
+              href={sanitizeUrl(project.github_url)!}
               target="_blank"
               rel="noopener noreferrer"
               className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded-lg transition-colors"

--- a/frontend/src/components/resources/ResourceCard.tsx
+++ b/frontend/src/components/resources/ResourceCard.tsx
@@ -5,6 +5,7 @@ import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin,
 import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import Avatar from '../common/Avatar';
 import { cardClass } from '../../constants/styles';
+import { sanitizeUrl } from '../../utils/url';
 
 interface ResourceCardProps {
   resource: LearningResource;
@@ -127,9 +128,9 @@ export default function ResourceCard({
 
         {/* Title & Description */}
         <h3 className="text-lg font-semibold text-white mt-3">
-          {resource.url ? (
+          {sanitizeUrl(resource.url) ? (
             <a
-              href={resource.url}
+              href={sanitizeUrl(resource.url)}
               target="_blank"
               rel="noopener noreferrer"
               className="hover:text-green-400 transition-colors"
@@ -216,9 +217,9 @@ export default function ResourceCard({
             </button>
 
             {/* External Link */}
-            {resource.url && (
+            {sanitizeUrl(resource.url) && (
               <a
-                href={resource.url}
+                href={sanitizeUrl(resource.url)!}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-gray-400 hover:text-white transition-colors"

--- a/frontend/src/components/studyCircles/CircleRoadmapTab.tsx
+++ b/frontend/src/components/studyCircles/CircleRoadmapTab.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Plus, Trash2, Check, ExternalLink } from 'lucide-react';
 import type { StudyCircle, StudyCircleMemberProgress } from '../../types/studyCircle';
 import type { User } from '../../types/user';
+import { sanitizeUrl } from '../../utils/url';
 
 interface CircleRoadmapTabProps {
   circle: StudyCircle;
@@ -83,9 +84,9 @@ export default function CircleRoadmapTab({
                     {step.description && (
                       <p className="text-xs text-gray-500 mt-1">{step.description}</p>
                     )}
-                    {step.resource_url && (
+                    {sanitizeUrl(step.resource_url) && (
                       <a
-                        href={step.resource_url}
+                        href={sanitizeUrl(step.resource_url)!}
                         target="_blank"
                         rel="noopener noreferrer"
                         className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 mt-1"


### PR DESCRIPTION
## 概要
ユーザー入力URLが未サニタイズのまま `href` や `src` に渡されている箇所に `sanitizeUrl` を適用。

## 変更箇所
- **ShareableProfileCard**: `avatar_url` → `sanitizeUrl(avatar_url)` で安全なフォールバック
- **ResourceCard**: `resource.url` → `sanitizeUrl(resource.url)` （タイトルリンク・外部リンクアイコンの2箇所）
- **ProjectCard**: `demo_url`/`github_url` → `sanitizeUrl()` 適用
- **CircleRoadmapTab**: `step.resource_url` → `sanitizeUrl()` 適用

## セキュリティ影響
`javascript:alert(1)` や `data:text/html,...` のような危険なプロトコルがブロックされ、XSS攻撃を防止。

Closes #1189