### PR TITLE
feat: スタディサークル一覧にフィルター・ソート機能追加

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1344,7 +1344,11 @@
     },
     "namePlaceholder": "React-Lerngruppe",
     "topicPlaceholder": "React-Grundlagen in 1 Monat lernen",
-    "searchUsers": "Benutzer suchen..."
+    "searchUsers": "Benutzer suchen...",
+    "sort": {
+      "newest": "Neueste",
+      "members": "Meiste Mitglieder"
+    }
   },
   "notes": {
     "title": "Lernnotizen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1344,7 +1344,11 @@
     },
     "namePlaceholder": "React Study Group",
     "topicPlaceholder": "Learn React basics in 1 month",
-    "searchUsers": "Search users..."
+    "searchUsers": "Search users...",
+    "sort": {
+      "newest": "Newest",
+      "members": "Most members"
+    }
   },
   "notes": {
     "title": "Learning Notes",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1344,7 +1344,11 @@
     },
     "namePlaceholder": "Grupo de estudio React",
     "topicPlaceholder": "Aprender React en 1 mes",
-    "searchUsers": "Buscar usuarios..."
+    "searchUsers": "Buscar usuarios...",
+    "sort": {
+      "newest": "Más recientes",
+      "members": "Más miembros"
+    }
   },
   "notes": {
     "title": "Notas de Aprendizaje",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1344,7 +1344,11 @@
     },
     "namePlaceholder": "Groupe d'étude React",
     "topicPlaceholder": "Apprendre React en 1 mois",
-    "searchUsers": "Rechercher des utilisateurs..."
+    "searchUsers": "Rechercher des utilisateurs...",
+    "sort": {
+      "newest": "Plus récents",
+      "members": "Plus de membres"
+    }
   },
   "notes": {
     "title": "Notes d'Apprentissage",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1245,7 +1245,11 @@
     },
     "namePlaceholder": "React学習会",
     "topicPlaceholder": "React入門を1ヶ月で",
-    "searchUsers": "ユーザーを検索..."
+    "searchUsers": "ユーザーを検索...",
+    "sort": {
+      "newest": "新しい順",
+      "members": "メンバー数順"
+    }
   },
   "notes": {
     "title": "学習ノート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1344,7 +1344,11 @@
     },
     "namePlaceholder": "React 스터디",
     "topicPlaceholder": "1개월 만에 React 입문",
-    "searchUsers": "사용자 검색..."
+    "searchUsers": "사용자 검색...",
+    "sort": {
+      "newest": "최신순",
+      "members": "멤버 수순"
+    }
   },
   "notes": {
     "title": "학습 노트",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1344,7 +1344,11 @@
     },
     "namePlaceholder": "Grupo de estudo React",
     "topicPlaceholder": "Aprender React em 1 mês",
-    "searchUsers": "Pesquisar usuários..."
+    "searchUsers": "Pesquisar usuários...",
+    "sort": {
+      "newest": "Mais recentes",
+      "members": "Mais membros"
+    }
   },
   "notes": {
     "title": "Notas de Aprendizado",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1344,7 +1344,11 @@
     },
     "namePlaceholder": "Группа изучения React",
     "topicPlaceholder": "Изучить основы React за 1 месяц",
-    "searchUsers": "Поиск пользователей..."
+    "searchUsers": "Поиск пользователей...",
+    "sort": {
+      "newest": "Новые",
+      "members": "По участникам"
+    }
   },
   "notes": {
     "title": "Учебные заметки",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1344,7 +1344,11 @@
     },
     "namePlaceholder": "React学习会",
     "topicPlaceholder": "一个月掌握React入门",
-    "searchUsers": "搜索用户..."
+    "searchUsers": "搜索用户...",
+    "sort": {
+      "newest": "最新",
+      "members": "成员数"
+    }
   },
   "notes": {
     "title": "学习笔记",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1344,7 +1344,11 @@
     },
     "namePlaceholder": "React學習會",
     "topicPlaceholder": "一個月學會React入門",
-    "searchUsers": "搜尋使用者..."
+    "searchUsers": "搜尋使用者...",
+    "sort": {
+      "newest": "最新",
+      "members": "成員數"
+    }
   },
   "notes": {
     "title": "學習筆記",

--- a/frontend/src/pages/StudyCirclesPage.tsx
+++ b/frontend/src/pages/StudyCirclesPage.tsx
@@ -1,7 +1,7 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Users, Plus, Crown } from 'lucide-react';
+import { Users, Plus, Crown, ArrowDownWideNarrow } from 'lucide-react';
 import { useStudyCircles } from '../hooks';
 import { useAuthStore } from '../store/authStore';
 import Avatar from '../components/common/Avatar';
@@ -13,6 +13,18 @@ export default function StudyCirclesPage() {
   const { circles, loading, saving, createCircle, deleteCircle } = useStudyCircles();
   const [showModal, setShowModal] = useState(false);
   const [form, setForm] = useState({ name: '', topic: '', description: '', max_members: 5 });
+  const [statusFilter, setStatusFilter] = useState<'all' | 'active' | 'completed'>('all');
+  const [sortBy, setSortBy] = useState<'newest' | 'members'>('newest');
+
+  const filteredCircles = useMemo(() => {
+    let filtered = statusFilter === 'all'
+      ? circles
+      : circles.filter((c) => c.status === statusFilter);
+    return [...filtered].sort((a, b) => {
+      if (sortBy === 'members') return (b.members?.length || 0) - (a.members?.length || 0);
+      return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+    });
+  }, [circles, statusFilter, sortBy]);
 
   const handleOpenModal = useCallback(() => setShowModal(true), []);
   const handleCloseModal = useCallback(() => setShowModal(false), []);
@@ -55,6 +67,37 @@ export default function StudyCirclesPage() {
         </button>
       </div>
 
+      {/* Filters & Sort */}
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex gap-2">
+          {(['all', 'active', 'completed'] as const).map((s) => (
+            <button
+              key={s}
+              onClick={() => setStatusFilter(s)}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                statusFilter === s ? 'bg-purple-500/20 text-purple-400' : 'bg-gray-800 text-gray-400 hover:text-white'
+              }`}
+            >
+              {s === 'all' ? t('common.all') : t(`studyCircle.${s}`)}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <ArrowDownWideNarrow className="w-4 h-4 text-gray-400" />
+          {(['newest', 'members'] as const).map((s) => (
+            <button
+              key={s}
+              onClick={() => setSortBy(s)}
+              className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                sortBy === s ? 'bg-purple-500/20 text-purple-400' : 'bg-gray-800 text-gray-400 hover:text-white'
+              }`}
+            >
+              {t(`studyCircle.sort.${s}`)}
+            </button>
+          ))}
+        </div>
+      </div>
+
       {/* Circle List */}
       {loading ? (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -80,7 +123,7 @@ export default function StudyCirclesPage() {
         </div>
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {circles.map((circle) => (
+          {filteredCircles.map((circle) => (
             <Link
               key={circle.id}
               to={`/study-circles/${circle.id}`}


### PR DESCRIPTION
## 概要
- StudyCirclesPageにステータスフィルター（すべて/アクティブ/完了）を追加
- ソート機能（新しい順/メンバー数順）を追加
- useMemoでフィルタリング・ソートロジックをメモ化
- 10言語のi18nキー（studyCircle.sort.newest / studyCircle.sort.members）を追加

## テスト計画
- [ ] フィルターボタンでステータス別に正しく絞り込まれること
- [ ] ソートボタンで並び順が切り替わること
- [ ] 全言語でラベルが正しく表示されること

closes #1407