### PR TITLE
test: ProfileCompletenessCard・CompetitiveProgrammingCardのテスト追加

### DIFF
--- a/frontend/src/components/profile/__tests__/CompetitiveProgrammingCard.test.tsx
+++ b/frontend/src/components/profile/__tests__/CompetitiveProgrammingCard.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CompetitiveProgrammingCard from '../CompetitiveProgrammingCard';
+import type { AtCoderRatingInfo } from '../../../api/atcoder';
+
+const mockAtcoder: AtCoderRatingInfo = {
+  username: 'testuser',
+  rating: 1200,
+  color: 'green',
+  rank: '5 Kyu',
+};
+
+describe('CompetitiveProgrammingCard', () => {
+  it('タイトルを表示する', () => {
+    render(<CompetitiveProgrammingCard atcoderRating={mockAtcoder} atcoderUsername="testuser" />);
+    expect(screen.getByText('競技プログラミング')).toBeInTheDocument();
+  });
+
+  it('AtCoderレーティングを表示する', () => {
+    render(<CompetitiveProgrammingCard atcoderRating={mockAtcoder} atcoderUsername="testuser" />);
+    expect(screen.getByText('1200')).toBeInTheDocument();
+    expect(screen.getByText('(5 Kyu)')).toBeInTheDocument();
+  });
+
+  it('AtCoderリンクが正しいURLを持つ', () => {
+    render(<CompetitiveProgrammingCard atcoderRating={mockAtcoder} atcoderUsername="testuser" />);
+    const link = screen.getByText('1200').closest('a');
+    expect(link).toHaveAttribute('href', 'https://atcoder.jp/users/testuser');
+  });
+
+  it('AtCoderリンクがnoopener noreferrerを持つ', () => {
+    render(<CompetitiveProgrammingCard atcoderRating={mockAtcoder} atcoderUsername="testuser" />);
+    const link = screen.getByText('1200').closest('a');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('paizaランクを表示する', () => {
+    render(<CompetitiveProgrammingCard atcoderRating={null} paizaRank="B" />);
+    expect(screen.getByText('paiza ランクB')).toBeInTheDocument();
+  });
+
+  it('AtCoderとpaiza両方表示できる', () => {
+    render(<CompetitiveProgrammingCard atcoderRating={mockAtcoder} atcoderUsername="testuser" paizaRank="A" />);
+    expect(screen.getByText('1200')).toBeInTheDocument();
+    expect(screen.getByText('paiza ランクA')).toBeInTheDocument();
+  });
+
+  it('両方nullの場合はnullを返す', () => {
+    const { container } = render(<CompetitiveProgrammingCard atcoderRating={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('AtCoderの色スタイルが適用される', () => {
+    render(<CompetitiveProgrammingCard atcoderRating={mockAtcoder} atcoderUsername="testuser" />);
+    const ratingEl = screen.getByText('1200');
+    expect(ratingEl).toHaveStyle({ color: '#008000' });
+  });
+});

--- a/frontend/src/components/profile/__tests__/ProfileCompletenessCard.test.tsx
+++ b/frontend/src/components/profile/__tests__/ProfileCompletenessCard.test.tsx
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ProfileCompletenessCard from '../ProfileCompletenessCard';
+
+const renderWithRouter = (ui: React.ReactElement) =>
+  render(<MemoryRouter>{ui}</MemoryRouter>);
+
+describe('ProfileCompletenessCard', () => {
+  it('完成度パーセンテージを表示する', () => {
+    renderWithRouter(<ProfileCompletenessCard percentage={60} missingFields={[]} />);
+    expect(screen.getByText('60%')).toBeInTheDocument();
+  });
+
+  it('タイトルを表示する', () => {
+    renderWithRouter(<ProfileCompletenessCard percentage={50} missingFields={[]} />);
+    expect(screen.getByText('プロフィール完成度')).toBeInTheDocument();
+  });
+
+  it('プログレスバーが表示される', () => {
+    renderWithRouter(<ProfileCompletenessCard percentage={75} missingFields={[]} />);
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '75');
+  });
+
+  it('不足フィールドのリンクを表示する', () => {
+    renderWithRouter(<ProfileCompletenessCard percentage={50} missingFields={['avatar', 'bio']} />);
+    expect(screen.getByText(/アバター画像を設定/)).toBeInTheDocument();
+    expect(screen.getByText(/自己紹介を追加/)).toBeInTheDocument();
+  });
+
+  it('不足フィールドのリンクが/settingsに向く', () => {
+    renderWithRouter(<ProfileCompletenessCard percentage={50} missingFields={['avatar']} />);
+    const link = screen.getByText(/アバター画像を設定/).closest('a');
+    expect(link).toHaveAttribute('href', '/settings');
+  });
+
+  it('100%の場合はnullを返す', () => {
+    const { container } = renderWithRouter(<ProfileCompletenessCard percentage={100} missingFields={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+});


### PR DESCRIPTION
## 概要
- Cycle 411で分離した2コンポーネントのユニットテスト追加
- 全14テスト合格

## テスト内容
### ProfileCompletenessCard（6テスト）
- パーセンテージ表示、タイトル表示
- プログレスバーのaria属性
- 不足フィールドのリンク表示・URL確認
- 100%時に非表示

### CompetitiveProgrammingCard（8テスト）
- タイトル表示
- AtCoderレーティング・ランク表示
- AtCoderリンクURL・rel属性
- paizaランク表示
- 両方同時表示
- 両方null時に非表示
- AtCoder色スタイル適用

Closes #1387