### PR TITLE
fix: クリップボードAPI使用箇所にtry-catchフォールバック追加

### DIFF
--- a/frontend/src/components/posts/CodeSnippetViewer.tsx
+++ b/frontend/src/components/posts/CodeSnippetViewer.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
 import { Copy, Check, MessageSquarePlus } from 'lucide-react';
 import { useSnippetComments } from '../../hooks';
 import type { CodeSnippet } from '../../types/post';
@@ -24,11 +25,15 @@ export default function CodeSnippetViewer({ snippet, showComments = true }: Code
     showComments ? snippet.id : 0
   );
 
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(snippet.code);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  }, [snippet.code]);
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(snippet.code);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  }, [snippet.code, t]);
 
   const handleAddComment = async () => {
     if (!commentText.trim() || commentLine === null) return;

--- a/frontend/src/components/profile/PortfolioModal.tsx
+++ b/frontend/src/components/profile/PortfolioModal.tsx
@@ -51,8 +51,12 @@ export default function PortfolioModal({
   };
 
   const handleCopyHTML = async () => {
-    await navigator.clipboard.writeText(html);
-    toast.success(t('portfolio.copied'));
+    try {
+      await navigator.clipboard.writeText(html);
+      toast.success(t('portfolio.copied'));
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
   };
 
   const handleOpenInNewTab = () => {


### PR DESCRIPTION
## 概要
- クリップボードAPI（navigator.clipboard.writeText）の呼び出しにエラーハンドリングを追加
- API未対応環境やHTTP接続時の失敗に対して適切なエラートーストを表示

## 対象ファイル
- `CodeSnippetViewer.tsx` — コードコピーボタン（try-catch追加+toast.error）
- `PortfolioModal.tsx` — HTMLコピーボタン（try-catch追加+toast.error）

## テスト
- `npx tsc --noEmit` 型チェック通過

Closes #1461