### PR TITLE
feat: AnswerFormにCtrl+Enter送信ショートカット追加

### DIFF
--- a/frontend/src/components/qa/AnswerForm.tsx
+++ b/frontend/src/components/qa/AnswerForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { textareaClass, buttonSecondaryClass } from '../../constants/styles';
 
@@ -22,17 +22,30 @@ export default function AnswerForm({ initialBody = '', onSubmit, onCancel, loadi
     }
   };
 
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+      e.preventDefault();
+      if (body.trim() && !loading) {
+        onSubmit(body).then((success) => {
+          if (success && !isEdit) setBody('');
+        });
+      }
+    }
+  }, [body, loading, onSubmit, isEdit]);
+
   return (
     <form onSubmit={handleSubmit} className="space-y-3">
       <textarea
         value={body}
         onChange={(e) => setBody(e.target.value)}
+        onKeyDown={handleKeyDown}
         required
         rows={isEdit ? 4 : 6}
         maxLength={5000}
         className={textareaClass}
         placeholder={t('qa.answerPlaceholder')}
       />
+      <p className="text-xs text-gray-500">{t('qa.submitShortcut')}</p>
       <div className="flex gap-3 justify-end">
         {onCancel && (
           <button

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -936,6 +936,7 @@
     "postAnswer": "Antwort posten",
     "updateAnswer": "Antwort aktualisieren",
     "answerPlaceholder": "Schreiben Sie Ihre Antwort...",
+    "submitShortcut": "Strg+Enter zum Absenden",
     "answersCount": "Antworten ({{count}})",
     "questionNotFound": "Frage nicht gefunden",
     "backToList": "Zurück zur Liste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -936,6 +936,7 @@
     "postAnswer": "Post Answer",
     "updateAnswer": "Update Answer",
     "answerPlaceholder": "Write your answer...",
+    "submitShortcut": "Press Ctrl+Enter to submit",
     "answersCount": "Answers ({{count}})",
     "questionNotFound": "Question not found",
     "backToList": "Back to list",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -936,6 +936,7 @@
     "postAnswer": "Publicar respuesta",
     "updateAnswer": "Actualizar respuesta",
     "answerPlaceholder": "Escribe tu respuesta...",
+    "submitShortcut": "Ctrl+Enter para enviar",
     "answersCount": "Respuestas ({{count}})",
     "questionNotFound": "Pregunta no encontrada",
     "backToList": "Volver a la lista",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -936,6 +936,7 @@
     "postAnswer": "Publier la réponse",
     "updateAnswer": "Mettre à jour la réponse",
     "answerPlaceholder": "Écrivez votre réponse...",
+    "submitShortcut": "Ctrl+Entrée pour envoyer",
     "answersCount": "Réponses ({{count}})",
     "questionNotFound": "Question non trouvée",
     "backToList": "Retour à la liste",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -890,6 +890,7 @@
     "postAnswer": "回答を投稿",
     "updateAnswer": "回答を更新",
     "answerPlaceholder": "回答を入力してください...",
+    "submitShortcut": "Ctrl+Enterで送信",
     "answersCount": "回答 ({{count}}件)",
     "questionNotFound": "質問が見つかりません",
     "backToList": "一覧に戻る",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -936,6 +936,7 @@
     "postAnswer": "답변 등록",
     "updateAnswer": "답변 수정",
     "answerPlaceholder": "답변을 작성하세요...",
+    "submitShortcut": "Ctrl+Enter로 제출",
     "answersCount": "답변 ({{count}}개)",
     "questionNotFound": "질문을 찾을 수 없습니다",
     "backToList": "목록으로 돌아가기",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -936,6 +936,7 @@
     "postAnswer": "Publicar resposta",
     "updateAnswer": "Atualizar resposta",
     "answerPlaceholder": "Escreva sua resposta...",
+    "submitShortcut": "Ctrl+Enter para enviar",
     "answersCount": "Respostas ({{count}})",
     "questionNotFound": "Pergunta não encontrada",
     "backToList": "Voltar à lista",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -936,6 +936,7 @@
     "postAnswer": "Опубликовать ответ",
     "updateAnswer": "Обновить ответ",
     "answerPlaceholder": "Напишите ваш ответ...",
+    "submitShortcut": "Ctrl+Enter для отправки",
     "answersCount": "Ответы ({{count}})",
     "questionNotFound": "Вопрос не найден",
     "backToList": "Вернуться к списку",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -936,6 +936,7 @@
     "postAnswer": "发布回答",
     "updateAnswer": "更新回答",
     "answerPlaceholder": "写下你的回答...",
+    "submitShortcut": "按Ctrl+Enter提交",
     "answersCount": "回答 ({{count}})",
     "questionNotFound": "问题未找到",
     "backToList": "返回列表",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -936,6 +936,7 @@
     "postAnswer": "發布回答",
     "updateAnswer": "更新回答",
     "answerPlaceholder": "寫下你的回答...",
+    "submitShortcut": "按Ctrl+Enter提交",
     "answersCount": "回答 ({{count}})",
     "questionNotFound": "問題未找到",
     "backToList": "返回列表",


### PR DESCRIPTION
## 概要
Q&AのAnswerFormにCtrl+Enter（Mac: Cmd+Enter）キーボードショートカットで回答を送信できる機能を追加

## 変更内容
- textareaにonKeyDownハンドラー追加（Ctrl+Enter / Meta+Enter対応）
- ショートカットヒントテキスト表示
- 10言語にqa.submitShortcutキー追加

closes #1495