### PR TITLE
fix: PortfolioModalのiframe sandbox属性を強化

### DIFF
--- a/frontend/src/components/profile/PortfolioModal.tsx
+++ b/frontend/src/components/profile/PortfolioModal.tsx
@@ -126,7 +126,7 @@ export default function PortfolioModal({
             <div className="bg-white rounded-lg overflow-hidden">
               <iframe
                 srcDoc={html}
-                sandbox="allow-same-origin"
+                sandbox=""
                 className="w-full h-96 border-0"
                 title={t('portfolio.preview')}
               />


### PR DESCRIPTION
## 概要
- PortfolioModalのiframe `sandbox` 属性を `allow-same-origin` → `""` に変更
- プレビュー用iframeに親ページのクッキー・ストレージアクセスは不要のため最大制限に

closes #1261