### PR TITLE
fix: メール入力にmaxLength=255を追加

### DIFF
--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -12,20 +12,20 @@ type UserResponse struct {
 type RegisterRequest struct {
 	Name            string `json:"name" binding:"required" validate:"required"`
 	Username        string `json:"username" binding:"required" validate:"required"`
-	Email           string `json:"email" binding:"required,email" validate:"required,email"`
+	Email           string `json:"email" binding:"required,email,max=255" validate:"required,email,max=255"`
 	Password        string `json:"password" binding:"required,min=6" validate:"required,min=6"`
 	ConfirmPassword string `json:"confirm_password" binding:"required" validate:"required"`
 }
 
 // LoginRequest はログインリクエスト
 type LoginRequest struct {
-	Email    string `json:"email" binding:"required,email" validate:"required,email"`
+	Email    string `json:"email" binding:"required,email,max=255" validate:"required,email,max=255"`
 	Password string `json:"password" binding:"required" validate:"required"`
 }
 
 // PasswordResetRequest はパスワードリセットリクエスト
 type PasswordResetRequest struct {
-	Email string `json:"email" binding:"required,email" validate:"required,email"`
+	Email string `json:"email" binding:"required,email,max=255" validate:"required,email,max=255"`
 }
 
 // ResetPasswordRequest はトークンによるパスワードリセットリクエスト

--- a/frontend/src/pages/ForgotPasswordPage.tsx
+++ b/frontend/src/pages/ForgotPasswordPage.tsx
@@ -81,6 +81,7 @@ export default function ForgotPasswordPage() {
                   className={inputClass}
                   placeholder={t('auth.emailPlaceholder')}
                   required
+                  maxLength={255}
                 />
               </div>
 

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -85,6 +85,7 @@ export default function LoginPage() {
                 value={email}
                 onChange={handleEmailChange}
                 required
+                maxLength={255}
                 className={inputClass}
               />
             </div>

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -122,6 +122,7 @@ export default function RegisterPage() {
                 value={email}
                 onChange={handleEmailChange}
                 required
+                maxLength={255}
                 className={inputClass}
               />
             </div>


### PR DESCRIPTION
## 概要
Closes #1357

バックエンドのMaxEmailLength=255に合わせて入力長制限を二重化。

## 変更内容
- **フロントエンド**: LoginPage/RegisterPage/ForgotPasswordPageのメール入力に`maxLength={255}`
- **バックエンド**: auth_dto.goの3つのEmail bindingタグに`max=255`追加

## テスト
- `npx tsc --noEmit` 型チェック通過
- `go build ./...` ビルド通過