### PR TITLE
fix: ログ出力からメールアドレスを除去してセキュリティ向上

### DIFF
--- a/backend/internal/service/email.go
+++ b/backend/internal/service/email.go
@@ -135,11 +135,11 @@ func (s *WeeklyReportEmailService) SendAllWeeklyReports() error {
 		}
 
 		if err := s.SendWeeklyReport(&user, report); err != nil {
-			log.Printf("ウィークリーレポートメール送信失敗 (userID=%d, email=%s): %v", user.ID, user.Email, err)
+			log.Printf("ウィークリーレポートメール送信失敗 (userID=%d): %v", user.ID, err)
 			continue
 		}
 
-		log.Printf("ウィークリーレポートメール送信成功 (userID=%d, email=%s)", user.ID, user.Email)
+		log.Printf("ウィークリーレポートメール送信成功 (userID=%d)", user.ID)
 	}
 
 	return nil


### PR DESCRIPTION
## 概要
ウィークリーレポート送信ログからメールアドレスを除去。

## 変更内容
- `email.go`: 送信成功/失敗ログのemail=%sを除去、userIDのみ出力

Closes #1333