### PR TITLE
refactor: NotesPageからNoteFormPanel・NoteCardコンポーネントを分離

### DIFF
--- a/frontend/src/components/notes/NoteCard.tsx
+++ b/frontend/src/components/notes/NoteCard.tsx
@@ -1,0 +1,71 @@
+import { useTranslation } from 'react-i18next';
+import { Star, Edit, Trash2 } from 'lucide-react';
+import type { Note } from '../../api/notes';
+import { formatDistanceToNow } from '../../utils/timeFormat';
+
+interface NoteCardProps {
+  note: Note;
+  onToggleFavorite: (id: number) => void;
+  onEdit: (note: Note) => void;
+  onDelete: (id: number) => void;
+}
+
+export default function NoteCard({ note, onToggleFavorite, onEdit, onDelete }: NoteCardProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="p-6 bg-gray-800 border border-gray-700 rounded-md hover:border-gray-600 transition-colors">
+      <div className="flex items-start justify-between">
+        <div className="flex-1">
+          <div className="flex items-center gap-2 mb-2">
+            <h3 className="text-xl font-semibold">{note.title}</h3>
+            {note.is_favorite && (
+              <Star className="w-5 h-5 fill-yellow-500 text-yellow-500" />
+            )}
+          </div>
+          <p className="text-gray-400 mb-3 line-clamp-2">{note.content}</p>
+          {note.tags && (
+            <div className="flex flex-wrap gap-2 mb-3">
+              {note.tags.split(',').map((tag, idx) => (
+                <span
+                  key={idx}
+                  className="px-2 py-1 text-xs bg-gray-700 text-gray-300 rounded"
+                >
+                  {tag.trim()}
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="flex items-center gap-3 text-sm text-gray-500">
+            <span>{t('notes.lastUpdated')}: {formatDistanceToNow(note.updated_at)}</span>
+            <span className="text-gray-600">·</span>
+            <span>{note.content.length.toLocaleString()} {t('notes.chars')}</span>
+          </div>
+        </div>
+        <div className="flex gap-2 ml-4">
+          <button
+            onClick={() => onToggleFavorite(note.id)}
+            className="p-2 text-gray-400 hover:text-yellow-500 transition-colors"
+            aria-label={t('notes.favorites')}
+          >
+            <Star aria-hidden="true" className={`w-5 h-5 ${note.is_favorite ? 'fill-yellow-500 text-yellow-500' : ''}`} />
+          </button>
+          <button
+            onClick={() => onEdit(note)}
+            className="p-2 text-gray-400 hover:text-blue-500 transition-colors"
+            aria-label={t('common.edit')}
+          >
+            <Edit aria-hidden="true" className="w-5 h-5" />
+          </button>
+          <button
+            onClick={() => onDelete(note.id)}
+            className="p-2 text-gray-400 hover:text-red-500 transition-colors"
+            aria-label={t('common.delete')}
+          >
+            <Trash2 aria-hidden="true" className="w-5 h-5" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/notes/NoteFormPanel.tsx
+++ b/frontend/src/components/notes/NoteFormPanel.tsx
@@ -1,0 +1,97 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { buttonPrimaryClass, buttonSecondaryClass } from '../../constants/styles';
+
+interface NoteFormPanelProps {
+  editingNote: boolean;
+  title: string;
+  setTitle: (v: string) => void;
+  content: string;
+  setContent: (v: string) => void;
+  tags: string;
+  setTags: (v: string) => void;
+  saving: boolean;
+  onSubmit: (e: React.FormEvent) => void;
+  onCancel: () => void;
+}
+
+export default function NoteFormPanel({
+  editingNote,
+  title,
+  setTitle,
+  content,
+  setContent,
+  tags,
+  setTags,
+  saving,
+  onSubmit,
+  onCancel,
+}: NoteFormPanelProps) {
+  const { t } = useTranslation();
+  const handleTitleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value), [setTitle]);
+  const handleContentChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => setContent(e.target.value), [setContent]);
+  const handleTagsChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setTags(e.target.value), [setTags]);
+
+  return (
+    <div className="mb-8 p-6 bg-gray-800 border border-gray-700 rounded-md">
+      <h2 className="text-xl font-semibold mb-4">
+        {editingNote ? t('notes.editNote') : t('notes.createNote')}
+      </h2>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="note-title" className="block text-sm font-medium mb-2">{t('notes.noteTitle')}</label>
+          <input
+            id="note-title"
+            type="text"
+            value={title}
+            onChange={handleTitleChange}
+            maxLength={200}
+            className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="note-content" className="block text-sm font-medium mb-2">{t('notes.noteContent')}</label>
+          <textarea
+            id="note-content"
+            value={content}
+            onChange={handleContentChange}
+            rows={8}
+            maxLength={10000}
+            className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            required
+          />
+          <p className="text-xs text-gray-500 text-right mt-1">{content.length}/10000</p>
+        </div>
+        <div>
+          <label htmlFor="note-tags" className="block text-sm font-medium mb-2">{t('notes.tags')}</label>
+          <input
+            id="note-tags"
+            type="text"
+            value={tags}
+            onChange={handleTagsChange}
+            maxLength={500}
+            placeholder={t('notes.tagsPlaceholder')}
+            className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          />
+        </div>
+        <div className="flex gap-3">
+          <button
+            type="submit"
+            disabled={saving}
+            className={`${buttonPrimaryClass} disabled:opacity-50`}
+          >
+            {saving ? t('common.saving') : t('common.save')}
+          </button>
+          <button
+            type="button"
+            onClick={onCancel}
+            className={buttonSecondaryClass}
+          >
+            {t('common.cancel')}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,11 +1,12 @@
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BookOpen, Star, Plus, Edit, Trash2, ArrowDownWideNarrow, Tag } from 'lucide-react';
+import { BookOpen, Plus, ArrowDownWideNarrow, Tag } from 'lucide-react';
 import { useNoteForm } from '../hooks';
 import { PageLoader, SearchInput } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
-import { buttonPrimaryClass, buttonSecondaryClass } from '../constants/styles';
-import { formatDistanceToNow } from '../utils/timeFormat';
+import NoteFormPanel from '../components/notes/NoteFormPanel';
+import NoteCard from '../components/notes/NoteCard';
+import { buttonPrimaryClass } from '../constants/styles';
 
 export default function NotesPage() {
   const { t } = useTranslation();
@@ -18,9 +19,6 @@ export default function NotesPage() {
   } = useNoteForm();
 
   const handleToggleForm = useCallback(() => setShowForm((prev) => !prev), [setShowForm]);
-  const handleTitleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setTitle(e.target.value), [setTitle]);
-  const handleContentChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => setContent(e.target.value), [setContent]);
-  const handleTagsChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setTags(e.target.value), [setTags]);
 
   if (loading) return <PageLoader />;
 
@@ -108,66 +106,18 @@ export default function NotesPage() {
 
       {/* Create/Edit Form */}
       {showForm && (
-        <div className="mb-8 p-6 bg-gray-800 border border-gray-700 rounded-md">
-          <h2 className="text-xl font-semibold mb-4">
-            {editingNote ? t('notes.editNote') : t('notes.createNote')}
-          </h2>
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div>
-              <label htmlFor="note-title" className="block text-sm font-medium mb-2">{t('notes.noteTitle')}</label>
-              <input
-                id="note-title"
-                type="text"
-                value={title}
-                onChange={handleTitleChange}
-                maxLength={200}
-                className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                required
-              />
-            </div>
-            <div>
-              <label htmlFor="note-content" className="block text-sm font-medium mb-2">{t('notes.noteContent')}</label>
-              <textarea
-                id="note-content"
-                value={content}
-                onChange={handleContentChange}
-                rows={8}
-                maxLength={10000}
-                className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-                required
-              />
-              <p className="text-xs text-gray-500 text-right mt-1">{content.length}/10000</p>
-            </div>
-            <div>
-              <label htmlFor="note-tags" className="block text-sm font-medium mb-2">{t('notes.tags')}</label>
-              <input
-                id="note-tags"
-                type="text"
-                value={tags}
-                onChange={handleTagsChange}
-                maxLength={500}
-                placeholder={t('notes.tagsPlaceholder')}
-                className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              />
-            </div>
-            <div className="flex gap-3">
-              <button
-                type="submit"
-                disabled={saving}
-                className={`${buttonPrimaryClass} disabled:opacity-50`}
-              >
-                {saving ? t('common.saving') : t('common.save')}
-              </button>
-              <button
-                type="button"
-                onClick={resetForm}
-                className={buttonSecondaryClass}
-              >
-                {t('common.cancel')}
-              </button>
-            </div>
-          </form>
-        </div>
+        <NoteFormPanel
+          editingNote={!!editingNote}
+          title={title}
+          setTitle={setTitle}
+          content={content}
+          setContent={setContent}
+          tags={tags}
+          setTags={setTags}
+          saving={saving}
+          onSubmit={handleSubmit}
+          onCancel={resetForm}
+        />
       )}
 
       {/* Notes List */}
@@ -180,62 +130,13 @@ export default function NotesPage() {
       ) : (
         <div className="grid gap-4">
           {filteredNotes.map((note) => (
-            <div
+            <NoteCard
               key={note.id}
-              className="p-6 bg-gray-800 border border-gray-700 rounded-md hover:border-gray-600 transition-colors"
-            >
-              <div className="flex items-start justify-between">
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-2">
-                    <h3 className="text-xl font-semibold">{note.title}</h3>
-                    {note.is_favorite && (
-                      <Star className="w-5 h-5 fill-yellow-500 text-yellow-500" />
-                    )}
-                  </div>
-                  <p className="text-gray-400 mb-3 line-clamp-2">{note.content}</p>
-                  {note.tags && (
-                    <div className="flex flex-wrap gap-2 mb-3">
-                      {note.tags.split(',').map((tag, idx) => (
-                        <span
-                          key={idx}
-                          className="px-2 py-1 text-xs bg-gray-700 text-gray-300 rounded"
-                        >
-                          {tag.trim()}
-                        </span>
-                      ))}
-                    </div>
-                  )}
-                  <div className="flex items-center gap-3 text-sm text-gray-500">
-                    <span>{t('notes.lastUpdated')}: {formatDistanceToNow(note.updated_at)}</span>
-                    <span className="text-gray-600">·</span>
-                    <span>{note.content.length.toLocaleString()} {t('notes.chars')}</span>
-                  </div>
-                </div>
-                <div className="flex gap-2 ml-4">
-                  <button
-                    onClick={() => toggleFavorite(note.id)}
-                    className="p-2 text-gray-400 hover:text-yellow-500 transition-colors"
-                    aria-label={t('notes.favorites')}
-                  >
-                    <Star aria-hidden="true" className={`w-5 h-5 ${note.is_favorite ? 'fill-yellow-500 text-yellow-500' : ''}`} />
-                  </button>
-                  <button
-                    onClick={() => handleEdit(note)}
-                    className="p-2 text-gray-400 hover:text-blue-500 transition-colors"
-                    aria-label={t('common.edit')}
-                  >
-                    <Edit aria-hidden="true" className="w-5 h-5" />
-                  </button>
-                  <button
-                    onClick={() => deleteNote(note.id)}
-                    className="p-2 text-gray-400 hover:text-red-500 transition-colors"
-                    aria-label={t('common.delete')}
-                  >
-                    <Trash2 aria-hidden="true" className="w-5 h-5" />
-                  </button>
-                </div>
-              </div>
-            </div>
+              note={note}
+              onToggleFavorite={toggleFavorite}
+              onEdit={handleEdit}
+              onDelete={deleteNote}
+            />
           ))}
         </div>
       )}


### PR DESCRIPTION
## 概要
- NotesPage（244行）からフォームとカードを独立コンポーネントに分離
- NotesPage: 244行→133行（111行削減）

## 新規コンポーネント
- `NoteFormPanel`（91行）: ノート作成/編集フォーム
- `NoteCard`（73行）: ノートカード表示（お気に入り・編集・削除アクション付き）

## テスト計画
- [ ] ノート作成フォームが正常に表示・送信されること
- [ ] ノートカードの各ボタン（お気に入り・編集・削除）が動作すること

Closes #1377