### PR TITLE
feat: ノートの更新日時を相対時間表示に変更

### DIFF
--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -5,6 +5,7 @@ import { useNoteForm } from '../hooks';
 import { PageLoader, SearchInput } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 import { buttonPrimaryClass, buttonSecondaryClass } from '../constants/styles';
+import { formatDistanceToNow } from '../utils/timeFormat';
 
 export default function NotesPage() {
   const { t } = useTranslation();
@@ -172,7 +173,7 @@ export default function NotesPage() {
                     </div>
                   )}
                   <p className="text-sm text-gray-500">
-                    {t('notes.lastUpdated')}: {new Date(note.updated_at).toLocaleString()}
+                    {t('notes.lastUpdated')}: {formatDistanceToNow(note.updated_at)}
                   </p>
                 </div>
                 <div className="flex gap-2 ml-4">

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -8,6 +8,7 @@ import Avatar from '../components/common/Avatar';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import EmptyState from '../components/common/EmptyState';
 import { buttonSecondaryClass } from '../constants/styles';
+import { formatDistanceToNow } from '../utils/timeFormat';
 
 const FILTER_TYPES: { key: NotificationType | ''; labelKey: string }[] = [
   { key: '', labelKey: 'notifications.filterAll' },
@@ -37,20 +38,6 @@ function getNotificationLink(notification: Notification): string {
     default:
       return '/';
   }
-}
-
-function formatTime(dateString: string, t: (key: string, opts?: Record<string, unknown>) => string): string {
-  const date = new Date(dateString);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMins = Math.floor(diffMs / 60000);
-  const diffHours = Math.floor(diffMs / 3600000);
-  const diffDays = Math.floor(diffMs / 86400000);
-
-  if (diffMins < 1) return t('notifications.justNow');
-  if (diffMins < 60) return t('notifications.minutesAgo', { count: diffMins });
-  if (diffHours < 24) return t('notifications.hoursAgo', { count: diffHours });
-  return t('notifications.daysAgo', { count: diffDays });
 }
 
 export default function NotificationsPage() {
@@ -196,7 +183,7 @@ export default function NotificationsPage() {
                       </p>
                     )}
                     <p className="text-xs text-gray-500 mt-1">
-                      {formatTime(notification.created_at, t)}
+                      {formatDistanceToNow(notification.created_at)}
                     </p>
                   </div>
                   {!notification.read && (


### PR DESCRIPTION
## 概要
ノート一覧の更新日時表示を相対時間（例: 5分前、2時間前）に変更。

## 変更内容
- NotesPage.tsx: `toLocaleString()` を `formatDistanceToNow` に置き換え
- NotificationsPage.tsx: ローカル `formatTime` 関数を削除し、共通 `formatDistanceToNow` ユーティリティに統一

Closes #1303