### PR TITLE
feat: テキストエリアに文字数カウンターを追加

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewForm.tsx
+++ b/frontend/src/components/bookReviews/BookReviewForm.tsx
@@ -129,6 +129,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
           className={textareaClass}
           placeholder={t('bookReviews.reviewPlaceholder')}
         />
+        <p className="text-xs text-gray-500 text-right mt-1">{reviewText.length}/2000</p>
       </div>
 
       {/* Image URL */}

--- a/frontend/src/components/qa/QuestionForm.tsx
+++ b/frontend/src/components/qa/QuestionForm.tsx
@@ -68,6 +68,7 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
           className={textareaClass}
           placeholder={t('qa.questionBodyPlaceholder')}
         />
+        <p className="text-xs text-gray-500 text-right mt-1">{body.length}/5000</p>
       </div>
 
       {/* Tags */}


### PR DESCRIPTION
## 概要
- maxLengthが設定されたテキストエリアに文字数カウンター表示を追加
- ユーザーが入力中に残り文字数を認識しやすくなるUX改善

## 変更ファイル
- `BookReviewForm.tsx` — review欄に文字数カウンター（0/2000）追加
- `QuestionForm.tsx` — body欄に文字数カウンター（0/5000）追加

Closes #1431