### PR TITLE
fix: テキスト入力にmaxLength属性を追加（CodeSnippetInput・外部連携ユーザー名）

### DIFF
--- a/frontend/src/components/onboarding/OnboardingIntegrationsStep.tsx
+++ b/frontend/src/components/onboarding/OnboardingIntegrationsStep.tsx
@@ -106,6 +106,7 @@ export default function OnboardingIntegrationsStep({
                 value={zennUsername}
                 onChange={handleZennChange}
                 placeholder={t('settings.zennUsername')}
+                maxLength={50}
                 className={`${inputClass} flex-1`}
               />
               <button
@@ -140,6 +141,7 @@ export default function OnboardingIntegrationsStep({
                 value={qiitaUsername}
                 onChange={handleQiitaChange}
                 placeholder={t('settings.qiitaUsername')}
+                maxLength={50}
                 className={`${inputClass} flex-1`}
               />
               <button
@@ -174,6 +176,7 @@ export default function OnboardingIntegrationsStep({
                 value={atcoderUsername}
                 onChange={handleAtcoderChange}
                 placeholder={t('settings.atcoderUsername')}
+                maxLength={50}
                 className={`${inputClass} flex-1`}
               />
               <button

--- a/frontend/src/components/posts/CodeSnippetInput.tsx
+++ b/frontend/src/components/posts/CodeSnippetInput.tsx
@@ -32,6 +32,7 @@ export default function CodeSnippetInput({ value, onChange, onRemove, index }: C
           value={value.file_name}
           onChange={(e) => onChange({ ...value, file_name: e.target.value })}
           placeholder={t('post.fileName')}
+          maxLength={255}
           className="flex-1 px-3 py-1.5 bg-gray-900/50 border border-gray-700 rounded text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
         />
         <button

--- a/frontend/src/pages/settings/IntegrationSection.tsx
+++ b/frontend/src/pages/settings/IntegrationSection.tsx
@@ -188,6 +188,7 @@ export default function IntegrationSection(props: Props) {
                   value={props.zennUsername}
                   onChange={(e) => props.setZennUsername(e.target.value)}
                   placeholder={t('settings.zennUsernamePlaceholder')}
+                  maxLength={50}
                   className={inputClass}
                 />
               </div>
@@ -248,6 +249,7 @@ export default function IntegrationSection(props: Props) {
                   value={props.qiitaUsername}
                   onChange={(e) => props.setQiitaUsername(e.target.value)}
                   placeholder={t('settings.qiitaUsernamePlaceholder')}
+                  maxLength={50}
                   className={inputClass}
                 />
               </div>
@@ -301,6 +303,7 @@ export default function IntegrationSection(props: Props) {
                   value={props.atcoderUsername}
                   onChange={(e) => props.setAtcoderUsername(e.target.value)}
                   placeholder={t('settings.atcoderUsernamePlaceholder')}
+                  maxLength={50}
                   className={inputClass}
                 />
               </div>


### PR DESCRIPTION
## 概要
- CodeSnippetInputのファイル名入力に`maxLength={255}`を追加
- OnboardingIntegrationsStep・IntegrationSectionのZenn/Qiita/AtCoderユーザー名入力に`maxLength={50}`を追加（計6箇所）

## 対象ファイル
| ファイル | フィールド | maxLength |
|----------|-----------|-----------|
| `CodeSnippetInput.tsx` | file_name | 255 |
| `OnboardingIntegrationsStep.tsx` | Zenn/Qiita/AtCoderユーザー名 | 50 |
| `IntegrationSection.tsx` | Zenn/Qiita/AtCoderユーザー名 | 50 |

closes #1389