### PR TITLE
fix: PostFormのJSON.parseにparseJsonArray適用

### DIFF
--- a/frontend/src/components/posts/PostForm.tsx
+++ b/frontend/src/components/posts/PostForm.tsx
@@ -4,6 +4,7 @@ import toast from 'react-hot-toast';
 import { Plus } from 'lucide-react';
 import { inputClass } from '../../constants/styles';
 import { useConfirm } from '../../hooks';
+import { parseJsonArray } from '../../utils/json';
 import ConfirmDialog from '../common/ConfirmDialog';
 import MarkdownEditor from './MarkdownEditor';
 import CodeSnippetInput, { type SnippetInputData } from './CodeSnippetInput';
@@ -26,7 +27,7 @@ export default function PostForm({ post, onSubmit, onCancel, loading: externalLo
   const [title, setTitle] = useState(post?.title || '');
   const [content, setContent] = useState(post?.content || '');
   const [imageUrls, setImageUrls] = useState<string[]>(
-    post?.image_urls ? JSON.parse(post.image_urls) : []
+    parseJsonArray(post?.image_urls)
   );
   const [snippets, setSnippets] = useState<SnippetInputData[]>([]);
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
## 概要
PostForm.tsxのimage_urlsパースにparseJsonArrayを適用し、不正JSONでのクラッシュを防止

## 変更内容
- `JSON.parse(post.image_urls)` → `parseJsonArray(post?.image_urls)`
- parseJsonArrayのtry-catchにより不正JSON時は空配列にフォールバック

closes #1509