### PR TITLE
fix: window.openにnoopener追加・URLパラメータエスケープ強化

### DIFF
--- a/frontend/src/components/profile/PortfolioModal.tsx
+++ b/frontend/src/components/profile/PortfolioModal.tsx
@@ -58,7 +58,7 @@ export default function PortfolioModal({
   const handleOpenInNewTab = () => {
     const blob = new Blob([html], { type: 'text/html' });
     const url = URL.createObjectURL(blob);
-    window.open(url, '_blank');
+    window.open(url, '_blank', 'noopener');
   };
 
   if (!isOpen) return null;

--- a/frontend/src/components/profile/ShareModal.tsx
+++ b/frontend/src/components/profile/ShareModal.tsx
@@ -90,12 +90,12 @@ export default function ShareModal({
   const handleShareTwitter = () => {
     const text = t('sharing.twitterText', { name: user.name || 'Developer' });
     const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(profileUrl)}`;
-    window.open(url, '_blank', 'width=600,height=400');
+    window.open(url, '_blank', 'width=600,height=400,noopener');
   };
 
   const handleShareLinkedIn = () => {
     const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(profileUrl)}`;
-    window.open(url, '_blank', 'width=600,height=400');
+    window.open(url, '_blank', 'width=600,height=400,noopener');
   };
 
   return (

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -158,13 +158,13 @@ export default function ProfilePage() {
           {user.skills_languages && (
             <div>
               <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2"><Sparkles className="w-4 h-4 text-yellow-400" aria-hidden="true" /> {t('profile.languages')}</h3>
-              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?i=${user.skills_languages}&theme=dark`} alt="Languages" className="h-12" /></a>
+              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?${new URLSearchParams({ i: user.skills_languages, theme: 'dark' })}`} alt="Languages" className="h-12" /></a>
             </div>
           )}
           {user.skills_frameworks && (
             <div>
               <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2"><Rocket className="w-4 h-4 text-blue-400" aria-hidden="true" /> {t('profile.frameworks')}</h3>
-              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?i=${user.skills_frameworks}&theme=dark`} alt="Frameworks" className="h-12" /></a>
+              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?${new URLSearchParams({ i: user.skills_frameworks, theme: 'dark' })}`} alt="Frameworks" className="h-12" /></a>
             </div>
           )}
         </div>


### PR DESCRIPTION
## 概要
window.open()のTabnabbingリスク対策とURLパラメータインジェクション防止。

## 変更内容
- ShareModal: Twitter/LinkedInシェアのwindow.openにnoopener追加
- PortfolioModal: 新規タブ表示のwindow.openにnoopener追加
- ProfilePage: skillicons.devのURLパラメータをURLSearchParamsでエスケープ

Closes #1213