### PR TITLE
test: GoalStatsPanel・GoalFormModalのテスト追加

### DIFF
--- a/frontend/src/components/goals/__tests__/GoalFormModal.test.tsx
+++ b/frontend/src/components/goals/__tests__/GoalFormModal.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GoalFormModal from '../GoalFormModal';
+
+const defaultProps = {
+  isOpen: true,
+  isEditing: false,
+  saving: false,
+  title: '',
+  setTitle: vi.fn(),
+  description: '',
+  setDescription: vi.fn(),
+  category: 'programming' as const,
+  setCategory: vi.fn(),
+  targetDate: '',
+  setTargetDate: vi.fn(),
+  onSubmit: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+describe('GoalFormModal', () => {
+  it('新規作成モードでタイトルを表示する', () => {
+    render(<GoalFormModal {...defaultProps} />);
+    expect(screen.getByText('目標を追加')).toBeInTheDocument();
+  });
+
+  it('編集モードでタイトルを表示する', () => {
+    render(<GoalFormModal {...defaultProps} isEditing={true} />);
+    expect(screen.getByText('目標を編集')).toBeInTheDocument();
+  });
+
+  it('タイトル入力フィールドを表示する', () => {
+    render(<GoalFormModal {...defaultProps} />);
+    expect(screen.getByLabelText('タイトル')).toBeInTheDocument();
+  });
+
+  it('説明入力フィールドを表示する', () => {
+    render(<GoalFormModal {...defaultProps} />);
+    expect(screen.getByLabelText('学習の進捗を追跡し、目標を設定しましょう')).toBeInTheDocument();
+  });
+
+  it('カテゴリ選択を表示する', () => {
+    render(<GoalFormModal {...defaultProps} />);
+    expect(screen.getByLabelText('カテゴリ')).toBeInTheDocument();
+  });
+
+  it('タイトルが空の場合は送信ボタンが無効', () => {
+    render(<GoalFormModal {...defaultProps} title="" />);
+    expect(screen.getByText('作成')).toBeDisabled();
+  });
+
+  it('タイトルがある場合は送信ボタンが有効', () => {
+    render(<GoalFormModal {...defaultProps} title="テスト目標" />);
+    expect(screen.getByText('作成')).not.toBeDisabled();
+  });
+
+  it('saving中はボタンテキストが変わる', () => {
+    render(<GoalFormModal {...defaultProps} saving={true} title="テスト" />);
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('編集モードでは保存ボタンを表示する', () => {
+    render(<GoalFormModal {...defaultProps} isEditing={true} title="テスト" />);
+    expect(screen.getByText('保存')).toBeInTheDocument();
+  });
+
+  it('キャンセルボタンを表示する', () => {
+    render(<GoalFormModal {...defaultProps} />);
+    expect(screen.getByText('キャンセル')).toBeInTheDocument();
+  });
+
+  it('isOpenがfalseの場合はモーダルを表示しない', () => {
+    render(<GoalFormModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText('目標を追加')).not.toBeInTheDocument();
+  });
+
+  it('説明の文字数カウンターを表示する', () => {
+    render(<GoalFormModal {...defaultProps} description="テスト説明" />);
+    expect(screen.getByText('5/2000')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/goals/__tests__/GoalStatsPanel.test.tsx
+++ b/frontend/src/components/goals/__tests__/GoalStatsPanel.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import GoalStatsPanel from '../GoalStatsPanel';
+
+describe('GoalStatsPanel', () => {
+  const defaultProps = {
+    total: 10,
+    active: 5,
+    completed: 3,
+    paused: 1,
+    overdue: 1,
+  };
+
+  it('合計目標数を表示する', () => {
+    render(<GoalStatsPanel {...defaultProps} />);
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('合計目標')).toBeInTheDocument();
+  });
+
+  it('進行中の目標数を表示する', () => {
+    render(<GoalStatsPanel {...defaultProps} />);
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('進行中')).toBeInTheDocument();
+  });
+
+  it('完了の目標数を表示する', () => {
+    render(<GoalStatsPanel {...defaultProps} />);
+    expect(screen.getByText('完了')).toBeInTheDocument();
+  });
+
+  it('一時停止の目標数を表示する', () => {
+    render(<GoalStatsPanel {...defaultProps} />);
+    expect(screen.getByText('一時停止')).toBeInTheDocument();
+  });
+
+  it('期限超過の目標数を表示する', () => {
+    render(<GoalStatsPanel {...defaultProps} />);
+    expect(screen.getByText('期限超過')).toBeInTheDocument();
+  });
+
+  it('5つの統計カードを表示する', () => {
+    const { container } = render(<GoalStatsPanel {...defaultProps} />);
+    const cards = container.querySelectorAll('.bg-gray-900');
+    expect(cards.length).toBe(5);
+  });
+});


### PR DESCRIPTION
## 概要
- Cycle 419で分離した`GoalStatsPanel`と`GoalFormModal`のユニットテストを追加
- 18テスト全て合格

## テスト内容
### GoalStatsPanel（6テスト）
- 各統計値・ラベルの表示（total/active/completed/paused/overdue）
- 5つの統計カード表示確認

### GoalFormModal（12テスト）
- 新規・編集モードのタイトル切替
- フォームフィールド表示（タイトル/説明/カテゴリ）
- 送信ボタンの有効・無効制御
- saving中の表示、isOpenの制御、文字数カウンター

closes #1403