### PR TITLE
fix: APIエンドポイントにCSPヘッダーを追加

### DIFF
--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -47,6 +47,8 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		}
 		if strings.HasPrefix(ctx.Request.URL.Path, "/uploads/") {
 			ctx.Header("Content-Security-Policy", "default-src 'none'; img-src 'self'; style-src 'none'; script-src 'none'")
+		} else {
+			ctx.Header("Content-Security-Policy", "default-src 'none'")
 		}
 		ctx.Next()
 	})


### PR DESCRIPTION
## 概要
APIエンドポイントにContent-Security-Policyヘッダーを追加。

## 変更内容
- router.go: uploads以外に`default-src 'none'`CSPを設定
- APIレスポンスのXSSリスク軽減

closes #1293