### PR TITLE
test: NoteFormPanel・NoteCardコンポーネントのテスト追加

### DIFF
--- a/frontend/src/components/notes/__tests__/NoteCard.test.tsx
+++ b/frontend/src/components/notes/__tests__/NoteCard.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import NoteCard from '../NoteCard';
+import type { Note } from '../../../api/notes';
+
+const makeNote = (overrides: Partial<Note> = {}): Note => ({
+  id: 1,
+  user_id: 10,
+  title: 'テストノート',
+  content: 'テスト内容です。これはサンプルテキストです。',
+  tags: 'React,TypeScript',
+  is_favorite: false,
+  is_archived: false,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-02-01T00:00:00Z',
+  ...overrides,
+});
+
+const defaultProps = {
+  note: makeNote(),
+  onToggleFavorite: vi.fn(),
+  onEdit: vi.fn(),
+  onDelete: vi.fn(),
+};
+
+describe('NoteCard', () => {
+  it('ノートタイトルを表示する', () => {
+    render(<NoteCard {...defaultProps} />);
+    expect(screen.getByText('テストノート')).toBeInTheDocument();
+  });
+
+  it('ノート内容を表示する', () => {
+    render(<NoteCard {...defaultProps} />);
+    expect(screen.getByText('テスト内容です。これはサンプルテキストです。')).toBeInTheDocument();
+  });
+
+  it('タグを表示する', () => {
+    render(<NoteCard {...defaultProps} />);
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+  });
+
+  it('タグが空の場合はタグセクションを表示しない', () => {
+    render(<NoteCard {...defaultProps} note={makeNote({ tags: '' })} />);
+    expect(screen.queryByText('React')).not.toBeInTheDocument();
+  });
+
+  it('文字数を表示する', () => {
+    render(<NoteCard {...defaultProps} />);
+    expect(screen.getByText(/22/)).toBeInTheDocument();
+  });
+
+  it('お気に入りボタンをクリックするとonToggleFavoriteが呼ばれる', () => {
+    const onToggleFavorite = vi.fn();
+    render(<NoteCard {...defaultProps} onToggleFavorite={onToggleFavorite} />);
+    fireEvent.click(screen.getByLabelText('お気に入り'));
+    expect(onToggleFavorite).toHaveBeenCalledWith(1);
+  });
+
+  it('編集ボタンをクリックするとonEditが呼ばれる', () => {
+    const onEdit = vi.fn();
+    const note = makeNote();
+    render(<NoteCard {...defaultProps} note={note} onEdit={onEdit} />);
+    fireEvent.click(screen.getByLabelText('編集'));
+    expect(onEdit).toHaveBeenCalledWith(note);
+  });
+
+  it('削除ボタンをクリックするとonDeleteが呼ばれる', () => {
+    const onDelete = vi.fn();
+    render(<NoteCard {...defaultProps} onDelete={onDelete} />);
+    fireEvent.click(screen.getByLabelText('削除'));
+    expect(onDelete).toHaveBeenCalledWith(1);
+  });
+
+  it('お気に入りノートにはお気に入りアイコンが表示される', () => {
+    render(<NoteCard {...defaultProps} note={makeNote({ is_favorite: true })} />);
+    const title = screen.getByText('テストノート');
+    const starIcon = title.parentElement?.querySelector('.fill-yellow-500');
+    expect(starIcon).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/notes/__tests__/NoteFormPanel.test.tsx
+++ b/frontend/src/components/notes/__tests__/NoteFormPanel.test.tsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import NoteFormPanel from '../NoteFormPanel';
+
+const defaultProps = {
+  editingNote: false,
+  title: '',
+  setTitle: vi.fn(),
+  content: '',
+  setContent: vi.fn(),
+  tags: '',
+  setTags: vi.fn(),
+  saving: false,
+  onSubmit: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe('NoteFormPanel', () => {
+  it('新規作成タイトルを表示する', () => {
+    render(<NoteFormPanel {...defaultProps} />);
+    expect(screen.getByText('新規ノート')).toBeInTheDocument();
+  });
+
+  it('編集タイトルを表示する', () => {
+    render(<NoteFormPanel {...defaultProps} editingNote={true} />);
+    expect(screen.getByText('ノート編集')).toBeInTheDocument();
+  });
+
+  it('タイトル・内容・タグのフィールドを表示する', () => {
+    render(<NoteFormPanel {...defaultProps} />);
+    expect(screen.getByLabelText('タイトル')).toBeInTheDocument();
+    expect(screen.getByLabelText('内容（マークダウン対応）')).toBeInTheDocument();
+    expect(screen.getByLabelText('タグ（カンマ区切り）')).toBeInTheDocument();
+  });
+
+  it('タイトル入力でsetTitleが呼ばれる', () => {
+    const setTitle = vi.fn();
+    render(<NoteFormPanel {...defaultProps} setTitle={setTitle} />);
+    fireEvent.change(screen.getByLabelText('タイトル'), { target: { value: 'テスト' } });
+    expect(setTitle).toHaveBeenCalledWith('テスト');
+  });
+
+  it('内容入力でsetContentが呼ばれる', () => {
+    const setContent = vi.fn();
+    render(<NoteFormPanel {...defaultProps} setContent={setContent} />);
+    fireEvent.change(screen.getByLabelText('内容（マークダウン対応）'), { target: { value: 'テスト内容' } });
+    expect(setContent).toHaveBeenCalledWith('テスト内容');
+  });
+
+  it('タグ入力でsetTagsが呼ばれる', () => {
+    const setTags = vi.fn();
+    render(<NoteFormPanel {...defaultProps} setTags={setTags} />);
+    fireEvent.change(screen.getByLabelText('タグ（カンマ区切り）'), { target: { value: 'React, Go' } });
+    expect(setTags).toHaveBeenCalledWith('React, Go');
+  });
+
+  it('文字数カウンターを表示する', () => {
+    render(<NoteFormPanel {...defaultProps} content="Hello" />);
+    expect(screen.getByText('5/10000')).toBeInTheDocument();
+  });
+
+  it('キャンセルボタンでonCancelが呼ばれる', () => {
+    const onCancel = vi.fn();
+    render(<NoteFormPanel {...defaultProps} onCancel={onCancel} />);
+    fireEvent.click(screen.getByText('キャンセル'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('保存中は保存ボタンが無効になる', () => {
+    render(<NoteFormPanel {...defaultProps} saving={true} />);
+    const saveBtn = screen.getByText('保存中...');
+    expect(saveBtn.closest('button')).toBeDisabled();
+  });
+
+  it('保存ボタンのテキストが通常時は「保存」', () => {
+    render(<NoteFormPanel {...defaultProps} />);
+    expect(screen.getByText('保存')).toBeInTheDocument();
+  });
+
+  it('タイトルにmaxLength=200が設定されている', () => {
+    render(<NoteFormPanel {...defaultProps} />);
+    expect(screen.getByLabelText('タイトル')).toHaveAttribute('maxLength', '200');
+  });
+
+  it('内容にmaxLength=10000が設定されている', () => {
+    render(<NoteFormPanel {...defaultProps} />);
+    expect(screen.getByLabelText('内容（マークダウン対応）')).toHaveAttribute('maxLength', '10000');
+  });
+});


### PR DESCRIPTION
## 概要
- Cycle 407で分離したNoteFormPanel・NoteCardのユニットテスト追加
- 全21テスト合格

## テスト内容
### NoteFormPanel（12テスト）
- 新規/編集時のタイトル表示
- タイトル・内容・タグフィールドの表示
- 各入力のコールバック呼び出し
- 文字数カウンター表示
- 保存/キャンセルボタン動作
- maxLength属性の設定確認

### NoteCard（9テスト）
- ノートタイトル・内容・タグ・文字数の表示
- タグ空時の非表示
- お気に入り・編集・削除ボタンのコールバック
- お気に入りアイコン表示

Closes #1379