### PR TITLE
fix: ValidateLoginState/ValidateOAuthStateにJWT署名アルゴリズム検証を追加

### DIFF
--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -160,6 +160,9 @@ func (s *AuthService) GenerateLoginState() (string, error) {
 // ValidateLoginState はGitHubログイン用のstateトークンを検証する。
 func (s *AuthService) ValidateLoginState(state string) error {
 	token, err := jwt.Parse(state, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, domain.NewError(domain.ErrCodeUnauthorized, "unexpected signing method", nil)
+		}
 		return s.jwtSecret, nil
 	})
 	if err != nil {
@@ -268,6 +271,9 @@ func (s *AuthService) GenerateOAuthState(userID uint) (string, error) {
 // ValidateOAuthState はOAuth stateトークンを検証し、埋め込まれたユーザーIDを返す。
 func (s *AuthService) ValidateOAuthState(state string) (uint, error) {
 	token, err := jwt.Parse(state, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, domain.NewError(domain.ErrCodeUnauthorized, "unexpected signing method", nil)
+		}
 		return s.jwtSecret, nil
 	})
 	if err != nil {


### PR DESCRIPTION
## 概要
ValidateLoginStateとValidateOAuthStateにHMAC署名アルゴリズム検証を追加。

## 変更内容
- `ValidateLoginState()`: jwt.Parseコールバック内にSigningMethodHMACチェック追加
- `ValidateOAuthState()`: 同様にSigningMethodHMACチェック追加
- ValidateToken()と同一パターンで統一

## 背景
alg=none攻撃等の署名アルゴリズム偽装を防止するため。

closes #1277