### PR TITLE
refactor: URL検証ロジックをfindInvalidUrlField関数に共通化

### DIFF
--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { Project, CreateProjectRequest } from '../../types/project';
 import type { GitHubRepository } from '../../types/github';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
-import { isHttpUrl } from '../../utils/url';
+import { findInvalidUrlField } from '../../utils/url';
 import TagInput from '../common/TagInput';
 import toast from 'react-hot-toast';
 
@@ -53,16 +53,14 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const urlFields = [
+    const invalidField = findInvalidUrlField([
       { value: demoUrl, label: t('projects.demoUrl') },
       { value: githubUrl, label: t('projects.githubUrl') },
       { value: imageUrl, label: t('projects.imageUrl') },
-    ];
-    for (const field of urlFields) {
-      if (field.value && !isHttpUrl(field.value)) {
-        toast.error(t('common.invalidUrl', { field: field.label }));
-        return;
-      }
+    ]);
+    if (invalidField) {
+      toast.error(t('common.invalidUrl', { field: invalidField }));
+      return;
     }
     await onSubmit({
       title,

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LearningResource, CreateResourceRequest, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
-import { isHttpUrl } from '../../utils/url';
+import { findInvalidUrlField } from '../../utils/url';
 import TagInput from '../common/TagInput';
 import toast from 'react-hot-toast';
 
@@ -38,15 +38,13 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    const urlFields = [
+    const invalidField = findInvalidUrlField([
       { value: url, label: t('resources.url') },
       { value: imageUrl, label: t('resources.imageUrl') },
-    ];
-    for (const field of urlFields) {
-      if (field.value && !isHttpUrl(field.value)) {
-        toast.error(t('common.invalidUrl', { field: field.label }));
-        return;
-      }
+    ]);
+    if (invalidField) {
+      toast.error(t('common.invalidUrl', { field: invalidField }));
+      return;
     }
     await onSubmit({
       title,

--- a/frontend/src/utils/url.ts
+++ b/frontend/src/utils/url.ts
@@ -20,3 +20,18 @@ export function sanitizeUrl(url: string | undefined): string | undefined {
   if (!url) return undefined;
   return isHttpUrl(url) ? url : undefined;
 }
+
+/**
+ * URLフィールド配列を検証し、不正なURLがあればエラーメッセージを返す。
+ * 全て有効ならnullを返す。
+ */
+export function findInvalidUrlField(
+  fields: { value: string; label: string }[],
+): string | null {
+  for (const field of fields) {
+    if (field.value && !isHttpUrl(field.value)) {
+      return field.label;
+    }
+  }
+  return null;
+}


### PR DESCRIPTION
## 概要
- ProjectFormとResourceFormで重複していたURL検証パターンを`findInvalidUrlField`関数に抽出
- forループ+isHttpUrl+toast.errorの重複を排除

## 変更内容
- `utils/url.ts`: `findInvalidUrlField`関数を追加（URLフィールド配列を検証し不正なフィールド名を返す）
- `ProjectForm.tsx`: 重複コードを`findInvalidUrlField`呼び出しに置換
- `ResourceForm.tsx`: 同上

## テスト
- `npx tsc --noEmit` 型チェック通過

Closes #1457