### PR TITLE
目標ページにキーワード検索フィルターを追加

### DIFF
--- a/frontend/src/hooks/useGoalForm.ts
+++ b/frontend/src/hooks/useGoalForm.ts
@@ -16,6 +16,7 @@ export function useGoalForm() {
   const [targetDate, setTargetDate] = useState('');
   const [filterStatus, setFilterStatus] = useState<GoalStatus | 'all'>('all');
   const [filterCategory, setFilterCategory] = useState<GoalCategory | 'all'>('all');
+  const [searchQuery, setSearchQuery] = useState('');
 
   const resetForm = () => {
     setTitle('');
@@ -78,6 +79,8 @@ export function useGoalForm() {
   const filteredGoals = goalsData.goals.filter(g => {
     if (filterStatus !== 'all' && g.status !== filterStatus) return false;
     if (filterCategory !== 'all' && g.category !== filterCategory) return false;
+    const q = searchQuery.toLowerCase().trim();
+    if (q && !g.title.toLowerCase().includes(q) && !g.description.toLowerCase().includes(q)) return false;
     return true;
   });
 
@@ -95,6 +98,8 @@ export function useGoalForm() {
     setFilterStatus,
     filterCategory,
     setFilterCategory,
+    searchQuery,
+    setSearchQuery,
     showForm,
     setShowForm,
     editingGoal,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -599,6 +599,7 @@
     "resume": "Fortsetzen",
     "filter": "Filter",
     "noFilterResults": "Keine Ziele entsprechen den ausgewählten Filtern",
+    "searchPlaceholder": "Nach Titel oder Beschreibung suchen...",
     "titlePlaceholder": "z.B. TypeScript lernen",
     "descriptionPlaceholder": "Beschreiben Sie Ihr Ziel...",
     "categoryLanguage": "Sprache",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -599,6 +599,7 @@
     "resume": "Resume",
     "filter": "Filter",
     "noFilterResults": "No goals match the selected filters",
+    "searchPlaceholder": "Search by title or description...",
     "titlePlaceholder": "e.g. Learn TypeScript",
     "descriptionPlaceholder": "Describe your goal...",
     "categoryLanguage": "Language",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -599,6 +599,7 @@
     "resume": "Reanudar",
     "filter": "Filtrar",
     "noFilterResults": "No hay objetivos que coincidan con los filtros",
+    "searchPlaceholder": "Buscar por título o descripción...",
     "titlePlaceholder": "Ej. Aprender TypeScript",
     "descriptionPlaceholder": "Describe tu objetivo...",
     "categoryLanguage": "Lenguaje",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -599,6 +599,7 @@
     "resume": "Reprendre",
     "filter": "Filtrer",
     "noFilterResults": "Aucun objectif ne correspond aux filtres sélectionnés",
+    "searchPlaceholder": "Rechercher par titre ou description...",
     "titlePlaceholder": "Ex. Apprendre TypeScript",
     "descriptionPlaceholder": "Décrivez votre objectif...",
     "categoryLanguage": "Langage",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -588,6 +588,7 @@
     "resume": "再開",
     "filter": "フィルター",
     "noFilterResults": "条件に一致する目標がありません",
+    "searchPlaceholder": "タイトルや説明で検索...",
     "titlePlaceholder": "例：TypeScriptを学ぶ",
     "descriptionPlaceholder": "目標を説明してください...",
     "categoryLanguage": "言語",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -599,6 +599,7 @@
     "resume": "재개",
     "filter": "필터",
     "noFilterResults": "선택한 필터에 맞는 목표가 없습니다",
+    "searchPlaceholder": "제목이나 설명으로 검색...",
     "titlePlaceholder": "예: TypeScript 배우기",
     "descriptionPlaceholder": "목표를 설명하세요...",
     "categoryLanguage": "언어",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -599,6 +599,7 @@
     "resume": "Retomar",
     "filter": "Filtrar",
     "noFilterResults": "Nenhuma meta corresponde aos filtros selecionados",
+    "searchPlaceholder": "Pesquisar por título ou descrição...",
     "titlePlaceholder": "Ex. Aprender TypeScript",
     "descriptionPlaceholder": "Descreva sua meta...",
     "categoryLanguage": "Linguagem",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -599,6 +599,7 @@
     "resume": "Возобновить",
     "filter": "Фильтр",
     "noFilterResults": "Нет целей, соответствующих выбранным фильтрам",
+    "searchPlaceholder": "Поиск по заголовку или описанию...",
     "titlePlaceholder": "Напр. Изучить TypeScript",
     "descriptionPlaceholder": "Опишите свою цель...",
     "categoryLanguage": "Язык",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -599,6 +599,7 @@
     "resume": "恢复",
     "filter": "筛选",
     "noFilterResults": "没有符合筛选条件的目标",
+    "searchPlaceholder": "按标题或描述搜索...",
     "titlePlaceholder": "例如：学习 TypeScript",
     "descriptionPlaceholder": "描述你的目标...",
     "categoryLanguage": "语言",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -599,6 +599,7 @@
     "resume": "繼續",
     "filter": "篩選",
     "noFilterResults": "沒有符合篩選條件的目標",
+    "searchPlaceholder": "按標題或描述搜尋...",
     "titlePlaceholder": "例如：學習 TypeScript",
     "descriptionPlaceholder": "描述你的目標...",
     "categoryLanguage": "語言",

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Target, Filter } from 'lucide-react';
+import { Target, Filter, Search } from 'lucide-react';
 import { type GoalCategory } from '../api/goals';
 import { useGoalForm } from '../hooks';
 import { Modal, PageLoader } from '../components/common';
@@ -14,6 +14,7 @@ export default function GoalsPage() {
     goals, loading, saving, activeGoals, completedGoals, pausedGoals,
     filteredGoals, filteredActiveGoals, filteredPausedGoals, filteredCompletedGoals,
     filterStatus, setFilterStatus, filterCategory, setFilterCategory,
+    searchQuery, setSearchQuery,
     showForm, setShowForm, editingGoal,
     title, setTitle, description, setDescription,
     category, setCategory, targetDate, setTargetDate,
@@ -23,7 +24,7 @@ export default function GoalsPage() {
     dialogProps,
   } = useGoalForm();
 
-  const isFiltered = filterStatus !== 'all' || filterCategory !== 'all';
+  const isFiltered = filterStatus !== 'all' || filterCategory !== 'all' || searchQuery.trim() !== '';
 
   if (loading) return <PageLoader />;
 
@@ -57,6 +58,18 @@ export default function GoalsPage() {
           <p className="text-2xl font-bold text-yellow-400">{pausedGoals.length}</p>
           <p className="text-sm text-gray-400">{t('goals.pausedGoals')}</p>
         </div>
+      </div>
+
+      {/* Search */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder={t('goals.searchPlaceholder')}
+          className={`${inputClass} pl-9`}
+        />
       </div>
 
       {/* Filters */}


### PR DESCRIPTION
## 概要
目標ページにテキスト検索機能を追加。タイトル・説明で目標を絞り込み可能。

## 変更内容
- `useGoalForm`にsearchQuery状態追加、filteredGoalsのフィルタに反映
- 検索アイコン付き入力欄をStats下、Filtersパネル上に配置
- 10言語i18nキー追加

Closes #1247