### PR TITLE
security: clearAuthCookieのSecure属性を本番環境で有効化

### DIFF
--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -59,8 +59,9 @@ func setAuthCookie(c *gin.Context, token string) {
 
 // clearAuthCookie は認証Cookieをクリアする（MaxAge=-1で即時削除）。
 func clearAuthCookie(c *gin.Context) {
+	secure := os.Getenv("ENVIRONMENT") == "production"
 	c.SetSameSite(http.SameSiteLaxMode)
-	c.SetCookie("token", "", -1, "/", "", false, true)
+	c.SetCookie("token", "", -1, "/", "", secure, true)
 }
 
 // Register はユーザー新規登録を処理する。


### PR DESCRIPTION
## 概要
ログアウト時のCookie削除でSecure属性を本番環境で有効化。

## 変更内容
- `clearAuthCookie`: 常に`false`だったSecure属性を、`setAuthCookie`と同様に`ENVIRONMENT=production`で`true`に設定

Closes #1317