### PR TITLE
feat: 学習ログのお気に入り機能を追加

### DIFF
--- a/frontend/src/api/learningLogs.ts
+++ b/frontend/src/api/learningLogs.ts
@@ -34,6 +34,12 @@ export const getLogsByCategory = (category: string) =>
 export const getLogsBySource = (source: string) =>
   client.get<LearningLog[]>(`/learning-logs/source/${source}`);
 
+export const favoriteLog = (id: number) =>
+  client.put<LearningLog>(`/learning-logs/${id}/favorite`);
+
+export const unfavoriteLog = (id: number) =>
+  client.put<LearningLog>(`/learning-logs/${id}/unfavorite`);
+
 export type ExportPeriod = '7' | '30' | '90' | 'all';
 
 export const exportLogsCSV = (period: ExportPeriod = '30') =>

--- a/frontend/src/hooks/useLearningLogForm.ts
+++ b/frontend/src/hooks/useLearningLogForm.ts
@@ -7,7 +7,7 @@ export function useLearningLogForm() {
   const user = useAuthStore((s) => s.user);
   const {
     logs, loading, saving,
-    createLog, updateLog, deleteLog,
+    createLog, updateLog, deleteLog, toggleFavorite,
   } = useLearningLogs();
   const { calendarData, refetchCalendar } = useLearningLogCalendar(user?.id);
 
@@ -17,6 +17,7 @@ export function useLearningLogForm() {
   const [editingLog, setEditingLog] = useState<LearningLog | null>(null);
   const [filterDate, setFilterDate] = useState<string | null>(null);
   const [filterCategory, setFilterCategory] = useState<'all' | LogCategory>('all');
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
 
   // フォーム状態
   const [title, setTitle] = useState('');
@@ -86,9 +87,10 @@ export function useLearningLogForm() {
     logs.filter((log) => {
       if (filterDate && log.created_at.split('T')[0] !== filterDate) return false;
       if (filterCategory !== 'all' && log.category !== filterCategory) return false;
+      if (showFavoritesOnly && !log.is_favorite) return false;
       return true;
     }),
-    [logs, filterDate, filterCategory]
+    [logs, filterDate, filterCategory, showFavoritesOnly]
   );
 
   return {
@@ -100,6 +102,7 @@ export function useLearningLogForm() {
     editingLog,
     filterDate, clearFilterDate,
     filterCategory, setFilterCategory,
+    showFavoritesOnly, setShowFavoritesOnly,
     // フォーム状態
     title, setTitle,
     content, setContent,
@@ -111,5 +114,6 @@ export function useLearningLogForm() {
     handleEdit,
     handleDelete,
     handleDateClick,
+    toggleFavorite,
   };
 }

--- a/frontend/src/hooks/useLearningLogs.ts
+++ b/frontend/src/hooks/useLearningLogs.ts
@@ -9,6 +9,8 @@ import {
   getCalendarData,
   getStreakInfo,
   getWeeklyDuration,
+  favoriteLog,
+  unfavoriteLog,
 } from '../api/learningLogs';
 import type { LearningLog, CalendarEntry, LogCategory, StreakInfo } from '../types/learningLog';
 import { useAsyncData } from './useAsyncData';
@@ -85,6 +87,19 @@ export function useLearningLogs() {
     }
   }, [t, setLogs]);
 
+  const handleToggleFavorite = useCallback(async (id: number) => {
+    const log = currentLogs.find(l => l.id === id);
+    if (!log) return;
+    try {
+      const { data: updated } = log.is_favorite
+        ? await unfavoriteLog(id)
+        : await favoriteLog(id);
+      setLogs(prev => prev.map(l => l.id === updated.id ? updated : l));
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  }, [currentLogs, t, setLogs]);
+
   return {
     logs: currentLogs,
     loading,
@@ -92,6 +107,7 @@ export function useLearningLogs() {
     createLog: handleCreate,
     updateLog: handleUpdate,
     deleteLog: handleDelete,
+    toggleFavorite: handleToggleFavorite,
     refetch,
   };
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -650,7 +650,9 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Aktuelle Serie",
     "days": " Tage",
-    "logCount": "Gesamteinträge"
+    "logCount": "Gesamteinträge",
+    "favorites": "Favoriten",
+    "toggleFavorite": "Favorit umschalten"
   },
   "reports": {
     "title": "Aktivitätsberichte",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -650,7 +650,9 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Current Streak",
     "days": " days",
-    "logCount": "Total Logs"
+    "logCount": "Total Logs",
+    "favorites": "Favorites",
+    "toggleFavorite": "Toggle Favorite"
   },
   "reports": {
     "title": "Activity Reports",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -650,7 +650,9 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Racha actual",
     "days": " días",
-    "logCount": "Total de registros"
+    "logCount": "Total de registros",
+    "favorites": "Favoritos",
+    "toggleFavorite": "Alternar favorito"
   },
   "reports": {
     "title": "Informes de Actividad",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -650,7 +650,9 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Série en cours",
     "days": " jours",
-    "logCount": "Total des entrées"
+    "logCount": "Total des entrées",
+    "favorites": "Favoris",
+    "toggleFavorite": "Basculer le favori"
   },
   "reports": {
     "title": "Rapports d'Activité",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -634,7 +634,9 @@
     "hoursMinutes": "{{hours}}時間{{minutes}}分",
     "currentStreak": "連続学習日数",
     "days": "日",
-    "logCount": "ログ件数"
+    "logCount": "ログ件数",
+    "favorites": "お気に入り",
+    "toggleFavorite": "お気に入り切替"
   },
   "reports": {
     "title": "アクティビティレポート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -650,7 +650,9 @@
     "hoursMinutes": "{{hours}}시간 {{minutes}}분",
     "currentStreak": "연속 학습일",
     "days": "일",
-    "logCount": "로그 수"
+    "logCount": "로그 수",
+    "favorites": "즐겨찾기",
+    "toggleFavorite": "즐겨찾기 전환"
   },
   "reports": {
     "title": "활동 리포트",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -650,7 +650,9 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Sequência atual",
     "days": " dias",
-    "logCount": "Total de registros"
+    "logCount": "Total de registros",
+    "favorites": "Favoritos",
+    "toggleFavorite": "Alternar favorito"
   },
   "reports": {
     "title": "Relatórios de Atividade",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -650,7 +650,9 @@
     "hoursMinutes": "{{hours}}ч {{minutes}}м",
     "currentStreak": "Текущая серия",
     "days": " дн.",
-    "logCount": "Всего записей"
+    "logCount": "Всего записей",
+    "favorites": "Избранное",
+    "toggleFavorite": "Переключить избранное"
   },
   "reports": {
     "title": "Отчёты об Активности",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -650,7 +650,9 @@
     "hoursMinutes": "{{hours}}小时{{minutes}}分钟",
     "currentStreak": "连续学习天数",
     "days": "天",
-    "logCount": "日志数量"
+    "logCount": "日志数量",
+    "favorites": "收藏",
+    "toggleFavorite": "切换收藏"
   },
   "reports": {
     "title": "活动报告",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -650,7 +650,9 @@
     "hoursMinutes": "{{hours}}小時{{minutes}}分鐘",
     "currentStreak": "連續學習天數",
     "days": "天",
-    "logCount": "日誌數量"
+    "logCount": "日誌數量",
+    "favorites": "收藏",
+    "toggleFavorite": "切換收藏"
   },
   "reports": {
     "title": "活動報告",

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Code, BookOpen, GraduationCap, Users, FileText, Calendar, List, Download, Clock, type LucideIcon } from 'lucide-react';
+import { Code, BookOpen, GraduationCap, Users, FileText, Calendar, List, Download, Clock, Star, type LucideIcon } from 'lucide-react';
 import { useLearningLogForm } from '../hooks/useLearningLogForm';
 import { useWeeklyDuration, useStreak } from '../hooks';
 import { useAuthStore } from '../store/authStore';
@@ -45,11 +45,12 @@ export default function LearningLogsPage() {
     editingLog,
     filterDate, clearFilterDate,
     filterCategory, setFilterCategory,
+    showFavoritesOnly, setShowFavoritesOnly,
     title, setTitle,
     content, setContent,
     category, setCategory,
     duration, setDuration,
-    resetForm, handleSubmit, handleEdit, handleDelete, handleDateClick,
+    resetForm, handleSubmit, handleEdit, handleDelete, handleDateClick, toggleFavorite,
   } = useLearningLogForm();
 
   const handleExport = useCallback(async (period: ExportPeriod) => {
@@ -71,6 +72,7 @@ export default function LearningLogsPage() {
   const handleViewList = useCallback(() => { setView('list'); clearFilterDate(); }, [setView, clearFilterDate]);
   const handleViewCalendar = useCallback(() => { setView('calendar'); clearFilterDate(); }, [setView, clearFilterDate]);
   const handleFilterAll = useCallback(() => setFilterCategory('all'), [setFilterCategory]);
+  const handleToggleFavoritesFilter = useCallback(() => setShowFavoritesOnly(prev => !prev), [setShowFavoritesOnly]);
   const handleTitleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value), [setTitle]);
   const handleContentChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => setContent(e.target.value), [setContent]);
   const handleCategoryChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => setCategory(e.target.value as LogCategory), [setCategory]);
@@ -163,6 +165,15 @@ export default function LearningLogsPage() {
         >
           <Calendar className="w-4 h-4" />
           {t('learningLogs.calendar')}
+        </button>
+        <button
+          onClick={handleToggleFavoritesFilter}
+          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+            showFavoritesOnly ? 'bg-yellow-500/20 text-yellow-400' : 'text-gray-400 hover:text-white'
+          }`}
+        >
+          <Star className={`w-4 h-4 ${showFavoritesOnly ? 'fill-yellow-400' : ''}`} />
+          {t('learningLogs.favorites')}
         </button>
         {filterDate && (
           <div className="flex items-center gap-2 ml-2">
@@ -350,6 +361,13 @@ export default function LearningLogsPage() {
                       </div>
 
                       <div className="flex items-center gap-1">
+                        <button
+                          onClick={() => toggleFavorite(log.id)}
+                          className={`p-2 transition-colors ${log.is_favorite ? 'text-yellow-400' : 'text-gray-400 hover:text-yellow-400'}`}
+                          title={t('learningLogs.toggleFavorite')}
+                        >
+                          <Star className={`w-4 h-4 ${log.is_favorite ? 'fill-yellow-400' : ''}`} />
+                        </button>
                         <button
                           onClick={() => handleEdit(log)}
                           className="p-2 text-gray-400 hover:text-blue-400 transition-colors"

--- a/frontend/src/types/learningLog.ts
+++ b/frontend/src/types/learningLog.ts
@@ -10,6 +10,7 @@ export interface LearningLog {
   category: LogCategory;
   duration: number;
   source: LogSource;
+  is_favorite: boolean;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## 概要
バックエンドAPIに対応するお気に入り機能のフロントエンド実装。

## 変更内容
- LearningLog型に`is_favorite`フィールド追加
- `favoriteLog` / `unfavoriteLog` API関数追加
- ログカードに星アイコンのお気に入りトグルボタン
- お気に入りフィルター機能追加
- 10言語にi18nキー追加

Closes #1199