### PR TITLE
feat: 通知ページに未読/全件カウントサマリー追加

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -517,6 +517,7 @@
     "deleteNotification": "Benachrichtigung löschen",
     "filterGroup": "Benachrichtigungsfilter",
     "listLabel": "Benachrichtigungsliste",
+    "countSummary": "{{unread}} ungelesen / {{total}} gesamt",
     "deleted": "Benachrichtigung gelöscht",
     "levelUp": "Sie haben Stufe {{level}} erreicht!",
     "filterLevel": "Aufgestiegen"

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -517,6 +517,7 @@
     "deleteNotification": "Delete notification",
     "filterGroup": "Notification filters",
     "listLabel": "Notification list",
+    "countSummary": "{{unread}} unread / {{total}} total",
     "deleted": "Notification deleted",
     "levelUp": "You reached Level {{level}}!",
     "filterLevel": "Level Up"

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -517,6 +517,7 @@
     "deleteNotification": "Eliminar notificación",
     "filterGroup": "Filtros de notificación",
     "listLabel": "Lista de notificaciones",
+    "countSummary": "{{unread}} no leídas / {{total}} en total",
     "deleted": "Notificación eliminada",
     "levelUp": "¡Has alcanzado el Nivel {{level}}!",
     "filterLevel": "Subida de Nivel"

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -517,6 +517,7 @@
     "deleteNotification": "Supprimer la notification",
     "filterGroup": "Filtres de notification",
     "listLabel": "Liste des notifications",
+    "countSummary": "{{unread}} non lues / {{total}} au total",
     "deleted": "Notification supprimée",
     "levelUp": "Vous avez atteint le Niveau {{level}} !",
     "filterLevel": "Niveau Supérieur"

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -510,6 +510,7 @@
     "deleteNotification": "通知を削除",
     "filterGroup": "通知フィルター",
     "listLabel": "通知一覧",
+    "countSummary": "未読 {{unread}}件 / 全{{total}}件",
     "deleted": "通知を削除しました",
     "levelUp": "レベル {{level}} に到達しました！",
     "filterLevel": "レベルアップ"

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -517,6 +517,7 @@
     "deleteNotification": "알림 삭제",
     "filterGroup": "알림 필터",
     "listLabel": "알림 목록",
+    "countSummary": "읽지 않음 {{unread}}건 / 전체 {{total}}건",
     "deleted": "알림이 삭제되었습니다",
     "levelUp": "레벨 {{level}}에 도달했습니다!",
     "filterLevel": "레벨 업"

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -517,6 +517,7 @@
     "deleteNotification": "Excluir notificação",
     "filterGroup": "Filtros de notificação",
     "listLabel": "Lista de notificações",
+    "countSummary": "{{unread}} não lidas / {{total}} no total",
     "deleted": "Notificação excluída",
     "levelUp": "Você alcançou o Nível {{level}}!",
     "filterLevel": "Subida de Nível"

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -517,6 +517,7 @@
     "deleteNotification": "Удалить уведомление",
     "filterGroup": "Фильтры уведомлений",
     "listLabel": "Список уведомлений",
+    "countSummary": "{{unread}} непрочитанных / {{total}} всего",
     "deleted": "Уведомление удалено",
     "levelUp": "Вы достигли уровня {{level}}!",
     "filterLevel": "Повышение уровня"

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -517,6 +517,7 @@
     "deleteNotification": "删除通知",
     "filterGroup": "通知筛选",
     "listLabel": "通知列表",
+    "countSummary": "未读 {{unread}}条 / 共{{total}}条",
     "deleted": "通知已删除",
     "levelUp": "已达到等级 {{level}}！",
     "filterLevel": "升级"

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -517,6 +517,7 @@
     "deleteNotification": "刪除通知",
     "filterGroup": "通知篩選",
     "listLabel": "通知列表",
+    "countSummary": "未讀 {{unread}}則 / 共{{total}}則",
     "deleted": "通知已刪除",
     "levelUp": "已達到等級 {{level}}！",
     "filterLevel": "升級"

--- a/frontend/src/pages/NotificationsPage.tsx
+++ b/frontend/src/pages/NotificationsPage.tsx
@@ -53,6 +53,12 @@ export default function NotificationsPage() {
         onToggleUnreadOnly={handleToggleUnreadOnly}
       />
 
+      {!loading && total > 0 && (
+        <p className="text-sm text-gray-400 mb-3">
+          {t('notifications.countSummary', { unread: unreadCount, total })}
+        </p>
+      )}
+
       {loading ? (
         <div className="flex justify-center items-center min-h-[400px]">
           <LoadingSpinner />


### PR DESCRIPTION
## 概要
- NotificationsPageのフィルター下部に「未読X件 / 全Y件」のカウントサマリーを表示
- 通知整理時にユーザーが未読状況を一目で把握可能に

## 変更内容
- `NotificationsPage.tsx`: loading完了後かつ通知がある場合にサマリーを表示
- 10言語に`notifications.countSummary`キーを追加

## テスト
- `npx tsc --noEmit` 型チェック通過

Closes #1463