### PR TITLE
fix: useBadgeNotifierのlocalStorage JSON.parseにtry-catch追加

### DIFF
--- a/frontend/src/hooks/useBadgeNotifier.ts
+++ b/frontend/src/hooks/useBadgeNotifier.ts
@@ -18,7 +18,14 @@ export function useBadgeNotifier(badges: BadgeResult[]) {
     const earnedIds = earnedBadges.map((b) => b.id);
 
     const stored = localStorage.getItem(STORAGE_KEY);
-    const previousIds: string[] = stored ? JSON.parse(stored) : [];
+    let previousIds: string[] = [];
+    if (stored) {
+      try {
+        previousIds = JSON.parse(stored);
+      } catch {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    }
 
     // Skip toasts on initial load when localStorage is empty
     if (initialLoadRef.current) {


### PR DESCRIPTION
## 概要
useBadgeNotifier.tsでlocalStorageのJSON.parseにtry-catchを追加し、データ破損時のクラッシュを防止

## 変更内容
- JSON.parse失敗時に空配列にフォールバック
- 破損データをlocalStorageから自動削除

closes #1501