### PR TITLE
test: Onboardingステップコンポーネントのユニットテスト追加

### DIFF
--- a/frontend/src/components/onboarding/__tests__/OnboardingCompleteStep.test.tsx
+++ b/frontend/src/components/onboarding/__tests__/OnboardingCompleteStep.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OnboardingCompleteStep from '../OnboardingCompleteStep';
+
+describe('OnboardingCompleteStep', () => {
+  it('完了タイトルと説明が表示される', () => {
+    render(<OnboardingCompleteStep saving={false} onComplete={vi.fn()} />);
+    expect(screen.getByText('セットアップ完了！')).toBeInTheDocument();
+    expect(screen.getByText('準備が整いました。ダッシュボードで活動を始めましょう。')).toBeInTheDocument();
+  });
+
+  it('ダッシュボードへボタンが表示される', () => {
+    render(<OnboardingCompleteStep saving={false} onComplete={vi.fn()} />);
+    expect(screen.getByText('ダッシュボードへ')).toBeInTheDocument();
+  });
+
+  it('ボタンクリックでonCompleteが呼ばれる', () => {
+    const onComplete = vi.fn();
+    render(<OnboardingCompleteStep saving={false} onComplete={onComplete} />);
+    fireEvent.click(screen.getByText('ダッシュボードへ'));
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('saving中はローディング表示になる', () => {
+    render(<OnboardingCompleteStep saving={true} onComplete={vi.fn()} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+    expect(screen.queryByText('ダッシュボードへ')).not.toBeInTheDocument();
+  });
+
+  it('saving中はボタンが無効化される', () => {
+    render(<OnboardingCompleteStep saving={true} onComplete={vi.fn()} />);
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
+});

--- a/frontend/src/components/onboarding/__tests__/OnboardingProfileStep.test.tsx
+++ b/frontend/src/components/onboarding/__tests__/OnboardingProfileStep.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OnboardingProfileStep from '../OnboardingProfileStep';
+
+const defaultProps = {
+  name: '',
+  setName: vi.fn(),
+  bio: '',
+  setBio: vi.fn(),
+  saving: false,
+  onSave: vi.fn(),
+  onSkip: vi.fn(),
+};
+
+describe('OnboardingProfileStep', () => {
+  it('タイトルと説明が表示される', () => {
+    render(<OnboardingProfileStep {...defaultProps} />);
+    expect(screen.getByText('DevSyncへようこそ！')).toBeInTheDocument();
+    expect(screen.getByText('まずはプロフィールを設定しましょう。')).toBeInTheDocument();
+  });
+
+  it('名前と自己紹介の入力欄が表示される', () => {
+    render(<OnboardingProfileStep {...defaultProps} />);
+    expect(screen.getByPlaceholderText('表示名を入力')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('自己紹介を入力')).toBeInTheDocument();
+  });
+
+  it('名前の変更がsetNameを呼び出す', () => {
+    const setName = vi.fn();
+    render(<OnboardingProfileStep {...defaultProps} setName={setName} />);
+    fireEvent.change(screen.getByPlaceholderText('表示名を入力'), { target: { value: 'テスト太郎' } });
+    expect(setName).toHaveBeenCalledWith('テスト太郎');
+  });
+
+  it('自己紹介の変更がsetBioを呼び出す', () => {
+    const setBio = vi.fn();
+    render(<OnboardingProfileStep {...defaultProps} setBio={setBio} />);
+    fireEvent.change(screen.getByPlaceholderText('自己紹介を入力'), { target: { value: 'エンジニアです' } });
+    expect(setBio).toHaveBeenCalledWith('エンジニアです');
+  });
+
+  it('次へボタンがonSaveを呼び出す', () => {
+    const onSave = vi.fn();
+    render(<OnboardingProfileStep {...defaultProps} onSave={onSave} />);
+    fireEvent.click(screen.getByText('次へ'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+
+  it('スキップボタンがonSkipを呼び出す', () => {
+    const onSkip = vi.fn();
+    render(<OnboardingProfileStep {...defaultProps} onSkip={onSkip} />);
+    fireEvent.click(screen.getByText('スキップ'));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('saving中はボタンが無効化される', () => {
+    render(<OnboardingProfileStep {...defaultProps} saving={true} />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('初期値が入力欄に表示される', () => {
+    render(<OnboardingProfileStep {...defaultProps} name="初期名" bio="初期自己紹介" />);
+    expect(screen.getByDisplayValue('初期名')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('初期自己紹介')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/onboarding/__tests__/OnboardingSkillsStep.test.tsx
+++ b/frontend/src/components/onboarding/__tests__/OnboardingSkillsStep.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import OnboardingSkillsStep from '../OnboardingSkillsStep';
+
+const defaultProps = {
+  selectedLanguages: [] as string[],
+  selectedFrameworks: [] as string[],
+  toggleLanguage: vi.fn(),
+  toggleFramework: vi.fn(),
+  saving: false,
+  onSave: vi.fn(),
+  onBack: vi.fn(),
+  onSkip: vi.fn(),
+};
+
+describe('OnboardingSkillsStep', () => {
+  it('タイトルと説明が表示される', () => {
+    render(<OnboardingSkillsStep {...defaultProps} />);
+    expect(screen.getByText('スキルを選択')).toBeInTheDocument();
+    expect(screen.getByText('使用している言語やフレームワークを選択してください。')).toBeInTheDocument();
+  });
+
+  it('言語ボタンが表示される', () => {
+    render(<OnboardingSkillsStep {...defaultProps} />);
+    expect(screen.getByText('javascript')).toBeInTheDocument();
+    expect(screen.getByText('python')).toBeInTheDocument();
+    expect(screen.getByText('go')).toBeInTheDocument();
+  });
+
+  it('言語クリックでtoggleLanguageが呼ばれる', () => {
+    const toggleLanguage = vi.fn();
+    render(<OnboardingSkillsStep {...defaultProps} toggleLanguage={toggleLanguage} />);
+    fireEvent.click(screen.getByText('python'));
+    expect(toggleLanguage).toHaveBeenCalledWith('python');
+  });
+
+  it('フレームワーククリックでtoggleFrameworkが呼ばれる', () => {
+    const toggleFramework = vi.fn();
+    render(<OnboardingSkillsStep {...defaultProps} toggleFramework={toggleFramework} />);
+    fireEvent.click(screen.getByText('react'));
+    expect(toggleFramework).toHaveBeenCalledWith('react');
+  });
+
+  it('選択済み言語のプレビューが表示される', () => {
+    render(<OnboardingSkillsStep {...defaultProps} selectedLanguages={['javascript', 'python']} />);
+    const imgs = screen.getAllByRole('img');
+    const langImg = imgs.find(img => img.getAttribute('alt') === 'Selected languages');
+    expect(langImg).toBeInTheDocument();
+  });
+
+  it('戻るボタンがonBackを呼び出す', () => {
+    const onBack = vi.fn();
+    render(<OnboardingSkillsStep {...defaultProps} onBack={onBack} />);
+    fireEvent.click(screen.getByText('戻る'));
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('スキップボタンがonSkipを呼び出す', () => {
+    const onSkip = vi.fn();
+    render(<OnboardingSkillsStep {...defaultProps} onSkip={onSkip} />);
+    fireEvent.click(screen.getByText('スキップ'));
+    expect(onSkip).toHaveBeenCalledTimes(1);
+  });
+
+  it('次へボタンがonSaveを呼び出す', () => {
+    const onSave = vi.fn();
+    render(<OnboardingSkillsStep {...defaultProps} onSave={onSave} />);
+    fireEvent.click(screen.getByText('次へ'));
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要
Cycle 315で分割したOnboardingステップコンポーネント3つに21テストを追加。

## テスト内容
- **OnboardingProfileStep** (8テスト): 入力・コールバック・saving状態・初期値
- **OnboardingSkillsStep** (8テスト): 言語/FW選択・プレビュー・ナビゲーション
- **OnboardingCompleteStep** (5テスト): 完了画面・ボタン・ローディング

Closes #1195