### PR TITLE
feat: タイトル入力フィールドに文字数カウンター追加

### DIFF
--- a/frontend/src/components/notes/NoteFormPanel.tsx
+++ b/frontend/src/components/notes/NoteFormPanel.tsx
@@ -49,6 +49,7 @@ export default function NoteFormPanel({
             className="w-full px-4 py-2 bg-gray-900 border border-gray-700 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-transparent"
             required
           />
+          <p className="text-xs text-gray-500 text-right mt-1">{title.length}/200</p>
         </div>
         <div>
           <label htmlFor="note-content" className="block text-sm font-medium mb-2">{t('notes.noteContent')}</label>

--- a/frontend/src/components/posts/PostForm.tsx
+++ b/frontend/src/components/posts/PostForm.tsx
@@ -87,6 +87,7 @@ export default function PostForm({ post, onSubmit, onCancel, loading: externalLo
         maxLength={300}
         className={inputClass}
       />
+      <p className="text-xs text-gray-500 text-right mt-1">{title.length}/300</p>
       {expanded && (
         <>
           <div className="mt-3">

--- a/frontend/src/components/qa/QuestionForm.tsx
+++ b/frontend/src/components/qa/QuestionForm.tsx
@@ -51,6 +51,7 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
           className={inputClass}
           placeholder={t('qa.questionTitlePlaceholder')}
         />
+        <p className="text-xs text-gray-500 text-right mt-1">{title.length}/500</p>
       </div>
 
       {/* Body */}


### PR DESCRIPTION
## 概要
- タイトル入力フィールドにリアルタイム文字数カウンターを追加

## 対象フォーム
- `PostForm.tsx` — 投稿タイトル（0/300）
- `QuestionForm.tsx` — 質問タイトル（0/500）
- `NoteFormPanel.tsx` — ノートタイトル（0/200）

## テスト
- `npx tsc --noEmit` 型チェック通過

Closes #1455