### PR TITLE
fix: ProjectForm・ResourceFormにURL入力バリデーション追加

### DIFF
--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -3,6 +3,8 @@ import { useTranslation } from 'react-i18next';
 import type { Project, CreateProjectRequest } from '../../types/project';
 import type { GitHubRepository } from '../../types/github';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
+import { isHttpUrl } from '../../utils/url';
+import toast from 'react-hot-toast';
 
 interface ProjectFormProps {
   project?: Project;
@@ -62,6 +64,17 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const urlFields = [
+      { value: demoUrl, label: t('projects.demoUrl') },
+      { value: githubUrl, label: t('projects.githubUrl') },
+      { value: imageUrl, label: t('projects.imageUrl') },
+    ];
+    for (const field of urlFields) {
+      if (field.value && !isHttpUrl(field.value)) {
+        toast.error(t('common.invalidUrl', { field: field.label }));
+        return;
+      }
+    }
     await onSubmit({
       title,
       description,

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LearningResource, CreateResourceRequest, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
+import { isHttpUrl } from '../../utils/url';
+import toast from 'react-hot-toast';
 
 interface ResourceFormProps {
   resource?: LearningResource;
@@ -47,6 +49,16 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    const urlFields = [
+      { value: url, label: t('resources.url') },
+      { value: imageUrl, label: t('resources.imageUrl') },
+    ];
+    for (const field of urlFields) {
+      if (field.value && !isHttpUrl(field.value)) {
+        toast.error(t('common.invalidUrl', { field: field.label }));
+        return;
+      }
+    }
     await onSubmit({
       title,
       description,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -22,6 +22,7 @@
     "and": "und",
     "menu": "Menü",
     "scrollToTop": "Nach oben",
+    "invalidUrl": "{{field}} ist keine gültige URL",
     "selectLanguage": "Sprache auswählen",
     "monthsShort": [
       "Jan",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -22,6 +22,7 @@
     "add": "Add",
     "menu": "Menu",
     "scrollToTop": "Back to top",
+    "invalidUrl": "{{field}} is not a valid URL",
     "selectLanguage": "Select language",
     "monthsShort": [
       "Jan",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -22,6 +22,7 @@
     "and": "y",
     "menu": "Menú",
     "scrollToTop": "Volver arriba",
+    "invalidUrl": "{{field}} no es una URL válida",
     "selectLanguage": "Seleccionar idioma",
     "monthsShort": [
       "Ene",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -22,6 +22,7 @@
     "and": "et",
     "menu": "Menu",
     "scrollToTop": "Retour en haut",
+    "invalidUrl": "{{field}} n'est pas une URL valide",
     "selectLanguage": "Choisir la langue",
     "monthsShort": [
       "Jan",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -23,6 +23,7 @@
     "menu": "メニュー",
     "scrollToTop": "ページ上部に戻る",
     "dismiss": "閉じる",
+    "invalidUrl": "{{field}}は有効なURLではありません",
     "selectLanguage": "言語を選択",
     "monthsShort": [
       "1月",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -22,6 +22,7 @@
     "and": "그리고",
     "menu": "메뉴",
     "scrollToTop": "맨 위로",
+    "invalidUrl": "{{field}}은(는) 유효한 URL이 아닙니다",
     "selectLanguage": "언어 선택",
     "monthsShort": [
       "1월",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -22,6 +22,7 @@
     "and": "e",
     "menu": "Menu",
     "scrollToTop": "Voltar ao topo",
+    "invalidUrl": "{{field}} não é uma URL válida",
     "selectLanguage": "Selecionar idioma",
     "monthsShort": [
       "Jan",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -22,6 +22,7 @@
     "and": "и",
     "menu": "Меню",
     "scrollToTop": "Наверх",
+    "invalidUrl": "{{field}} не является допустимым URL",
     "selectLanguage": "Выбрать язык",
     "monthsShort": [
       "Янв",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -22,6 +22,7 @@
     "and": "和",
     "menu": "菜单",
     "scrollToTop": "返回顶部",
+    "invalidUrl": "{{field}}不是有效的URL",
     "selectLanguage": "选择语言",
     "monthsShort": [
       "1月",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -22,6 +22,7 @@
     "and": "和",
     "menu": "選單",
     "scrollToTop": "返回頂部",
+    "invalidUrl": "{{field}}不是有效的URL",
     "selectLanguage": "選擇語言",
     "monthsShort": [
       "1月",


### PR DESCRIPTION
## 概要
ProjectFormおよびResourceFormのURL入力フィールドに`isHttpUrl()`バリデーションを追加し、`javascript:`や`data:`等の危険なプロトコルの入力を防止する。

## 変更内容
- ProjectForm: demoUrl, githubUrl, imageUrlの3フィールドにバリデーション追加
- ResourceForm: url, imageUrlの2フィールドにバリデーション追加
- `common.invalidUrl` i18nキーを全10言語に追加

Closes #1205