### PR TITLE
feat: Q&Aページに解決済み/未解決フィルタ機能を追加

### DIFF
--- a/frontend/src/hooks/useQuestions.ts
+++ b/frontend/src/hooks/useQuestions.ts
@@ -12,6 +12,7 @@ import {
 import { useAsyncData } from './useAsyncData';
 
 type SortType = 'newest' | 'votes' | 'unanswered';
+type SolvedFilter = 'all' | 'solved' | 'unsolved';
 
 export function useQuestions() {
   const { t } = useTranslation();
@@ -19,6 +20,7 @@ export function useQuestions() {
   const [searchQuery, setSearchQuery] = useState('');
   const [tagFilter, setTagFilter] = useState('');
   const [sort, setSort] = useState<SortType>('newest');
+  const [solvedFilter, setSolvedFilter] = useState<SolvedFilter>('all');
   const [page, setPage] = useState(0);
   const limit = 20;
 
@@ -36,7 +38,10 @@ export function useQuestions() {
   const total = data?.total ?? 0;
 
   const [localQuestions, setLocalQuestions] = useState<Question[] | null>(null);
-  const currentQuestions = localQuestions ?? questions;
+  const allQuestions = localQuestions ?? questions;
+  const currentQuestions = solvedFilter === 'all'
+    ? allQuestions
+    : allQuestions.filter(q => solvedFilter === 'solved' ? q.is_solved : !q.is_solved);
 
   const handleSearch = useCallback(() => {
     setPage(0);
@@ -91,6 +96,11 @@ export function useQuestions() {
     setLocalQuestions(null);
   }, []);
 
+  const changeSolvedFilter = useCallback((f: SolvedFilter) => {
+    setSolvedFilter(f);
+    setPage(0);
+  }, []);
+
   return {
     questions: currentQuestions,
     total,
@@ -102,6 +112,8 @@ export function useQuestions() {
     setTagFilter: (v: string) => { setTagFilter(v); setPage(0); setLocalQuestions(null); },
     sort,
     setSort: changeSort,
+    solvedFilter,
+    setSolvedFilter: changeSolvedFilter,
     page,
     setPage,
     limit,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -901,6 +901,10 @@
       "votes": "Stimmen",
       "unanswered": "Unbeantwortet"
     },
+    "filter": {
+      "solved": "Gelöst",
+      "unsolved": "Ungelöst"
+    },
     "createSuccess": "Frage erstellt",
     "updateSuccess": "Frage aktualisiert",
     "deleteSuccess": "Frage gelöscht",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -901,6 +901,10 @@
       "votes": "Votes",
       "unanswered": "Unanswered"
     },
+    "filter": {
+      "solved": "Solved",
+      "unsolved": "Unsolved"
+    },
     "createSuccess": "Question created",
     "updateSuccess": "Question updated",
     "deleteSuccess": "Question deleted",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -901,6 +901,10 @@
       "votes": "Votos",
       "unanswered": "Sin respuesta"
     },
+    "filter": {
+      "solved": "Resueltas",
+      "unsolved": "Sin resolver"
+    },
     "createSuccess": "Pregunta creada",
     "updateSuccess": "Pregunta actualizada",
     "deleteSuccess": "Pregunta eliminada",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -901,6 +901,10 @@
       "votes": "Votes",
       "unanswered": "Sans réponse"
     },
+    "filter": {
+      "solved": "Résolues",
+      "unsolved": "Non résolues"
+    },
     "createSuccess": "Question créée",
     "updateSuccess": "Question mise à jour",
     "deleteSuccess": "Question supprimée",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -855,6 +855,10 @@
       "votes": "投票数",
       "unanswered": "未回答"
     },
+    "filter": {
+      "solved": "解決済み",
+      "unsolved": "未解決"
+    },
     "createSuccess": "質問を作成しました",
     "updateSuccess": "質問を更新しました",
     "deleteSuccess": "質問を削除しました",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -901,6 +901,10 @@
       "votes": "투표순",
       "unanswered": "미답변"
     },
+    "filter": {
+      "solved": "해결됨",
+      "unsolved": "미해결"
+    },
     "createSuccess": "질문이 작성되었습니다",
     "updateSuccess": "질문이 수정되었습니다",
     "deleteSuccess": "질문이 삭제되었습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -901,6 +901,10 @@
       "votes": "Votos",
       "unanswered": "Sem resposta"
     },
+    "filter": {
+      "solved": "Resolvidas",
+      "unsolved": "Não resolvidas"
+    },
     "createSuccess": "Pergunta criada",
     "updateSuccess": "Pergunta atualizada",
     "deleteSuccess": "Pergunta excluída",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -901,6 +901,10 @@
       "votes": "Голоса",
       "unanswered": "Без ответа"
     },
+    "filter": {
+      "solved": "Решённые",
+      "unsolved": "Нерешённые"
+    },
     "createSuccess": "Вопрос создан",
     "updateSuccess": "Вопрос обновлён",
     "deleteSuccess": "Вопрос удалён",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -901,6 +901,10 @@
       "votes": "投票数",
       "unanswered": "未回答"
     },
+    "filter": {
+      "solved": "已解决",
+      "unsolved": "未解决"
+    },
     "createSuccess": "问题已创建",
     "updateSuccess": "问题已更新",
     "deleteSuccess": "问题已删除",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -901,6 +901,10 @@
       "votes": "投票數",
       "unanswered": "未回答"
     },
+    "filter": {
+      "solved": "已解決",
+      "unsolved": "未解決"
+    },
     "createSuccess": "問題已建立",
     "updateSuccess": "問題已更新",
     "deleteSuccess": "問題已刪除",

--- a/frontend/src/pages/QAPage.tsx
+++ b/frontend/src/pages/QAPage.tsx
@@ -17,6 +17,7 @@ export default function QAPage() {
     questions, total, loading, saving,
     searchQuery, setSearchQuery,
     sort, setSort,
+    solvedFilter, setSolvedFilter,
     page, setPage, limit,
     handleSearch,
     createQuestion, updateQuestion, deleteQuestion,
@@ -87,6 +88,19 @@ export default function QAPage() {
               }`}
             >
               {t(`qa.sort.${s}`)}
+            </button>
+          ))}
+        </div>
+        <div className="flex gap-2">
+          {(['all', 'solved', 'unsolved'] as const).map(f => (
+            <button
+              key={f}
+              onClick={() => setSolvedFilter(f)}
+              className={`px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                solvedFilter === f ? 'bg-green-700/50 text-green-300' : 'bg-gray-800 text-gray-400 hover:text-white'
+              }`}
+            >
+              {f === 'all' ? t('common.all') : t(`qa.filter.${f}`)}
             </button>
           ))}
         </div>


### PR DESCRIPTION
## 概要
Q&Aページに解決済み/未解決フィルタを追加し、質問の状態で絞り込めるようにする。

## 変更内容
- フィルタボタン: すべて / 解決済み / 未解決
- useQuestionsフックにsolvedFilter状態管理を追加
- is_solvedフィールドによるクライアントサイドフィルタリング
- qa.filter.solved/unsolvedキーを全10言語に追加

Closes #1215