### PR TITLE
feat: ノートカードに文字数カウント表示を追加

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1354,6 +1354,7 @@
     "confirmDelete": "Möchten Sie diese Notiz wirklich löschen?",
     "favoriteToggled": "Favoritenstatus aktualisiert",
     "lastUpdated": "Zuletzt aktualisiert",
+    "chars": "Zeichen",
     "createdAt": "Erstellt am",
     "tagsPlaceholder": "z.B. React, TypeScript, Go"
   },

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1354,6 +1354,7 @@
     "confirmDelete": "Are you sure you want to delete this note?",
     "favoriteToggled": "Favorite status updated",
     "lastUpdated": "Last updated",
+    "chars": "chars",
     "createdAt": "Created at",
     "tagsPlaceholder": "e.g., React, TypeScript, Go"
   },

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1354,6 +1354,7 @@
     "confirmDelete": "¿Está seguro de que desea eliminar esta nota?",
     "favoriteToggled": "Estado de favorito actualizado",
     "lastUpdated": "Última actualización",
+    "chars": "caracteres",
     "createdAt": "Creado el",
     "tagsPlaceholder": "Ej: React, TypeScript, Go"
   },

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1354,6 +1354,7 @@
     "confirmDelete": "Êtes-vous sûr de vouloir supprimer cette note ?",
     "favoriteToggled": "Statut favori mis à jour",
     "lastUpdated": "Dernière mise à jour",
+    "chars": "caractères",
     "createdAt": "Créé le",
     "tagsPlaceholder": "Ex : React, TypeScript, Go"
   },

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1255,6 +1255,7 @@
     "confirmDelete": "このノートを削除しますか？",
     "favoriteToggled": "お気に入りを更新しました",
     "lastUpdated": "最終更新",
+    "chars": "文字",
     "createdAt": "作成日時",
     "tagsPlaceholder": "例: React, TypeScript, Go"
   },

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1354,6 +1354,7 @@
     "confirmDelete": "이 노트를 삭제하시겠습니까?",
     "favoriteToggled": "즐겨찾기 상태가 업데이트되었습니다",
     "lastUpdated": "마지막 업데이트",
+    "chars": "자",
     "createdAt": "생성일",
     "tagsPlaceholder": "예: React, TypeScript, Go"
   },

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1354,6 +1354,7 @@
     "confirmDelete": "Tem certeza de que deseja excluir esta nota?",
     "favoriteToggled": "Status de favorito atualizado",
     "lastUpdated": "Última atualização",
+    "chars": "caracteres",
     "createdAt": "Criado em",
     "tagsPlaceholder": "Ex: React, TypeScript, Go"
   },

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1354,6 +1354,7 @@
     "confirmDelete": "Вы уверены, что хотите удалить эту заметку?",
     "favoriteToggled": "Статус избранного обновлен",
     "lastUpdated": "Последнее обновление",
+    "chars": "символов",
     "createdAt": "Создано",
     "tagsPlaceholder": "Напр.: React, TypeScript, Go"
   },

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1354,6 +1354,7 @@
     "confirmDelete": "确定要删除这条笔记吗？",
     "favoriteToggled": "收藏状态已更新",
     "lastUpdated": "最后更新",
+    "chars": "字符",
     "createdAt": "创建时间",
     "tagsPlaceholder": "例如：React, TypeScript, Go"
   },

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1354,6 +1354,7 @@
     "confirmDelete": "確定要刪除這條筆記嗎？",
     "favoriteToggled": "收藏狀態已更新",
     "lastUpdated": "最後更新",
+    "chars": "字元",
     "createdAt": "創建時間",
     "tagsPlaceholder": "例如：React, TypeScript, Go"
   },

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -172,9 +172,11 @@ export default function NotesPage() {
                       ))}
                     </div>
                   )}
-                  <p className="text-sm text-gray-500">
-                    {t('notes.lastUpdated')}: {formatDistanceToNow(note.updated_at)}
-                  </p>
+                  <div className="flex items-center gap-3 text-sm text-gray-500">
+                    <span>{t('notes.lastUpdated')}: {formatDistanceToNow(note.updated_at)}</span>
+                    <span className="text-gray-600">·</span>
+                    <span>{note.content.length.toLocaleString()} {t('notes.chars')}</span>
+                  </div>
                 </div>
                 <div className="flex gap-2 ml-4">
                   <button


### PR DESCRIPTION
## 概要
ノート一覧カードに文字数カウントを表示。

## 変更内容
- `NotesPage.tsx`: 更新日横に「· X,XXX 文字」表示追加
- 10言語i18nキー追加（notes.chars）

Closes #1335