### PR TITLE
fix: フォームのtextareaにmaxLength制限を追加

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewForm.tsx
+++ b/frontend/src/components/bookReviews/BookReviewForm.tsx
@@ -125,6 +125,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
           value={reviewText}
           onChange={(e) => setReviewText(e.target.value)}
           rows={4}
+          maxLength={2000}
           className={textareaClass}
           placeholder={t('bookReviews.reviewPlaceholder')}
         />

--- a/frontend/src/components/onboarding/OnboardingProfileStep.tsx
+++ b/frontend/src/components/onboarding/OnboardingProfileStep.tsx
@@ -49,6 +49,7 @@ export default function OnboardingProfileStep({
             value={bio}
             onChange={handleBioChange}
             rows={3}
+            maxLength={500}
             placeholder={t('onboarding.bioPlaceholder')}
             className={`${inputClass} resize-none`}
           />

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -138,6 +138,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           rows={3}
+          maxLength={2000}
           className={textareaClass}
           placeholder={t('projects.descriptionPlaceholder')}
         />

--- a/frontend/src/components/qa/AnswerForm.tsx
+++ b/frontend/src/components/qa/AnswerForm.tsx
@@ -29,6 +29,7 @@ export default function AnswerForm({ initialBody = '', onSubmit, onCancel, loadi
         onChange={(e) => setBody(e.target.value)}
         required
         rows={isEdit ? 4 : 6}
+        maxLength={5000}
         className={textareaClass}
         placeholder={t('qa.answerPlaceholder')}
       />

--- a/frontend/src/components/qa/QuestionForm.tsx
+++ b/frontend/src/components/qa/QuestionForm.tsx
@@ -64,6 +64,7 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
           onChange={(e) => setBody(e.target.value)}
           required
           rows={8}
+          maxLength={5000}
           className={textareaClass}
           placeholder={t('qa.questionBodyPlaceholder')}
         />

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -154,6 +154,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           value={description}
           onChange={(e) => setDescription(e.target.value)}
           rows={3}
+          maxLength={1000}
           className={textareaClass}
           placeholder={t('resources.descriptionPlaceholder')}
         />


### PR DESCRIPTION
## 概要
- maxLength未設定のtextareaに文字数制限を追加し、入力制限をフロントエンドで統一

## 変更内容
- QuestionForm.tsx（質問本文）: maxLength={5000}
- AnswerForm.tsx（回答本文）: maxLength={5000}
- BookReviewForm.tsx（レビュー文）: maxLength={2000}
- ResourceForm.tsx（説明文）: maxLength={1000}
- ProjectForm.tsx（説明文）: maxLength={2000}
- OnboardingProfileStep.tsx（自己紹介）: maxLength={500}

Closes #1373