### PR TITLE
fix: useSettingsのavatar_url送信前にURL検証を追加

### DIFF
--- a/frontend/src/hooks/useSettings.ts
+++ b/frontend/src/hooks/useSettings.ts
@@ -72,6 +72,10 @@ export function useSettings() {
   const handleSaveProfile = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!user) return;
+    if (avatarUrl && !isHttpUrl(avatarUrl)) {
+      toast.error(t('settings.invalidAvatarUrl'));
+      return;
+    }
     setSaving(true);
     try {
       const { data } = await updateUser(user.id, { name, bio, avatar_url: avatarUrl });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -289,6 +289,7 @@
     "email": "E-Mail",
     "saved": "Einstellungen gespeichert",
     "saveFailed": "Speichern fehlgeschlagen",
+    "invalidAvatarUrl": "Ungültige Avatar-URL. Bitte geben Sie eine http/https-URL ein",
     "skills": "Fähigkeiten",
     "selectLanguages": "Programmiersprachen auswählen",
     "selectFrameworks": "Frameworks & Bibliotheken auswählen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -289,6 +289,7 @@
     "email": "Email",
     "saved": "Settings saved",
     "saveFailed": "Failed to save settings",
+    "invalidAvatarUrl": "Invalid avatar URL. Please enter an http/https URL",
     "skills": "Skills",
     "selectLanguages": "Select programming languages",
     "selectFrameworks": "Select frameworks & libraries",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -289,6 +289,7 @@
     "email": "Correo electrónico",
     "saved": "Configuración guardada",
     "saveFailed": "Error al guardar configuración",
+    "invalidAvatarUrl": "URL de avatar no válida. Ingrese una URL http/https",
     "skills": "Habilidades",
     "selectLanguages": "Seleccionar lenguajes de programación",
     "selectFrameworks": "Seleccionar frameworks y librerías",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -289,6 +289,7 @@
     "email": "Email",
     "saved": "Paramètres enregistrés",
     "saveFailed": "Échec de l'enregistrement",
+    "invalidAvatarUrl": "URL d'avatar invalide. Veuillez entrer une URL http/https",
     "skills": "Compétences",
     "selectLanguages": "Sélectionner les langages de programmation",
     "selectFrameworks": "Sélectionner les frameworks et bibliothèques",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -302,6 +302,7 @@
     "email": "メールアドレス",
     "saved": "設定を保存しました",
     "saveFailed": "設定の保存に失敗しました",
+    "invalidAvatarUrl": "アバターURLが無効です。http/httpsのURLを入力してください",
     "skills": "スキル",
     "selectLanguages": "プログラミング言語を選択",
     "selectFrameworks": "フレームワーク＆ライブラリを選択",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -289,6 +289,7 @@
     "email": "이메일",
     "saved": "설정이 저장되었습니다",
     "saveFailed": "설정 저장에 실패했습니다",
+    "invalidAvatarUrl": "잘못된 아바타 URL입니다. http/https URL을 입력하세요",
     "skills": "스킬",
     "selectLanguages": "프로그래밍 언어 선택",
     "selectFrameworks": "프레임워크 및 라이브러리 선택",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -289,6 +289,7 @@
     "email": "Email",
     "saved": "Configurações salvas",
     "saveFailed": "Falha ao salvar configurações",
+    "invalidAvatarUrl": "URL de avatar inválida. Insira uma URL http/https",
     "skills": "Habilidades",
     "selectLanguages": "Selecionar linguagens de programação",
     "selectFrameworks": "Selecionar frameworks e bibliotecas",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -289,6 +289,7 @@
     "email": "Email",
     "saved": "Настройки сохранены",
     "saveFailed": "Ошибка сохранения настроек",
+    "invalidAvatarUrl": "Недопустимый URL аватара. Введите URL http/https",
     "skills": "Навыки",
     "selectLanguages": "Выберите языки программирования",
     "selectFrameworks": "Выберите фреймворки и библиотеки",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -289,6 +289,7 @@
     "email": "邮箱",
     "saved": "设置已保存",
     "saveFailed": "保存设置失败",
+    "invalidAvatarUrl": "头像URL无效，请输入http/https URL",
     "skills": "技能",
     "selectLanguages": "选择编程语言",
     "selectFrameworks": "选择框架和库",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -289,6 +289,7 @@
     "email": "電子郵件",
     "saved": "設定已儲存",
     "saveFailed": "儲存設定失敗",
+    "invalidAvatarUrl": "頭像URL無效，請輸入http/https URL",
     "skills": "技能",
     "selectLanguages": "選擇程式語言",
     "selectFrameworks": "選擇框架和函式庫",


### PR DESCRIPTION
## 概要
- プロフィール保存時にavatar_urlがhttp/httpsであることをisHttpUrlで検証
- javascript:やdata:スキーム等の不正URLを拒否しエラートースト表示
- 10言語にsettings.invalidAvatarUrlキーを追加

closes #1541