### PR TITLE
refactor: useClickOutsideフックを作成しHeader.tsxの重複ロジックを共通化

### DIFF
--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import {
@@ -21,6 +21,7 @@ import Avatar from '../common/Avatar';
 import ThemeToggle from '../common/ThemeToggle';
 import LanguageSelector from '../common/LanguageSelector';
 import NotificationDropdown from '../notifications/NotificationDropdown';
+import { useClickOutside } from '../../hooks/useClickOutside';
 
 /** 常に表示する主要ナビ（5個以内に抑える） */
 const navItems = [
@@ -76,29 +77,10 @@ export default function Header() {
     setMoreOpen(false);
   }, [location.pathname]);
 
-  // Close mobile menu on outside click
-  useEffect(() => {
-    if (!mobileOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setMobileOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [mobileOpen]);
-
-  // Close more dropdown on outside click
-  useEffect(() => {
-    if (!moreOpen) return;
-    const handleClick = (e: MouseEvent) => {
-      if (moreRef.current && !moreRef.current.contains(e.target as Node)) {
-        setMoreOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [moreOpen]);
+  const closeMobile = useCallback(() => setMobileOpen(false), []);
+  const closeMore = useCallback(() => setMoreOpen(false), []);
+  useClickOutside(menuRef, mobileOpen, closeMobile);
+  useClickOutside(moreRef, moreOpen, closeMore);
 
   return (
     <header className="bg-gray-900/80 backdrop-blur-sm border-b border-gray-800 sticky top-0 z-50">

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -52,3 +52,4 @@ export { useOnboarding } from './useOnboarding';
 export { useYoutube } from './useYoutube';
 export { useCommentLike } from './useCommentLike';
 export { useReactions } from './useReactions';
+export { useClickOutside } from './useClickOutside';

--- a/frontend/src/hooks/useClickOutside.ts
+++ b/frontend/src/hooks/useClickOutside.ts
@@ -1,0 +1,18 @@
+import { useEffect, type RefObject } from 'react';
+
+export function useClickOutside(
+  ref: RefObject<HTMLElement | null>,
+  isOpen: boolean,
+  onClose: () => void,
+) {
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [ref, isOpen, onClose]);
+}


### PR DESCRIPTION
## 概要
Header.tsxの外側クリック検出の重複useEffect2つを`useClickOutside`カスタムフックに抽出

## 変更内容
- `hooks/useClickOutside.ts`新規作成（汎用的な外側クリック検出フック）
- Header.tsxの重複useEffect（約20行）を`useClickOutside`呼び出し2行に置換
- `hooks/index.ts`にバレルエクスポート追加
- 機能変更なし

closes #1513