### PR TITLE
feat: 読書レビューに評価フィルター機能を追加

### DIFF
--- a/frontend/src/hooks/useBookReviews.ts
+++ b/frontend/src/hooks/useBookReviews.ts
@@ -15,6 +15,7 @@ export function useBookReviews() {
   const [statusFilter, setStatusFilter] = useState<ReviewStatus | 'all'>('all');
   const [showArchived, setShowArchived] = useState(false);
   const [sortBy, setSortBy] = useState<'newest' | 'oldest' | 'ratingDesc' | 'ratingAsc'>('newest');
+  const [ratingFilter, setRatingFilter] = useState<number>(0);
   const limit = 20;
 
   const { data, loading, refetch } = useAsyncData(
@@ -33,6 +34,7 @@ export function useBookReviews() {
     if (!showArchived && r.is_archived) return false;
     if (showArchived && !r.is_archived) return false;
     if (statusFilter !== 'all' && r.status !== statusFilter) return false;
+    if (ratingFilter > 0 && r.rating < ratingFilter) return false;
     return true;
   });
 
@@ -140,6 +142,8 @@ export function useBookReviews() {
     setShowArchived,
     sortBy,
     setSortBy,
+    ratingFilter,
+    setRatingFilter,
     createReview: handleCreate,
     updateReview: handleUpdate,
     deleteReview: handleDelete,

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -889,6 +889,10 @@
       "oldest": "Älteste",
       "ratingDesc": "Beste Bewertung",
       "ratingAsc": "Schlechteste Bewertung"
+    },
+    "ratingFilter": {
+      "all": "Alle Bewertungen",
+      "minRating": "★{{stars}}+"
     }
   },
   "qa": {

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -889,6 +889,10 @@
       "oldest": "Oldest",
       "ratingDesc": "Highest Rated",
       "ratingAsc": "Lowest Rated"
+    },
+    "ratingFilter": {
+      "all": "All Ratings",
+      "minRating": "★{{stars}}+"
     }
   },
   "qa": {

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -889,6 +889,10 @@
       "oldest": "Más antiguo",
       "ratingDesc": "Mayor puntuación",
       "ratingAsc": "Menor puntuación"
+    },
+    "ratingFilter": {
+      "all": "Todas las puntuaciones",
+      "minRating": "★{{stars}}+"
     }
   },
   "qa": {

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -889,6 +889,10 @@
       "oldest": "Plus ancien",
       "ratingDesc": "Mieux noté",
       "ratingAsc": "Moins bien noté"
+    },
+    "ratingFilter": {
+      "all": "Toutes les notes",
+      "minRating": "★{{stars}}+"
     }
   },
   "qa": {

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -843,6 +843,10 @@
       "oldest": "古い順",
       "ratingDesc": "評価が高い順",
       "ratingAsc": "評価が低い順"
+    },
+    "ratingFilter": {
+      "all": "全評価",
+      "minRating": "★{{stars}}以上"
     }
   },
   "qa": {

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -889,6 +889,10 @@
       "oldest": "오래된순",
       "ratingDesc": "평점 높은순",
       "ratingAsc": "평점 낮은순"
+    },
+    "ratingFilter": {
+      "all": "전체 평점",
+      "minRating": "★{{stars}}이상"
     }
   },
   "qa": {

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -889,6 +889,10 @@
       "oldest": "Mais antigo",
       "ratingDesc": "Melhor avaliado",
       "ratingAsc": "Pior avaliado"
+    },
+    "ratingFilter": {
+      "all": "Todas as avaliações",
+      "minRating": "★{{stars}}+"
     }
   },
   "qa": {

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -889,6 +889,10 @@
       "oldest": "Старые",
       "ratingDesc": "Высокий рейтинг",
       "ratingAsc": "Низкий рейтинг"
+    },
+    "ratingFilter": {
+      "all": "Все оценки",
+      "minRating": "★{{stars}}+"
     }
   },
   "qa": {

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -889,6 +889,10 @@
       "oldest": "最旧",
       "ratingDesc": "评分最高",
       "ratingAsc": "评分最低"
+    },
+    "ratingFilter": {
+      "all": "全部评分",
+      "minRating": "★{{stars}}及以上"
     }
   },
   "qa": {

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -889,6 +889,10 @@
       "oldest": "最舊",
       "ratingDesc": "評分最高",
       "ratingAsc": "評分最低"
+    },
+    "ratingFilter": {
+      "all": "全部評分",
+      "minRating": "★{{stars}}以上"
     }
   },
   "qa": {

--- a/frontend/src/pages/BookReviewsPage.tsx
+++ b/frontend/src/pages/BookReviewsPage.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BookOpen } from 'lucide-react';
+import { BookOpen, Star } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import type { BookReview, ReviewStatus } from '../types/bookReview';
 import { useBookReviews, useConfirm } from '../hooks';
@@ -15,7 +15,7 @@ export default function BookReviewsPage() {
   const {
     reviews, total, loading, saving, page, setPage, limit,
     statusFilter, setStatusFilter, showArchived, setShowArchived,
-    sortBy, setSortBy,
+    sortBy, setSortBy, ratingFilter, setRatingFilter,
     createReview, updateReview, deleteReview,
     updateStatus, archiveReview, unarchiveReview,
   } = useBookReviews();
@@ -92,6 +92,34 @@ export default function BookReviewsPage() {
             }`}
           >
             {t(`bookReviews.sort.${sort}`)}
+          </button>
+        ))}
+      </div>
+
+      {/* Rating Filter */}
+      <div className="flex flex-wrap items-center gap-2 mb-6">
+        <Star className="w-4 h-4 text-yellow-400" />
+        <button
+          onClick={() => setRatingFilter(0)}
+          className={`px-3 py-1.5 text-sm rounded-lg transition-colors ${
+            ratingFilter === 0
+              ? 'bg-yellow-600 text-white'
+              : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+          }`}
+        >
+          {t('bookReviews.ratingFilter.all')}
+        </button>
+        {[3, 4, 5].map(star => (
+          <button
+            key={star}
+            onClick={() => setRatingFilter(star)}
+            className={`px-3 py-1.5 text-sm rounded-lg transition-colors inline-flex items-center gap-1 ${
+              ratingFilter === star
+                ? 'bg-yellow-600 text-white'
+                : 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+            }`}
+          >
+            {t('bookReviews.ratingFilter.minRating', { stars: star })}
           </button>
         ))}
       </div>


### PR DESCRIPTION
## 概要
- 読書レビューページに最小評価フィルター（★3+/★4+/★5）を追加
- 既存のステータスフィルター・ソート機能と併用可能
- useBookReviewsフックにratingFilter状態を追加
- 10言語のi18nキー追加（`bookReviews.ratingFilter.all/minRating`）

## テスト計画
- [ ] フィルターボタンのクリックで正しく絞り込まれること
- [ ] 「全評価」で全レビュー表示に戻ること
- [ ] ステータスフィルター・ソートとの併用が正常に動作すること

Closes #1375