### PR TITLE
fix: iframeにsandbox属性追加・ダウンロードファイル名サニタイズ

### DIFF
--- a/frontend/src/components/profile/PortfolioModal.tsx
+++ b/frontend/src/components/profile/PortfolioModal.tsx
@@ -45,7 +45,7 @@ export default function PortfolioModal({
   const html = useMemo(() => generatePortfolioHTML(data, theme), [data, theme]);
 
   const handleDownload = () => {
-    const filename = `${user.name.toLowerCase().replace(/\s+/g, '-')}-portfolio.html`;
+    const filename = `${user.name.toLowerCase().replace(/[^a-z0-9_-]/g, '-')}-portfolio.html`;
     downloadPortfolio(html, filename);
     toast.success(t('sharing.downloaded'));
   };
@@ -126,6 +126,7 @@ export default function PortfolioModal({
             <div className="bg-white rounded-lg overflow-hidden">
               <iframe
                 srcDoc={html}
+                sandbox="allow-same-origin"
                 className="w-full h-96 border-0"
                 title={t('portfolio.preview')}
               />

--- a/frontend/src/components/profile/ShareModal.tsx
+++ b/frontend/src/components/profile/ShareModal.tsx
@@ -67,7 +67,7 @@ export default function ShareModal({
       const url = URL.createObjectURL(blob);
       const link = document.createElement('a');
       link.href = url;
-      link.download = `devsync-${user.github_username || user.name || 'profile'}.png`;
+      link.download = `devsync-${(user.github_username || user.name || 'profile').replace(/[^a-zA-Z0-9_-]/g, '_')}.png`;
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);


### PR DESCRIPTION
## 概要
- PortfolioModalのiframeプレビューに `sandbox="allow-same-origin"` 追加（スクリプト実行制限）
- ダウンロードファイル名の特殊文字をサニタイズ（ポートフォリオ・画像共有）

## テスト
- TypeScript型チェック通過（`npx tsc --noEmit`）

Closes #1229