### PR TITLE
fix: StudyCircle関連フォームにmaxLength属性を追加

### DIFF
--- a/frontend/src/components/studyCircles/CircleCheckinTab.tsx
+++ b/frontend/src/components/studyCircles/CircleCheckinTab.tsx
@@ -31,6 +31,7 @@ export default function CircleCheckinTab({ checkins, onCheckin }: CircleCheckinT
             value={checkinContent}
             onChange={(e) => setCheckinContent(e.target.value)}
             placeholder={t('studyCircle.checkin.placeholder')}
+            maxLength={200}
             className="flex-1 bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
             onKeyDown={(e) => e.key === 'Enter' && handleCheckin()}
           />

--- a/frontend/src/components/studyCircles/CircleRoadmapTab.tsx
+++ b/frontend/src/components/studyCircles/CircleRoadmapTab.tsx
@@ -148,12 +148,14 @@ export default function CircleRoadmapTab({
             value={stepForm.title}
             onChange={(e) => setStepForm({ ...stepForm, title: e.target.value })}
             placeholder={t('studyCircle.steps.title')}
+            maxLength={100}
             className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500"
           />
           <textarea
             value={stepForm.description}
             onChange={(e) => setStepForm({ ...stepForm, description: e.target.value })}
             placeholder={t('studyCircle.description')}
+            maxLength={500}
             className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500 h-16 resize-none"
           />
           <input

--- a/frontend/src/components/studyCircles/CircleSettingsTab.tsx
+++ b/frontend/src/components/studyCircles/CircleSettingsTab.tsx
@@ -51,6 +51,7 @@ export default function CircleSettingsTab({ circle, onAddMember, onRemoveMember 
               value={memberSearch}
               onChange={(e) => setMemberSearch(e.target.value)}
               placeholder={t('studyCircle.searchUsers')}
+              maxLength={50}
               className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-purple-500 mb-2"
             />
             {searchUsers.length > 0 && (


### PR DESCRIPTION
## 概要
StudyCircle関連コンポーネントのフォーム入力にmaxLength属性を追加

## 対象
| ファイル | フィールド | maxLength |
|----------|-----------|-----------|
| `CircleRoadmapTab.tsx` | ステップタイトル | 100 |
| `CircleRoadmapTab.tsx` | ステップ説明 | 500 |
| `CircleCheckinTab.tsx` | チェックイン内容 | 200 |
| `CircleSettingsTab.tsx` | メンバー検索 | 50 |

closes #1397