### PR TITLE
refactor: GoalsPageからGoalStatsPanel・GoalFormModalを分離

### DIFF
--- a/frontend/src/components/goals/GoalFormModal.tsx
+++ b/frontend/src/components/goals/GoalFormModal.tsx
@@ -1,0 +1,117 @@
+import { useTranslation } from 'react-i18next';
+import { type GoalCategory } from '../../api/goals';
+import { Modal } from '../common';
+import { CATEGORIES } from './GoalCard';
+import { inputClass, buttonSecondaryClass, labelClass } from '../../constants/styles';
+
+interface GoalFormModalProps {
+  isOpen: boolean;
+  isEditing: boolean;
+  saving: boolean;
+  title: string;
+  setTitle: (v: string) => void;
+  description: string;
+  setDescription: (v: string) => void;
+  category: GoalCategory;
+  setCategory: (v: GoalCategory) => void;
+  targetDate: string;
+  setTargetDate: (v: string) => void;
+  onSubmit: (e: React.FormEvent) => void;
+  onCancel: () => void;
+}
+
+export default function GoalFormModal({
+  isOpen, isEditing, saving,
+  title, setTitle, description, setDescription,
+  category, setCategory, targetDate, setTargetDate,
+  onSubmit, onCancel,
+}: GoalFormModalProps) {
+  const { t } = useTranslation();
+
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onCancel}
+      title={isEditing ? t('goals.editGoal') : t('goals.addGoal')}
+      maxWidth="max-w-md"
+    >
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
+          <label htmlFor="goal-title" className={labelClass}>
+            {t('goals.goalTitle')}
+          </label>
+          <input
+            id="goal-title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder={t('goals.titlePlaceholder')}
+            maxLength={200}
+            className={inputClass}
+            required
+          />
+        </div>
+        <div>
+          <label htmlFor="goal-description" className={labelClass}>
+            {t('goals.description')}
+          </label>
+          <textarea
+            id="goal-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder={t('goals.descriptionPlaceholder')}
+            rows={3}
+            maxLength={2000}
+            className={`${inputClass} resize-none`}
+          />
+          <p className="text-xs text-gray-500 text-right mt-1">{description.length}/2000</p>
+        </div>
+        <div>
+          <label htmlFor="goal-category" className={labelClass}>
+            {t('goals.category')}
+          </label>
+          <select
+            id="goal-category"
+            value={category}
+            onChange={(e) => setCategory(e.target.value as GoalCategory)}
+            className={inputClass}
+          >
+            {CATEGORIES.map((cat) => (
+              <option key={cat.value} value={cat.value}>
+                {cat.icon} {t(cat.label)}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label htmlFor="goal-target-date" className={labelClass}>
+            {t('goals.targetDate')}
+          </label>
+          <input
+            id="goal-target-date"
+            type="date"
+            value={targetDate}
+            onChange={(e) => setTargetDate(e.target.value)}
+            className={inputClass}
+          />
+        </div>
+        <div className="flex gap-3 justify-end pt-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            className={`${buttonSecondaryClass} text-sm font-medium`}
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            type="submit"
+            disabled={saving || !title.trim()}
+            className={`${buttonSecondaryClass} disabled:opacity-50 text-sm font-medium`}
+          >
+            {saving ? t('common.loading') : isEditing ? t('common.save') : t('goals.create')}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/frontend/src/components/goals/GoalStatsPanel.tsx
+++ b/frontend/src/components/goals/GoalStatsPanel.tsx
@@ -1,0 +1,32 @@
+import { useTranslation } from 'react-i18next';
+
+interface GoalStatsPanelProps {
+  total: number;
+  active: number;
+  completed: number;
+  paused: number;
+  overdue: number;
+}
+
+export default function GoalStatsPanel({ total, active, completed, paused, overdue }: GoalStatsPanelProps) {
+  const { t } = useTranslation();
+
+  const stats = [
+    { value: total, label: t('goals.totalGoals'), color: '' },
+    { value: active, label: t('goals.activeGoals'), color: 'text-blue-400' },
+    { value: completed, label: t('goals.completedGoals'), color: 'text-green-400' },
+    { value: paused, label: t('goals.pausedGoals'), color: 'text-yellow-400' },
+    { value: overdue, label: t('goals.overdueGoals'), color: 'text-red-400' },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+      {stats.map((stat) => (
+        <div key={stat.label} className="bg-gray-900 border border-gray-800 rounded-md p-4">
+          <p className={`text-2xl font-bold ${stat.color}`}>{stat.value}</p>
+          <p className="text-sm text-gray-400">{stat.label}</p>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -1,13 +1,14 @@
 import { useTranslation } from 'react-i18next';
 import { Target, Search } from 'lucide-react';
-import { type GoalCategory } from '../api/goals';
 import { useGoalForm } from '../hooks';
-import { Modal, PageLoader } from '../components/common';
+import { PageLoader } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 import ConfirmDialog from '../components/common/ConfirmDialog';
-import GoalCard, { CATEGORIES } from '../components/goals/GoalCard';
+import GoalCard from '../components/goals/GoalCard';
 import GoalFilters from '../components/goals/GoalFilters';
-import { inputClass, buttonSecondaryClass, labelClass } from '../constants/styles';
+import GoalStatsPanel from '../components/goals/GoalStatsPanel';
+import GoalFormModal from '../components/goals/GoalFormModal';
+import { inputClass, buttonSecondaryClass } from '../constants/styles';
 
 export default function GoalsPage() {
   const { t } = useTranslation();
@@ -47,28 +48,13 @@ export default function GoalsPage() {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
-          <p className="text-2xl font-bold">{goals.length}</p>
-          <p className="text-sm text-gray-400">{t('goals.totalGoals')}</p>
-        </div>
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
-          <p className="text-2xl font-bold text-blue-400">{activeGoals.length}</p>
-          <p className="text-sm text-gray-400">{t('goals.activeGoals')}</p>
-        </div>
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
-          <p className="text-2xl font-bold text-green-400">{completedGoals.length}</p>
-          <p className="text-sm text-gray-400">{t('goals.completedGoals')}</p>
-        </div>
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
-          <p className="text-2xl font-bold text-yellow-400">{pausedGoals.length}</p>
-          <p className="text-sm text-gray-400">{t('goals.pausedGoals')}</p>
-        </div>
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
-          <p className="text-2xl font-bold text-red-400">{overdueGoals.length}</p>
-          <p className="text-sm text-gray-400">{t('goals.overdueGoals')}</p>
-        </div>
-      </div>
+      <GoalStatsPanel
+        total={goals.length}
+        active={activeGoals.length}
+        completed={completedGoals.length}
+        paused={pausedGoals.length}
+        overdue={overdueGoals.length}
+      />
 
       {/* Search */}
       <div className="relative">
@@ -93,90 +79,21 @@ export default function GoalsPage() {
       />
 
       {/* Create/Edit Form Modal */}
-      <Modal
+      <GoalFormModal
         isOpen={showForm}
-        onClose={resetForm}
-        title={editingGoal ? t('goals.editGoal') : t('goals.addGoal')}
-        maxWidth="max-w-md"
-      >
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label htmlFor="goal-title" className={labelClass}>
-              {t('goals.goalTitle')}
-            </label>
-            <input
-              id="goal-title"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              placeholder={t('goals.titlePlaceholder')}
-              maxLength={200}
-              className={inputClass}
-              required
-            />
-          </div>
-          <div>
-            <label htmlFor="goal-description" className={labelClass}>
-              {t('goals.description')}
-            </label>
-            <textarea
-              id="goal-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              placeholder={t('goals.descriptionPlaceholder')}
-              rows={3}
-              maxLength={2000}
-              className={`${inputClass} resize-none`}
-            />
-            <p className="text-xs text-gray-500 text-right mt-1">{description.length}/2000</p>
-          </div>
-          <div>
-            <label htmlFor="goal-category" className={labelClass}>
-              {t('goals.category')}
-            </label>
-            <select
-              id="goal-category"
-              value={category}
-              onChange={(e) => setCategory(e.target.value as GoalCategory)}
-              className={inputClass}
-            >
-              {CATEGORIES.map((cat) => (
-                <option key={cat.value} value={cat.value}>
-                  {cat.icon} {t(cat.label)}
-                </option>
-              ))}
-            </select>
-          </div>
-          <div>
-            <label htmlFor="goal-target-date" className={labelClass}>
-              {t('goals.targetDate')}
-            </label>
-            <input
-              id="goal-target-date"
-              type="date"
-              value={targetDate}
-              onChange={(e) => setTargetDate(e.target.value)}
-              className={inputClass}
-            />
-          </div>
-          <div className="flex gap-3 justify-end pt-2">
-            <button
-              type="button"
-              onClick={resetForm}
-              className={`${buttonSecondaryClass} text-sm font-medium`}
-            >
-              {t('common.cancel')}
-            </button>
-            <button
-              type="submit"
-              disabled={saving || !title.trim()}
-              className={`${buttonSecondaryClass} disabled:opacity-50 text-sm font-medium`}
-            >
-              {saving ? t('common.loading') : editingGoal ? t('common.save') : t('goals.create')}
-            </button>
-          </div>
-        </form>
-      </Modal>
+        isEditing={!!editingGoal}
+        saving={saving}
+        title={title}
+        setTitle={setTitle}
+        description={description}
+        setDescription={setDescription}
+        category={category}
+        setCategory={setCategory}
+        targetDate={targetDate}
+        setTargetDate={setTargetDate}
+        onSubmit={handleSubmit}
+        onCancel={resetForm}
+      />
 
       {/* Goals List */}
       {goals.length === 0 ? (


### PR DESCRIPTION
## 概要
- GoalsPageの統計パネルを`GoalStatsPanel`に分離
- GoalsPageの作成・編集フォームモーダルを`GoalFormModal`に分離

## 変更内容
| ファイル | 変更 |
|----------|------|
| `GoalsPage.tsx` | 265行→182行（83行削減） |
| `GoalStatsPanel.tsx` | 新規32行 |
| `GoalFormModal.tsx` | 新規117行 |

closes #1401