### PR TITLE
fix: 名前入力フィールドにautocomplete属性追加

### DIFF
--- a/frontend/src/components/onboarding/OnboardingProfileStep.tsx
+++ b/frontend/src/components/onboarding/OnboardingProfileStep.tsx
@@ -37,6 +37,7 @@ export default function OnboardingProfileStep({
           <label className={labelClass}>{t('settings.name')}</label>
           <input
             type="text"
+            autoComplete="name"
             value={name}
             onChange={handleNameChange}
             placeholder={t('onboarding.namePlaceholder')}

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -100,6 +100,7 @@ export default function RegisterPage() {
               <input
                 id="register-name"
                 type="text"
+                autoComplete="name"
                 value={name}
                 onChange={handleNameChange}
                 required

--- a/frontend/src/pages/settings/ProfileSection.tsx
+++ b/frontend/src/pages/settings/ProfileSection.tsx
@@ -23,7 +23,7 @@ export default function ProfileSection({ name, setName, bio, setBio, avatarUrl, 
       <div className="p-6 space-y-4">
         <div>
           <label htmlFor="profile-name" className={labelClass}>{t('settings.name')}</label>
-          <input id="profile-name" type="text" value={name} onChange={(e) => setName(e.target.value)} maxLength={50} className={inputClass} />
+          <input id="profile-name" type="text" autoComplete="name" value={name} onChange={(e) => setName(e.target.value)} maxLength={50} className={inputClass} />
         </div>
         <div>
           <label htmlFor="profile-bio" className={labelClass}>{t('settings.bio')}</label>


### PR DESCRIPTION
## 概要
- 名前入力フィールドに`autocomplete="name"`を追加してブラウザのオートコンプリート対応を改善

## 対象ファイル
- `RegisterPage.tsx` — 登録フォームの名前フィールド
- `ProfileSection.tsx` — プロフィール設定の名前フィールド
- `OnboardingProfileStep.tsx` — オンボーディングの名前フィールド

## テスト
- `npx tsc --noEmit` 型チェック通過

Closes #1453