### PR TITLE
refactor: StarRatingコンポーネントの共通化

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewCard.tsx
+++ b/frontend/src/components/bookReviews/BookReviewCard.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { BookReview, ReviewStatus } from '../../types/bookReview';
 import Avatar from '../common/Avatar';
+import StarRating from '../common/StarRating';
 import { cardClass } from '../../constants/styles';
 
 const statusColors: Record<ReviewStatus, string> = {
@@ -32,24 +33,6 @@ export default function BookReviewCard({
   showUser = true,
 }: BookReviewCardProps) {
   const { t } = useTranslation();
-
-  const renderStars = (rating: number) => {
-    return (
-      <div className="flex gap-0.5">
-        {[1, 2, 3, 4, 5].map((star) => (
-          <svg
-            key={star}
-            className={`w-4 h-4 ${star <= rating ? 'text-yellow-400' : 'text-gray-600'}`}
-            fill="currentColor"
-            viewBox="0 0 20 20"
-            aria-hidden="true"
-          >
-            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-          </svg>
-        ))}
-      </div>
-    );
-  };
 
   return (
     <div className={cardClass}>
@@ -102,7 +85,7 @@ export default function BookReviewCard({
 
           {/* Status & Rating */}
           <div className="mt-2 flex items-center gap-3">
-            {renderStars(review.rating)}
+            <StarRating rating={review.rating} />
             {review.status && (
               <span className={`text-xs px-2 py-0.5 rounded-full ${statusColors[review.status]}`}>
                 {t(`bookReviews.status.${review.status}`)}

--- a/frontend/src/components/bookReviews/BookReviewForm.tsx
+++ b/frontend/src/components/bookReviews/BookReviewForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { BookReview, CreateBookReviewRequest } from '../../types/bookReview';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
+import StarRating from '../common/StarRating';
 
 interface BookReviewFormProps {
   review?: BookReview;
@@ -29,31 +30,6 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
       review: reviewText,
       image_url: imageUrl,
     });
-  };
-
-  const renderStarInput = () => {
-    return (
-      <div className="flex gap-1">
-        {[1, 2, 3, 4, 5].map((star) => (
-          <button
-            key={star}
-            type="button"
-            onClick={() => setRating(star)}
-            className="focus:outline-none"
-          >
-            <svg
-              className={`w-8 h-8 transition-colors ${
-                star <= rating ? 'text-yellow-400' : 'text-gray-600 hover:text-gray-500'
-              }`}
-              fill="currentColor"
-              viewBox="0 0 20 20"
-            >
-              <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-            </svg>
-          </button>
-        ))}
-      </div>
-    );
   };
 
   return (
@@ -112,7 +88,7 @@ export default function BookReviewForm({ review, onSubmit, onCancel, loading }: 
         <label className="block text-sm font-medium text-gray-300 mb-2">
           {t('bookReviews.rating')} *
         </label>
-        {renderStarInput()}
+        <StarRating rating={rating} onChange={setRating} size="lg" />
       </div>
 
       {/* Review */}

--- a/frontend/src/components/common/StarRating.tsx
+++ b/frontend/src/components/common/StarRating.tsx
@@ -1,0 +1,58 @@
+const STAR_PATH = 'M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z';
+
+const sizeClasses = {
+  sm: 'w-4 h-4',
+  md: 'w-6 h-6',
+  lg: 'w-8 h-8',
+};
+
+interface StarRatingProps {
+  rating: number;
+  onChange?: (rating: number) => void;
+  size?: 'sm' | 'md' | 'lg';
+}
+
+export default function StarRating({ rating, onChange, size = 'sm' }: StarRatingProps) {
+  const iconClass = sizeClasses[size];
+
+  if (onChange) {
+    return (
+      <div className="flex gap-1">
+        {[1, 2, 3, 4, 5].map((star) => (
+          <button
+            key={star}
+            type="button"
+            onClick={() => onChange(star)}
+            className="focus:outline-none"
+          >
+            <svg
+              className={`${iconClass} transition-colors ${
+                star <= rating ? 'text-yellow-400' : 'text-gray-600 hover:text-gray-500'
+              }`}
+              fill="currentColor"
+              viewBox="0 0 20 20"
+            >
+              <path d={STAR_PATH} />
+            </svg>
+          </button>
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-0.5">
+      {[1, 2, 3, 4, 5].map((star) => (
+        <svg
+          key={star}
+          className={`${iconClass} ${star <= rating ? 'text-yellow-400' : 'text-gray-600'}`}
+          fill="currentColor"
+          viewBox="0 0 20 20"
+          aria-hidden="true"
+        >
+          <path d={STAR_PATH} />
+        </svg>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
- BookReviewCardとBookReviewFormで重複していた星形レーティングUIを`StarRating`共通コンポーネントに統合
- 同一SVGパスの重複を排除し、45行削減

## StarRating仕様
- `rating`: 表示する星の数（1-5）
- `onChange`: 設定すると星がクリック可能（インタラクティブモード）
- `size`: sm/md/lg（デフォルトsm）
- onChangeなしの場合は読み取り専用（aria-hidden付き）

## テスト
- `npx tsc --noEmit` 型チェック通過

Closes #1449