### PR TITLE
refactor: DashboardPageからQuickStatsWidgetを分離

### DIFF
--- a/frontend/src/components/dashboard/QuickStatsWidget.tsx
+++ b/frontend/src/components/dashboard/QuickStatsWidget.tsx
@@ -1,0 +1,39 @@
+import { Link } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { TrendingUp, CheckCircle2, Clock } from 'lucide-react';
+
+interface QuickStatsWidgetProps {
+  activeCount: number;
+  completedCount: number;
+}
+
+export default function QuickStatsWidget({ activeCount, completedCount }: QuickStatsWidgetProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <h3 className="flex items-center gap-2 text-sm font-medium text-white mb-3">
+        <TrendingUp className="w-4 h-4 text-green-400" aria-hidden="true" />
+        {t('dashboard.quickStats')}
+      </h3>
+      <div className="space-y-2">
+        <Link
+          to="/goals"
+          className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-800/50 transition-colors"
+        >
+          <CheckCircle2 className="w-4 h-4 text-green-400" aria-hidden="true" />
+          <span className="text-xs text-gray-300 flex-1">{t('dashboard.goalsCompleted')}</span>
+          <span className="text-xs font-medium text-white">{completedCount}</span>
+        </Link>
+        <Link
+          to="/goals"
+          className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-800/50 transition-colors"
+        >
+          <Clock className="w-4 h-4 text-blue-400" aria-hidden="true" />
+          <span className="text-xs text-gray-300 flex-1">{t('dashboard.goalsInProgress')}</span>
+          <span className="text-xs font-medium text-white">{activeCount}</span>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { TrendingUp, CheckCircle2, Clock } from 'lucide-react';
+import QuickStatsWidget from '../components/dashboard/QuickStatsWidget';
 import { useAuthStore } from '../store/authStore';
 import { usePosts, useDashboard, useBadgeNotifier, useConfirm } from '../hooks';
 import { getUserBadges } from '../api/badges';
@@ -224,30 +224,10 @@ export default function DashboardPage() {
         />
 
         {/* Quick Stats */}
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
-          <h3 className="flex items-center gap-2 text-sm font-medium text-white mb-3">
-            <TrendingUp className="w-4 h-4 text-green-400" aria-hidden="true" />
-            {t('dashboard.quickStats')}
-          </h3>
-          <div className="space-y-2">
-            <Link
-              to="/goals"
-              className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-800/50 transition-colors"
-            >
-              <CheckCircle2 className="w-4 h-4 text-green-400" aria-hidden="true" />
-              <span className="text-xs text-gray-300 flex-1">{t('dashboard.goalsCompleted')}</span>
-              <span className="text-xs font-medium text-white">{completedGoals.length}</span>
-            </Link>
-            <Link
-              to="/goals"
-              className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-800/50 transition-colors"
-            >
-              <Clock className="w-4 h-4 text-blue-400" aria-hidden="true" />
-              <span className="text-xs text-gray-300 flex-1">{t('dashboard.goalsInProgress')}</span>
-              <span className="text-xs font-medium text-white">{activeGoals.length}</span>
-            </Link>
-          </div>
-        </div>
+        <QuickStatsWidget
+          activeCount={activeGoals.length}
+          completedCount={completedGoals.length}
+        />
       </div>
       <ConfirmDialog {...dialogProps} />
     </div>


### PR DESCRIPTION
## 概要
- Quick Statsセクションを `QuickStatsWidget` として独立コンポーネント化
- Props: `activeCount`, `completedCount` のみの軽量インターフェース
- DashboardPage: 255→235行（20行削減）

closes #1265