### PR TITLE
fix: 本番環境でHSTSヘッダーを追加

### DIFF
--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -3,6 +3,7 @@
 package router
 
 import (
+	"os"
 	"strings"
 
 	"github.com/gin-contrib/cors"
@@ -41,6 +42,9 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		ctx.Header("X-Frame-Options", "DENY")
 		ctx.Header("X-XSS-Protection", "1; mode=block")
 		ctx.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		if os.Getenv("ENVIRONMENT") == "production" {
+			ctx.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
+		}
 		if strings.HasPrefix(ctx.Request.URL.Path, "/uploads/") {
 			ctx.Header("Content-Security-Policy", "default-src 'none'; img-src 'self'; style-src 'none'; script-src 'none'")
 		}


### PR DESCRIPTION
## 概要
本番環境でStrict-Transport-Security（HSTS）ヘッダーを追加。

## 変更内容
- router.go: セキュリティヘッダーミドルウェアにHSTS追加
- ENVIRONMENT=productionの場合のみ有効化
- max-age=31536000（1年）、includeSubDomains付き

closes #1285