### PR TITLE
fix: 6箇所のテキスト入力にmaxLength制限を追加

### DIFF
--- a/frontend/src/components/advice/AIChatPanel.tsx
+++ b/frontend/src/components/advice/AIChatPanel.tsx
@@ -126,6 +126,7 @@ export default function AIChatPanel({
               value={input}
               onChange={(e) => setInput(e.target.value)}
               placeholder={t('advice.chatPlaceholder')}
+              maxLength={2000}
               disabled={sending}
               className="flex-1 bg-gray-700 border border-gray-600 rounded-lg px-4 py-2 text-white text-sm placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
             />

--- a/frontend/src/components/chat/MessageInputForm.tsx
+++ b/frontend/src/components/chat/MessageInputForm.tsx
@@ -24,6 +24,7 @@ export default function MessageInputForm({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         placeholder={placeholder}
+        maxLength={1000}
         className={messageInputClass}
       />
       <button

--- a/frontend/src/components/onboarding/OnboardingProfileStep.tsx
+++ b/frontend/src/components/onboarding/OnboardingProfileStep.tsx
@@ -40,6 +40,7 @@ export default function OnboardingProfileStep({
             value={name}
             onChange={handleNameChange}
             placeholder={t('onboarding.namePlaceholder')}
+            maxLength={200}
             className={inputClass}
           />
         </div>

--- a/frontend/src/components/posts/CodeSnippetInput.tsx
+++ b/frontend/src/components/posts/CodeSnippetInput.tsx
@@ -50,6 +50,7 @@ export default function CodeSnippetInput({ value, onChange, onRemove, index }: C
         value={value.code}
         onChange={(e) => onChange({ ...value, code: e.target.value })}
         placeholder={t('post.codePlaceholder')}
+        maxLength={10000}
         className="w-full p-4 bg-transparent text-white resize-none focus:outline-none font-mono text-sm"
         style={{ minHeight: '120px' }}
       />

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -155,6 +155,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
             value={techStackInput}
             onChange={(e) => setTechStackInput(e.target.value)}
             onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTech())}
+            maxLength={100}
             className={`${inputClass} flex-1`}
             placeholder={t('projects.techStackPlaceholder')}
           />

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -173,6 +173,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
             value={tagInput}
             onChange={(e) => setTagInput(e.target.value)}
             onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
+            maxLength={50}
             className={`${inputClass} flex-1`}
             placeholder={t('resources.tagsPlaceholder')}
           />


### PR DESCRIPTION
## 概要
- MessageInputForm: チャットメッセージ(1000)
- OnboardingProfileStep: name(200)
- CodeSnippetInput: code(10000)
- ProjectForm: techStackInput(100)
- ResourceForm: tagInput(50)
- AIChatPanel: AI質問入力(2000)

## テスト計画
- [ ] 各入力フィールドで文字数制限が機能すること

closes #1421