### PR TITLE
refactor: 空状態カードのスタイルをemptyStateClassに共通化

### DIFF
--- a/frontend/src/components/search/SearchResults.tsx
+++ b/frontend/src/components/search/SearchResults.tsx
@@ -7,6 +7,7 @@ import { UserCardSkeleton, PostCardSkeleton } from '../common/Skeleton';
 import type { User } from '../../types/user';
 import type { Post } from '../../types/post';
 import type { StudyCircle } from '../../types/studyCircle';
+import { emptyStateClass } from '../../constants/styles';
 
 export function LoadingResults({ tab }: { tab: SearchTab }) {
   if (tab === 'users') {
@@ -29,7 +30,7 @@ export function LoadingResults({ tab }: { tab: SearchTab }) {
 
 export function SearchEmptyState({ message }: { message: string }) {
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center">
+    <div className={emptyStateClass}>
       <svg
         className="w-16 h-16 mx-auto mb-4 text-gray-700"
         fill="none"
@@ -51,7 +52,7 @@ export function SearchEmptyState({ message }: { message: string }) {
 function NoResults({ query }: { query: string }) {
   const { t } = useTranslation();
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center">
+    <div className={emptyStateClass}>
       <p className="text-gray-400 mb-1">{t('search.noResults')}</p>
       <p className="text-gray-500 text-sm">"{query}"</p>
     </div>

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -39,3 +39,6 @@ export const textareaClass =
 
 export const labelClass =
   'block text-sm font-medium text-gray-300 mb-1.5';
+
+export const emptyStateClass =
+  'bg-gray-900 border border-gray-800 rounded-md p-12 text-center';

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -13,6 +13,7 @@ import PostForm from '../components/posts/PostForm';
 import { Modal } from '../components/common';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 import QuickPostForm from '../components/posts/QuickPostForm';
+import { emptyStateClass } from '../constants/styles';
 import { buttonPrimaryClass } from '../constants/styles';
 import { PostCardSkeleton } from '../components/common/Skeleton';
 import RecentNotificationsWidget from '../components/dashboard/RecentNotificationsWidget';
@@ -117,7 +118,7 @@ export default function DashboardPage() {
             <PostCardSkeleton />
           </div>
         ) : posts.length === 0 ? (
-          <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center">
+          <div className={emptyStateClass}>
             <svg className="w-16 h-16 mx-auto mb-4 text-gray-700" fill="none" stroke="currentColor" strokeWidth="1" viewBox="0 0 24 24" aria-hidden="true">
               <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
             </svg>

--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -9,6 +9,7 @@ import { getDrafts, publishPost, deletePost } from '../api/posts';
 import { PostCardSkeleton } from '../components/common/Skeleton';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 import { formatDistanceToNow } from '../utils/timeFormat';
+import { emptyStateClass } from '../constants/styles';
 
 export default function DraftsPage() {
   const { t } = useTranslation();
@@ -111,7 +112,7 @@ export default function DraftsPage() {
           <PostCardSkeleton />
         </div>
       ) : drafts.length === 0 ? (
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center">
+        <div className={emptyStateClass}>
           <FileEdit className="w-16 h-16 mx-auto mb-4 text-gray-700" />
           <p className="text-gray-400">{t('post.noDrafts')}</p>
         </div>

--- a/frontend/src/pages/FollowListPage.tsx
+++ b/frontend/src/pages/FollowListPage.tsx
@@ -5,6 +5,7 @@ import { useFollowList } from '../hooks';
 import Avatar from '../components/common/Avatar';
 import FollowButton from '../components/profile/FollowButton';
 import LoadingSpinner from '../components/common/LoadingSpinner';
+import { emptyStateClass } from '../constants/styles';
 
 export default function FollowListPage() {
   const { username } = useParams<{ username: string }>();
@@ -63,7 +64,7 @@ export default function FollowListPage() {
       {loading ? (
         <div className="py-12"><LoadingSpinner /></div>
       ) : users.length === 0 ? (
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center text-gray-500 text-sm">
+        <div className={`${emptyStateClass} text-gray-500 text-sm`}>
           {tab === 'followers' ? t('follow.noFollowers') : t('follow.noFollowing')}
         </div>
       ) : (

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -11,7 +11,7 @@ import LogFiltersBar from '../components/learning-logs/LogFiltersBar';
 import LogFormModal from '../components/learning-logs/LogFormModal';
 import WeeklySummaryCard from '../components/learning-logs/WeeklySummaryCard';
 import LoadingSpinner from '../components/common/LoadingSpinner';
-import { inputClass, buttonSecondaryClass } from '../constants/styles';
+import { inputClass, buttonSecondaryClass, emptyStateClass } from '../constants/styles';
 
 
 export default function LearningLogsPage() {
@@ -160,7 +160,7 @@ export default function LearningLogsPage() {
       {view === 'list' && (
         <>
           {filteredLogs.length === 0 ? (
-            <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center">
+            <div className={emptyStateClass}>
               <p className="text-gray-400 text-sm mb-4">
                 {filterDate ? t('learningLogs.noLogsOnDate') : t('learningLogs.noLogs')}
               </p>

--- a/frontend/src/pages/PostCollectionDetailPage.tsx
+++ b/frontend/src/pages/PostCollectionDetailPage.tsx
@@ -8,6 +8,7 @@ import { PageLoader } from '../components/common';
 import PostCard from '../components/posts/PostCard';
 import { useAuthStore } from '../store/authStore';
 import { Globe, Lock } from 'lucide-react';
+import { emptyStateClass } from '../constants/styles';
 
 export default function PostCollectionDetailPage() {
   const { t } = useTranslation();
@@ -60,7 +61,7 @@ export default function PostCollectionDetailPage() {
           {t('collections.posts')} ({items.length})
         </h2>
         {items.length === 0 ? (
-          <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center text-gray-400 text-sm">
+          <div className={`${emptyStateClass} text-gray-400 text-sm`}>
             {t('collections.noPosts')}
           </div>
         ) : (

--- a/frontend/src/pages/PostSeriesDetailPage.tsx
+++ b/frontend/src/pages/PostSeriesDetailPage.tsx
@@ -7,6 +7,7 @@ import type { PostSeries } from '../types/post';
 import { PageLoader } from '../components/common';
 import PostCard from '../components/posts/PostCard';
 import { useAuthStore } from '../store/authStore';
+import { emptyStateClass } from '../constants/styles';
 
 export default function PostSeriesDetailPage() {
   const { t } = useTranslation();
@@ -52,7 +53,7 @@ export default function PostSeriesDetailPage() {
           {t('series.posts')} ({items.length})
         </h2>
         {items.length === 0 ? (
-          <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center text-gray-400 text-sm">
+          <div className={`${emptyStateClass} text-gray-400 text-sm`}>
             {t('series.noPosts')}
           </div>
         ) : (

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Sparkles, Rocket, FolderOpen, Pin } from 'lucide-react';
 import { useAuthStore } from '../store/authStore';
 import { useProfile, usePostSeries, usePostCollections, useProfileCompleteness, usePinnedPosts } from '../hooks';
-import { sectionContainerClass } from '../constants/styles';
+import { sectionContainerClass, emptyStateClass } from '../constants/styles';
 import { PageLoader } from '../components/common';
 import ProfileHeader from '../components/profile/ProfileHeader';
 import ContributionCalendar from '../components/profile/ContributionCalendar';
@@ -190,7 +190,7 @@ export default function ProfilePage() {
       <div>
         <h2 className="text-sm font-semibold text-gray-300 uppercase tracking-wide mb-3">{t('profile.posts')}</h2>
         {posts.length === 0 ? (
-          <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center text-gray-400 text-sm">{t('profile.noPosts')}</div>
+          <div className={`${emptyStateClass} text-gray-400 text-sm`}>{t('profile.noPosts')}</div>
         ) : (
           <div className="space-y-3">{posts.map((post) => (
             <PostCard

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Search } from 'lucide-react';
 import { useRankings } from '../hooks';
-import { sectionContainerClass, inputClass } from '../constants/styles';
+import { sectionContainerClass, inputClass, emptyStateClass } from '../constants/styles';
 import Avatar from '../components/common/Avatar';
 import { PageLoader } from '../components/common';
 
@@ -140,7 +140,7 @@ export default function RankingsPage() {
       {loading ? (
         <PageLoader />
       ) : rankings.length === 0 ? (
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center text-gray-400 text-sm">
+        <div className={`${emptyStateClass} text-gray-400 text-sm`}>
           {t('rankings.noData')}
         </div>
       ) : (

--- a/frontend/src/pages/StudyCirclesPage.tsx
+++ b/frontend/src/pages/StudyCirclesPage.tsx
@@ -6,6 +6,7 @@ import { useStudyCircles } from '../hooks';
 import { useAuthStore } from '../store/authStore';
 import Avatar from '../components/common/Avatar';
 import { Modal } from '../components/common';
+import { emptyStateClass } from '../constants/styles';
 
 export default function StudyCirclesPage() {
   const { t } = useTranslation();
@@ -110,7 +111,7 @@ export default function StudyCirclesPage() {
           ))}
         </div>
       ) : circles.length === 0 ? (
-        <div className="bg-gray-900 border border-gray-800 rounded-md p-12 text-center">
+        <div className={emptyStateClass}>
           <Users className="w-16 h-16 mx-auto mb-4 text-gray-700" />
           <p className="text-gray-400 mb-4">{t('studyCircle.noCircles')}</p>
           <button


### PR DESCRIPTION
## 概要
- 10ファイルで重複していた空状態カードのTailwindクラスをconstants/styles.tsのemptyStateClassに統一
- 既存のcardDarkClass等と同じパターンで定数化

## 変更ファイル
- constants/styles.ts: emptyStateClass追加
- SearchResults.tsx, DashboardPage.tsx, DraftsPage.tsx, RankingsPage.tsx, FollowListPage.tsx, PostSeriesDetailPage.tsx, PostCollectionDetailPage.tsx, ProfilePage.tsx, StudyCirclesPage.tsx, LearningLogsPage.tsx

closes #1529