### PR TITLE
feat: ロードマップステップの完了日時を表示

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -965,6 +965,7 @@
     "totalRoadmaps": "Gesamt",
     "activeRoadmaps": "In Bearbeitung",
     "completedRoadmaps": "Abgeschlossen",
+    "completedOn": "Abgeschlossen am {{date}}",
     "complete": "Abschließen",
     "completed": "Abgeschlossen",
     "stepsCompleted": "Schritte abgeschlossen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -965,6 +965,7 @@
     "totalRoadmaps": "Total",
     "activeRoadmaps": "In Progress",
     "completedRoadmaps": "Completed",
+    "completedOn": "Completed on {{date}}",
     "complete": "Complete",
     "completed": "Completed",
     "stepsCompleted": "Steps Completed",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -965,6 +965,7 @@
     "totalRoadmaps": "Total",
     "activeRoadmaps": "En Progreso",
     "completedRoadmaps": "Completadas",
+    "completedOn": "Completado el {{date}}",
     "complete": "Completar",
     "completed": "Completada",
     "stepsCompleted": "Pasos Completados",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -965,6 +965,7 @@
     "totalRoadmaps": "Total",
     "activeRoadmaps": "En cours",
     "completedRoadmaps": "Terminées",
+    "completedOn": "Terminé le {{date}}",
     "complete": "Terminé",
     "completed": "Terminé",
     "stepsCompleted": "Étapes terminées",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -914,6 +914,7 @@
     "totalRoadmaps": "合計",
     "activeRoadmaps": "進行中",
     "completedRoadmaps": "完了",
+    "completedOn": "{{date}} に完了",
     "progress": "進捗",
     "complete": "完了",
     "completed": "完了",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -965,6 +965,7 @@
     "totalRoadmaps": "전체",
     "activeRoadmaps": "진행 중",
     "completedRoadmaps": "완료",
+    "completedOn": "{{date}}에 완료",
     "complete": "완료",
     "completed": "완료",
     "stepsCompleted": "단계 완료",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -965,6 +965,7 @@
     "totalRoadmaps": "Total",
     "activeRoadmaps": "Em andamento",
     "completedRoadmaps": "Concluídos",
+    "completedOn": "Concluído em {{date}}",
     "complete": "Concluído",
     "completed": "Concluído",
     "stepsCompleted": "Etapas concluídas",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -965,6 +965,7 @@
     "totalRoadmaps": "Всего",
     "activeRoadmaps": "В процессе",
     "completedRoadmaps": "Завершено",
+    "completedOn": "Завершено {{date}}",
     "complete": "Завершить",
     "completed": "Завершено",
     "stepsCompleted": "Шагов завершено",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -965,6 +965,7 @@
     "totalRoadmaps": "总计",
     "activeRoadmaps": "进行中",
     "completedRoadmaps": "已完成",
+    "completedOn": "{{date}} 完成",
     "complete": "完成",
     "completed": "已完成",
     "stepsCompleted": "步骤完成",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -965,6 +965,7 @@
     "totalRoadmaps": "總計",
     "activeRoadmaps": "進行中",
     "completedRoadmaps": "已完成",
+    "completedOn": "{{date}} 完成",
     "complete": "完成",
     "completed": "已完成",
     "stepsCompleted": "步驟完成",

--- a/frontend/src/pages/RoadmapDetailPage.tsx
+++ b/frontend/src/pages/RoadmapDetailPage.tsx
@@ -263,6 +263,11 @@ export default function RoadmapDetailPage() {
                           {step.title}
                         </h3>
                       </div>
+                      {step.is_completed && step.completed_at && (
+                        <p className="text-xs text-green-400 mt-0.5">
+                          {t('roadmaps.completedOn', { date: new Date(step.completed_at).toLocaleDateString() })}
+                        </p>
+                      )}
                       {step.description && (
                         <p className="text-sm text-gray-400 mt-1">{step.description}</p>
                       )}


### PR DESCRIPTION
## 概要
ロードマップ詳細ページで完了済みステップにcompleted_at日付を緑色で表示。

## 変更内容
- RoadmapDetailPage: 完了ステップのタイトル下に完了日時を表示
- 10言語に `roadmaps.completedOn` キーを追加

## 効果
学習進捗の時系列把握が容易になる。

closes #1279