### PR TITLE
feat: 読書レビューページにソート機能を追加

### DIFF
--- a/frontend/src/hooks/useBookReviews.ts
+++ b/frontend/src/hooks/useBookReviews.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import type { BookReview, CreateBookReviewRequest, ReviewStatus } from '../types/bookReview';
@@ -14,6 +14,7 @@ export function useBookReviews() {
   const [page, setPage] = useState(0);
   const [statusFilter, setStatusFilter] = useState<ReviewStatus | 'all'>('all');
   const [showArchived, setShowArchived] = useState(false);
+  const [sortBy, setSortBy] = useState<'newest' | 'oldest' | 'ratingDesc' | 'ratingAsc'>('newest');
   const limit = 20;
 
   const { data, loading, refetch } = useAsyncData(
@@ -34,6 +35,18 @@ export function useBookReviews() {
     if (statusFilter !== 'all' && r.status !== statusFilter) return false;
     return true;
   });
+
+  const sortedReviews = useMemo(
+    () => [...currentReviews].sort((a, b) => {
+      switch (sortBy) {
+        case 'oldest': return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+        case 'ratingDesc': return b.rating - a.rating;
+        case 'ratingAsc': return a.rating - b.rating;
+        default: return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+      }
+    }),
+    [currentReviews, sortBy]
+  );
 
   const handleCreate = useCallback(async (reqData: CreateBookReviewRequest) => {
     setSaving(true);
@@ -114,7 +127,7 @@ export function useBookReviews() {
   }, [t, reviews]);
 
   return {
-    reviews: currentReviews,
+    reviews: sortedReviews,
     total,
     loading,
     saving,
@@ -125,6 +138,8 @@ export function useBookReviews() {
     setStatusFilter,
     showArchived,
     setShowArchived,
+    sortBy,
+    setSortBy,
     createReview: handleCreate,
     updateReview: handleUpdate,
     deleteReview: handleDelete,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -883,7 +883,13 @@
     "archiveFailed": "Archivierung fehlgeschlagen",
     "unarchiveFailed": "Entarchivierung fehlgeschlagen",
     "statusUpdated": "Status aktualisiert",
-    "statusUpdateFailed": "Statusaktualisierung fehlgeschlagen"
+    "statusUpdateFailed": "Statusaktualisierung fehlgeschlagen",
+    "sort": {
+      "newest": "Neueste",
+      "oldest": "Älteste",
+      "ratingDesc": "Beste Bewertung",
+      "ratingAsc": "Schlechteste Bewertung"
+    }
   },
   "qa": {
     "pageTitle": "Tech Q&A",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -883,7 +883,13 @@
     "archiveFailed": "Failed to archive",
     "unarchiveFailed": "Failed to unarchive",
     "statusUpdated": "Status updated",
-    "statusUpdateFailed": "Failed to update status"
+    "statusUpdateFailed": "Failed to update status",
+    "sort": {
+      "newest": "Newest",
+      "oldest": "Oldest",
+      "ratingDesc": "Highest Rated",
+      "ratingAsc": "Lowest Rated"
+    }
   },
   "qa": {
     "pageTitle": "Tech Q&A",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -883,7 +883,13 @@
     "archiveFailed": "Error al archivar",
     "unarchiveFailed": "Error al desarchivar",
     "statusUpdated": "Estado actualizado",
-    "statusUpdateFailed": "Error al actualizar el estado"
+    "statusUpdateFailed": "Error al actualizar el estado",
+    "sort": {
+      "newest": "Más reciente",
+      "oldest": "Más antiguo",
+      "ratingDesc": "Mayor puntuación",
+      "ratingAsc": "Menor puntuación"
+    }
   },
   "qa": {
     "pageTitle": "Q&A Técnico",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -883,7 +883,13 @@
     "archiveFailed": "Échec de l'archivage",
     "unarchiveFailed": "Échec du désarchivage",
     "statusUpdated": "Statut mis à jour",
-    "statusUpdateFailed": "Échec de la mise à jour du statut"
+    "statusUpdateFailed": "Échec de la mise à jour du statut",
+    "sort": {
+      "newest": "Plus récent",
+      "oldest": "Plus ancien",
+      "ratingDesc": "Mieux noté",
+      "ratingAsc": "Moins bien noté"
+    }
   },
   "qa": {
     "pageTitle": "Q&A Technique",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -837,7 +837,13 @@
     "archiveFailed": "アーカイブに失敗しました",
     "unarchiveFailed": "アーカイブ解除に失敗しました",
     "statusUpdated": "ステータスを更新しました",
-    "statusUpdateFailed": "ステータスの更新に失敗しました"
+    "statusUpdateFailed": "ステータスの更新に失敗しました",
+    "sort": {
+      "newest": "新着順",
+      "oldest": "古い順",
+      "ratingDesc": "評価が高い順",
+      "ratingAsc": "評価が低い順"
+    }
   },
   "qa": {
     "pageTitle": "技術Q&A",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -883,7 +883,13 @@
     "archiveFailed": "보관에 실패했습니다",
     "unarchiveFailed": "보관 해제에 실패했습니다",
     "statusUpdated": "상태가 업데이트되었습니다",
-    "statusUpdateFailed": "상태 업데이트에 실패했습니다"
+    "statusUpdateFailed": "상태 업데이트에 실패했습니다",
+    "sort": {
+      "newest": "최신순",
+      "oldest": "오래된순",
+      "ratingDesc": "평점 높은순",
+      "ratingAsc": "평점 낮은순"
+    }
   },
   "qa": {
     "pageTitle": "기술 Q&A",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -883,7 +883,13 @@
     "archiveFailed": "Falha ao arquivar",
     "unarchiveFailed": "Falha ao desarquivar",
     "statusUpdated": "Status atualizado",
-    "statusUpdateFailed": "Falha ao atualizar status"
+    "statusUpdateFailed": "Falha ao atualizar status",
+    "sort": {
+      "newest": "Mais recente",
+      "oldest": "Mais antigo",
+      "ratingDesc": "Melhor avaliado",
+      "ratingAsc": "Pior avaliado"
+    }
   },
   "qa": {
     "pageTitle": "Q&A Técnico",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -883,7 +883,13 @@
     "archiveFailed": "Не удалось архивировать",
     "unarchiveFailed": "Не удалось разархивировать",
     "statusUpdated": "Статус обновлён",
-    "statusUpdateFailed": "Не удалось обновить статус"
+    "statusUpdateFailed": "Не удалось обновить статус",
+    "sort": {
+      "newest": "Новые",
+      "oldest": "Старые",
+      "ratingDesc": "Высокий рейтинг",
+      "ratingAsc": "Низкий рейтинг"
+    }
   },
   "qa": {
     "pageTitle": "Технический Q&A",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -883,7 +883,13 @@
     "archiveFailed": "归档失败",
     "unarchiveFailed": "取消归档失败",
     "statusUpdated": "状态已更新",
-    "statusUpdateFailed": "状态更新失败"
+    "statusUpdateFailed": "状态更新失败",
+    "sort": {
+      "newest": "最新",
+      "oldest": "最旧",
+      "ratingDesc": "评分最高",
+      "ratingAsc": "评分最低"
+    }
   },
   "qa": {
     "pageTitle": "技术问答",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -883,7 +883,13 @@
     "archiveFailed": "封存失敗",
     "unarchiveFailed": "取消封存失敗",
     "statusUpdated": "狀態已更新",
-    "statusUpdateFailed": "狀態更新失敗"
+    "statusUpdateFailed": "狀態更新失敗",
+    "sort": {
+      "newest": "最新",
+      "oldest": "最舊",
+      "ratingDesc": "評分最高",
+      "ratingAsc": "評分最低"
+    }
   },
   "qa": {
     "pageTitle": "技術問答",

--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -15,6 +15,7 @@ export default function BookReviewsPage() {
   const {
     reviews, total, loading, saving, page, setPage, limit,
     statusFilter, setStatusFilter, showArchived, setShowArchived,
+    sortBy, setSortBy,
     createReview, updateReview, deleteReview,
     updateStatus, archiveReview, unarchiveReview,
   } = useBookReviews();
@@ -78,6 +79,21 @@ export default function BookReviewsPage() {
         >
           {t('bookReviews.archivedLabel')}
         </button>
+
+        <div className="flex-1" />
+        {(['newest', 'oldest', 'ratingDesc', 'ratingAsc'] as const).map(sort => (
+          <button
+            key={sort}
+            onClick={() => setSortBy(sort)}
+            className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
+              sortBy === sort
+                ? 'bg-orange-600 text-white'
+                : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+            }`}
+          >
+            {t(`bookReviews.sort.${sort}`)}
+          </button>
+        ))}
       </div>
 
       {/* Form Modal */}


### PR DESCRIPTION
## 概要
- 読書レビューページに4種類のソート機能を追加（新着順/古い順/評価が高い順/評価が低い順）
- `useBookReviews` フックに `sortBy` 状態と `useMemo` ソートロジック追加
- BookReviewsPage にオレンジ色のソートボタンUI追加

## 変更ファイル
- `frontend/src/hooks/useBookReviews.ts` — ソート状態・ロジック追加
- `frontend/src/pages/BookReviewsPage.tsx` — ソートボタンUI追加
- `frontend/src/i18n/locales/*.json` — 10言語にソートキー追加

closes #1359