### PR TITLE
fix: 外部画像のreferrerPolicy属性追加によるreferrer漏洩防止

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewCard.tsx
+++ b/frontend/src/components/bookReviews/BookReviewCard.tsx
@@ -60,6 +60,7 @@ export default function BookReviewCard({
             <img
               src={review.image_url}
               alt={review.title}
+              referrerPolicy="no-referrer"
               className="w-full h-full object-cover"
             />
           </div>

--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -20,6 +20,7 @@ export default function Avatar({ name, avatarUrl, size = 'md' }: AvatarProps) {
       <img
         src={safeUrl}
         alt={name}
+        referrerPolicy="no-referrer"
         className={`${sizeClasses[size]} rounded-full object-cover`}
       />
     );

--- a/frontend/src/components/onboarding/OnboardingSkillsStep.tsx
+++ b/frontend/src/components/onboarding/OnboardingSkillsStep.tsx
@@ -57,6 +57,7 @@ export default function OnboardingSkillsStep({
               <img
                 src={`https://skillicons.dev/icons?${new URLSearchParams({ i: selectedLanguages.join(','), theme: 'dark' })}`}
                 alt="Selected languages"
+                referrerPolicy="no-referrer"
                 className="h-12"
               />
             </div>
@@ -88,6 +89,7 @@ export default function OnboardingSkillsStep({
               <img
                 src={`https://skillicons.dev/icons?${new URLSearchParams({ i: selectedFrameworks.join(','), theme: 'dark' })}`}
                 alt="Selected frameworks"
+                referrerPolicy="no-referrer"
                 className="h-12"
               />
             </div>

--- a/frontend/src/components/profile/ShareableProfileCard.tsx
+++ b/frontend/src/components/profile/ShareableProfileCard.tsx
@@ -52,6 +52,7 @@ const ShareableProfileCard = forwardRef<HTMLDivElement, ShareableProfileCardProp
             <img
               src={sanitizeUrl(user.avatar_url) || `https://ui-avatars.com/api/?name=${encodeURIComponent(user.name || 'User')}&background=7c3aed&color=fff&size=128`}
               alt={user.name}
+              referrerPolicy="no-referrer"
               className="w-24 h-24 rounded-full border-4 border-purple-500/50"
             />
             <h2 className="mt-3 text-xl font-bold text-white truncate max-w-full">

--- a/frontend/src/components/profile/SpotifyNowPlaying.tsx
+++ b/frontend/src/components/profile/SpotifyNowPlaying.tsx
@@ -69,6 +69,7 @@ export default function SpotifyNowPlaying({ userId }: Props) {
             <img
               src={currentTrack.album_image}
               alt={currentTrack.album_name}
+              referrerPolicy="no-referrer"
               className="w-16 h-16 rounded-lg object-cover"
             />
           )}
@@ -113,6 +114,7 @@ export default function SpotifyNowPlaying({ userId }: Props) {
                 <img
                   src={track.album_image}
                   alt={track.album_name}
+                  referrerPolicy="no-referrer"
                   className="w-10 h-10 rounded object-cover"
                 />
               )}

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -27,6 +27,7 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
           <img
             src={project.image_url}
             alt={project.title}
+            referrerPolicy="no-referrer"
             className="w-full h-full object-cover"
           />
         </div>

--- a/frontend/src/components/youtube/YouTubeVideoCard.tsx
+++ b/frontend/src/components/youtube/YouTubeVideoCard.tsx
@@ -18,6 +18,7 @@ export default function YouTubeVideoCard({ video }: YouTubeVideoCardProps) {
         <img
           src={video.thumbnail_url}
           alt={video.title}
+          referrerPolicy="no-referrer"
           className="w-full aspect-video object-cover"
           loading="lazy"
         />

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -69,13 +69,13 @@ export default function ProfilePage() {
           {user.skills_languages && (
             <div>
               <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2"><Sparkles className="w-4 h-4 text-yellow-400" aria-hidden="true" /> {t('profile.languages')}</h3>
-              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?${new URLSearchParams({ i: user.skills_languages, theme: 'dark' })}`} alt="Languages" className="h-12" /></a>
+              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?${new URLSearchParams({ i: user.skills_languages, theme: 'dark' })}`} alt="Languages" referrerPolicy="no-referrer" className="h-12" /></a>
             </div>
           )}
           {user.skills_frameworks && (
             <div>
               <h3 className="text-sm font-semibold text-gray-300 mb-3 flex items-center gap-2"><Rocket className="w-4 h-4 text-blue-400" aria-hidden="true" /> {t('profile.frameworks')}</h3>
-              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?${new URLSearchParams({ i: user.skills_frameworks, theme: 'dark' })}`} alt="Frameworks" className="h-12" /></a>
+              <a href="https://skillicons.dev" target="_blank" rel="noopener noreferrer"><img src={`https://skillicons.dev/icons?${new URLSearchParams({ i: user.skills_frameworks, theme: 'dark' })}`} alt="Frameworks" referrerPolicy="no-referrer" className="h-12" /></a>
             </div>
           )}
         </div>


### PR DESCRIPTION
## 概要
- 外部サービスから画像を読み込む全imgタグに`referrerPolicy="no-referrer"`を追加
- ユーザーの閲覧ページURLがreferrerヘッダーとして外部に漏洩するのを防止

## 対象コンポーネント（計11箇所）
- `Avatar.tsx` — ユーザーアバター（GitHub等）
- `ShareableProfileCard.tsx` — プロフィールカードのアバター
- `SpotifyNowPlaying.tsx` — Spotifyアルバム画像（2箇所）
- `YouTubeVideoCard.tsx` — YouTubeサムネイル
- `BookReviewCard.tsx` — 書籍カバー画像
- `ProjectCard.tsx` — プロジェクト画像
- `OnboardingSkillsStep.tsx` — skillicons.devプレビュー（2箇所）
- `ProfilePage.tsx` — skillicons.devアイコン（2箇所）

## テスト
- `npx tsc --noEmit` 型チェック通過

Closes #1445