### PR TITLE
feat: ログイン・登録フォームにパスワード表示/非表示トグルを追加

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -86,6 +86,8 @@
     "confirmPassword": "Passwort bestätigen",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "Mindestens 6 Zeichen",
+    "showPassword": "Passwort anzeigen",
+    "hidePassword": "Passwort verbergen",
     "forgotPassword": "Passwort vergessen?",
     "noAccount": "Kein Konto?",
     "hasAccount": "Bereits ein Konto?",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -86,6 +86,8 @@
     "confirmPassword": "Confirm Password",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6+ characters",
+    "showPassword": "Show password",
+    "hidePassword": "Hide password",
     "forgotPassword": "Forgot password?",
     "noAccount": "Don't have an account?",
     "hasAccount": "Already have an account?",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -86,6 +86,8 @@
     "confirmPassword": "Confirmar contraseña",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6+ caracteres",
+    "showPassword": "Mostrar contraseña",
+    "hidePassword": "Ocultar contraseña",
     "forgotPassword": "¿Olvidaste tu contraseña?",
     "noAccount": "¿No tienes cuenta?",
     "hasAccount": "¿Ya tienes cuenta?",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -86,6 +86,8 @@
     "confirmPassword": "Confirmer le mot de passe",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6 caractères minimum",
+    "showPassword": "Afficher le mot de passe",
+    "hidePassword": "Masquer le mot de passe",
     "forgotPassword": "Mot de passe oublié ?",
     "noAccount": "Pas de compte ?",
     "hasAccount": "Déjà un compte ?",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -87,6 +87,8 @@
     "confirmPassword": "パスワード確認",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6文字以上",
+    "showPassword": "パスワードを表示",
+    "hidePassword": "パスワードを非表示",
     "forgotPassword": "パスワードを忘れた方",
     "noAccount": "アカウントをお持ちでない方",
     "hasAccount": "すでにアカウントをお持ちの方",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -86,6 +86,8 @@
     "confirmPassword": "비밀번호 확인",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6자 이상",
+    "showPassword": "비밀번호 표시",
+    "hidePassword": "비밀번호 숨기기",
     "forgotPassword": "비밀번호를 잊으셨나요?",
     "noAccount": "계정이 없으신가요?",
     "hasAccount": "이미 계정이 있으신가요?",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -86,6 +86,8 @@
     "confirmPassword": "Confirmar senha",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6+ caracteres",
+    "showPassword": "Mostrar senha",
+    "hidePassword": "Ocultar senha",
     "forgotPassword": "Esqueceu a senha?",
     "noAccount": "Não tem conta?",
     "hasAccount": "Já tem conta?",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -86,6 +86,8 @@
     "confirmPassword": "Подтвердите пароль",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "Минимум 6 символов",
+    "showPassword": "Показать пароль",
+    "hidePassword": "Скрыть пароль",
     "forgotPassword": "Забыли пароль?",
     "noAccount": "Нет аккаунта?",
     "hasAccount": "Уже есть аккаунт?",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -86,6 +86,8 @@
     "confirmPassword": "确认密码",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6个字符以上",
+    "showPassword": "显示密码",
+    "hidePassword": "隐藏密码",
     "forgotPassword": "忘记密码？",
     "noAccount": "没有账号？",
     "hasAccount": "已有账号？",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -86,6 +86,8 @@
     "confirmPassword": "確認密碼",
     "emailPlaceholder": "you@example.com",
     "passwordPlaceholder": "6個字元以上",
+    "showPassword": "顯示密碼",
+    "hidePassword": "隱藏密碼",
     "forgotPassword": "忘記密碼？",
     "noAccount": "沒有帳號？",
     "hasAccount": "已有帳號？",

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Eye, EyeOff } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { useToast } from '../hooks';
 import { inputClass, labelClass } from '../constants/styles';
@@ -11,6 +12,7 @@ export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const login = useAuthStore((s) => s.login);
   const loginWithGitHub = useAuthStore((s) => s.loginWithGitHub);
   const navigate = useNavigate();
@@ -93,16 +95,26 @@ export default function LoginPage() {
               <label htmlFor="login-password" className={labelClass}>
                 {t('auth.password')}
               </label>
-              <input
-                id="login-password"
-                type="password"
-                autoComplete="current-password"
-                value={password}
-                onChange={handlePasswordChange}
-                required
-                maxLength={128}
-                className={inputClass}
-              />
+              <div className="relative">
+                <input
+                  id="login-password"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="current-password"
+                  value={password}
+                  onChange={handlePasswordChange}
+                  required
+                  maxLength={128}
+                  className={inputClass}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white transition-colors"
+                  aria-label={t(showPassword ? 'auth.hidePassword' : 'auth.showPassword')}
+                >
+                  {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                </button>
+              </div>
             </div>
             <button
               type="submit"

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Eye, EyeOff } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import toast from 'react-hot-toast';
 import { inputClass, labelClass } from '../constants/styles';
@@ -12,6 +13,7 @@ export default function RegisterPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
   const register = useAuthStore((s) => s.register);
   const loginWithGitHub = useAuthStore((s) => s.loginWithGitHub);
   const navigate = useNavigate();
@@ -131,18 +133,28 @@ export default function RegisterPage() {
               <label htmlFor="register-password" className={labelClass}>
                 {t('auth.password')}
               </label>
-              <input
-                id="register-password"
-                type="password"
-                autoComplete="new-password"
-                value={password}
-                onChange={handlePasswordChange}
-                required
-                minLength={8}
-                maxLength={128}
-                placeholder={t('auth.passwordPlaceholder')}
-                className={inputClass}
-              />
+              <div className="relative">
+                <input
+                  id="register-password"
+                  type={showPassword ? 'text' : 'password'}
+                  autoComplete="new-password"
+                  value={password}
+                  onChange={handlePasswordChange}
+                  required
+                  minLength={8}
+                  maxLength={128}
+                  placeholder={t('auth.passwordPlaceholder')}
+                  className={inputClass}
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white transition-colors"
+                  aria-label={t(showPassword ? 'auth.hidePassword' : 'auth.showPassword')}
+                >
+                  {showPassword ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                </button>
+              </div>
             </div>
             <button
               type="submit"


### PR DESCRIPTION
## 概要
- LoginPageとRegisterPageのパスワード入力にEye/EyeOffアイコントグルを追加
- クリックでtype="password"⇔type="text"を切替
- aria-labelで10言語対応のアクセシビリティラベルを設定
- 10言語のi18nキー（auth.showPassword/hidePassword）を追加

## テスト計画
- [ ] ログイン画面でパスワード表示/非表示が切り替わること
- [ ] 登録画面でパスワード表示/非表示が切り替わること
- [ ] アイコンが状態に応じて切り替わること

closes #1415