### PR TITLE
refactor: JSONパースのtry-catchパターンをparseJsonArrayユーティリティに共通化

### DIFF
--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -4,6 +4,7 @@ import type { Post } from '../../types/post';
 import Avatar from '../common/Avatar';
 import { format } from 'date-fns';
 import { cardDarkClass } from '../../constants/styles';
+import { parseJsonArray } from '../../utils/json';
 import PostCardContent from './PostCardContent';
 import PostCardActions from './PostCardActions';
 
@@ -18,14 +19,7 @@ interface PostCardProps {
 export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUpdate }: PostCardProps) {
   const { t } = useTranslation();
 
-  let imageUrls: string[] = [];
-  try {
-    if (post.image_urls) {
-      imageUrls = JSON.parse(post.image_urls);
-    }
-  } catch {
-    // ignore parse error
-  }
+  const imageUrls = parseJsonArray(post.image_urls);
 
   return (
     <div className={cardDarkClass}>

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import type { Project } from '../../types/project';
 import { cardClass } from '../../constants/styles';
+import { parseJsonArray } from '../../utils/json';
 import { sanitizeUrl } from '../../utils/url';
 
 interface ProjectCardProps {
@@ -13,7 +14,7 @@ interface ProjectCardProps {
 export default function ProjectCard({ project, onEdit, onDelete, isOwner }: ProjectCardProps) {
   const { t } = useTranslation();
 
-  const techStack = project.tech_stack ? JSON.parse(project.tech_stack) : [];
+  const techStack = parseJsonArray(project.tech_stack);
 
   const formatDate = (dateStr: string | null) => {
     if (!dateStr) return null;

--- a/frontend/src/components/resources/ResourceCard.tsx
+++ b/frontend/src/components/resources/ResourceCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin, type LucideIcon } from 'lucide-react';
 import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../../types/resource';
+import { parseJsonArray } from '../../utils/json';
 import Avatar from '../common/Avatar';
 import { cardClass } from '../../constants/styles';
 import { sanitizeUrl } from '../../utils/url';
@@ -57,7 +58,7 @@ export default function ResourceCard({
   const [likeCount, setLikeCount] = useState(resource.like_count);
   const [saveCount, setSaveCount] = useState(resource.save_count);
 
-  const tags = resource.tags ? JSON.parse(resource.tags) : [];
+  const tags = parseJsonArray(resource.tags);
 
   const handleLike = () => {
     if (liked) {

--- a/frontend/src/utils/json.ts
+++ b/frontend/src/utils/json.ts
@@ -1,0 +1,8 @@
+export function parseJsonArray<T = string>(json: string | undefined | null): T[] {
+  if (!json) return [];
+  try {
+    return JSON.parse(json);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## 概要
- `utils/json.ts`に`parseJsonArray<T>`ユーティリティ関数を作成
- PostCard、ProjectCard、ResourceCardの重複JSON.parseパターンを`parseJsonArray`呼び出しに置換
- try-catchなしの危険なJSON.parse使用箇所（ProjectCard、ResourceCard）にもエラーハンドリングが追加される

## テスト計画
- [x] TypeScript型チェック通過
- [x] 既存の表示動作に影響なし

closes #1473