### PR TITLE
fix: GitHubCallbackPage parseStatePurposeの型検証を追加

### DIFF
--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -11,7 +11,7 @@ function parseStatePurpose(state: string): string {
     const parts = state.split('.');
     if (parts.length < 2 || !parts[1]) return '';
     const decoded = JSON.parse(atob(parts[1]));
-    return decoded.purpose || '';
+    return typeof decoded.purpose === 'string' ? decoded.purpose : '';
   } catch {
     return '';
   }


### PR DESCRIPTION
## 概要
- parseStatePurpose関数でJSON.parse結果のpurposeフィールドにtypeofチェックを追加
- string以外の不正な値（object, number等）が返されることを防止

## 変更内容
- `decoded.purpose || ''` → `typeof decoded.purpose === 'string' ? decoded.purpose : ''`

closes #1525