### PR TITLE
feat: コメントに編集済みマーク表示を追加

### DIFF
--- a/frontend/src/components/posts/CommentItem.tsx
+++ b/frontend/src/components/posts/CommentItem.tsx
@@ -44,6 +44,11 @@ export default function CommentItem({
           </Link>
           <span className="text-xs text-gray-600">
             {format(new Date(comment.created_at), 'MMM d, yyyy · HH:mm')}
+            {comment.updated_at !== comment.created_at && (
+              <span className="ml-1 text-gray-600" title={format(new Date(comment.updated_at), 'MMM d, yyyy · HH:mm')}>
+                ({t('post.edited')})
+              </span>
+            )}
           </span>
         </div>
         <p className={`${isXs ? 'text-sm mt-0.5' : 'text-sm mt-1'} text-gray-300 leading-relaxed`}>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -208,6 +208,7 @@
     "writeReply": "Antwort schreiben...",
     "readTime": "{{minutes}} Min. Lesezeit",
     "newBadge": "NEU",
+    "edited": "bearbeitet",
     "notFound": "Beitrag nicht gefunden",
     "bookmark": "Lesezeichen",
     "unbookmark": "Lesezeichen entfernen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -208,6 +208,7 @@
     "writeReply": "Write a reply...",
     "readTime": "{{minutes}} min read",
     "newBadge": "NEW",
+    "edited": "edited",
     "notFound": "Post not found",
     "bookmark": "Bookmark",
     "unbookmark": "Remove Bookmark",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -208,6 +208,7 @@
     "writeReply": "Escribe una respuesta...",
     "readTime": "{{minutes}} min de lectura",
     "newBadge": "NEW",
+    "edited": "editado",
     "notFound": "Publicación no encontrada",
     "bookmark": "Marcador",
     "unbookmark": "Quitar marcador",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -208,6 +208,7 @@
     "writeReply": "Écrire une réponse...",
     "readTime": "{{minutes}} min de lecture",
     "newBadge": "NEW",
+    "edited": "modifié",
     "notFound": "Publication introuvable",
     "bookmark": "Signet",
     "unbookmark": "Retirer le signet",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -228,6 +228,7 @@
     "writeReply": "返信を書く...",
     "readTime": "{{minutes}}分で読める",
     "newBadge": "NEW",
+    "edited": "編集済み",
     "notFound": "投稿が見つかりません",
     "bookmark": "ブックマーク",
     "unbookmark": "ブックマーク解除",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -208,6 +208,7 @@
     "writeReply": "답글 작성...",
     "readTime": "{{minutes}}분 소요",
     "newBadge": "NEW",
+    "edited": "수정됨",
     "notFound": "게시물을 찾을 수 없습니다",
     "bookmark": "북마크",
     "unbookmark": "북마크 해제",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -208,6 +208,7 @@
     "writeReply": "Escrever uma resposta...",
     "readTime": "{{minutes}} min de leitura",
     "newBadge": "NOVO",
+    "edited": "editado",
     "notFound": "Publicação não encontrada",
     "bookmark": "Favorito",
     "unbookmark": "Remover favorito",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -208,6 +208,7 @@
     "writeReply": "Написать ответ...",
     "readTime": "{{minutes}} мин чтения",
     "newBadge": "НОВОЕ",
+    "edited": "отредактировано",
     "notFound": "Публикация не найдена",
     "bookmark": "Закладка",
     "unbookmark": "Удалить закладку",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -208,6 +208,7 @@
     "writeReply": "写回复...",
     "readTime": "{{minutes}}分钟阅读",
     "newBadge": "NEW",
+    "edited": "已编辑",
     "notFound": "未找到帖子",
     "bookmark": "书签",
     "unbookmark": "取消书签",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -208,6 +208,7 @@
     "writeReply": "寫回覆...",
     "readTime": "{{minutes}}分鐘閱讀",
     "newBadge": "NEW",
+    "edited": "已編輯",
     "notFound": "找不到貼文",
     "bookmark": "書籤",
     "unbookmark": "取消書籤",


### PR DESCRIPTION
## 概要
- コメントの`created_at`と`updated_at`を比較し、異なる場合にタイムスタンプ横に「(編集済み)」マークを表示
- ホバーで編集日時をツールチップ表示
- 10言語に`post.edited`のi18nキー追加

Closes #1543