### PR TITLE
refactor: 残りのJSON.parseパターンをparseJsonArrayに置換

### DIFF
--- a/frontend/src/components/projects/ProjectForm.tsx
+++ b/frontend/src/components/projects/ProjectForm.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { Project, CreateProjectRequest } from '../../types/project';
 import type { GitHubRepository } from '../../types/github';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
+import { parseJsonArray } from '../../utils/json';
 import { findInvalidUrlField } from '../../utils/url';
 import TagInput from '../common/TagInput';
 import toast from 'react-hot-toast';
@@ -20,14 +21,7 @@ export default function ProjectForm({ project, repos = [], onSubmit, onCancel, l
   const [title, setTitle] = useState(project?.title || '');
   const [description, setDescription] = useState(project?.description || '');
   const [techStack, setTechStack] = useState<string[]>(() => {
-    if (project?.tech_stack) {
-      try {
-        return JSON.parse(project.tech_stack);
-      } catch {
-        return [];
-      }
-    }
-    return [];
+    return parseJsonArray(project?.tech_stack);
   });
   const [demoUrl, setDemoUrl] = useState(project?.demo_url || '');
   const [githubUrl, setGithubUrl] = useState(project?.github_url || '');

--- a/frontend/src/components/qa/QuestionCard.tsx
+++ b/frontend/src/components/qa/QuestionCard.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import type { Question } from '../../types/qa';
 import Avatar from '../common/Avatar';
 import { cardPaddedClass } from '../../constants/styles';
+import { parseJsonArray } from '../../utils/json';
 
 interface QuestionCardProps {
   question: Question;
@@ -14,9 +15,7 @@ interface QuestionCardProps {
 export default function QuestionCard({ question, isOwner = false, onEdit, onDelete }: QuestionCardProps) {
   const { t } = useTranslation();
 
-  const tags: string[] = question.tags ? (() => {
-    try { return JSON.parse(question.tags); } catch { return []; }
-  })() : [];
+  const tags = parseJsonArray(question.tags);
 
   const statusBorderClass = question.is_solved
     ? 'border-l-4 border-l-green-500'

--- a/frontend/src/components/resources/ResourceForm.tsx
+++ b/frontend/src/components/resources/ResourceForm.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { LearningResource, CreateResourceRequest, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
+import { parseJsonArray } from '../../utils/json';
 import { findInvalidUrlField } from '../../utils/url';
 import TagInput from '../common/TagInput';
 import toast from 'react-hot-toast';
@@ -23,16 +24,7 @@ export default function ResourceForm({ resource, onSubmit, onCancel, loading }: 
   const [url, setUrl] = useState(resource?.url || '');
   const [category, setCategory] = useState<ResourceCategory>(resource?.category || 'article');
   const [difficulty, setDifficulty] = useState<ResourceDifficulty | ''>(resource?.difficulty || '');
-  const [tags, setTags] = useState<string[]>(() => {
-    if (resource?.tags) {
-      try {
-        return JSON.parse(resource.tags);
-      } catch {
-        return [];
-      }
-    }
-    return [];
-  });
+  const [tags, setTags] = useState<string[]>(() => parseJsonArray(resource?.tags));
   const [imageUrl, setImageUrl] = useState(resource?.image_url || '');
   const [isPublic, setIsPublic] = useState(resource?.is_public ?? true);
 

--- a/frontend/src/pages/QADetailPage.tsx
+++ b/frontend/src/pages/QADetailPage.tsx
@@ -8,6 +8,7 @@ import AnswerCard from '../components/qa/AnswerCard';
 import AnswerForm from '../components/qa/AnswerForm';
 import Avatar from '../components/common/Avatar';
 import { PageLoader } from '../components/common';
+import { parseJsonArray } from '../utils/json';
 
 export default function QADetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -24,9 +25,7 @@ export default function QADetailPage() {
 
   const [editingAnswer, setEditingAnswer] = useState<Answer | null>(null);
 
-  const tags: string[] = question?.tags ? (() => {
-    try { return JSON.parse(question.tags); } catch { return []; }
-  })() : [];
+  const tags = parseJsonArray(question?.tags);
 
   const isQuestionOwner = user?.id === question?.user_id;
 


### PR DESCRIPTION
## 概要
- #1474で作成したparseJsonArray関数の適用を残りの4ファイルに拡大
- QuestionCard、QADetailPage、ProjectForm、ResourceFormの重複JSON.parseパターンを統一
- 合計24行削減、8行追加（16行純減）

## テスト計画
- [x] TypeScript型チェック通過
- [x] 各コンポーネントのタグ・tech_stack表示に影響なし

closes #1489