### PR TITLE
feat: Q&A質問カードに回答状態のカラーバーを追加

### DIFF
--- a/frontend/src/components/qa/QuestionCard.tsx
+++ b/frontend/src/components/qa/QuestionCard.tsx
@@ -18,8 +18,14 @@ export default function QuestionCard({ question, isOwner = false, onEdit, onDele
     try { return JSON.parse(question.tags); } catch { return []; }
   })() : [];
 
+  const statusBorderClass = question.is_solved
+    ? 'border-l-4 border-l-green-500'
+    : question.answer_count > 0
+    ? 'border-l-4 border-l-yellow-500'
+    : '';
+
   return (
-    <div className={cardPaddedClass}>
+    <div className={`${cardPaddedClass} ${statusBorderClass}`}>
       <div className="flex gap-4">
         {/* Vote & Answer counts */}
         <div className="flex flex-col items-center gap-2 text-center min-w-[60px]">


### PR DESCRIPTION
## 概要
- Q&A質問カードの左側に回答状態を示すカラーバーを追加
- 解決済み: 緑色の左ボーダー
- 回答あり（未解決）: 黄色の左ボーダー
- 回答なし: デフォルト（ボーダーなし）

## 対象ファイル
- `QuestionCard.tsx`: `statusBorderClass`ロジック追加

closes #1391