### PR TITLE
feat: MarkdownEditorに文字数カウンター追加

### DIFF
--- a/frontend/src/components/posts/MarkdownEditor.tsx
+++ b/frontend/src/components/posts/MarkdownEditor.tsx
@@ -306,6 +306,7 @@ export default function MarkdownEditor({
       <div className="border-t border-gray-700 px-4 py-2 text-xs text-gray-500 flex items-center gap-4">
         <span>{t('editor.markdownSupported')}</span>
         <span>{t('editor.pasteOrDragImages')}</span>
+        <span className="ml-auto">{value.length.toLocaleString()} / 10,000</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## 概要
- MarkdownEditorのフッター（ヒント行）に現在の文字数/上限10,000の表示を追加
- ユーザーが投稿作成中に残り文字数を把握できるようになる

## テスト計画
- [x] TypeScript型チェック通過
- [x] エディタフッターに文字数が正しく表示される

closes #1479