### PR TITLE
refactor: RoomSettingsModalのメンバー管理セクションをChatRoomMemberSectionに分離

### DIFF
--- a/frontend/src/components/chat/ChatRoomMemberSection.tsx
+++ b/frontend/src/components/chat/ChatRoomMemberSection.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { UserPlus, UserMinus } from 'lucide-react';
+import type { User } from '../../types/user';
+import type { ChatRoomMember } from '../../types/chat';
+import Avatar from '../common/Avatar';
+
+interface ChatRoomMemberSectionProps {
+  members: ChatRoomMember[];
+  availableUsers: User[];
+  isOwner: boolean;
+  currentUserId: number;
+  ownerUserId: number;
+  onAddMember: (userId: number) => void;
+  onRemoveMember: (userId: number) => void;
+}
+
+export default function ChatRoomMemberSection({
+  members,
+  availableUsers,
+  isOwner,
+  currentUserId,
+  ownerUserId,
+  onAddMember,
+  onRemoveMember,
+}: ChatRoomMemberSectionProps) {
+  const { t } = useTranslation();
+  const [showAddMember, setShowAddMember] = useState(false);
+
+  return (
+    <div className="mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <h3 className="text-sm font-medium text-gray-300">
+          {t('chat.members')} ({members.length})
+        </h3>
+        <button
+          onClick={() => setShowAddMember(!showAddMember)}
+          className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+        >
+          <UserPlus className="w-3.5 h-3.5" />
+          {t('chat.addMember')}
+        </button>
+      </div>
+
+      {/* Add Member List */}
+      {showAddMember && availableUsers.length > 0 && (
+        <div className="mb-3 p-2 bg-gray-700/50 rounded-lg space-y-1">
+          {availableUsers.map((user) => (
+            <button
+              key={user.id}
+              onClick={() => onAddMember(user.id)}
+              className="w-full flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-600 transition-colors"
+            >
+              <Avatar name={user.name} avatarUrl={user.avatar_url} size="xs" />
+              <span className="text-sm text-white">{user.name}</span>
+              <UserPlus className="w-3.5 h-3.5 text-green-400 ml-auto" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Member List */}
+      <div className="space-y-1">
+        {members.map((member) => (
+          <div
+            key={member.id}
+            className="flex items-center gap-3 px-2 py-2 rounded-lg"
+          >
+            <Avatar
+              name={member.user?.name || ''}
+              avatarUrl={member.user?.avatar_url}
+              size="sm"
+            />
+            <div className="flex-1 min-w-0">
+              <div className="text-sm text-white">{member.user?.name}</div>
+              {member.user_id === ownerUserId && (
+                <span className="text-xs text-yellow-400">{t('chat.owner')}</span>
+              )}
+            </div>
+            {isOwner && member.user_id !== currentUserId && (
+              <button
+                onClick={() => onRemoveMember(member.user_id)}
+                className="p-1 text-gray-500 hover:text-red-400 transition-colors"
+                title={t('chat.removeMember')}
+              >
+                <UserMinus className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/chat/RoomSettingsModal.tsx
+++ b/frontend/src/components/chat/RoomSettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, UserPlus, UserMinus, LogOut, Trash2 } from 'lucide-react';
+import { X, LogOut, Trash2 } from 'lucide-react';
 import toast from 'react-hot-toast';
 import {
   getChatRoomMembers, updateChatRoom, deleteChatRoom,
@@ -10,8 +10,8 @@ import { inputClass, labelClass, textareaClass, buttonPrimaryClass } from '../..
 import { useConfirm } from '../../hooks';
 import type { User } from '../../types/user';
 import type { ChatRoom, ChatRoomMember } from '../../types/chat';
-import Avatar from '../common/Avatar';
 import ConfirmDialog from '../common/ConfirmDialog';
+import ChatRoomMemberSection from './ChatRoomMemberSection';
 
 interface Props {
   room: ChatRoom;
@@ -31,7 +31,6 @@ export default function RoomSettingsModal({
   const [members, setMembers] = useState<ChatRoomMember[]>([]);
   const [name, setName] = useState(room.name);
   const [description, setDescription] = useState(room.description);
-  const [showAddMember, setShowAddMember] = useState(false);
   const [loading, setLoading] = useState(false);
   const { confirm, dialogProps } = useConfirm();
 
@@ -158,68 +157,15 @@ export default function RoomSettingsModal({
         )}
 
         {/* Members */}
-        <div className="mb-6">
-          <div className="flex items-center justify-between mb-3">
-            <h3 className="text-sm font-medium text-gray-300">
-              {t('chat.members')} ({members.length})
-            </h3>
-            <button
-              onClick={() => setShowAddMember(!showAddMember)}
-              className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
-            >
-              <UserPlus className="w-3.5 h-3.5" />
-              {t('chat.addMember')}
-            </button>
-          </div>
-
-          {/* Add Member List */}
-          {showAddMember && availableUsers.length > 0 && (
-            <div className="mb-3 p-2 bg-gray-700/50 rounded-lg space-y-1">
-              {availableUsers.map((user) => (
-                <button
-                  key={user.id}
-                  onClick={() => handleAddMember(user.id)}
-                  className="w-full flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-600 transition-colors"
-                >
-                  <Avatar name={user.name} avatarUrl={user.avatar_url} size="xs" />
-                  <span className="text-sm text-white">{user.name}</span>
-                  <UserPlus className="w-3.5 h-3.5 text-green-400 ml-auto" />
-                </button>
-              ))}
-            </div>
-          )}
-
-          {/* Member List */}
-          <div className="space-y-1">
-            {members.map((member) => (
-              <div
-                key={member.id}
-                className="flex items-center gap-3 px-2 py-2 rounded-lg"
-              >
-                <Avatar
-                  name={member.user?.name || ''}
-                  avatarUrl={member.user?.avatar_url}
-                  size="sm"
-                />
-                <div className="flex-1 min-w-0">
-                  <div className="text-sm text-white">{member.user?.name}</div>
-                  {member.user_id === room.owner_id && (
-                    <span className="text-xs text-yellow-400">{t('chat.owner')}</span>
-                  )}
-                </div>
-                {isOwner && member.user_id !== currentUserId && (
-                  <button
-                    onClick={() => handleRemoveMember(member.user_id)}
-                    className="p-1 text-gray-500 hover:text-red-400 transition-colors"
-                    title={t('chat.removeMember')}
-                  >
-                    <UserMinus className="w-4 h-4" />
-                  </button>
-                )}
-              </div>
-            ))}
-          </div>
-        </div>
+        <ChatRoomMemberSection
+          members={members}
+          availableUsers={availableUsers}
+          isOwner={isOwner}
+          currentUserId={currentUserId}
+          ownerUserId={room.owner_id}
+          onAddMember={handleAddMember}
+          onRemoveMember={handleRemoveMember}
+        />
 
         {/* Actions */}
         <div className="space-y-2 border-t border-gray-700 pt-4">


### PR DESCRIPTION
## 概要
- RoomSettingsModal.tsx（249行）からメンバー管理UI（メンバー一覧・追加・削除）をChatRoomMemberSection.tsx（98行）に分離
- RoomSettingsModalは249→184行に削減（65行削減）

## テスト計画
- [x] TypeScript型チェック通過
- [x] メンバー一覧表示・追加・削除の動作に影響なし

closes #1481