### PR TITLE
RecentNotificationsWidgetをDashboardPageから分離

### DIFF
--- a/frontend/src/components/dashboard/RecentNotificationsWidget.tsx
+++ b/frontend/src/components/dashboard/RecentNotificationsWidget.tsx
@@ -1,0 +1,84 @@
+import { useMemo, useCallback } from 'react';
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Bell } from 'lucide-react';
+import Avatar from '../common/Avatar';
+import { formatDistanceToNow } from '../../utils/timeFormat';
+import type { Notification } from '../../types/notification';
+
+interface RecentNotificationsWidgetProps {
+  notifications: Notification[];
+  loading: boolean;
+}
+
+export default function RecentNotificationsWidget({ notifications, loading }: RecentNotificationsWidgetProps) {
+  const { t } = useTranslation();
+
+  const notificationNameMap = useMemo<Record<string, string>>(() => ({
+    post: 'notifications.newPost',
+    message: 'notifications.newMessage',
+    like: 'notifications.newLike',
+    comment: 'notifications.newComment',
+    follow: 'notifications.newFollow',
+    answer: 'notifications.newAnswer',
+    badge: 'notifications.newBadge',
+  }), []);
+
+  const getNotificationText = useCallback((notification: { type: string; actor: { name: string } }) => {
+    return t(notificationNameMap[notification.type] || 'notifications.newPost', {
+      name: notification.actor?.name || '',
+    });
+  }, [t, notificationNameMap]);
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="flex items-center gap-2 text-sm font-medium text-white">
+          <Bell className="w-4 h-4 text-yellow-400" aria-hidden="true" />
+          {t('dashboard.recentNotifications')}
+        </h3>
+        <Link to="/notifications" className="text-xs text-gray-400 hover:text-blue-400 transition-colors">
+          {t('dashboard.viewAll')}
+        </Link>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-10 bg-gray-800 rounded animate-pulse" />
+          ))}
+        </div>
+      ) : notifications.length === 0 ? (
+        <p className="text-xs text-gray-500 text-center py-4">{t('dashboard.noNotifications')}</p>
+      ) : (
+        <div className="space-y-1">
+          {notifications.slice(0, 5).map((notification) => (
+            <div
+              key={notification.id}
+              className={`flex items-start gap-2.5 p-2 rounded-lg transition-colors ${
+                !notification.read ? 'bg-gray-800/50' : ''
+              }`}
+            >
+              <Avatar
+                name={notification.actor?.name || ''}
+                avatarUrl={notification.actor?.avatar_url}
+                size="xs"
+              />
+              <div className="flex-1 min-w-0">
+                <p className="text-xs text-gray-300 leading-relaxed truncate">
+                  {getNotificationText(notification)}
+                </p>
+                <p className="text-[10px] text-gray-500 mt-0.5">
+                  {formatDistanceToNow(notification.created_at)}
+                </p>
+              </div>
+              {!notification.read && (
+                <span className="w-1.5 h-1.5 bg-blue-500 rounded-full mt-1.5 shrink-0" />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
-import { useState, useCallback, useMemo } from 'react';
+import { useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Bell, TrendingUp, CheckCircle2, Clock } from 'lucide-react';
+import { TrendingUp, CheckCircle2, Clock } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { usePosts, useDashboard, useBadgeNotifier, useConfirm } from '../hooks';
 import { getUserBadges } from '../api/badges';
@@ -16,7 +16,7 @@ import QuickPostForm from '../components/posts/QuickPostForm';
 import { buttonPrimaryClass } from '../constants/styles';
 import { PostCardSkeleton } from '../components/common/Skeleton';
 import Avatar from '../components/common/Avatar';
-import { formatDistanceToNow } from '../utils/timeFormat';
+import RecentNotificationsWidget from '../components/dashboard/RecentNotificationsWidget';
 import LevelWidget from '../components/dashboard/LevelWidget';
 import StreakWidget from '../components/dashboard/StreakWidget';
 import DailyChallengeWidget from '../components/dashboard/DailyChallengeWidget';
@@ -71,22 +71,6 @@ export default function DashboardPage() {
   ) => {
     await createPost(title, content, imageUrls, codeSnippets, isDraft);
   }, [createPost]);
-
-  const notificationNameMap = useMemo<Record<string, string>>(() => ({
-    post: 'notifications.newPost',
-    message: 'notifications.newMessage',
-    like: 'notifications.newLike',
-    comment: 'notifications.newComment',
-    follow: 'notifications.newFollow',
-    answer: 'notifications.newAnswer',
-    badge: 'notifications.newBadge',
-  }), []);
-
-  const getNotificationText = useCallback((notification: { type: string; actor: { name: string } }) => {
-    return t(notificationNameMap[notification.type] || 'notifications.newPost', {
-      name: notification.actor?.name || '',
-    });
-  }, [t, notificationNameMap]);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
@@ -267,55 +251,10 @@ export default function DashboardPage() {
         />
 
         {/* Recent Notifications Widget */}
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="flex items-center gap-2 text-sm font-medium text-white">
-              <Bell className="w-4 h-4 text-yellow-400" aria-hidden="true" />
-              {t('dashboard.recentNotifications')}
-            </h3>
-            <Link to="/notifications" className="text-xs text-gray-400 hover:text-blue-400 transition-colors">
-              {t('dashboard.viewAll')}
-            </Link>
-          </div>
-
-          {notificationsLoading ? (
-            <div className="space-y-2">
-              {[1, 2, 3].map((i) => (
-                <div key={i} className="h-10 bg-gray-800 rounded animate-pulse" />
-              ))}
-            </div>
-          ) : recentNotifications.length === 0 ? (
-            <p className="text-xs text-gray-500 text-center py-4">{t('dashboard.noNotifications')}</p>
-          ) : (
-            <div className="space-y-1">
-              {recentNotifications.slice(0, 5).map((notification) => (
-                <div
-                  key={notification.id}
-                  className={`flex items-start gap-2.5 p-2 rounded-lg transition-colors ${
-                    !notification.read ? 'bg-gray-800/50' : ''
-                  }`}
-                >
-                  <Avatar
-                    name={notification.actor?.name || ''}
-                    avatarUrl={notification.actor?.avatar_url}
-                    size="xs"
-                  />
-                  <div className="flex-1 min-w-0">
-                    <p className="text-xs text-gray-300 leading-relaxed truncate">
-                      {getNotificationText(notification)}
-                    </p>
-                    <p className="text-[10px] text-gray-500 mt-0.5">
-                      {formatDistanceToNow(notification.created_at)}
-                    </p>
-                  </div>
-                  {!notification.read && (
-                    <span className="w-1.5 h-1.5 bg-blue-500 rounded-full mt-1.5 shrink-0" />
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
+        <RecentNotificationsWidget
+          notifications={recentNotifications}
+          loading={notificationsLoading}
+        />
 
         {/* Quick Stats */}
         <div className="bg-gray-900 border border-gray-800 rounded-md p-4">


### PR DESCRIPTION
## 概要
DashboardPageの最近の通知セクションを独立コンポーネントに抽出。

## 変更内容
- `RecentNotificationsWidget.tsx` 新規作成（通知リスト・ローディング・空状態・未読マーカー）
- notificationNameMap/getNotificationTextもウィジェットに内包
- DashboardPageから不要インポート削除（Bell, formatDistanceToNow, useMemo）

## 効果
- DashboardPage: 350→288行（62行削減）

Closes #1249