### PR TITLE
残りのフォーム入力フィールドにmaxLength制限を追加

### DIFF
--- a/frontend/src/components/chat/CreateRoomModal.tsx
+++ b/frontend/src/components/chat/CreateRoomModal.tsx
@@ -67,6 +67,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
               value={name}
               onChange={(e) => setName(e.target.value)}
               placeholder={t('chat.groupNamePlaceholder')}
+              maxLength={100}
               className={inputClass}
               required
             />
@@ -82,6 +83,7 @@ export default function CreateRoomModal({ followingUsers, onClose, onCreated }: 
               onChange={(e) => setDescription(e.target.value)}
               placeholder={t('chat.groupDescriptionPlaceholder')}
               rows={2}
+              maxLength={500}
               className={textareaClass}
             />
           </div>

--- a/frontend/src/components/chat/RoomSettingsModal.tsx
+++ b/frontend/src/components/chat/RoomSettingsModal.tsx
@@ -131,6 +131,7 @@ export default function RoomSettingsModal({
                 type="text"
                 value={name}
                 onChange={(e) => setName(e.target.value)}
+                maxLength={100}
                 className={inputClass}
               />
             </div>
@@ -142,6 +143,7 @@ export default function RoomSettingsModal({
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={2}
+                maxLength={500}
                 className={textareaClass}
               />
             </div>

--- a/frontend/src/components/posts/PostForm.tsx
+++ b/frontend/src/components/posts/PostForm.tsx
@@ -81,6 +81,7 @@ export default function PostForm({ post, onSubmit, onCancel, loading: externalLo
         onChange={(e) => setTitle(e.target.value)}
         onFocus={() => setExpanded(true)}
         placeholder={t('post.createTitle')}
+        maxLength={300}
         className={inputClass}
       />
       {expanded && (

--- a/frontend/src/components/posts/QuickPostForm.tsx
+++ b/frontend/src/components/posts/QuickPostForm.tsx
@@ -108,6 +108,7 @@ export default function QuickPostForm({ onSubmit }: QuickPostFormProps) {
             onChange={(e) => setContent(e.target.value)}
             onFocus={() => setIsFocused(true)}
             placeholder={t('post.createTitle')}
+            maxLength={5000}
             className={`w-full bg-gray-800/50 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none transition-all ${
               isFocused ? 'min-h-[120px]' : 'min-h-[60px]'
             }`}

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -130,6 +130,7 @@ export default function GoalsPage() {
               value={title}
               onChange={(e) => setTitle(e.target.value)}
               placeholder={t('goals.titlePlaceholder')}
+              maxLength={200}
               className={inputClass}
               required
             />
@@ -144,6 +145,7 @@ export default function GoalsPage() {
               onChange={(e) => setDescription(e.target.value)}
               placeholder={t('goals.descriptionPlaceholder')}
               rows={3}
+              maxLength={2000}
               className={`${inputClass} resize-none`}
             />
           </div>

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -86,6 +86,7 @@ export default function NotesPage() {
                 type="text"
                 value={title}
                 onChange={handleTitleChange}
+                maxLength={200}
                 className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 required
               />
@@ -97,6 +98,7 @@ export default function NotesPage() {
                 value={content}
                 onChange={handleContentChange}
                 rows={8}
+                maxLength={10000}
                 className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 required
               />
@@ -108,6 +110,7 @@ export default function NotesPage() {
                 type="text"
                 value={tags}
                 onChange={handleTagsChange}
+                maxLength={500}
                 placeholder={t('notes.tagsPlaceholder')}
                 className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               />


### PR DESCRIPTION
## 概要
ノート・目標・投稿・チャットルームの全入力フィールドにmaxLength属性を追加。

## 変更内容
- NotesPage: タイトル(200), 内容(10000), タグ(500)
- GoalsPage: タイトル(200), 説明(2000)
- QuickPostForm: 内容(5000), PostForm: タイトル(300)
- CreateRoomModal/RoomSettingsModal: ルーム名(100), 説明(500)

Closes #1253