### PR TITLE
fix: APIレスポンスURLのsanitizeUrl検証追加・onKeyPress→onKeyDown移行

### DIFF
--- a/frontend/src/components/common/TagInput.tsx
+++ b/frontend/src/components/common/TagInput.tsx
@@ -41,7 +41,7 @@ export default function TagInput({ tags, onChange, placeholder, maxLength = 50, 
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          onKeyPress={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
+          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
           maxLength={maxLength}
           className={`${inputClass} flex-1`}
           placeholder={placeholder}

--- a/frontend/src/components/profile/ProfileArticlesSection.tsx
+++ b/frontend/src/components/profile/ProfileArticlesSection.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { FileText } from 'lucide-react';
 import { type ZennArticle, type ZennStats } from '../../api/zenn';
 import { type QiitaArticle, type QiitaStats } from '../../api/qiita';
+import { sanitizeUrl } from '../../utils/url';
 
 interface ProfileArticlesSectionProps {
   zennUsername?: string;
@@ -68,7 +69,7 @@ export default function ProfileArticlesSection({
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {qiitaArticles.slice(0, 6).map((article) => (
-              <a key={article.id} href={article.url} target="_blank" rel="noopener noreferrer" className="bg-gray-900 border border-gray-800 rounded-md p-4 hover:border-gray-600 transition-colors group">
+              <a key={article.id} href={sanitizeUrl(article.url) || '#'} target="_blank" rel="noopener noreferrer" className="bg-gray-900 border border-gray-800 rounded-md p-4 hover:border-gray-600 transition-colors group">
                 <div className="flex items-start gap-3">
                   <FileText className="w-6 h-6 text-green-400 flex-shrink-0" aria-hidden="true" />
                   <div className="min-w-0 flex-1">

--- a/frontend/src/components/profile/SpotifyNowPlaying.tsx
+++ b/frontend/src/components/profile/SpotifyNowPlaying.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { getCurrentlyPlaying, getRecentlyPlayed } from '../../api/spotify';
 import type { SpotifyCurrentlyPlaying, SpotifyRecentTrack } from '../../types/spotify';
+import { sanitizeUrl } from '../../utils/url';
 
 interface Props {
   userId: number;
@@ -59,7 +60,7 @@ export default function SpotifyNowPlaying({ userId }: Props) {
 
       {currentTrack ? (
         <a
-          href={currentTrack.track_url}
+          href={sanitizeUrl(currentTrack.track_url) || '#'}
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center gap-4 p-3 bg-gray-800/50 rounded-lg hover:bg-gray-800 transition-colors"
@@ -103,7 +104,7 @@ export default function SpotifyNowPlaying({ userId }: Props) {
           {recentTracks.slice(0, 5).map((track, index) => (
             <a
               key={`${track.track_url}-${index}`}
-              href={track.track_url}
+              href={sanitizeUrl(track.track_url) || '#'}
               target="_blank"
               rel="noopener noreferrer"
               className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-800/50 transition-colors"


### PR DESCRIPTION
## 概要
- SpotifyNowPlaying・ProfileArticlesSectionでAPIレスポンスURLにsanitizeUrl()検証を追加
- TagInputのonKeyPress（deprecated）をonKeyDownに移行

## 変更ファイル
- `SpotifyNowPlaying.tsx` — track_url にsanitizeUrl追加（2箇所）
- `ProfileArticlesSection.tsx` — article.url にsanitizeUrl追加
- `TagInput.tsx` — onKeyPress → onKeyDown

Closes #1437