### PR TITLE
refactor: ProjectFormとResourceFormの重複タグ入力をTagInputに統合

### DIFF
--- a/frontend/src/components/common/TagInput.tsx
+++ b/frontend/src/components/common/TagInput.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { inputClass } from '../../constants/styles';
+
+interface TagInputProps {
+  tags: string[];
+  onChange: (tags: string[]) => void;
+  placeholder?: string;
+  maxLength?: number;
+  prefix?: string;
+  label?: string;
+  id?: string;
+}
+
+export default function TagInput({ tags, onChange, placeholder, maxLength = 50, prefix, label, id }: TagInputProps) {
+  const { t } = useTranslation();
+  const [input, setInput] = useState('');
+
+  const addTag = () => {
+    const trimmed = input.trim();
+    if (trimmed && !tags.includes(trimmed)) {
+      onChange([...tags, trimmed]);
+      setInput('');
+    }
+  };
+
+  const removeTag = (tag: string) => {
+    onChange(tags.filter(t => t !== tag));
+  };
+
+  return (
+    <div>
+      {label && (
+        <label htmlFor={id} className="block text-sm font-medium text-gray-300 mb-1">
+          {label}
+        </label>
+      )}
+      <div className="flex gap-2">
+        <input
+          id={id}
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
+          maxLength={maxLength}
+          className={`${inputClass} flex-1`}
+          placeholder={placeholder}
+        />
+        <button
+          type="button"
+          onClick={addTag}
+          className="px-4 py-2 bg-gray-600 hover:bg-gray-500 text-white rounded-lg transition-colors"
+        >
+          {t('common.add')}
+        </button>
+      </div>
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-2 mt-2">
+          {tags.map((tag, idx) => (
+            <span
+              key={idx}
+              className="inline-flex items-center gap-1 px-2 py-1 bg-gray-700 text-gray-300 text-sm rounded"
+            >
+              {prefix}{tag}
+              <button
+                type="button"
+                onClick={() => removeTag(tag)}
+                className="text-gray-400 hover:text-white"
+              >
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -4,6 +4,7 @@ import type { Project, CreateProjectRequest } from '../../types/project';
 import type { GitHubRepository } from '../../types/github';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
 import { isHttpUrl } from '../../utils/url';
+import TagInput from '../common/TagInput';
 import toast from 'react-hot-toast';
 
 interface ProjectFormProps {
@@ -18,7 +19,6 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
   const { t } = useTranslation();
   const [title, setTitle] = useState(project?.title || '');
   const [description, setDescription] = useState(project?.description || '');
-  const [techStackInput, setTechStackInput] = useState('');
   const [techStack, setTechStack] = useState<string[]>(() => {
     if (project?.tech_stack) {
       try {
@@ -37,17 +37,6 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
   const [endDate, setEndDate] = useState(project?.end_date?.split('T')[0] || '');
   const [featured, setFeatured] = useState(project?.featured || false);
   const [githubRepoId, setGithubRepoId] = useState<number | undefined>(project?.github_repo_id || undefined);
-
-  const addTech = () => {
-    if (techStackInput.trim() && !techStack.includes(techStackInput.trim())) {
-      setTechStack([...techStack, techStackInput.trim()]);
-      setTechStackInput('');
-    }
-  };
-
-  const removeTech = (tech: string) => {
-    setTechStack(techStack.filter(t => t !== tech));
-  };
 
   const handleRepoSelect = (repoId: number) => {
     const repo = repos.find(r => r.id === repoId);
@@ -145,50 +134,13 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
       </div>
 
       {/* Tech Stack */}
-      <div>
-        <label className={labelClass}>
-          {t('projects.techStack')}
-        </label>
-        <div className="flex gap-2">
-          <input
-            type="text"
-            value={techStackInput}
-            onChange={(e) => setTechStackInput(e.target.value)}
-            onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTech())}
-            maxLength={100}
-            className={`${inputClass} flex-1`}
-            placeholder={t('projects.techStackPlaceholder')}
-          />
-          <button
-            type="button"
-            onClick={addTech}
-            className="px-4 py-2 bg-gray-600 hover:bg-gray-500 text-white rounded-lg transition-colors"
-          >
-            {t('common.add')}
-          </button>
-        </div>
-        {techStack.length > 0 && (
-          <div className="flex flex-wrap gap-2 mt-2">
-            {techStack.map((tech, idx) => (
-              <span
-                key={idx}
-                className="inline-flex items-center gap-1 px-2 py-1 bg-gray-700 text-gray-300 text-sm rounded"
-              >
-                {tech}
-                <button
-                  type="button"
-                  onClick={() => removeTech(tech)}
-                  className="text-gray-400 hover:text-white"
-                >
-                  <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
+      <TagInput
+        tags={techStack}
+        onChange={setTechStack}
+        label={t('projects.techStack')}
+        placeholder={t('projects.techStackPlaceholder')}
+        maxLength={100}
+      />
 
       {/* URLs */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { LearningResource, CreateResourceRequest, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
 import { isHttpUrl } from '../../utils/url';
+import TagInput from '../common/TagInput';
 import toast from 'react-hot-toast';
 
 interface ResourceFormProps {
@@ -22,7 +23,6 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
   const [url, setUrl] = useState(resource?.url || '');
   const [category, setCategory] = useState<ResourceCategory>(resource?.category || 'article');
   const [difficulty, setDifficulty] = useState<ResourceDifficulty | ''>(resource?.difficulty || '');
-  const [tagInput, setTagInput] = useState('');
   const [tags, setTags] = useState<string[]>(() => {
     if (resource?.tags) {
       try {
@@ -35,17 +35,6 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
   });
   const [imageUrl, setImageUrl] = useState(resource?.image_url || '');
   const [isPublic, setIsPublic] = useState(resource?.is_public ?? true);
-
-  const addTag = () => {
-    if (tagInput.trim() && !tags.includes(tagInput.trim())) {
-      setTags([...tags, tagInput.trim()]);
-      setTagInput('');
-    }
-  };
-
-  const removeTag = (tag: string) => {
-    setTags(tags.filter(t => t !== tag));
-  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -162,51 +151,15 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
       </div>
 
       {/* Tags */}
-      <div>
-        <label htmlFor="resource-tags" className={labelClass}>
-          {t('resources.tags')}
-        </label>
-        <div className="flex gap-2">
-          <input
-            id="resource-tags"
-            type="text"
-            value={tagInput}
-            onChange={(e) => setTagInput(e.target.value)}
-            onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
-            maxLength={50}
-            className={`${inputClass} flex-1`}
-            placeholder={t('resources.tagsPlaceholder')}
-          />
-          <button
-            type="button"
-            onClick={addTag}
-            className="px-4 py-2 bg-gray-600 hover:bg-gray-500 text-white rounded-lg transition-colors"
-          >
-            {t('common.add')}
-          </button>
-        </div>
-        {tags.length > 0 && (
-          <div className="flex flex-wrap gap-2 mt-2">
-            {tags.map((tag, idx) => (
-              <span
-                key={idx}
-                className="inline-flex items-center gap-1 px-2 py-1 bg-gray-700 text-gray-300 text-sm rounded"
-              >
-                #{tag}
-                <button
-                  type="button"
-                  onClick={() => removeTag(tag)}
-                  className="text-gray-400 hover:text-white"
-                >
-                  <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M6 18 18 6M6 6l12 12" />
-                  </svg>
-                </button>
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
+      <TagInput
+        tags={tags}
+        onChange={setTags}
+        label={t('resources.tags')}
+        id="resource-tags"
+        placeholder={t('resources.tagsPlaceholder')}
+        maxLength={50}
+        prefix="#"
+      />
 
       {/* Image URL */}
       <div>


### PR DESCRIPTION
## 概要
- 共通TagInputコンポーネント（80行）を新規作成
- ProjectFormとResourceFormの重複タグ入力UIをTagInputに置換
- ProjectForm: 313行→264行（49行削減）
- ResourceForm: 261行→213行（48行削減）
- 合計97行の重複コード削減

## 変更ファイル
- `frontend/src/components/common/TagInput.tsx` — 新規作成（共通タグ入力コンポーネント）
- `frontend/src/components/projects/ProjectForm.tsx` — TagInput利用に置換
- `frontend/src/components/resources/ResourceForm.tsx` — TagInput利用に置換

Closes #1433