### PR TITLE
fix: URL入力フィールドにmaxLength制限を追加

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewForm.tsx
+++ b/frontend/src/components/bookReviews/BookReviewForm.tsx
@@ -141,6 +141,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
           type="url"
           value={imageUrl}
           onChange={(e) => setImageUrl(e.target.value)}
+          maxLength={2048}
           className={inputClass}
           placeholder="https://..."
         />

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -199,6 +199,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
             type="url"
             value={demoUrl}
             onChange={(e) => setDemoUrl(e.target.value)}
+            maxLength={2048}
             className={inputClass}
             placeholder="https://..."
           />
@@ -211,6 +212,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
             type="url"
             value={githubUrl}
             onChange={(e) => setGithubUrl(e.target.value)}
+            maxLength={2048}
             className={inputClass}
             placeholder="https://github.com/..."
           />
@@ -226,6 +228,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
           type="url"
           value={imageUrl}
           onChange={(e) => setImageUrl(e.target.value)}
+          maxLength={2048}
           className={inputClass}
           placeholder="https://..."
         />

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -100,6 +100,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           type="url"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
+          maxLength={2048}
           className={inputClass}
           placeholder="https://..."
         />
@@ -216,6 +217,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
           type="url"
           value={imageUrl}
           onChange={(e) => setImageUrl(e.target.value)}
+          maxLength={2048}
           className={inputClass}
           placeholder="https://..."
         />

--- a/frontend/src/components/studyCircles/CircleRoadmapTab.tsx
+++ b/frontend/src/components/studyCircles/CircleRoadmapTab.tsx
@@ -160,6 +160,7 @@ export default function CircleRoadmapTab({
             type="url"
             value={stepForm.resource_url}
             onChange={(e) => setStepForm({ ...stepForm, resource_url: e.target.value })}
+            maxLength={2048}
             placeholder={t('studyCircle.steps.resourceUrl')}
             className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
           />


### PR DESCRIPTION
## 概要
- type="url"のinput要素にmaxLength={2048}を追加（RFC 3986準拠のURL長上限）

## 変更箇所（7箇所）
- ResourceForm.tsx: url, image_url
- ProjectForm.tsx: demo_url, github_url, image_url
- BookReviewForm.tsx: image_url
- CircleRoadmapTab.tsx: resource_url

## テスト計画
- [ ] 各フォームのURL入力が2048文字で制限されること

Closes #1381