### PR TITLE
refactor: PostCardActionsのリアクションロジックをuseReactionsフックに抽出

### DIFF
--- a/frontend/src/components/posts/PostCardActions.tsx
+++ b/frontend/src/components/posts/PostCardActions.tsx
@@ -2,9 +2,8 @@ import { useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
-import { likePost, unlikePost, bookmarkPost, unbookmarkPost, getReactions, addReaction, removeReaction } from '../../api/posts';
-import type { ReactionCount } from '../../types/post';
-import { useEffect } from 'react';
+import { likePost, unlikePost, bookmarkPost, unbookmarkPost } from '../../api/posts';
+import { useReactions } from '../../hooks/useReactions';
 
 interface PostCardActionsProps {
   postId: number;
@@ -33,8 +32,7 @@ export default function PostCardActions({
   const [liked, setLiked] = useState(initialLiked);
   const [likeCount, setLikeCount] = useState(initialLikeCount);
   const [bookmarked, setBookmarked] = useState(initialBookmarked);
-  const [reactions, setReactions] = useState<ReactionCount[]>([]);
-  const [userReactions, setUserReactions] = useState<string[]>([]);
+  const { reactions, userReactions, toggleReaction } = useReactions(postId);
   const [showReactionPicker, setShowReactionPicker] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
 
@@ -49,37 +47,10 @@ export default function PostCardActions({
     }
   }, [postId, t]);
 
-  useEffect(() => {
-    getReactions(postId).then((res) => {
-      setReactions(res.data.reactions || []);
-      setUserReactions(res.data.user_reactions || []);
-    }).catch(() => {});
-  }, [postId]);
-
-  const handleReaction = async (emoji: string) => {
-    try {
-      if (userReactions.includes(emoji)) {
-        await removeReaction(postId, emoji);
-        setUserReactions((prev) => prev.filter((e) => e !== emoji));
-        setReactions((prev) =>
-          prev.map((r) => r.emoji === emoji ? { ...r, count: r.count - 1 } : r).filter((r) => r.count > 0)
-        );
-      } else {
-        await addReaction(postId, emoji);
-        setUserReactions((prev) => [...prev, emoji]);
-        setReactions((prev) => {
-          const existing = prev.find((r) => r.emoji === emoji);
-          if (existing) {
-            return prev.map((r) => r.emoji === emoji ? { ...r, count: r.count + 1 } : r);
-          }
-          return [...prev, { emoji, count: 1 }];
-        });
-      }
-      setShowReactionPicker(false);
-    } catch (e) {
-      console.warn('Failed to toggle reaction:', e);
-    }
-  };
+  const handleReaction = useCallback(async (emoji: string) => {
+    await toggleReaction(emoji);
+    setShowReactionPicker(false);
+  }, [toggleReaction]);
 
   const handleLike = async () => {
     try {

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -51,3 +51,4 @@ export { useConfirm } from './useConfirm';
 export { useOnboarding } from './useOnboarding';
 export { useYoutube } from './useYoutube';
 export { useCommentLike } from './useCommentLike';
+export { useReactions } from './useReactions';

--- a/frontend/src/hooks/useReactions.ts
+++ b/frontend/src/hooks/useReactions.ts
@@ -1,0 +1,41 @@
+import { useState, useCallback, useEffect } from 'react';
+import { getReactions, addReaction, removeReaction } from '../api/posts';
+import type { ReactionCount } from '../types/post';
+
+export function useReactions(postId: number) {
+  const [reactions, setReactions] = useState<ReactionCount[]>([]);
+  const [userReactions, setUserReactions] = useState<string[]>([]);
+
+  useEffect(() => {
+    getReactions(postId).then((res) => {
+      setReactions(res.data.reactions || []);
+      setUserReactions(res.data.user_reactions || []);
+    }).catch(() => {});
+  }, [postId]);
+
+  const toggleReaction = useCallback(async (emoji: string) => {
+    try {
+      if (userReactions.includes(emoji)) {
+        await removeReaction(postId, emoji);
+        setUserReactions((prev) => prev.filter((e) => e !== emoji));
+        setReactions((prev) =>
+          prev.map((r) => r.emoji === emoji ? { ...r, count: r.count - 1 } : r).filter((r) => r.count > 0)
+        );
+      } else {
+        await addReaction(postId, emoji);
+        setUserReactions((prev) => [...prev, emoji]);
+        setReactions((prev) => {
+          const existing = prev.find((r) => r.emoji === emoji);
+          if (existing) {
+            return prev.map((r) => r.emoji === emoji ? { ...r, count: r.count + 1 } : r);
+          }
+          return [...prev, { emoji, count: 1 }];
+        });
+      }
+    } catch (e) {
+      console.warn('Failed to toggle reaction:', e);
+    }
+  }, [postId, userReactions]);
+
+  return { reactions, userReactions, toggleReaction };
+}


### PR DESCRIPTION
## 概要
PostCardActions.tsxからリアクション関連のロジックを`useReactions`カスタムフックに抽出

## 変更内容
- `hooks/useReactions.ts`新規作成（リアクション取得・状態管理・トグル）
- PostCardActionsからリアクション状態・useEffect・handleReactionロジック（約30行）を削除
- `hooks/index.ts`にバレルエクスポート追加
- 機能変更なし

closes #1497