### PR TITLE
test: NotificationItem getNotificationLink/getNotificationMessageのユニットテスト追加

### DIFF
--- a/frontend/src/components/notifications/__tests__/NotificationItem.test.ts
+++ b/frontend/src/components/notifications/__tests__/NotificationItem.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getNotificationLink, getNotificationMessage } from '../NotificationItem';
+import type { Notification } from '../../../types/notification';
+
+const baseNotification: Notification = {
+  id: 1,
+  user_id: 10,
+  type: 'post',
+  actor_id: 20,
+  actor: { id: 20, name: 'Alice', username: 'alice' } as Notification['actor'],
+  read: false,
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+describe('getNotificationLink', () => {
+  it('post タイプで post_id ありの場合 /posts/:id を返す', () => {
+    const n = { ...baseNotification, type: 'post' as const, post_id: 5 };
+    expect(getNotificationLink(n)).toBe('/posts/5');
+  });
+
+  it('post タイプで post_id なしの場合 / を返す', () => {
+    const n = { ...baseNotification, type: 'post' as const, post_id: undefined };
+    expect(getNotificationLink(n)).toBe('/');
+  });
+
+  it('like タイプで post_id ありの場合 /posts/:id を返す', () => {
+    const n = { ...baseNotification, type: 'like' as const, post_id: 3 };
+    expect(getNotificationLink(n)).toBe('/posts/3');
+  });
+
+  it('comment タイプで post_id ありの場合 /posts/:id を返す', () => {
+    const n = { ...baseNotification, type: 'comment' as const, post_id: 7 };
+    expect(getNotificationLink(n)).toBe('/posts/7');
+  });
+
+  it('follow タイプの場合 /profile/:username を返す', () => {
+    const n = { ...baseNotification, type: 'follow' as const };
+    expect(getNotificationLink(n)).toBe('/profile/alice');
+  });
+
+  it('message タイプの場合 /chat を返す', () => {
+    const n = { ...baseNotification, type: 'message' as const };
+    expect(getNotificationLink(n)).toBe('/chat');
+  });
+
+  it('answer タイプで question_id ありの場合 /qa/:id を返す', () => {
+    const n = { ...baseNotification, type: 'answer' as const, question_id: 9 };
+    expect(getNotificationLink(n)).toBe('/qa/9');
+  });
+
+  it('answer タイプで question_id なしの場合 / を返す', () => {
+    const n = { ...baseNotification, type: 'answer' as const, question_id: undefined };
+    expect(getNotificationLink(n)).toBe('/');
+  });
+
+  it('badge タイプの場合 /profile/:username を返す', () => {
+    const n = { ...baseNotification, type: 'badge' as const };
+    expect(getNotificationLink(n)).toBe('/profile/alice');
+  });
+});
+
+describe('getNotificationMessage', () => {
+  const t = vi.fn((key: string, opts?: Record<string, string>) =>
+    opts ? `${key}:${JSON.stringify(opts)}` : key,
+  );
+
+  it('post タイプで正しいキーとactor名を渡す', () => {
+    const n = { ...baseNotification, type: 'post' as const };
+    getNotificationMessage(n, t);
+    expect(t).toHaveBeenCalledWith('notifications.newPost', { name: 'Alice' });
+  });
+
+  it('like タイプで正しいキーを渡す', () => {
+    const n = { ...baseNotification, type: 'like' as const };
+    getNotificationMessage(n, t);
+    expect(t).toHaveBeenCalledWith('notifications.newLike', { name: 'Alice' });
+  });
+
+  it('comment タイプで正しいキーを渡す', () => {
+    const n = { ...baseNotification, type: 'comment' as const };
+    getNotificationMessage(n, t);
+    expect(t).toHaveBeenCalledWith('notifications.newComment', { name: 'Alice' });
+  });
+
+  it('follow タイプで正しいキーを渡す', () => {
+    const n = { ...baseNotification, type: 'follow' as const };
+    getNotificationMessage(n, t);
+    expect(t).toHaveBeenCalledWith('notifications.newFollow', { name: 'Alice' });
+  });
+
+  it('message タイプで正しいキーを渡す', () => {
+    const n = { ...baseNotification, type: 'message' as const };
+    getNotificationMessage(n, t);
+    expect(t).toHaveBeenCalledWith('notifications.newMessage', { name: 'Alice' });
+  });
+
+  it('answer タイプで正しいキーを渡す', () => {
+    const n = { ...baseNotification, type: 'answer' as const };
+    getNotificationMessage(n, t);
+    expect(t).toHaveBeenCalledWith('notifications.newAnswer', { name: 'Alice' });
+  });
+
+  it('badge タイプで名前なしの正しいキーを渡す', () => {
+    const n = { ...baseNotification, type: 'badge' as const };
+    getNotificationMessage(n, t);
+    expect(t).toHaveBeenCalledWith('notifications.newBadge');
+  });
+});


### PR DESCRIPTION
## 概要
- getNotificationLinkの9テスト（各通知タイプのリンク生成、post_id/question_id有無の分岐）
- getNotificationMessageの7テスト（各タイプのi18nキー呼び出し検証）

## テストケース
### getNotificationLink (9件)
- post/like/comment: post_idあり→/posts/:id、なし→/
- follow/badge: /profile/:username
- message: /chat
- answer: question_idあり→/qa/:id、なし→/

### getNotificationMessage (7件)
- 各通知タイプで正しいi18nキーとactor名が渡されることを検証

closes #1531