### PR TITLE
fix: Permissions-Policyヘッダーを追加

### DIFF
--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -42,6 +42,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		ctx.Header("X-Frame-Options", "DENY")
 		ctx.Header("X-XSS-Protection", "1; mode=block")
 		ctx.Header("Referrer-Policy", "strict-origin-when-cross-origin")
+		ctx.Header("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
 		if os.Getenv("ENVIRONMENT") == "production" {
 			ctx.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		}


### PR DESCRIPTION
## 概要
Permissions-Policyヘッダーでカメラ・マイク・位置情報を無効化。

## 変更内容
- router.go: `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- 攻撃面の最小化

closes #1301