### PR TITLE
feat: LogCardの学習時間表示を時間・分形式に改善

### DIFF
--- a/frontend/src/components/learning-logs/LogCard.tsx
+++ b/frontend/src/components/learning-logs/LogCard.tsx
@@ -51,7 +51,11 @@ export default function LogCard({ log, onEdit, onDelete, onToggleFavorite }: Log
             <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
               <span>{new Date(log.created_at).toLocaleDateString()}</span>
               {log.duration > 0 && (
-                <span>{t('learningLogs.durationMinutes', { minutes: log.duration })}</span>
+                <span>
+                  {log.duration >= 60
+                    ? t('learningLogs.durationHoursMinutes', { hours: Math.floor(log.duration / 60), minutes: log.duration % 60 })
+                    : t('learningLogs.durationMinutes', { minutes: log.duration })}
+                </span>
               )}
             </div>
           </div>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -659,6 +659,7 @@
     "categoryOther": "Sonstiges",
     "duration": "Lernzeit",
     "durationMinutes": "{{minutes}} Min.",
+    "durationHoursMinutes": "{{hours}} Std. {{minutes}} Min.",
     "durationPlaceholder": "Minuten",
     "calendar": "Kalender",
     "list": "Liste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -659,6 +659,7 @@
     "categoryOther": "Other",
     "duration": "Study Time",
     "durationMinutes": "{{minutes}} min",
+    "durationHoursMinutes": "{{hours}}h {{minutes}}m",
     "durationPlaceholder": "minutes",
     "calendar": "Calendar",
     "list": "List",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -659,6 +659,7 @@
     "categoryOther": "Otro",
     "duration": "Tiempo de estudio",
     "durationMinutes": "{{minutes}} min",
+    "durationHoursMinutes": "{{hours}}h {{minutes}}m",
     "durationPlaceholder": "minutos",
     "calendar": "Calendario",
     "list": "Lista",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -659,6 +659,7 @@
     "categoryOther": "Autre",
     "duration": "Temps d'étude",
     "durationMinutes": "{{minutes}} min",
+    "durationHoursMinutes": "{{hours}}h {{minutes}}m",
     "durationPlaceholder": "minutes",
     "calendar": "Calendrier",
     "list": "Liste",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -643,6 +643,7 @@
     "categoryOther": "その他",
     "duration": "学習時間",
     "durationMinutes": "{{minutes}}分",
+    "durationHoursMinutes": "{{hours}}時間{{minutes}}分",
     "durationPlaceholder": "分",
     "calendar": "カレンダー",
     "list": "リスト",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -659,6 +659,7 @@
     "categoryOther": "기타",
     "duration": "학습 시간",
     "durationMinutes": "{{minutes}}분",
+    "durationHoursMinutes": "{{hours}}시간 {{minutes}}분",
     "durationPlaceholder": "분",
     "calendar": "캘린더",
     "list": "목록",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -659,6 +659,7 @@
     "categoryOther": "Outro",
     "duration": "Tempo de estudo",
     "durationMinutes": "{{minutes}} min",
+    "durationHoursMinutes": "{{hours}}h {{minutes}}m",
     "durationPlaceholder": "minutos",
     "calendar": "Calendário",
     "list": "Lista",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -659,6 +659,7 @@
     "categoryOther": "Другое",
     "duration": "Время обучения",
     "durationMinutes": "{{minutes}} мин",
+    "durationHoursMinutes": "{{hours}} ч {{minutes}} мин",
     "durationPlaceholder": "минуты",
     "calendar": "Календарь",
     "list": "Список",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -659,6 +659,7 @@
     "categoryOther": "其他",
     "duration": "学习时长",
     "durationMinutes": "{{minutes}}分钟",
+    "durationHoursMinutes": "{{hours}}小时{{minutes}}分钟",
     "durationPlaceholder": "分钟",
     "calendar": "日历",
     "list": "列表",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -659,6 +659,7 @@
     "categoryOther": "其他",
     "duration": "學習時間",
     "durationMinutes": "{{minutes}}分鐘",
+    "durationHoursMinutes": "{{hours}}小時{{minutes}}分鐘",
     "durationPlaceholder": "分鐘",
     "calendar": "日曆",
     "list": "列表",


### PR DESCRIPTION
## 概要
学習ログカードの時間表示を改善。60分以上の場合に「X時間Y分」形式で表示。

## 変更内容
- 60分以上: `durationHoursMinutes`キーで「2時間30分」形式
- 60分未満: 従来の`durationMinutes`キーで「45分」形式
- 10言語にdurationHoursMinutesキー追加

closes #1503