### PR TITLE
test: MessageBubble・MessageInputFormのユニットテスト追加

### DIFF
--- a/frontend/src/components/chat/__tests__/MessageBubble.test.tsx
+++ b/frontend/src/components/chat/__tests__/MessageBubble.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MessageBubble from '../MessageBubble';
+
+const baseProps = {
+  content: 'テストメッセージ',
+  createdAt: '2026-02-19T14:30:00Z',
+  isOwn: false,
+};
+
+describe('MessageBubble', () => {
+  it('メッセージ内容を表示する', () => {
+    render(<MessageBubble {...baseProps} />);
+    expect(screen.getByText('テストメッセージ')).toBeInTheDocument();
+  });
+
+  it('時刻をHH:mm形式で表示する', () => {
+    render(<MessageBubble {...baseProps} />);
+    expect(screen.getByText('23:30')).toBeInTheDocument();
+  });
+
+  it('自分のメッセージはjustify-endクラスを持つ', () => {
+    const { container } = render(<MessageBubble {...baseProps} isOwn={true} />);
+    expect(container.firstChild).toHaveClass('justify-end');
+  });
+
+  it('他人のメッセージはjustify-startクラスを持つ', () => {
+    const { container } = render(<MessageBubble {...baseProps} isOwn={false} />);
+    expect(container.firstChild).toHaveClass('justify-start');
+  });
+
+  it('自分のメッセージにchat-bubble-ownクラスが適用される', () => {
+    render(<MessageBubble {...baseProps} isOwn={true} />);
+    const bubble = screen.getByText('テストメッセージ').parentElement;
+    expect(bubble).toHaveClass('chat-bubble-own');
+  });
+
+  it('他人のメッセージにchat-bubble-otherクラスが適用される', () => {
+    render(<MessageBubble {...baseProps} isOwn={false} />);
+    const bubble = screen.getByText('テストメッセージ').parentElement;
+    expect(bubble).toHaveClass('chat-bubble-other');
+  });
+
+  it('showSenderInfo=trueで送信者名を表示する', () => {
+    render(
+      <MessageBubble {...baseProps} showSenderInfo senderName="Alice" />
+    );
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('showSenderInfo=falseでは送信者名を表示しない', () => {
+    render(
+      <MessageBubble {...baseProps} showSenderInfo={false} senderName="Alice" />
+    );
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  });
+
+  it('自分のメッセージではshowSenderInfoがあっても送信者名を表示しない', () => {
+    render(
+      <MessageBubble {...baseProps} isOwn={true} showSenderInfo senderName="Me" />
+    );
+    expect(screen.queryByText('Me')).not.toBeInTheDocument();
+  });
+
+  it('自分のメッセージにchat-bubble-time-ownクラスの時刻を表示する', () => {
+    render(<MessageBubble {...baseProps} isOwn={true} />);
+    const timeEl = screen.getByText('23:30');
+    expect(timeEl).toHaveClass('chat-bubble-time-own');
+  });
+
+  it('他人のメッセージにchat-bubble-time-otherクラスの時刻を表示する', () => {
+    render(<MessageBubble {...baseProps} isOwn={false} />);
+    const timeEl = screen.getByText('23:30');
+    expect(timeEl).toHaveClass('chat-bubble-time-other');
+  });
+});

--- a/frontend/src/components/chat/__tests__/MessageInputForm.test.tsx
+++ b/frontend/src/components/chat/__tests__/MessageInputForm.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MessageInputForm from '../MessageInputForm';
+
+const defaultProps = {
+  value: '',
+  onChange: vi.fn(),
+  onSubmit: vi.fn(),
+  placeholder: 'メッセージを入力...',
+};
+
+describe('MessageInputForm', () => {
+  it('入力フィールドを表示する', () => {
+    render(<MessageInputForm {...defaultProps} />);
+    expect(screen.getByPlaceholderText('メッセージを入力...')).toBeInTheDocument();
+  });
+
+  it('送信ボタンを表示する', () => {
+    render(<MessageInputForm {...defaultProps} />);
+    expect(screen.getByText('送信')).toBeInTheDocument();
+  });
+
+  it('値が空の場合は送信ボタンが無効', () => {
+    render(<MessageInputForm {...defaultProps} value="" />);
+    expect(screen.getByText('送信').closest('button')).toBeDisabled();
+  });
+
+  it('値がある場合は送信ボタンが有効', () => {
+    render(<MessageInputForm {...defaultProps} value="テスト" />);
+    expect(screen.getByText('送信').closest('button')).not.toBeDisabled();
+  });
+
+  it('空白のみの場合は送信ボタンが無効', () => {
+    render(<MessageInputForm {...defaultProps} value="   " />);
+    expect(screen.getByText('送信').closest('button')).toBeDisabled();
+  });
+
+  it('入力変更でonChangeが呼ばれる', () => {
+    const onChange = vi.fn();
+    render(<MessageInputForm {...defaultProps} onChange={onChange} />);
+    fireEvent.change(screen.getByPlaceholderText('メッセージを入力...'), {
+      target: { value: 'Hello' },
+    });
+    expect(onChange).toHaveBeenCalledWith('Hello');
+  });
+
+  it('フォーム送信でonSubmitが呼ばれる', () => {
+    const onSubmit = vi.fn((e) => e.preventDefault());
+    render(<MessageInputForm {...defaultProps} value="テスト" onSubmit={onSubmit} />);
+    fireEvent.submit(screen.getByText('送信').closest('form')!);
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('プレースホルダーが設定される', () => {
+    render(<MessageInputForm {...defaultProps} placeholder="カスタムプレースホルダー" />);
+    expect(screen.getByPlaceholderText('カスタムプレースホルダー')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- MessageBubble: 11テスト（メッセージ表示、時刻フォーマット、自分/他人のスタイル、送信者情報表示制御）
- MessageInputForm: 8テスト（入力フォーム、送信ボタン有効/無効、onChange/onSubmit呼び出し、プレースホルダー）
- 全19テスト合格

## テスト計画
- [x] `npx vitest run` で全テスト合格確認済み

closes #1411