### PR TITLE
feat: PostCardに新着バッジ表示（24時間以内の投稿）

### DIFF
--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -20,6 +20,7 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
   const { t } = useTranslation();
 
   const imageUrls = parseJsonArray(post.image_urls);
+  const isNew = Date.now() - new Date(post.created_at).getTime() < 24 * 60 * 60 * 1000;
 
   return (
     <div className={cardDarkClass}>
@@ -39,7 +40,14 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
 
       <div className="flex items-start justify-between gap-2 mb-2">
         <Link to={`/posts/${post.id}`} className="flex-1 group">
-          <h3 className="text-base font-semibold group-hover:text-blue-400 transition-colors">{post.title}</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-base font-semibold group-hover:text-blue-400 transition-colors">{post.title}</h3>
+            {isNew && (
+              <span className="text-[10px] font-bold px-1.5 py-0.5 bg-green-500/20 text-green-400 rounded shrink-0">
+                {t('post.newBadge')}
+              </span>
+            )}
+          </div>
           {post.estimated_read_time > 0 && (
             <p className="text-xs text-gray-500 mt-0.5">{t('post.readTime', { minutes: post.estimated_read_time })}</p>
           )}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -207,6 +207,7 @@
     "writeComment": "Kommentar schreiben...",
     "writeReply": "Antwort schreiben...",
     "readTime": "{{minutes}} Min. Lesezeit",
+    "newBadge": "NEU",
     "notFound": "Beitrag nicht gefunden",
     "bookmark": "Lesezeichen",
     "unbookmark": "Lesezeichen entfernen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -207,6 +207,7 @@
     "writeComment": "Write a comment...",
     "writeReply": "Write a reply...",
     "readTime": "{{minutes}} min read",
+    "newBadge": "NEW",
     "notFound": "Post not found",
     "bookmark": "Bookmark",
     "unbookmark": "Remove Bookmark",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -207,6 +207,7 @@
     "writeComment": "Escribe un comentario...",
     "writeReply": "Escribe una respuesta...",
     "readTime": "{{minutes}} min de lectura",
+    "newBadge": "NEW",
     "notFound": "Publicación no encontrada",
     "bookmark": "Marcador",
     "unbookmark": "Quitar marcador",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -207,6 +207,7 @@
     "writeComment": "Écrire un commentaire...",
     "writeReply": "Écrire une réponse...",
     "readTime": "{{minutes}} min de lecture",
+    "newBadge": "NEW",
     "notFound": "Publication introuvable",
     "bookmark": "Signet",
     "unbookmark": "Retirer le signet",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -227,6 +227,7 @@
     "writeComment": "コメントを書く...",
     "writeReply": "返信を書く...",
     "readTime": "{{minutes}}分で読める",
+    "newBadge": "NEW",
     "notFound": "投稿が見つかりません",
     "bookmark": "ブックマーク",
     "unbookmark": "ブックマーク解除",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -207,6 +207,7 @@
     "writeComment": "댓글 작성...",
     "writeReply": "답글 작성...",
     "readTime": "{{minutes}}분 소요",
+    "newBadge": "NEW",
     "notFound": "게시물을 찾을 수 없습니다",
     "bookmark": "북마크",
     "unbookmark": "북마크 해제",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -207,6 +207,7 @@
     "writeComment": "Escrever um comentário...",
     "writeReply": "Escrever uma resposta...",
     "readTime": "{{minutes}} min de leitura",
+    "newBadge": "NOVO",
     "notFound": "Publicação não encontrada",
     "bookmark": "Favorito",
     "unbookmark": "Remover favorito",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -207,6 +207,7 @@
     "writeComment": "Написать комментарий...",
     "writeReply": "Написать ответ...",
     "readTime": "{{minutes}} мин чтения",
+    "newBadge": "НОВОЕ",
     "notFound": "Публикация не найдена",
     "bookmark": "Закладка",
     "unbookmark": "Удалить закладку",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -207,6 +207,7 @@
     "writeComment": "写评论...",
     "writeReply": "写回复...",
     "readTime": "{{minutes}}分钟阅读",
+    "newBadge": "NEW",
     "notFound": "未找到帖子",
     "bookmark": "书签",
     "unbookmark": "取消书签",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -207,6 +207,7 @@
     "writeComment": "寫評論...",
     "writeReply": "寫回覆...",
     "readTime": "{{minutes}}分鐘閱讀",
+    "newBadge": "NEW",
     "notFound": "找不到貼文",
     "bookmark": "書籤",
     "unbookmark": "取消書籤",


### PR DESCRIPTION
## 概要
- 投稿作成から24時間以内のPostCardにNEWバッジを表示
- タイトル横に緑色のバッジで新しいコンテンツを視覚的に識別可能に

## 変更内容
- PostCard.tsx: isNew判定追加、タイトル横にバッジ表示
- 10言語にpost.newBadgeキー追加（ja/en/ko等: NEW、de: NEU、pt: NOVO、ru: НОВОЕ）

closes #1527