### PR TITLE
fix: window.openにnoreferrer追加・JWTデコード境界チェック強化

### DIFF
--- a/frontend/src/components/profile/PortfolioModal.tsx
+++ b/frontend/src/components/profile/PortfolioModal.tsx
@@ -58,7 +58,7 @@ export default function PortfolioModal({
   const handleOpenInNewTab = () => {
     const blob = new Blob([html], { type: 'text/html' });
     const url = URL.createObjectURL(blob);
-    window.open(url, '_blank', 'noopener');
+    window.open(url, '_blank', 'noopener,noreferrer');
   };
 
   if (!isOpen) return null;

--- a/frontend/src/components/profile/ShareModal.tsx
+++ b/frontend/src/components/profile/ShareModal.tsx
@@ -90,12 +90,12 @@ export default function ShareModal({
   const handleShareTwitter = () => {
     const text = t('sharing.twitterText', { name: user.name || 'Developer' });
     const url = `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(profileUrl)}`;
-    window.open(url, '_blank', 'width=600,height=400,noopener');
+    window.open(url, '_blank', 'width=600,height=400,noopener,noreferrer');
   };
 
   const handleShareLinkedIn = () => {
     const url = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(profileUrl)}`;
-    window.open(url, '_blank', 'width=600,height=400,noopener');
+    window.open(url, '_blank', 'width=600,height=400,noopener,noreferrer');
   };
 
   return (

--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -8,8 +8,9 @@ import toast from 'react-hot-toast';
 
 function parseStatePurpose(state: string): string {
   try {
-    const payload = state.split('.')[1];
-    const decoded = JSON.parse(atob(payload));
+    const parts = state.split('.');
+    if (parts.length < 2 || !parts[1]) return '';
+    const decoded = JSON.parse(atob(parts[1]));
     return decoded.purpose || '';
   } catch {
     return '';


### PR DESCRIPTION
## 概要
- ShareModal/PortfolioModal: window.openにnoreferrerフラグ追加（リファラ漏洩防止）
- GitHubCallbackPage: JWTペイロードデコード前にparts長・空文字チェック追加

## テスト
- TypeScript型チェック通過（`npx tsc --noEmit`）

Closes #1221