### PR TITLE
fix: MarkdownEditorにmaxLength追加・URLパラメータのエンコード統一

### DIFF
--- a/frontend/src/components/onboarding/OnboardingSkillsStep.tsx
+++ b/frontend/src/components/onboarding/OnboardingSkillsStep.tsx
@@ -55,7 +55,7 @@ export default function OnboardingSkillsStep({
             <div className="mt-3 p-3 bg-gray-800/50 rounded-lg">
               <p className="text-xs text-gray-500 mb-2">{t('settings.preview')}:</p>
               <img
-                src={`https://skillicons.dev/icons?i=${selectedLanguages.join(',')}&theme=dark`}
+                src={`https://skillicons.dev/icons?${new URLSearchParams({ i: selectedLanguages.join(','), theme: 'dark' })}`}
                 alt="Selected languages"
                 className="h-12"
               />
@@ -86,7 +86,7 @@ export default function OnboardingSkillsStep({
             <div className="mt-3 p-3 bg-gray-800/50 rounded-lg">
               <p className="text-xs text-gray-500 mb-2">{t('settings.preview')}:</p>
               <img
-                src={`https://skillicons.dev/icons?i=${selectedFrameworks.join(',')}&theme=dark`}
+                src={`https://skillicons.dev/icons?${new URLSearchParams({ i: selectedFrameworks.join(','), theme: 'dark' })}`}
                 alt="Selected frameworks"
                 className="h-12"
               />

--- a/frontend/src/components/posts/MarkdownEditor.tsx
+++ b/frontend/src/components/posts/MarkdownEditor.tsx
@@ -238,6 +238,7 @@ export default function MarkdownEditor({
               onDrop={handleDrop}
               onDragOver={handleDragOver}
               placeholder={placeholder || t('editor.placeholder')}
+              maxLength={10000}
               className="w-full p-4 bg-transparent text-white resize-none focus:outline-none font-mono text-sm"
               style={{ minHeight }}
             />

--- a/frontend/src/pages/settings/SkillsSection.tsx
+++ b/frontend/src/pages/settings/SkillsSection.tsx
@@ -55,7 +55,7 @@ export default function SkillsSection({
             <div className="mt-3 p-3 bg-gray-800/50 rounded-lg">
               <p className="text-xs text-gray-500 mb-2">{t('settings.preview')}:</p>
               <img
-                src={`https://skillicons.dev/icons?i=${selectedLanguages.join(',')}&theme=dark`}
+                src={`https://skillicons.dev/icons?${new URLSearchParams({ i: selectedLanguages.join(','), theme: 'dark' })}`}
                 alt="Selected languages"
                 className="h-12"
               />
@@ -91,7 +91,7 @@ export default function SkillsSection({
             <div className="mt-3 p-3 bg-gray-800/50 rounded-lg">
               <p className="text-xs text-gray-500 mb-2">{t('settings.preview')}:</p>
               <img
-                src={`https://skillicons.dev/icons?i=${selectedFrameworks.join(',')}&theme=dark`}
+                src={`https://skillicons.dev/icons?${new URLSearchParams({ i: selectedFrameworks.join(','), theme: 'dark' })}`}
                 alt="Selected frameworks"
                 className="h-12"
               />


### PR DESCRIPTION
## 概要
- MarkdownEditorのtextareaに`maxLength={10000}`を追加
- SkillsSection・OnboardingSkillsStepのskillicons.dev URLをURLSearchParamsで安全に構築（ProfilePageと同じパターンに統一）

## 対象
| ファイル | 修正内容 |
|----------|---------|
| `MarkdownEditor.tsx` | textarea maxLength={10000} |
| `SkillsSection.tsx` | URLSearchParams使用（2箇所） |
| `OnboardingSkillsStep.tsx` | URLSearchParams使用（2箇所） |

closes #1405