### PR TITLE
fix: downloadPortfolioのファイル名サニタイズを追加

### DIFF
--- a/frontend/src/utils/portfolioGenerator.ts
+++ b/frontend/src/utils/portfolioGenerator.ts
@@ -232,11 +232,14 @@ export const generatePortfolioHTML = (data: PortfolioData, theme: PortfolioTheme
 };
 
 export const downloadPortfolio = (html: string, filename: string): void => {
+  const sanitized = filename
+    .replace(/[/\\:*?"<>|\0]/g, '')
+    .substring(0, 255) || 'portfolio.html';
   const blob = new Blob([html], { type: 'text/html' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;
-  a.download = filename;
+  a.download = sanitized;
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);


### PR DESCRIPTION
## 概要
- portfolioGenerator.tsのdownloadPortfolio関数にファイル名サニタイズを追加
- パス区切り文字(/\)・OS禁止文字(*?"<>|:)・ナル文字を除去
- 255文字制限とフォールバック('portfolio.html')を設定

closes #1533