### PR TITLE
feat: ロードマップページにカテゴリフィルター追加

### DIFF
--- a/frontend/src/hooks/useRoadmapForm.ts
+++ b/frontend/src/hooks/useRoadmapForm.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { type RoadmapCategory, type Roadmap } from '../api/roadmaps';
 import { useRoadmaps, useRoadmapTemplates } from './useRoadmaps';
@@ -19,6 +19,16 @@ export function useRoadmapForm() {
   const [isPublic, setIsPublic] = useState(false);
   const [showTemplates, setShowTemplates] = useState(false);
   const [expandedTemplate, setExpandedTemplate] = useState<number | null>(null);
+  const [categoryFilter, setCategoryFilter] = useState<RoadmapCategory | ''>('');
+
+  const filteredActiveRoadmaps = useMemo(
+    () => categoryFilter ? activeRoadmaps.filter(r => r.category === categoryFilter) : activeRoadmaps,
+    [activeRoadmaps, categoryFilter]
+  );
+  const filteredCompletedRoadmaps = useMemo(
+    () => categoryFilter ? completedRoadmaps.filter(r => r.category === categoryFilter) : completedRoadmaps,
+    [completedRoadmaps, categoryFilter]
+  );
 
   const resetForm = useCallback(() => {
     setTitle('');
@@ -73,8 +83,8 @@ export function useRoadmapForm() {
   return {
     // データ
     roadmaps,
-    activeRoadmaps,
-    completedRoadmaps,
+    activeRoadmaps: filteredActiveRoadmaps,
+    completedRoadmaps: filteredCompletedRoadmaps,
     templates,
     loading,
     saving,
@@ -92,6 +102,9 @@ export function useRoadmapForm() {
     setCategory,
     isPublic,
     setIsPublic,
+    // フィルター
+    categoryFilter,
+    setCategoryFilter,
     // テンプレート状態
     showTemplates,
     expandedTemplate,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -958,6 +958,7 @@
     "categorySkill": "Fähigkeit",
     "categoryProject": "Projekt",
     "categoryOther": "Sonstiges",
+    "allCategories": "Alle Kategorien",
     "makePublic": "Öffentlich machen (andere können kopieren)",
     "public": "Öffentlich",
     "create": "Erstellen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -958,6 +958,7 @@
     "categorySkill": "Skill",
     "categoryProject": "Project",
     "categoryOther": "Other",
+    "allCategories": "All Categories",
     "makePublic": "Make public (others can copy)",
     "public": "Public",
     "create": "Create",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -958,6 +958,7 @@
     "categorySkill": "Habilidad",
     "categoryProject": "Proyecto",
     "categoryOther": "Otro",
+    "allCategories": "Todas las categorías",
     "makePublic": "Hacer público (otros pueden copiar)",
     "public": "Público",
     "create": "Crear",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -958,6 +958,7 @@
     "categorySkill": "Compétence",
     "categoryProject": "Projet",
     "categoryOther": "Autre",
+    "allCategories": "Toutes les catégories",
     "makePublic": "Rendre public (peut être copié par d'autres utilisateurs)",
     "public": "Public",
     "create": "Créer",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -907,6 +907,7 @@
     "categorySkill": "スキル",
     "categoryProject": "プロジェクト",
     "categoryOther": "その他",
+    "allCategories": "全カテゴリ",
     "makePublic": "公開する（他のユーザーがコピー可能）",
     "public": "公開",
     "create": "作成",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -958,6 +958,7 @@
     "categorySkill": "스킬",
     "categoryProject": "프로젝트",
     "categoryOther": "기타",
+    "allCategories": "모든 카테고리",
     "makePublic": "공개하기 (다른 사용자가 복사 가능)",
     "public": "공개",
     "create": "만들기",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -958,6 +958,7 @@
     "categorySkill": "Habilidade",
     "categoryProject": "Projeto",
     "categoryOther": "Outro",
+    "allCategories": "Todas as categorias",
     "makePublic": "Tornar público (pode ser copiado por outros usuários)",
     "public": "Público",
     "create": "Criar",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -958,6 +958,7 @@
     "categorySkill": "Навык",
     "categoryProject": "Проект",
     "categoryOther": "Другое",
+    "allCategories": "Все категории",
     "makePublic": "Сделать публичной (другие пользователи могут скопировать)",
     "public": "Публичная",
     "create": "Создать",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -958,6 +958,7 @@
     "categorySkill": "技能",
     "categoryProject": "项目",
     "categoryOther": "其他",
+    "allCategories": "所有分类",
     "makePublic": "公开（其他用户可复制）",
     "public": "公开",
     "create": "创建",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -958,6 +958,7 @@
     "categorySkill": "技能",
     "categoryProject": "專案",
     "categoryOther": "其他",
+    "allCategories": "所有分類",
     "makePublic": "公開（其他使用者可複製）",
     "public": "公開",
     "create": "建立",

--- a/frontend/src/pages/RoadmapsPage.tsx
+++ b/frontend/src/pages/RoadmapsPage.tsx
@@ -4,7 +4,7 @@ import { type RoadmapCategory } from '../api/roadmaps';
 import { useRoadmapForm } from '../hooks';
 import EmptyState from '../components/common/EmptyState';
 import { Modal, PageHeader, PageLoader } from '../components/common';
-import { inputClass, buttonSecondaryClass, labelClass } from '../constants/styles';
+import { inputClass, selectClass, buttonSecondaryClass, labelClass } from '../constants/styles';
 import RoadmapTemplatesSection from '../components/roadmaps/RoadmapTemplatesSection';
 import RoadmapCard from '../components/roadmaps/RoadmapCard';
 
@@ -24,6 +24,7 @@ export default function RoadmapsPage() {
     showForm, setShowForm, editingRoadmap,
     title, setTitle, description, setDescription,
     category, setCategory, isPublic, setIsPublic,
+    categoryFilter, setCategoryFilter,
     showTemplates, expandedTemplate,
     resetForm, handleSubmit, handleEdit, handleUseTemplate,
     deleteRoadmap, toggleTemplates, toggleExpandedTemplate, navigate,
@@ -142,6 +143,24 @@ export default function RoadmapsPage() {
           </div>
         </form>
       </Modal>
+
+      {/* Category Filter */}
+      {roadmaps.length > 0 && (
+        <div className="mb-6">
+          <select
+            value={categoryFilter}
+            onChange={e => setCategoryFilter(e.target.value as RoadmapCategory | '')}
+            className={selectClass}
+          >
+            <option value="">{t('roadmaps.allCategories')}</option>
+            {CATEGORIES.map(cat => (
+              <option key={cat.value} value={cat.value}>
+                {cat.icon} {t(cat.label)}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       {/* Content */}
       {roadmaps.length === 0 ? (


### PR DESCRIPTION
## 概要
Closes #1343

ロードマップ一覧ページにカテゴリフィルター機能を追加。
5カテゴリ（言語・フレームワーク・スキル・プロジェクト・その他）で絞り込み可能。

## 変更内容
- **useRoadmapForm.ts**: `categoryFilter`状態とuseMemoによるフィルタリング追加
- **RoadmapsPage.tsx**: カテゴリフィルタードロップダウンUI追加
- **i18n**: 10言語に`roadmaps.allCategories`キー追加

## テスト
- `npx tsc --noEmit` 型チェック通過