### PR TITLE
feat: 学習目標ページにカテゴリ・ステータスフィルタ機能を追加

### DIFF
--- a/frontend/src/hooks/useGoalForm.ts
+++ b/frontend/src/hooks/useGoalForm.ts
@@ -14,6 +14,8 @@ export function useGoalForm() {
   const [description, setDescription] = useState('');
   const [category, setCategory] = useState<GoalCategory>('other');
   const [targetDate, setTargetDate] = useState('');
+  const [filterStatus, setFilterStatus] = useState<GoalStatus | 'all'>('all');
+  const [filterCategory, setFilterCategory] = useState<GoalCategory | 'all'>('all');
 
   const resetForm = () => {
     setTitle('');
@@ -73,8 +75,26 @@ export function useGoalForm() {
     await goalsData.duplicateGoal(id);
   };
 
+  const filteredGoals = goalsData.goals.filter(g => {
+    if (filterStatus !== 'all' && g.status !== filterStatus) return false;
+    if (filterCategory !== 'all' && g.category !== filterCategory) return false;
+    return true;
+  });
+
+  const filteredActiveGoals = filteredGoals.filter(g => g.status === 'active');
+  const filteredPausedGoals = filteredGoals.filter(g => g.status === 'paused');
+  const filteredCompletedGoals = filteredGoals.filter(g => g.status === 'completed');
+
   return {
     ...goalsData,
+    filteredGoals,
+    filteredActiveGoals,
+    filteredPausedGoals,
+    filteredCompletedGoals,
+    filterStatus,
+    setFilterStatus,
+    filterCategory,
+    setFilterCategory,
     showForm,
     setShowForm,
     editingGoal,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -23,6 +23,7 @@
     "menu": "Menü",
     "scrollToTop": "Nach oben",
     "invalidUrl": "{{field}} ist keine gültige URL",
+    "all": "Alle",
     "selectLanguage": "Sprache auswählen",
     "monthsShort": [
       "Jan",
@@ -596,6 +597,8 @@
     "statusPaused": "Pausiert",
     "pause": "Pausieren",
     "resume": "Fortsetzen",
+    "filter": "Filter",
+    "noFilterResults": "Keine Ziele entsprechen den ausgewählten Filtern",
     "titlePlaceholder": "z.B. TypeScript lernen",
     "descriptionPlaceholder": "Beschreiben Sie Ihr Ziel...",
     "categoryLanguage": "Sprache",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -23,6 +23,7 @@
     "menu": "Menu",
     "scrollToTop": "Back to top",
     "invalidUrl": "{{field}} is not a valid URL",
+    "all": "All",
     "selectLanguage": "Select language",
     "monthsShort": [
       "Jan",
@@ -596,6 +597,8 @@
     "statusPaused": "Paused",
     "pause": "Pause",
     "resume": "Resume",
+    "filter": "Filter",
+    "noFilterResults": "No goals match the selected filters",
     "titlePlaceholder": "e.g. Learn TypeScript",
     "descriptionPlaceholder": "Describe your goal...",
     "categoryLanguage": "Language",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -23,6 +23,7 @@
     "menu": "Menú",
     "scrollToTop": "Volver arriba",
     "invalidUrl": "{{field}} no es una URL válida",
+    "all": "Todos",
     "selectLanguage": "Seleccionar idioma",
     "monthsShort": [
       "Ene",
@@ -596,6 +597,8 @@
     "statusPaused": "Pausado",
     "pause": "Pausar",
     "resume": "Reanudar",
+    "filter": "Filtrar",
+    "noFilterResults": "No hay objetivos que coincidan con los filtros",
     "titlePlaceholder": "Ej. Aprender TypeScript",
     "descriptionPlaceholder": "Describe tu objetivo...",
     "categoryLanguage": "Lenguaje",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -23,6 +23,7 @@
     "menu": "Menu",
     "scrollToTop": "Retour en haut",
     "invalidUrl": "{{field}} n'est pas une URL valide",
+    "all": "Tous",
     "selectLanguage": "Choisir la langue",
     "monthsShort": [
       "Jan",
@@ -596,6 +597,8 @@
     "statusPaused": "En pause",
     "pause": "Pause",
     "resume": "Reprendre",
+    "filter": "Filtrer",
+    "noFilterResults": "Aucun objectif ne correspond aux filtres sélectionnés",
     "titlePlaceholder": "Ex. Apprendre TypeScript",
     "descriptionPlaceholder": "Décrivez votre objectif...",
     "categoryLanguage": "Langage",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -24,6 +24,7 @@
     "scrollToTop": "ページ上部に戻る",
     "dismiss": "閉じる",
     "invalidUrl": "{{field}}は有効なURLではありません",
+    "all": "すべて",
     "selectLanguage": "言語を選択",
     "monthsShort": [
       "1月",
@@ -585,6 +586,8 @@
     "statusPaused": "一時停止",
     "pause": "一時停止",
     "resume": "再開",
+    "filter": "フィルター",
+    "noFilterResults": "条件に一致する目標がありません",
     "titlePlaceholder": "例：TypeScriptを学ぶ",
     "descriptionPlaceholder": "目標を説明してください...",
     "categoryLanguage": "言語",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -23,6 +23,7 @@
     "menu": "메뉴",
     "scrollToTop": "맨 위로",
     "invalidUrl": "{{field}}은(는) 유효한 URL이 아닙니다",
+    "all": "전체",
     "selectLanguage": "언어 선택",
     "monthsShort": [
       "1월",
@@ -596,6 +597,8 @@
     "statusPaused": "일시 중지",
     "pause": "일시 중지",
     "resume": "재개",
+    "filter": "필터",
+    "noFilterResults": "선택한 필터에 맞는 목표가 없습니다",
     "titlePlaceholder": "예: TypeScript 배우기",
     "descriptionPlaceholder": "목표를 설명하세요...",
     "categoryLanguage": "언어",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -23,6 +23,7 @@
     "menu": "Menu",
     "scrollToTop": "Voltar ao topo",
     "invalidUrl": "{{field}} não é uma URL válida",
+    "all": "Todos",
     "selectLanguage": "Selecionar idioma",
     "monthsShort": [
       "Jan",
@@ -596,6 +597,8 @@
     "statusPaused": "Pausado",
     "pause": "Pausar",
     "resume": "Retomar",
+    "filter": "Filtrar",
+    "noFilterResults": "Nenhuma meta corresponde aos filtros selecionados",
     "titlePlaceholder": "Ex. Aprender TypeScript",
     "descriptionPlaceholder": "Descreva sua meta...",
     "categoryLanguage": "Linguagem",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -23,6 +23,7 @@
     "menu": "Меню",
     "scrollToTop": "Наверх",
     "invalidUrl": "{{field}} не является допустимым URL",
+    "all": "Все",
     "selectLanguage": "Выбрать язык",
     "monthsShort": [
       "Янв",
@@ -596,6 +597,8 @@
     "statusPaused": "Приостановлена",
     "pause": "Приостановить",
     "resume": "Возобновить",
+    "filter": "Фильтр",
+    "noFilterResults": "Нет целей, соответствующих выбранным фильтрам",
     "titlePlaceholder": "Напр. Изучить TypeScript",
     "descriptionPlaceholder": "Опишите свою цель...",
     "categoryLanguage": "Язык",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -23,6 +23,7 @@
     "menu": "菜单",
     "scrollToTop": "返回顶部",
     "invalidUrl": "{{field}}不是有效的URL",
+    "all": "全部",
     "selectLanguage": "选择语言",
     "monthsShort": [
       "1月",
@@ -596,6 +597,8 @@
     "statusPaused": "已暂停",
     "pause": "暂停",
     "resume": "恢复",
+    "filter": "筛选",
+    "noFilterResults": "没有符合筛选条件的目标",
     "titlePlaceholder": "例如：学习 TypeScript",
     "descriptionPlaceholder": "描述你的目标...",
     "categoryLanguage": "语言",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -23,6 +23,7 @@
     "menu": "選單",
     "scrollToTop": "返回頂部",
     "invalidUrl": "{{field}}不是有效的URL",
+    "all": "全部",
     "selectLanguage": "選擇語言",
     "monthsShort": [
       "1月",
@@ -596,6 +597,8 @@
     "statusPaused": "已暫停",
     "pause": "暫停",
     "resume": "繼續",
+    "filter": "篩選",
+    "noFilterResults": "沒有符合篩選條件的目標",
     "titlePlaceholder": "例如：學習 TypeScript",
     "descriptionPlaceholder": "描述你的目標...",
     "categoryLanguage": "語言",

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Monitor, Rocket, Target, FolderOpen, FileText, Copy, type LucideIcon } from 'lucide-react';
+import { Monitor, Rocket, Target, FolderOpen, FileText, Copy, Filter, type LucideIcon } from 'lucide-react';
 import { type GoalCategory, type GoalStatus, type LearningGoal } from '../api/goals';
 import { useGoalForm } from '../hooks';
 import { Modal, PageLoader } from '../components/common';
@@ -46,6 +46,8 @@ export default function GoalsPage() {
   const { t } = useTranslation();
   const {
     goals, loading, saving, activeGoals, completedGoals, pausedGoals,
+    filteredGoals, filteredActiveGoals, filteredPausedGoals, filteredCompletedGoals,
+    filterStatus, setFilterStatus, filterCategory, setFilterCategory,
     showForm, setShowForm, editingGoal,
     title, setTitle, description, setDescription,
     category, setCategory, targetDate, setTargetDate,
@@ -54,6 +56,8 @@ export default function GoalsPage() {
     handleDuplicateGoal,
     dialogProps,
   } = useGoalForm();
+
+  const isFiltered = filterStatus !== 'all' || filterCategory !== 'all';
 
   if (loading) return <PageLoader />;
 
@@ -86,6 +90,46 @@ export default function GoalsPage() {
         <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
           <p className="text-2xl font-bold text-yellow-400">{pausedGoals.length}</p>
           <p className="text-sm text-gray-400">{t('goals.pausedGoals')}</p>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="bg-gray-900 border border-gray-800 rounded-md p-4 space-y-3">
+        <div className="flex items-center gap-2 text-sm text-gray-400">
+          <Filter className="w-4 h-4" />
+          <span>{t('goals.filter')}</span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <span className="text-xs text-gray-500 self-center mr-1">{t('goals.status')}:</span>
+          {(['all', 'active', 'paused', 'completed'] as const).map((s) => (
+            <button
+              key={s}
+              onClick={() => setFilterStatus(s)}
+              className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                filterStatus === s
+                  ? 'border-blue-500 bg-blue-500/10 text-blue-400'
+                  : 'border-gray-700 text-gray-400 hover:border-gray-600'
+              }`}
+            >
+              {s === 'all' ? t('common.all') : t(`goals.status${s.charAt(0).toUpperCase() + s.slice(1)}`)}
+            </button>
+          ))}
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <span className="text-xs text-gray-500 self-center mr-1">{t('goals.category')}:</span>
+          {(['all', ...CATEGORIES.map(c => c.value)] as const).map((c) => (
+            <button
+              key={c}
+              onClick={() => setFilterCategory(c)}
+              className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                filterCategory === c
+                  ? 'border-purple-500 bg-purple-500/10 text-purple-400'
+                  : 'border-gray-700 text-gray-400 hover:border-gray-600'
+              }`}
+            >
+              {c === 'all' ? t('common.all') : t(`goals.category${c.charAt(0).toUpperCase() + c.slice(1)}`)}
+            </button>
+          ))}
         </div>
       </div>
 
@@ -182,15 +226,19 @@ export default function GoalsPage() {
             onAction={() => setShowForm(true)}
           />
         </div>
+      ) : isFiltered && filteredGoals.length === 0 ? (
+        <div className="bg-gray-900 border border-gray-800 rounded-md p-8 text-center text-gray-400">
+          {t('goals.noFilterResults')}
+        </div>
       ) : (
         <div className="space-y-4">
-          {activeGoals.length > 0 && (
+          {filteredActiveGoals.length > 0 && (
             <div>
               <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-3">
                 {t('goals.activeGoals')}
               </h2>
               <div className="space-y-3">
-                {activeGoals.map((goal) => (
+                {filteredActiveGoals.map((goal) => (
                   <GoalCard
                     key={goal.id}
                     goal={goal}
@@ -208,13 +256,13 @@ export default function GoalsPage() {
             </div>
           )}
 
-          {pausedGoals.length > 0 && (
+          {filteredPausedGoals.length > 0 && (
             <div>
               <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-3">
                 {t('goals.pausedGoals')}
               </h2>
               <div className="space-y-3">
-                {pausedGoals.map((goal) => (
+                {filteredPausedGoals.map((goal) => (
                   <GoalCard
                     key={goal.id}
                     goal={goal}
@@ -232,13 +280,13 @@ export default function GoalsPage() {
             </div>
           )}
 
-          {completedGoals.length > 0 && (
+          {filteredCompletedGoals.length > 0 && (
             <div>
               <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-3">
                 {t('goals.completedGoals')}
               </h2>
               <div className="space-y-3">
-                {completedGoals.map((goal) => (
+                {filteredCompletedGoals.map((goal) => (
                   <GoalCard
                     key={goal.id}
                     goal={goal}


### PR DESCRIPTION
## 概要
学習目標ページにカテゴリおよびステータスによるフィルタ機能を追加。

## 変更内容
- ステータスフィルタ: すべて / 進行中 / 一時停止 / 完了
- カテゴリフィルタ: すべて / 言語 / フレームワーク / スキル / プロジェクト / その他
- フィルタ結果が0件の場合のメッセージ表示
- useGoalFormフックにフィルタ状態管理を追加
- i18nキー（common.all, goals.filter, goals.noFilterResults）を全10言語に追加

Closes #1207