### PR TITLE
feat: NoteCardにコンテンツ展開/折りたたみ機能追加

### DIFF
--- a/frontend/src/components/notes/NoteCard.tsx
+++ b/frontend/src/components/notes/NoteCard.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Star, Edit, Trash2 } from 'lucide-react';
 import type { Note } from '../../api/notes';
@@ -12,6 +13,8 @@ interface NoteCardProps {
 
 export default function NoteCard({ note, onToggleFavorite, onEdit, onDelete }: NoteCardProps) {
   const { t } = useTranslation();
+  const [expanded, setExpanded] = useState(false);
+  const isLong = note.content.length > 100;
 
   return (
     <div className="p-6 bg-gray-800 border border-gray-700 rounded-md hover:border-gray-600 transition-colors">
@@ -23,7 +26,16 @@ export default function NoteCard({ note, onToggleFavorite, onEdit, onDelete }: N
               <Star className="w-5 h-5 fill-yellow-500 text-yellow-500" />
             )}
           </div>
-          <p className="text-gray-400 mb-3 line-clamp-2">{note.content}</p>
+          <p className={`text-gray-400 mb-1 whitespace-pre-wrap ${!expanded ? 'line-clamp-2' : ''}`}>{note.content}</p>
+          {isLong && (
+            <button
+              onClick={() => setExpanded(!expanded)}
+              className="text-xs text-blue-400 hover:text-blue-300 transition-colors mb-2"
+            >
+              {expanded ? t('notes.collapse') : t('notes.expand')}
+            </button>
+          )}
+          {!isLong && <div className="mb-2" />}
           {note.tags && (
             <div className="flex flex-wrap gap-2 mb-3">
               {note.tags.split(',').map((tag, idx) => (

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1392,6 +1392,8 @@
     "favoriteToggled": "Favoritenstatus aktualisiert",
     "lastUpdated": "Zuletzt aktualisiert",
     "chars": "Zeichen",
+    "expand": "Mehr anzeigen",
+    "collapse": "Weniger anzeigen",
     "createdAt": "Erstellt am",
     "tagsPlaceholder": "z.B. React, TypeScript, Go",
     "allTags": "Alle Tags"

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1392,6 +1392,8 @@
     "favoriteToggled": "Favorite status updated",
     "lastUpdated": "Last updated",
     "chars": "chars",
+    "expand": "Show more",
+    "collapse": "Show less",
     "createdAt": "Created at",
     "tagsPlaceholder": "e.g., React, TypeScript, Go",
     "allTags": "All Tags"

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1392,6 +1392,8 @@
     "favoriteToggled": "Estado de favorito actualizado",
     "lastUpdated": "Última actualización",
     "chars": "caracteres",
+    "expand": "Ver más",
+    "collapse": "Ver menos",
     "createdAt": "Creado el",
     "tagsPlaceholder": "Ej: React, TypeScript, Go",
     "allTags": "Todas las etiquetas"

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1392,6 +1392,8 @@
     "favoriteToggled": "Statut favori mis à jour",
     "lastUpdated": "Dernière mise à jour",
     "chars": "caractères",
+    "expand": "Voir plus",
+    "collapse": "Voir moins",
     "createdAt": "Créé le",
     "tagsPlaceholder": "Ex : React, TypeScript, Go",
     "allTags": "Tous les tags"

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1293,6 +1293,8 @@
     "favoriteToggled": "お気に入りを更新しました",
     "lastUpdated": "最終更新",
     "chars": "文字",
+    "expand": "もっと見る",
+    "collapse": "折りたたむ",
     "createdAt": "作成日時",
     "tagsPlaceholder": "例: React, TypeScript, Go",
     "allTags": "すべてのタグ"

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1392,6 +1392,8 @@
     "favoriteToggled": "즐겨찾기 상태가 업데이트되었습니다",
     "lastUpdated": "마지막 업데이트",
     "chars": "자",
+    "expand": "더 보기",
+    "collapse": "접기",
     "createdAt": "생성일",
     "tagsPlaceholder": "예: React, TypeScript, Go",
     "allTags": "모든 태그"

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1392,6 +1392,8 @@
     "favoriteToggled": "Status de favorito atualizado",
     "lastUpdated": "Última atualização",
     "chars": "caracteres",
+    "expand": "Ver mais",
+    "collapse": "Ver menos",
     "createdAt": "Criado em",
     "tagsPlaceholder": "Ex: React, TypeScript, Go",
     "allTags": "Todas as tags"

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1392,6 +1392,8 @@
     "favoriteToggled": "Статус избранного обновлен",
     "lastUpdated": "Последнее обновление",
     "chars": "символов",
+    "expand": "Показать больше",
+    "collapse": "Свернуть",
     "createdAt": "Создано",
     "tagsPlaceholder": "Напр.: React, TypeScript, Go",
     "allTags": "Все теги"

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1392,6 +1392,8 @@
     "favoriteToggled": "收藏状态已更新",
     "lastUpdated": "最后更新",
     "chars": "字符",
+    "expand": "展开更多",
+    "collapse": "收起",
     "createdAt": "创建时间",
     "tagsPlaceholder": "例如：React, TypeScript, Go",
     "allTags": "所有标签"

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1392,6 +1392,8 @@
     "favoriteToggled": "收藏狀態已更新",
     "lastUpdated": "最後更新",
     "chars": "字元",
+    "expand": "展開更多",
+    "collapse": "收起",
     "createdAt": "創建時間",
     "tagsPlaceholder": "例如：React, TypeScript, Go",
     "allTags": "所有標籤"


### PR DESCRIPTION
## 概要
NoteCardのメモ内容が長い場合（100文字以上）に「もっと見る」ボタンで全文表示/折りたたみを切り替え可能に

## 変更内容
- `expanded`状態追加、100文字以上で展開ボタン表示
- `line-clamp-2`の動的切り替え
- 10言語にnotes.expand/notes.collapseキー追加

closes #1511