### PR TITLE
security: APIレスポンスにCache-Control: no-storeヘッダーを追加

### DIFF
--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -43,13 +43,15 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		ctx.Header("X-XSS-Protection", "1; mode=block")
 		ctx.Header("Referrer-Policy", "strict-origin-when-cross-origin")
 		ctx.Header("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
-		if os.Getenv("ENVIRONMENT") == "production" {
-			ctx.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
-		}
 		if strings.HasPrefix(ctx.Request.URL.Path, "/uploads/") {
+			ctx.Header("Cache-Control", "public, max-age=86400")
 			ctx.Header("Content-Security-Policy", "default-src 'none'; img-src 'self'; style-src 'none'; script-src 'none'")
 		} else {
+			ctx.Header("Cache-Control", "no-store")
 			ctx.Header("Content-Security-Policy", "default-src 'none'")
+		}
+		if os.Getenv("ENVIRONMENT") == "production" {
+			ctx.Header("Strict-Transport-Security", "max-age=31536000; includeSubDomains")
 		}
 		ctx.Next()
 	})


### PR DESCRIPTION
## 概要
APIレスポンスのキャッシュ防止ヘッダーを追加。

## 変更内容
- APIエンドポイント: `Cache-Control: no-store` — 認証情報・個人データのキャッシュ防止
- `/uploads/` パス: `Cache-Control: public, max-age=86400` — 画像はキャッシュ許可

Closes #1309