### PR TITLE
feat: ノートページにタグフィルター機能を追加

### DIFF
--- a/frontend/src/hooks/useNoteForm.ts
+++ b/frontend/src/hooks/useNoteForm.ts
@@ -9,9 +9,23 @@ export function useNoteForm() {
   const [editingNote, setEditingNote] = useState<Note | null>(null);
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<'latest' | 'oldest' | 'updated' | 'favorites_first'>('latest');
+  const [filterTag, setFilterTag] = useState('');
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [tags, setTags] = useState('');
+
+  const allTags = useMemo(() => {
+    const tagSet = new Set<string>();
+    notes.forEach(note => {
+      if (note.tags) {
+        note.tags.split(',').forEach(t => {
+          const trimmed = t.trim();
+          if (trimmed) tagSet.add(trimmed);
+        });
+      }
+    });
+    return Array.from(tagSet).sort();
+  }, [notes]);
 
   const resetForm = useCallback(() => {
     setTitle('');
@@ -43,12 +57,17 @@ export function useNoteForm() {
   }, []);
 
   const filteredNotes = useMemo(() => {
-    const filtered = searchQuery
+    let filtered = searchQuery
       ? notes.filter(note =>
           note.title.toLowerCase().includes(searchQuery.toLowerCase()) ||
           note.content.toLowerCase().includes(searchQuery.toLowerCase())
         )
       : notes;
+    if (filterTag) {
+      filtered = filtered.filter(note =>
+        note.tags?.split(',').some(t => t.trim() === filterTag)
+      );
+    }
     return [...filtered].sort((a, b) => {
       switch (sortBy) {
         case 'oldest':
@@ -62,13 +81,13 @@ export function useNoteForm() {
           return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
       }
     });
-  }, [notes, searchQuery, sortBy]);
+  }, [notes, searchQuery, sortBy, filterTag]);
 
   return {
     // Data
     notes, favoriteNotes, filteredNotes, loading, saving,
     // Form state
-    showForm, setShowForm, editingNote, searchQuery, setSearchQuery, sortBy, setSortBy,
+    showForm, setShowForm, editingNote, searchQuery, setSearchQuery, sortBy, setSortBy, filterTag, setFilterTag, allTags,
     title, setTitle, content, setContent, tags, setTags,
     // Actions
     resetForm, handleSubmit, handleEdit, deleteNote, toggleFavorite,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1366,7 +1366,8 @@
     "lastUpdated": "Zuletzt aktualisiert",
     "chars": "Zeichen",
     "createdAt": "Erstellt am",
-    "tagsPlaceholder": "z.B. React, TypeScript, Go"
+    "tagsPlaceholder": "z.B. React, TypeScript, Go",
+    "allTags": "Alle Tags"
   },
   "githubCallback": {
     "missingOAuthParams": "Fehlende OAuth-Parameter",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1366,7 +1366,8 @@
     "lastUpdated": "Last updated",
     "chars": "chars",
     "createdAt": "Created at",
-    "tagsPlaceholder": "e.g., React, TypeScript, Go"
+    "tagsPlaceholder": "e.g., React, TypeScript, Go",
+    "allTags": "All Tags"
   },
   "githubCallback": {
     "missingOAuthParams": "Missing OAuth parameters",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1366,7 +1366,8 @@
     "lastUpdated": "Última actualización",
     "chars": "caracteres",
     "createdAt": "Creado el",
-    "tagsPlaceholder": "Ej: React, TypeScript, Go"
+    "tagsPlaceholder": "Ej: React, TypeScript, Go",
+    "allTags": "Todas las etiquetas"
   },
   "githubCallback": {
     "missingOAuthParams": "Faltan parámetros OAuth",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1366,7 +1366,8 @@
     "lastUpdated": "Dernière mise à jour",
     "chars": "caractères",
     "createdAt": "Créé le",
-    "tagsPlaceholder": "Ex : React, TypeScript, Go"
+    "tagsPlaceholder": "Ex : React, TypeScript, Go",
+    "allTags": "Tous les tags"
   },
   "githubCallback": {
     "missingOAuthParams": "Paramètres OAuth manquants",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1267,7 +1267,8 @@
     "lastUpdated": "最終更新",
     "chars": "文字",
     "createdAt": "作成日時",
-    "tagsPlaceholder": "例: React, TypeScript, Go"
+    "tagsPlaceholder": "例: React, TypeScript, Go",
+    "allTags": "すべてのタグ"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuthパラメータが不足しています",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1366,7 +1366,8 @@
     "lastUpdated": "마지막 업데이트",
     "chars": "자",
     "createdAt": "생성일",
-    "tagsPlaceholder": "예: React, TypeScript, Go"
+    "tagsPlaceholder": "예: React, TypeScript, Go",
+    "allTags": "모든 태그"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuth 매개변수가 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1366,7 +1366,8 @@
     "lastUpdated": "Última atualização",
     "chars": "caracteres",
     "createdAt": "Criado em",
-    "tagsPlaceholder": "Ex: React, TypeScript, Go"
+    "tagsPlaceholder": "Ex: React, TypeScript, Go",
+    "allTags": "Todas as tags"
   },
   "githubCallback": {
     "missingOAuthParams": "Parâmetros OAuth ausentes",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1366,7 +1366,8 @@
     "lastUpdated": "Последнее обновление",
     "chars": "символов",
     "createdAt": "Создано",
-    "tagsPlaceholder": "Напр.: React, TypeScript, Go"
+    "tagsPlaceholder": "Напр.: React, TypeScript, Go",
+    "allTags": "Все теги"
   },
   "githubCallback": {
     "missingOAuthParams": "Отсутствуют параметры OAuth",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1366,7 +1366,8 @@
     "lastUpdated": "最后更新",
     "chars": "字符",
     "createdAt": "创建时间",
-    "tagsPlaceholder": "例如：React, TypeScript, Go"
+    "tagsPlaceholder": "例如：React, TypeScript, Go",
+    "allTags": "所有标签"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth参数",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1366,7 +1366,8 @@
     "lastUpdated": "最後更新",
     "chars": "字元",
     "createdAt": "創建時間",
-    "tagsPlaceholder": "例如：React, TypeScript, Go"
+    "tagsPlaceholder": "例如：React, TypeScript, Go",
+    "allTags": "所有標籤"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth參數",

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BookOpen, Star, Plus, Edit, Trash2, ArrowDownWideNarrow } from 'lucide-react';
+import { BookOpen, Star, Plus, Edit, Trash2, ArrowDownWideNarrow, Tag } from 'lucide-react';
 import { useNoteForm } from '../hooks';
 import { PageLoader, SearchInput } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
@@ -12,6 +12,7 @@ export default function NotesPage() {
   const {
     filteredNotes, loading, saving,
     showForm, setShowForm, editingNote, searchQuery, setSearchQuery, sortBy, setSortBy,
+    filterTag, setFilterTag, allTags,
     title, setTitle, content, setContent, tags, setTags,
     resetForm, handleSubmit, handleEdit, deleteNote, toggleFavorite,
   } = useNoteForm();
@@ -72,6 +73,38 @@ export default function NotesPage() {
           ))}
         </div>
       </div>
+
+      {/* Tag Filter */}
+      {allTags.length > 0 && (
+        <div className="flex items-center gap-3 mb-6">
+          <Tag className="w-4 h-4 text-gray-400" />
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() => setFilterTag('')}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                filterTag === ''
+                  ? 'bg-green-500/20 text-green-400'
+                  : 'bg-gray-800/50 text-gray-400 hover:text-white'
+              }`}
+            >
+              {t('notes.allTags')}
+            </button>
+            {allTags.map(tag => (
+              <button
+                key={tag}
+                onClick={() => setFilterTag(filterTag === tag ? '' : tag)}
+                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                  filterTag === tag
+                    ? 'bg-green-500/20 text-green-400'
+                    : 'bg-gray-800/50 text-gray-400 hover:text-white'
+                }`}
+              >
+                {tag}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
 
       {/* Create/Edit Form */}
       {showForm && (


### PR DESCRIPTION
## 概要
- ノートに付けたタグを収集し、フィルターバッジとして表示
- タグクリックでそのタグを持つノートのみ表示、再クリックで解除
- useNoteFormにfilterTag状態・allTagsリスト・フィルタリングロジック追加
- 10言語のi18nキー追加

## 変更ファイル
- `frontend/src/hooks/useNoteForm.ts` — filterTag状態・allTags useMemo・フィルターロジック
- `frontend/src/pages/NotesPage.tsx` — タグフィルターUI追加
- `frontend/src/i18n/locales/*.json` — 10言語に`notes.allTags`追加

closes #1367