### PR TITLE
feat: テキストエリアに文字数カウンター表示を追加

### DIFF
--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -148,6 +148,7 @@ export default function GoalsPage() {
               maxLength={2000}
               className={`${inputClass} resize-none`}
             />
+            <p className="text-xs text-gray-500 text-right mt-1">{description.length}/2000</p>
           </div>
           <div>
             <label htmlFor="goal-category" className={labelClass}>

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -268,6 +268,7 @@ export default function LearningLogsPage() {
               className={`${inputClass} resize-none`}
               required
             />
+            <p className="text-xs text-gray-500 text-right mt-1">{content.length}/5000</p>
           </div>
           <div className="grid grid-cols-2 gap-4">
             <div>

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -102,6 +102,7 @@ export default function NotesPage() {
                 className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
                 required
               />
+              <p className="text-xs text-gray-500 text-right mt-1">{content.length}/10000</p>
             </div>
             <div>
               <label htmlFor="note-tags" className="block text-sm font-medium mb-2">{t('notes.tags')}</label>


### PR DESCRIPTION
## 概要
- ノート内容、目標説明、学習ログ内容のtextareaに文字数カウンター追加
- `{current}/{max}` 形式で右寄せ表示

closes #1271