### PR TITLE
feat: 目標ページの統計セクションに期限超過カウントを追加

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -594,6 +594,7 @@
     "activeGoals": "Aktiv",
     "completedGoals": "Abgeschlossen",
     "pausedGoals": "Pausiert",
+    "overdueGoals": "Überfällig",
     "statusActive": "Aktiv",
     "statusCompleted": "Abgeschlossen",
     "statusPaused": "Pausiert",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -594,6 +594,7 @@
     "activeGoals": "Active",
     "completedGoals": "Completed",
     "pausedGoals": "Paused",
+    "overdueGoals": "Overdue",
     "statusActive": "Active",
     "statusCompleted": "Completed",
     "statusPaused": "Paused",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -594,6 +594,7 @@
     "activeGoals": "Activos",
     "completedGoals": "Completados",
     "pausedGoals": "Pausados",
+    "overdueGoals": "Vencidos",
     "statusActive": "Activo",
     "statusCompleted": "Completado",
     "statusPaused": "Pausado",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -594,6 +594,7 @@
     "activeGoals": "Actifs",
     "completedGoals": "Terminés",
     "pausedGoals": "En pause",
+    "overdueGoals": "En retard",
     "statusActive": "Actif",
     "statusCompleted": "Terminé",
     "statusPaused": "En pause",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -583,6 +583,7 @@
     "activeGoals": "進行中",
     "completedGoals": "完了",
     "pausedGoals": "一時停止",
+    "overdueGoals": "期限超過",
     "statusActive": "進行中",
     "statusCompleted": "完了",
     "statusPaused": "一時停止",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -594,6 +594,7 @@
     "activeGoals": "진행 중",
     "completedGoals": "완료",
     "pausedGoals": "일시 중지",
+    "overdueGoals": "기한 초과",
     "statusActive": "진행 중",
     "statusCompleted": "완료",
     "statusPaused": "일시 중지",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -594,6 +594,7 @@
     "activeGoals": "Ativas",
     "completedGoals": "Concluídas",
     "pausedGoals": "Pausadas",
+    "overdueGoals": "Atrasadas",
     "statusActive": "Ativo",
     "statusCompleted": "Concluído",
     "statusPaused": "Pausado",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -594,6 +594,7 @@
     "activeGoals": "Активные",
     "completedGoals": "Завершённые",
     "pausedGoals": "Приостановленные",
+    "overdueGoals": "Просроченные",
     "statusActive": "Активная",
     "statusCompleted": "Завершена",
     "statusPaused": "Приостановлена",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -594,6 +594,7 @@
     "activeGoals": "进行中",
     "completedGoals": "已完成",
     "pausedGoals": "已暂停",
+    "overdueGoals": "已逾期",
     "statusActive": "进行中",
     "statusCompleted": "已完成",
     "statusPaused": "已暂停",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -594,6 +594,7 @@
     "activeGoals": "進行中",
     "completedGoals": "已完成",
     "pausedGoals": "已暫停",
+    "overdueGoals": "已逾期",
     "statusActive": "進行中",
     "statusCompleted": "已完成",
     "statusPaused": "已暫停",

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -24,6 +24,11 @@ export default function GoalsPage() {
     dialogProps,
   } = useGoalForm();
 
+  const overdueGoals = activeGoals.filter((g) => {
+    if (!g.target_date) return false;
+    return new Date(g.target_date).getTime() < Date.now();
+  });
+
   const isFiltered = filterStatus !== 'all' || filterCategory !== 'all' || searchQuery.trim() !== '';
 
   if (loading) return <PageLoader />;
@@ -41,7 +46,7 @@ export default function GoalsPage() {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
         <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
           <p className="text-2xl font-bold">{goals.length}</p>
           <p className="text-sm text-gray-400">{t('goals.totalGoals')}</p>
@@ -57,6 +62,10 @@ export default function GoalsPage() {
         <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
           <p className="text-2xl font-bold text-yellow-400">{pausedGoals.length}</p>
           <p className="text-sm text-gray-400">{t('goals.pausedGoals')}</p>
+        </div>
+        <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+          <p className="text-2xl font-bold text-red-400">{overdueGoals.length}</p>
+          <p className="text-sm text-gray-400">{t('goals.overdueGoals')}</p>
         </div>
       </div>
 


### PR DESCRIPTION
## 概要
GoalsPageのstatsセクションに「期限超過」カウントを追加。

## 変更内容
- statsグリッドを4列→5列に変更
- 期限を過ぎたactive目標のカウントを赤色で表示
- 10言語に `goals.overdueGoals` キーを追加

Closes #1311