### PR TITLE
fix: 登録フォームのname・usernameフィールドにmaxLength制限を追加

### DIFF
--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -10,8 +10,8 @@ type UserResponse struct {
 
 // RegisterRequest は新規ユーザー登録リクエスト
 type RegisterRequest struct {
-	Name            string `json:"name" binding:"required" validate:"required"`
-	Username        string `json:"username" binding:"required" validate:"required"`
+	Name            string `json:"name" binding:"required,max=50" validate:"required,max=50"`
+	Username        string `json:"username" binding:"required,max=30" validate:"required,max=30"`
 	Email           string `json:"email" binding:"required,email,max=255" validate:"required,email,max=255"`
 	Password        string `json:"password" binding:"required,min=6" validate:"required,min=6"`
 	ConfirmPassword string `json:"confirm_password" binding:"required" validate:"required"`

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -91,6 +91,7 @@ export default function RegisterPage() {
                 value={name}
                 onChange={handleNameChange}
                 required
+                maxLength={50}
                 className={inputClass}
               />
             </div>


### PR DESCRIPTION
## 概要
- RegisterPage: nameフィールドに `maxLength={50}` 追加（usernameは既に `maxLength={30}` 設定済み）
- backend DTOのRegisterRequest: Nameに `max=50`、Usernameに `max=30` バリデーションタグ追加
- フロントエンド・バックエンド間の入力長制限を統一

## 変更ファイル
- `frontend/src/pages/RegisterPage.tsx`
- `backend/internal/dto/auth_dto.go`

closes #1365