### PR TITLE
fix: パスワード最小文字数をバックエンド仕様（8文字）に統一

### DIFF
--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -135,7 +135,7 @@ export default function RegisterPage() {
                 value={password}
                 onChange={handlePasswordChange}
                 required
-                minLength={6}
+                minLength={8}
                 placeholder={t('auth.passwordPlaceholder')}
                 className={inputClass}
               />

--- a/frontend/src/pages/ResetPasswordPage.tsx
+++ b/frontend/src/pages/ResetPasswordPage.tsx
@@ -112,7 +112,7 @@ export default function ResetPasswordPage() {
                   className={inputClass}
                   placeholder={t('auth.passwordPlaceholder')}
                   required
-                  minLength={6}
+                  minLength={8}
                 />
               </div>
 
@@ -128,7 +128,7 @@ export default function ResetPasswordPage() {
                   className={inputClass}
                   placeholder={t('auth.passwordPlaceholder')}
                   required
-                  minLength={6}
+                  minLength={8}
                 />
               </div>
 


### PR DESCRIPTION
## 概要
パスワード入力のminLengthをバックエンド仕様（8文字）に統一。

## 変更内容
- `RegisterPage.tsx`: minLength 6→8
- `ResetPasswordPage.tsx`: password/confirmPasswordの2箇所を minLength 6→8

Closes #1325