### PR TITLE
refactor: Ctrl+Enter送信ロジックをuseSubmitShortcutフックに共通化

### DIFF
--- a/frontend/src/components/posts/QuickPostForm.tsx
+++ b/frontend/src/components/posts/QuickPostForm.tsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Send, FileText, Check, Clock } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useAutoSave } from '../../hooks/useAutoSave';
+import { useSubmitShortcut } from '../../hooks/useSubmitShortcut';
 import Avatar from '../common/Avatar';
 
 interface QuickPostFormProps {
@@ -63,14 +64,7 @@ export default function QuickPostForm({ onSubmit }: QuickPostFormProps) {
     }
   };
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-      e.preventDefault();
-      if (content.trim() && !isSubmitting) {
-        handleSubmit(false);
-      }
-    }
-  }, [content, isSubmitting]);
+  const handleKeyDown = useSubmitShortcut(() => handleSubmit(false), !!content.trim() && !isSubmitting);
 
   // 保存状態の表示テキスト
   const getSaveStatusText = () => {

--- a/frontend/src/components/qa/AnswerForm.tsx
+++ b/frontend/src/components/qa/AnswerForm.tsx
@@ -1,6 +1,7 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { textareaClass, buttonSecondaryClass } from '../../constants/styles';
+import { useSubmitShortcut } from '../../hooks/useSubmitShortcut';
 
 interface AnswerFormProps {
   initialBody?: string;
@@ -22,16 +23,11 @@ export default function AnswerForm({ initialBody = '', onSubmit, onCancel, loadi
     }
   };
 
-  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
-      e.preventDefault();
-      if (body.trim() && !loading) {
-        onSubmit(body).then((success) => {
-          if (success && !isEdit) setBody('');
-        });
-      }
-    }
-  }, [body, loading, onSubmit, isEdit]);
+  const handleKeyDown = useSubmitShortcut(() => {
+    onSubmit(body).then((success) => {
+      if (success && !isEdit) setBody('');
+    });
+  }, !!body.trim() && !loading);
 
   return (
     <form onSubmit={handleSubmit} className="space-y-3">

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -53,3 +53,4 @@ export { useYoutube } from './useYoutube';
 export { useCommentLike } from './useCommentLike';
 export { useReactions } from './useReactions';
 export { useClickOutside } from './useClickOutside';
+export { useSubmitShortcut } from './useSubmitShortcut';

--- a/frontend/src/hooks/useSubmitShortcut.ts
+++ b/frontend/src/hooks/useSubmitShortcut.ts
@@ -1,0 +1,20 @@
+import { useCallback } from 'react';
+
+/**
+ * Ctrl+Enter / Cmd+Enter でフォーム送信するキーハンドラーを返すフック。
+ * canSubmit が true の時のみ onSubmit を呼び出す。
+ */
+export function useSubmitShortcut(
+  onSubmit: () => void,
+  canSubmit: boolean,
+) {
+  return useCallback(
+    (e: React.KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
+        e.preventDefault();
+        if (canSubmit) onSubmit();
+      }
+    },
+    [onSubmit, canSubmit],
+  );
+}


### PR DESCRIPTION
## 概要
- AnswerFormとQuickPostFormで重複していたCtrl+Enter/Cmd+Enter送信判定ロジックをuseSubmitShortcutフックに抽出
- 各コンポーネントから約10行の重複コードを削減

## 変更内容
- `hooks/useSubmitShortcut.ts` 新規作成（canSubmit条件付きキーハンドラー）
- `AnswerForm.tsx`: useCallback+手動判定 → useSubmitShortcut呼び出し
- `QuickPostForm.tsx`: 同上
- `hooks/index.ts`: バレルエクスポート追加

closes #1521