### PR TITLE
feat: Avatarコンポーネントにオンラインステータスインジケーター追加

### DIFF
--- a/frontend/src/components/common/Avatar.tsx
+++ b/frontend/src/components/common/Avatar.tsx
@@ -4,7 +4,15 @@ interface AvatarProps {
   name: string;
   avatarUrl?: string;
   size?: 'xs' | 'sm' | 'md' | 'lg';
+  isOnline?: boolean;
 }
+
+const dotSizeClasses = {
+  xs: 'w-1.5 h-1.5',
+  sm: 'w-2 h-2',
+  md: 'w-2.5 h-2.5',
+  lg: 'w-3.5 h-3.5',
+};
 
 const sizeClasses = {
   xs: 'w-6 h-6 text-xs',
@@ -13,24 +21,38 @@ const sizeClasses = {
   lg: 'w-16 h-16 text-xl',
 };
 
-export default function Avatar({ name, avatarUrl, size = 'md' }: AvatarProps) {
+export default function Avatar({ name, avatarUrl, size = 'md', isOnline }: AvatarProps) {
   const safeUrl = sanitizeUrl(avatarUrl);
+
+  const indicator = isOnline != null && (
+    <span
+      className={`absolute bottom-0 right-0 ${dotSizeClasses[size]} rounded-full ring-2 ring-gray-900 ${isOnline ? 'bg-green-500' : 'bg-gray-500'}`}
+      aria-hidden="true"
+    />
+  );
+
   if (safeUrl) {
     return (
-      <img
-        src={safeUrl}
-        alt={name}
-        referrerPolicy="no-referrer"
-        className={`${sizeClasses[size]} rounded-full object-cover`}
-      />
+      <span className="relative inline-block">
+        <img
+          src={safeUrl}
+          alt={name}
+          referrerPolicy="no-referrer"
+          className={`${sizeClasses[size]} rounded-full object-cover`}
+        />
+        {indicator}
+      </span>
     );
   }
 
   return (
-    <div
-      className={`${sizeClasses[size]} bg-blue-600 rounded-full flex items-center justify-center font-medium text-white`}
-    >
-      {name.charAt(0).toUpperCase()}
-    </div>
+    <span className="relative inline-block">
+      <div
+        className={`${sizeClasses[size]} bg-blue-600 rounded-full flex items-center justify-center font-medium text-white`}
+      >
+        {name.charAt(0).toUpperCase()}
+      </div>
+      {indicator}
+    </span>
   );
 }


### PR DESCRIPTION
## 概要
- Avatarコンポーネントにオプショナルな`isOnline`プロップを追加
- オンライン状態を示すドットインジケーターをアバター右下に表示

## 動作
| isOnline | 表示 |
|----------|------|
| true | 緑色ドット（オンライン） |
| false | グレードット（オフライン） |
| 未指定 | ドット非表示（後方互換） |

## 技術詳細
- サイズ別にドットの大きさを調整（xs→1.5, sm→2, md→2.5, lg→3.5）
- ring-2 ring-gray-900 で背景との境界を明確化
- 既存の全使用箇所は後方互換（isOnline未指定でドット非表示）

closes #1535