### PR TITLE
feat: ロードマップ詳細ページにステップ進捗サマリーを追加

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -969,6 +969,7 @@
     "complete": "Abschließen",
     "completed": "Abgeschlossen",
     "stepsCompleted": "Schritte abgeschlossen",
+    "stepsProgress": "{{completed}} / {{total}} Schritte abgeschlossen",
     "notFound": "Roadmap nicht gefunden",
     "backToList": "Zurück zur Liste",
     "addStep": "Schritt hinzufügen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -969,6 +969,7 @@
     "complete": "Complete",
     "completed": "Completed",
     "stepsCompleted": "Steps Completed",
+    "stepsProgress": "{{completed}} / {{total}} steps completed",
     "notFound": "Roadmap not found",
     "backToList": "Back to list",
     "addStep": "Add Step",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -969,6 +969,7 @@
     "complete": "Completar",
     "completed": "Completada",
     "stepsCompleted": "Pasos Completados",
+    "stepsProgress": "{{completed}} / {{total}} pasos completados",
     "notFound": "Hoja de ruta no encontrada",
     "backToList": "Volver a la lista",
     "addStep": "Agregar Paso",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -969,6 +969,7 @@
     "complete": "Terminé",
     "completed": "Terminé",
     "stepsCompleted": "Étapes terminées",
+    "stepsProgress": "{{completed}} / {{total}} étapes terminées",
     "notFound": "Feuille de route non trouvée",
     "backToList": "Retour à la liste",
     "addStep": "Ajouter une étape",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -919,6 +919,7 @@
     "complete": "完了",
     "completed": "完了",
     "stepsCompleted": "ステップ完了",
+    "stepsProgress": "{{completed}} / {{total}} ステップ完了",
     "notFound": "ロードマップが見つかりません",
     "backToList": "一覧に戻る",
     "addStep": "ステップを追加",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -969,6 +969,7 @@
     "complete": "완료",
     "completed": "완료",
     "stepsCompleted": "단계 완료",
+    "stepsProgress": "{{completed}} / {{total}} 단계 완료",
     "notFound": "로드맵을 찾을 수 없습니다",
     "backToList": "목록으로",
     "addStep": "단계 추가",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -969,6 +969,7 @@
     "complete": "Concluído",
     "completed": "Concluído",
     "stepsCompleted": "Etapas concluídas",
+    "stepsProgress": "{{completed}} / {{total}} etapas concluídas",
     "notFound": "Roteiro não encontrado",
     "backToList": "Voltar à lista",
     "addStep": "Adicionar etapa",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -969,6 +969,7 @@
     "complete": "Завершить",
     "completed": "Завершено",
     "stepsCompleted": "Шагов завершено",
+    "stepsProgress": "{{completed}} / {{total}} шагов завершено",
     "notFound": "Дорожная карта не найдена",
     "backToList": "Вернуться к списку",
     "addStep": "Добавить шаг",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -969,6 +969,7 @@
     "complete": "完成",
     "completed": "已完成",
     "stepsCompleted": "步骤完成",
+    "stepsProgress": "{{completed}} / {{total}} 步骤已完成",
     "notFound": "未找到路线图",
     "backToList": "返回列表",
     "addStep": "添加步骤",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -969,6 +969,7 @@
     "complete": "完成",
     "completed": "已完成",
     "stepsCompleted": "步驟完成",
+    "stepsProgress": "{{completed}} / {{total}} 步驟已完成",
     "notFound": "未找到路線圖",
     "backToList": "返回列表",
     "addStep": "新增步驟",

--- a/frontend/src/pages/RoadmapDetailPage.tsx
+++ b/frontend/src/pages/RoadmapDetailPage.tsx
@@ -218,6 +218,19 @@ export default function RoadmapDetailPage() {
         </form>
       </Modal>
 
+      {/* Steps Summary */}
+      {roadmap.steps && roadmap.steps.length > 0 && (
+        <div className="flex items-center justify-between text-sm text-gray-400 mb-2">
+          <span>
+            {t('roadmaps.stepsProgress', {
+              completed: roadmap.completed_step_count,
+              total: roadmap.step_count,
+            })}
+          </span>
+          <span className="text-gray-500">{roadmap.progress}%</span>
+        </div>
+      )}
+
       {/* Steps List */}
       {roadmap.steps && roadmap.steps.length === 0 ? (
         <EmptyState


### PR DESCRIPTION
## 概要
ロードマップ詳細ページにステップ進捗サマリーを追加。

## 変更内容
- ステップリスト上部に「N / M ステップ完了」と進捗率を表示
- 10言語に `roadmaps.stepsProgress` キー追加

closes #1295