### PR TITLE
feat: 学習ログページに週別学習時間サマリーと統計ウィジェットを追加

### DIFF
--- a/frontend/src/api/learningLogs.ts
+++ b/frontend/src/api/learningLogs.ts
@@ -25,6 +25,15 @@ export const getCalendarData = (userId: number) =>
 export const getStreakInfo = (userId: number) =>
   client.get<StreakInfo>(`/learning-logs/streak/${userId}`);
 
+export const getWeeklyDuration = (userId: number) =>
+  client.get<{ duration: number }>(`/learning-logs/weekly-duration/${userId}`);
+
+export const getLogsByCategory = (category: string) =>
+  client.get<LearningLog[]>(`/learning-logs/category/${category}`);
+
+export const getLogsBySource = (source: string) =>
+  client.get<LearningLog[]>(`/learning-logs/source/${source}`);
+
 export type ExportPeriod = '7' | '30' | '90' | 'all';
 
 export const exportLogsCSV = (period: ExportPeriod = '30') =>

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -19,7 +19,7 @@ export { useRoadmaps, useRoadmapDetail, useRoadmapTemplates } from './useRoadmap
 export { useRoadmapForm } from './useRoadmapForm';
 export { useDashboard } from './useDashboard';
 export { useBadgeNotifier } from './useBadgeNotifier';
-export { useLearningLogs, useLearningLogCalendar, useStreak } from './useLearningLogs';
+export { useLearningLogs, useLearningLogCalendar, useStreak, useWeeklyDuration } from './useLearningLogs';
 export { useLearningLogForm } from './useLearningLogForm';
 export { useGoalForm } from './useGoalForm';
 export { useSnippetComments } from './useSnippetComments';

--- a/frontend/src/hooks/useLearningLogs.ts
+++ b/frontend/src/hooks/useLearningLogs.ts
@@ -8,6 +8,7 @@ import {
   deleteLog,
   getCalendarData,
   getStreakInfo,
+  getWeeklyDuration,
 } from '../api/learningLogs';
 import type { LearningLog, CalendarEntry, LogCategory, StreakInfo } from '../types/learningLog';
 import { useAsyncData } from './useAsyncData';
@@ -106,6 +107,19 @@ export function useStreak(userId: number | undefined) {
   );
 
   return { streakInfo, loading, refetchStreak: refetch };
+}
+
+export function useWeeklyDuration(userId: number | undefined) {
+  const { data: weeklyDuration, loading } = useAsyncData(
+    async () => {
+      if (!userId) return 0;
+      const { data } = await getWeeklyDuration(userId);
+      return data?.duration ?? 0;
+    },
+    { initialData: 0, deps: [userId] }
+  );
+
+  return { weeklyDuration, loading };
 }
 
 export function useLearningLogCalendar(userId: number | undefined) {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -645,7 +645,12 @@
     "logsOnDate": "Einträge am {{date}}",
     "exportCSV": "CSV exportieren",
     "exportDays": "Letzte {{days}} Tage",
-    "exportAll": "Gesamter Zeitraum"
+    "exportAll": "Gesamter Zeitraum",
+    "weeklyDuration": "Diese Woche",
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "currentStreak": "Aktuelle Serie",
+    "days": " Tage",
+    "logCount": "Gesamteinträge"
   },
   "reports": {
     "title": "Aktivitätsberichte",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -645,7 +645,12 @@
     "logsOnDate": "Logs on {{date}}",
     "exportCSV": "Export CSV",
     "exportDays": "Last {{days}} days",
-    "exportAll": "All time"
+    "exportAll": "All time",
+    "weeklyDuration": "This Week",
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "currentStreak": "Current Streak",
+    "days": " days",
+    "logCount": "Total Logs"
   },
   "reports": {
     "title": "Activity Reports",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -645,7 +645,12 @@
     "logsOnDate": "Registros del {{date}}",
     "exportCSV": "Exportar CSV",
     "exportDays": "Últimos {{days}} días",
-    "exportAll": "Todo el tiempo"
+    "exportAll": "Todo el tiempo",
+    "weeklyDuration": "Tiempo esta semana",
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "currentStreak": "Racha actual",
+    "days": " días",
+    "logCount": "Total de registros"
   },
   "reports": {
     "title": "Informes de Actividad",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -645,7 +645,12 @@
     "logsOnDate": "Entrées du {{date}}",
     "exportCSV": "Exporter CSV",
     "exportDays": "Derniers {{days}} jours",
-    "exportAll": "Toute la période"
+    "exportAll": "Toute la période",
+    "weeklyDuration": "Temps cette semaine",
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "currentStreak": "Série en cours",
+    "days": " jours",
+    "logCount": "Total des entrées"
   },
   "reports": {
     "title": "Rapports d'Activité",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -629,7 +629,12 @@
     "logsOnDate": "{{date}}のログ",
     "exportCSV": "CSVエクスポート",
     "exportDays": "過去{{days}}日",
-    "exportAll": "全期間"
+    "exportAll": "全期間",
+    "weeklyDuration": "今週の学習時間",
+    "hoursMinutes": "{{hours}}時間{{minutes}}分",
+    "currentStreak": "連続学習日数",
+    "days": "日",
+    "logCount": "ログ件数"
   },
   "reports": {
     "title": "アクティビティレポート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -645,7 +645,12 @@
     "logsOnDate": "{{date}}의 로그",
     "exportCSV": "CSV 내보내기",
     "exportDays": "최근 {{days}}일",
-    "exportAll": "전체 기간"
+    "exportAll": "전체 기간",
+    "weeklyDuration": "이번 주 학습 시간",
+    "hoursMinutes": "{{hours}}시간 {{minutes}}분",
+    "currentStreak": "연속 학습일",
+    "days": "일",
+    "logCount": "로그 수"
   },
   "reports": {
     "title": "활동 리포트",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -645,7 +645,12 @@
     "logsOnDate": "Registros em {{date}}",
     "exportCSV": "Exportar CSV",
     "exportDays": "Últimos {{days}} dias",
-    "exportAll": "Todo o período"
+    "exportAll": "Todo o período",
+    "weeklyDuration": "Tempo esta semana",
+    "hoursMinutes": "{{hours}}h {{minutes}}m",
+    "currentStreak": "Sequência atual",
+    "days": " dias",
+    "logCount": "Total de registros"
   },
   "reports": {
     "title": "Relatórios de Atividade",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -645,7 +645,12 @@
     "logsOnDate": "Записи за {{date}}",
     "exportCSV": "Экспорт CSV",
     "exportDays": "Последние {{days}} дней",
-    "exportAll": "Весь период"
+    "exportAll": "Весь период",
+    "weeklyDuration": "За эту неделю",
+    "hoursMinutes": "{{hours}}ч {{minutes}}м",
+    "currentStreak": "Текущая серия",
+    "days": " дн.",
+    "logCount": "Всего записей"
   },
   "reports": {
     "title": "Отчёты об Активности",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -645,7 +645,12 @@
     "logsOnDate": "{{date}}的日志",
     "exportCSV": "导出CSV",
     "exportDays": "最近{{days}}天",
-    "exportAll": "全部"
+    "exportAll": "全部",
+    "weeklyDuration": "本周学习时间",
+    "hoursMinutes": "{{hours}}小时{{minutes}}分钟",
+    "currentStreak": "连续学习天数",
+    "days": "天",
+    "logCount": "日志数量"
   },
   "reports": {
     "title": "活动报告",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -645,7 +645,12 @@
     "logsOnDate": "{{date}}的日誌",
     "exportCSV": "匯出CSV",
     "exportDays": "最近{{days}}天",
-    "exportAll": "全部"
+    "exportAll": "全部",
+    "weeklyDuration": "本週學習時間",
+    "hoursMinutes": "{{hours}}小時{{minutes}}分鐘",
+    "currentStreak": "連續學習天數",
+    "days": "天",
+    "logCount": "日誌數量"
   },
   "reports": {
     "title": "活動報告",

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Code, BookOpen, GraduationCap, Users, FileText, Calendar, List, Download, type LucideIcon } from 'lucide-react';
+import { Code, BookOpen, GraduationCap, Users, FileText, Calendar, List, Download, Clock, type LucideIcon } from 'lucide-react';
 import { useLearningLogForm } from '../hooks/useLearningLogForm';
+import { useWeeklyDuration, useStreak } from '../hooks';
+import { useAuthStore } from '../store/authStore';
 import { exportLogsCSV, type ExportPeriod } from '../api/learningLogs';
 import type { LogCategory } from '../types/learningLog';
 import LogCalendar from '../components/learning-logs/LogCalendar';
@@ -32,6 +34,9 @@ const getCategoryColor = (cat: LogCategory) => {
 
 export default function LearningLogsPage() {
   const { t } = useTranslation();
+  const user = useAuthStore((s) => s.user);
+  const { weeklyDuration } = useWeeklyDuration(user?.id);
+  const { streakInfo } = useStreak(user?.id);
   const [exporting, setExporting] = useState(false);
   const {
     filteredLogs, calendarData, loading, saving,
@@ -107,6 +112,35 @@ export default function LearningLogsPage() {
           >
             {t('learningLogs.addLog')}
           </button>
+        </div>
+      </div>
+
+      {/* Weekly Summary */}
+      <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
+        <div className="bg-gray-900 border border-gray-800 rounded-md p-4 flex items-center gap-3">
+          <Clock className="w-8 h-8 text-blue-400" />
+          <div>
+            <p className="text-xs text-gray-400">{t('learningLogs.weeklyDuration')}</p>
+            <p className="text-lg font-bold text-white">
+              {weeklyDuration >= 60
+                ? t('learningLogs.hoursMinutes', { hours: Math.floor(weeklyDuration / 60), minutes: weeklyDuration % 60 })
+                : t('learningLogs.durationMinutes', { minutes: weeklyDuration })}
+            </p>
+          </div>
+        </div>
+        <div className="bg-gray-900 border border-gray-800 rounded-md p-4 flex items-center gap-3">
+          <Calendar className="w-8 h-8 text-orange-400" />
+          <div>
+            <p className="text-xs text-gray-400">{t('learningLogs.currentStreak')}</p>
+            <p className="text-lg font-bold text-white">{streakInfo?.current_streak ?? 0}{t('learningLogs.days')}</p>
+          </div>
+        </div>
+        <div className="bg-gray-900 border border-gray-800 rounded-md p-4 flex items-center gap-3 col-span-2 md:col-span-1">
+          <FileText className="w-8 h-8 text-green-400" />
+          <div>
+            <p className="text-xs text-gray-400">{t('learningLogs.logCount')}</p>
+            <p className="text-lg font-bold text-white">{filteredLogs.length}</p>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## 概要
学習ログページにバックエンドの既存API（weekly-duration, category, source）を活用した統計サマリーウィジェットを追加。

## 変更内容
- **APIクライアント**: `getWeeklyDuration`, `getLogsByCategory`, `getLogsBySource` 3関数追加
- **useWeeklyDurationフック**: ユーザーの過去7日間の学習時間合計を取得
- **LearningLogsPage**: ヘッダー下に3つの統計カードを追加
  - 週別学習時間（時間/分表示）
  - 連続学習日数（ストリーク）
  - ログ件数（フィルタ後の件数）
- **i18n**: 10言語に5キー追加（weeklyDuration, hoursMinutes, currentStreak, days, logCount）

Closes #1191