### PR TITLE
test: findInvalidUrlField関数のユニットテスト追加

### DIFF
--- a/frontend/src/utils/__tests__/url.test.ts
+++ b/frontend/src/utils/__tests__/url.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { isHttpUrl, sanitizeUrl } from '../url';
+import { isHttpUrl, sanitizeUrl, findInvalidUrlField } from '../url';
 
 describe('isHttpUrl', () => {
   it('https URLを許可する', () => {
@@ -51,5 +51,39 @@ describe('sanitizeUrl', () => {
 
   it('空文字列に対してundefinedを返す', () => {
     expect(sanitizeUrl('')).toBeUndefined();
+  });
+});
+
+describe('findInvalidUrlField', () => {
+  it('全て有効なURLの場合nullを返す', () => {
+    expect(findInvalidUrlField([
+      { value: 'https://example.com', label: 'Demo URL' },
+      { value: 'https://github.com/repo', label: 'GitHub URL' },
+    ])).toBeNull();
+  });
+
+  it('不正なURLがある場合そのラベルを返す', () => {
+    expect(findInvalidUrlField([
+      { value: 'https://example.com', label: 'Demo URL' },
+      { value: 'not-a-url', label: 'GitHub URL' },
+    ])).toBe('GitHub URL');
+  });
+
+  it('空の値はスキップする', () => {
+    expect(findInvalidUrlField([
+      { value: '', label: 'Demo URL' },
+      { value: 'https://example.com', label: 'GitHub URL' },
+    ])).toBeNull();
+  });
+
+  it('空配列の場合nullを返す', () => {
+    expect(findInvalidUrlField([])).toBeNull();
+  });
+
+  it('最初の不正URLのラベルを返す', () => {
+    expect(findInvalidUrlField([
+      { value: 'invalid1', label: 'Field A' },
+      { value: 'invalid2', label: 'Field B' },
+    ])).toBe('Field A');
   });
 });


### PR DESCRIPTION
## 概要
- findInvalidUrlField関数の動作を検証する5テストケースを既存のurl.test.tsに追加

## テスト内容
- 全URL有効時にnull返却
- 不正URL検出時にラベル返却
- 空値のスキップ
- 空配列でnull返却
- 複数不正URLで最初のラベル返却

## 結果
- 17テスト全て通過（既存12+新規5）

Closes #1459