### PR TITLE
fix: OAuth URLバリデーション追加とsessionStorage移行

### DIFF
--- a/frontend/src/hooks/useOnboarding.ts
+++ b/frontend/src/hooks/useOnboarding.ts
@@ -7,6 +7,7 @@ import { getGitHubConnectURL } from '../api/github';
 import { connectZenn } from '../api/zenn';
 import { connectQiita } from '../api/qiita';
 import { connectAtCoder } from '../api/atcoder';
+import { isHttpUrl } from '../utils/url';
 import toast from 'react-hot-toast';
 
 export function useOnboarding() {
@@ -82,8 +83,9 @@ export function useOnboarding() {
 
   const handleConnectGitHub = async () => {
     try {
-      localStorage.setItem('onboarding_redirect', 'true');
+      sessionStorage.setItem('onboarding_redirect', 'true');
       const { data } = await getGitHubConnectURL();
+      if (!isHttpUrl(data.url)) throw new Error('Invalid OAuth URL');
       window.location.href = data.url;
     } catch {
       toast.error(t('errors.somethingWrong'));

--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -9,6 +9,7 @@ import { connectAtCoder, disconnectAtCoder } from '../api/atcoder';
 import { getSpotifyConnectURL, disconnectSpotify } from '../api/spotify';
 import { deleteAccount } from '../api/auth';
 import { getEmailPreferences, updateEmailPreferences } from '../api/emailPreferences';
+import { isHttpUrl } from '../utils/url';
 import toast from 'react-hot-toast';
 import { useTranslation } from 'react-i18next';
 
@@ -130,6 +131,7 @@ export function useSettings() {
   const handleConnectGitHub = async () => {
     try {
       const { data } = await getGitHubConnectURL();
+      if (!isHttpUrl(data.url)) throw new Error('Invalid OAuth URL');
       window.location.href = data.url;
     } catch {
       toast.error(t('errors.somethingWrong'));
@@ -266,6 +268,7 @@ export function useSettings() {
   const handleConnectSpotify = async () => {
     try {
       const { data } = await getSpotifyConnectURL();
+      if (!isHttpUrl(data.url)) throw new Error('Invalid OAuth URL');
       window.location.href = data.url;
     } catch {
       toast.error(t('errors.somethingWrong'));

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -57,9 +57,9 @@ export default function GitHubCallbackPage() {
         .then(async () => {
           await loadUser();
           toast.success(t('githubCallback.connectSuccess'));
-          const onboardingRedirect = localStorage.getItem('onboarding_redirect');
+          const onboardingRedirect = sessionStorage.getItem('onboarding_redirect');
           if (onboardingRedirect) {
-            localStorage.removeItem('onboarding_redirect');
+            sessionStorage.removeItem('onboarding_redirect');
             navigate('/onboarding');
           } else {
             navigate('/settings');

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import type { User } from '../types/user';
 import * as authApi from '../api/auth';
+import { isHttpUrl } from '../utils/url';
 
 interface AuthState {
   user: User | null;
@@ -32,6 +33,7 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   loginWithGitHub: async () => {
     const { data } = await authApi.getGitHubLoginURL();
+    if (!isHttpUrl(data.url)) throw new Error('Invalid OAuth URL');
     window.location.href = data.url;
   },
 


### PR DESCRIPTION
## 概要
OAuth認証フローのセキュリティ強化。

## 変更内容
1. **OAuth URLバリデーション**: `window.location.href`設定前に`isHttpUrl()`でHTTP/HTTPSプロトコルを検証（4箇所）
2. **sessionStorage移行**: onboarding_redirectフラグをlocalStorageからsessionStorageに変更し、XSSリスクを低減

Closes #1197