### PR TITLE
test: NotificationFilters・NotificationItemのテストを追加

### DIFF
--- a/frontend/src/components/notifications/__tests__/NotificationFilters.test.tsx
+++ b/frontend/src/components/notifications/__tests__/NotificationFilters.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NotificationFilters from '../NotificationFilters';
+
+describe('NotificationFilters', () => {
+  const defaultProps = {
+    filterType: '' as const,
+    setFilterType: vi.fn(),
+    showUnreadOnly: false,
+    onToggleUnreadOnly: vi.fn(),
+  };
+
+  it('全8つのフィルターボタンを表示する', () => {
+    render(<NotificationFilters {...defaultProps} />);
+    expect(screen.getByText('すべて')).toBeInTheDocument();
+    expect(screen.getByText('投稿')).toBeInTheDocument();
+    expect(screen.getByText('いいね')).toBeInTheDocument();
+    expect(screen.getByText('コメント')).toBeInTheDocument();
+    expect(screen.getByText('フォロー')).toBeInTheDocument();
+    expect(screen.getByText('メッセージ')).toBeInTheDocument();
+    expect(screen.getByText('Q&A回答')).toBeInTheDocument();
+    expect(screen.getByText('バッジ')).toBeInTheDocument();
+  });
+
+  it('フィルターボタンクリック時にsetFilterTypeが呼ばれる', () => {
+    const setFilterType = vi.fn();
+    render(<NotificationFilters {...defaultProps} setFilterType={setFilterType} />);
+    fireEvent.click(screen.getByText('いいね'));
+    expect(setFilterType).toHaveBeenCalledWith('like');
+  });
+
+  it('未読のみトグルボタンを表示する', () => {
+    render(<NotificationFilters {...defaultProps} />);
+    expect(screen.getByText('未読のみ表示')).toBeInTheDocument();
+  });
+
+  it('未読のみトグルクリック時にonToggleUnreadOnlyが呼ばれる', () => {
+    const onToggleUnreadOnly = vi.fn();
+    render(<NotificationFilters {...defaultProps} onToggleUnreadOnly={onToggleUnreadOnly} />);
+    fireEvent.click(screen.getByText('未読のみ表示'));
+    expect(onToggleUnreadOnly).toHaveBeenCalledTimes(1);
+  });
+
+  it('選択中のフィルターにaria-pressed="true"が設定される', () => {
+    render(<NotificationFilters {...defaultProps} filterType="post" />);
+    expect(screen.getByText('投稿')).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByText('すべて')).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('showUnreadOnly=trueの場合にaria-pressed="true"が設定される', () => {
+    render(<NotificationFilters {...defaultProps} showUnreadOnly={true} />);
+    expect(screen.getByText('未読のみ表示')).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/frontend/src/components/notifications/__tests__/NotificationItem.test.tsx
+++ b/frontend/src/components/notifications/__tests__/NotificationItem.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import NotificationItem from '../NotificationItem';
+import type { Notification } from '../../../types/notification';
+
+const wrap = (ui: React.ReactElement) =>
+  render(<BrowserRouter>{ui}</BrowserRouter>);
+
+const baseActor = {
+  id: 1,
+  username: 'testuser',
+  name: 'Test User',
+  email: 'test@example.com',
+  avatar_url: '',
+  bio: '',
+  github_id: 0,
+  github_username: '',
+  github_connected: false,
+  spotify_connected: false,
+  zenn_username: '',
+  qiita_username: '',
+  atcoder_username: '',
+  paiza_rank: '',
+  skills_languages: '',
+  skills_frameworks: '',
+  onboarding_completed: true,
+  email_weekly_report: false,
+  email_language: 'ja',
+  created_at: '2025-01-01',
+  updated_at: '2025-01-01',
+};
+
+const makeNotification = (overrides: Partial<Notification> = {}): Notification => ({
+  id: 1,
+  user_id: 2,
+  type: 'like',
+  actor_id: 1,
+  actor: baseActor,
+  read: false,
+  created_at: '2025-01-01T00:00:00Z',
+  ...overrides,
+});
+
+describe('NotificationItem', () => {
+  const defaultProps = {
+    onMarkAsRead: vi.fn(),
+    onDelete: vi.fn(),
+  };
+
+  it('いいね通知のメッセージを表示する', () => {
+    const notification = makeNotification({ type: 'like' });
+    wrap(<NotificationItem notification={notification} {...defaultProps} />);
+    expect(screen.getByText('Test Userさんがあなたの投稿にいいねしました')).toBeInTheDocument();
+  });
+
+  it('フォロー通知のメッセージを表示する', () => {
+    const notification = makeNotification({ type: 'follow' });
+    wrap(<NotificationItem notification={notification} {...defaultProps} />);
+    expect(screen.getByText('Test Userさんがあなたをフォローしました')).toBeInTheDocument();
+  });
+
+  it('未読通知に青いドットが表示される', () => {
+    const notification = makeNotification({ read: false });
+    const { container } = wrap(<NotificationItem notification={notification} {...defaultProps} />);
+    expect(container.querySelector('.bg-blue-500')).toBeInTheDocument();
+  });
+
+  it('既読通知に青いドットが表示されない', () => {
+    const notification = makeNotification({ read: true });
+    const { container } = wrap(<NotificationItem notification={notification} {...defaultProps} />);
+    expect(container.querySelector('.bg-blue-500')).not.toBeInTheDocument();
+  });
+
+  it('削除ボタンクリック時にonDeleteが呼ばれる', () => {
+    const onDelete = vi.fn();
+    const notification = makeNotification();
+    wrap(<NotificationItem notification={notification} onMarkAsRead={vi.fn()} onDelete={onDelete} />);
+    fireEvent.click(screen.getByLabelText('通知を削除'));
+    expect(onDelete).toHaveBeenCalledWith(1);
+  });
+
+  it('投稿通知にpost.titleが表示される', () => {
+    const notification = makeNotification({
+      type: 'post',
+      post_id: 10,
+      post: {
+        id: 10, user_id: 1, user: baseActor, title: 'テスト投稿', content: '',
+        image_urls: '', is_draft: false, like_count: 0, comment_count: 0,
+        bookmark_count: 0, view_count: 0, estimated_read_time: 1,
+        created_at: '2025-01-01', updated_at: '2025-01-01',
+      },
+    });
+    wrap(<NotificationItem notification={notification} {...defaultProps} />);
+    expect(screen.getByText('テスト投稿')).toBeInTheDocument();
+  });
+
+  it('回答通知にquestion.titleが表示される', () => {
+    const notification = makeNotification({
+      type: 'answer',
+      question_id: 5,
+      question: { id: 5, title: 'テスト質問' },
+    });
+    wrap(<NotificationItem notification={notification} {...defaultProps} />);
+    expect(screen.getByText('テスト質問')).toBeInTheDocument();
+  });
+
+  it('投稿通知のリンク先が/posts/:idになる', () => {
+    const notification = makeNotification({ type: 'post', post_id: 10 });
+    wrap(<NotificationItem notification={notification} {...defaultProps} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/posts/10');
+  });
+
+  it('フォロー通知のリンク先が/profile/:usernameになる', () => {
+    const notification = makeNotification({ type: 'follow' });
+    wrap(<NotificationItem notification={notification} {...defaultProps} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/profile/testuser');
+  });
+
+  it('メッセージ通知のリンク先が/chatになる', () => {
+    const notification = makeNotification({ type: 'message' });
+    wrap(<NotificationItem notification={notification} {...defaultProps} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/chat');
+  });
+});


### PR DESCRIPTION
## 概要
- NotificationFilters: 6テスト（フィルターボタン表示・クリックコールバック・未読トグル・aria-pressed）
- NotificationItem: 10テスト（通知タイプ別メッセージ・未読/既読スタイル・削除・投稿/質問タイトル・リンク先）
- 計16テスト、全て合格

## 変更ファイル
- `frontend/src/components/notifications/__tests__/NotificationFilters.test.tsx`（新規）
- `frontend/src/components/notifications/__tests__/NotificationItem.test.tsx`（新規）

closes #1363