### PR TITLE
fix: YouTubeVideoCardの画像URLサニタイズ追加

### DIFF
--- a/frontend/src/components/youtube/YouTubeVideoCard.tsx
+++ b/frontend/src/components/youtube/YouTubeVideoCard.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { ExternalLink, Play } from 'lucide-react';
 import type { YouTubeVideo } from '../../types/youtube';
 import { cardClass } from '../../constants/styles';
+import { sanitizeUrl } from '../../utils/url';
 
 interface YouTubeVideoCardProps {
   video: YouTubeVideo;
@@ -16,7 +17,7 @@ export default function YouTubeVideoCard({ video }: YouTubeVideoCardProps) {
     <div className={cardClass}>
       <a href={videoURL} target="_blank" rel="noopener noreferrer" className="block relative group">
         <img
-          src={video.thumbnail_url}
+          src={sanitizeUrl(video.thumbnail_url) ?? ''}
           alt={video.title}
           referrerPolicy="no-referrer"
           className="w-full aspect-video object-cover"


### PR DESCRIPTION
## 概要
YouTubeVideoCardのthumbnail_urlにsanitizeUrl()を適用し、危険なプロトコル（javascript:, data:等）のURLを拒否

## 変更内容
- `video.thumbnail_url` → `sanitizeUrl(video.thumbnail_url) ?? ''`
- 既存のsanitizeUrlユーティリティを再利用

closes #1493