### PR TITLE
feat: QuickPostFormにCtrl+Enter送信ショートカット追加

### DIFF
--- a/frontend/src/components/posts/QuickPostForm.tsx
+++ b/frontend/src/components/posts/QuickPostForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Send, FileText, Check, Clock } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
@@ -63,6 +63,15 @@ export default function QuickPostForm({ onSubmit }: QuickPostFormProps) {
     }
   };
 
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      if (content.trim() && !isSubmitting) {
+        handleSubmit(false);
+      }
+    }
+  }, [content, isSubmitting]);
+
   // 保存状態の表示テキスト
   const getSaveStatusText = () => {
     if (saveStatus === 'saving') return t('post.saving');
@@ -107,6 +116,7 @@ export default function QuickPostForm({ onSubmit }: QuickPostFormProps) {
             value={content}
             onChange={(e) => setContent(e.target.value)}
             onFocus={() => setIsFocused(true)}
+            onKeyDown={handleKeyDown}
             placeholder={t('post.createTitle')}
             maxLength={5000}
             className={`w-full bg-gray-800/50 border border-gray-700 rounded-lg px-4 py-3 text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none transition-all ${
@@ -119,7 +129,7 @@ export default function QuickPostForm({ onSubmit }: QuickPostFormProps) {
             <div className="mt-3 flex items-center justify-between animate-in fade-in duration-200">
               <div className="flex items-center gap-2">
                 <p className="text-xs text-gray-500">
-                  {t('post.markdownSupported')}
+                  {t('post.markdownSupported')} · {t('post.submitShortcut')}
                 </p>
                 {/* 保存状態の表示 */}
                 {saveStatus !== 'idle' && (

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -176,6 +176,7 @@
     "reply": "Antworten",
     "share": "Teilen",
     "markdownSupported": "Unterstützt **fett**, *kursiv*, `code`, und mehr",
+    "submitShortcut": "Strg+Enter zum Posten",
     "write": "Schreiben",
     "preview": "Vorschau",
     "nothingToPreview": "Nichts zum Vorschauen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -176,6 +176,7 @@
     "reply": "Reply",
     "share": "Share",
     "markdownSupported": "Supports **bold**, *italic*, `code`, and more",
+    "submitShortcut": "Ctrl+Enter to post",
     "write": "Write",
     "preview": "Preview",
     "nothingToPreview": "Nothing to preview",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -176,6 +176,7 @@
     "reply": "Responder",
     "share": "Compartir",
     "markdownSupported": "Soporta **negrita**, *cursiva*, `código`, y más",
+    "submitShortcut": "Ctrl+Enter para publicar",
     "write": "Escribir",
     "preview": "Vista previa",
     "nothingToPreview": "Nada que previsualizar",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -176,6 +176,7 @@
     "reply": "Répondre",
     "share": "Partager",
     "markdownSupported": "Supporte **gras**, *italique*, `code`, et plus",
+    "submitShortcut": "Ctrl+Entrée pour publier",
     "write": "Écrire",
     "preview": "Aperçu",
     "nothingToPreview": "Rien à prévisualiser",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -177,6 +177,7 @@
     "reply": "返信",
     "share": "共有",
     "markdownSupported": "**太字**、*斜体*、`コード`などに対応",
+    "submitShortcut": "Ctrl+Enterで投稿",
     "write": "編集",
     "preview": "プレビュー",
     "nothingToPreview": "プレビューするものがありません",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -176,6 +176,7 @@
     "reply": "답글",
     "share": "공유",
     "markdownSupported": "**굵게**, *기울임*, `코드` 등 지원",
+    "submitShortcut": "Ctrl+Enter로 게시",
     "write": "작성",
     "preview": "미리보기",
     "nothingToPreview": "미리볼 내용이 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -176,6 +176,7 @@
     "reply": "Responder",
     "share": "Compartilhar",
     "markdownSupported": "Suporta **negrito**, *itálico*, `código`, e mais",
+    "submitShortcut": "Ctrl+Enter para publicar",
     "write": "Escrever",
     "preview": "Pré-visualizar",
     "nothingToPreview": "Nada para pré-visualizar",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -176,6 +176,7 @@
     "reply": "Ответить",
     "share": "Поделиться",
     "markdownSupported": "Поддерживает **жирный**, *курсив*, `код` и др.",
+    "submitShortcut": "Ctrl+Enter для публикации",
     "write": "Писать",
     "preview": "Предпросмотр",
     "nothingToPreview": "Нечего показывать",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -176,6 +176,7 @@
     "reply": "回复",
     "share": "分享",
     "markdownSupported": "支持 **粗体**、*斜体*、`代码` 等",
+    "submitShortcut": "Ctrl+Enter发布",
     "write": "编辑",
     "preview": "预览",
     "nothingToPreview": "没有可预览的内容",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -176,6 +176,7 @@
     "reply": "回覆",
     "share": "分享",
     "markdownSupported": "支援 **粗體**、*斜體*、`程式碼` 等",
+    "submitShortcut": "Ctrl+Enter發布",
     "write": "編輯",
     "preview": "預覽",
     "nothingToPreview": "沒有可預覽的內容",


### PR DESCRIPTION
## 概要
- QuickPostFormのテキストエリアでCtrl+Enter（Mac: Cmd+Enter）を押すと投稿を即送信できるショートカットを追加
- フォーム展開時にショートカットのヒントテキストを表示
- 10言語にsubmitShortcutキー追加

## テスト計画
- [x] TypeScript型チェック通過
- [x] Ctrl+Enterで投稿が送信される
- [x] 内容が空の場合はCtrl+Enterでも送信されない

closes #1487