### PR TITLE
refactor: アイコンボタンスタイルをiconButtonClass定数に統一

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewCard.tsx
+++ b/frontend/src/components/bookReviews/BookReviewCard.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import type { BookReview, ReviewStatus } from '../../types/bookReview';
 import Avatar from '../common/Avatar';
 import StarRating from '../common/StarRating';
-import { cardClass } from '../../constants/styles';
+import { cardClass, iconButtonClass } from '../../constants/styles';
 
 const statusColors: Record<ReviewStatus, string> = {
   not_started: 'bg-gray-600 text-gray-200',
@@ -63,7 +63,7 @@ export default function BookReviewCard({
               <div className="flex gap-1">
                 <button
                   onClick={onEdit}
-                  className="p-1.5 text-gray-400 hover:text-white transition-colors"
+                  className={iconButtonClass}
                   aria-label={t('common.edit')}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">

--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { Post } from '../../types/post';
 import Avatar from '../common/Avatar';
 import { format } from 'date-fns';
-import { cardDarkClass } from '../../constants/styles';
+import { cardDarkClass, iconButtonClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
 import PostCardContent from './PostCardContent';
 import PostCardActions from './PostCardActions';
@@ -57,7 +57,7 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
           <div className="flex gap-1 flex-shrink-0">
             <button
               onClick={onEdit}
-              className="p-1.5 text-gray-400 hover:text-white transition-colors"
+              className={iconButtonClass}
               aria-label={t('common.edit')}
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { Project } from '../../types/project';
-import { cardClass } from '../../constants/styles';
+import { cardClass, iconButtonClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
 import { sanitizeUrl } from '../../utils/url';
 
@@ -54,7 +54,7 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
             <div className="flex gap-1">
               <button
                 onClick={onEdit}
-                className="p-1.5 text-gray-400 hover:text-white transition-colors"
+                className={iconButtonClass}
                 aria-label={t('common.edit')}
               >
                 <svg aria-hidden="true" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">

--- a/frontend/src/components/qa/AnswerCard.tsx
+++ b/frontend/src/components/qa/AnswerCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { Answer } from '../../types/qa';
 import Avatar from '../common/Avatar';
+import { iconButtonClass } from '../../constants/styles';
 
 interface AnswerCardProps {
   answer: Answer;
@@ -115,7 +116,7 @@ export default function AnswerCard({
                 <>
                   <button
                     onClick={onEdit}
-                    className="p-1.5 text-gray-400 hover:text-white transition-colors"
+                    className={iconButtonClass}
                     title={t('common.edit')}
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">

--- a/frontend/src/components/qa/QuestionCard.tsx
+++ b/frontend/src/components/qa/QuestionCard.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { Question } from '../../types/qa';
 import Avatar from '../common/Avatar';
-import { cardPaddedClass } from '../../constants/styles';
+import { cardPaddedClass, iconButtonClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
 
 interface QuestionCardProps {
@@ -65,7 +65,7 @@ export default function QuestionCard({ question, isOwner = false, onEdit, onDele
               <div className="flex gap-1 flex-shrink-0">
                 <button
                   onClick={onEdit}
-                  className="p-1.5 text-gray-400 hover:text-white transition-colors"
+                  className={iconButtonClass}
                   title={t('common.edit')}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">

--- a/frontend/src/components/resources/ResourceCard.tsx
+++ b/frontend/src/components/resources/ResourceCard.tsx
@@ -5,7 +5,7 @@ import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin,
 import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import { parseJsonArray } from '../../utils/json';
 import Avatar from '../common/Avatar';
-import { cardClass } from '../../constants/styles';
+import { cardClass, iconButtonClass } from '../../constants/styles';
 import { sanitizeUrl } from '../../utils/url';
 
 interface ResourceCardProps {
@@ -107,7 +107,7 @@ export default function ResourceCard({
             <div className="flex gap-1">
               <button
                 onClick={onEdit}
-                className="p-1.5 text-gray-400 hover:text-white transition-colors"
+                className={iconButtonClass}
                 title={t('common.edit')}
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">

--- a/frontend/src/components/series/PostSeriesCard.tsx
+++ b/frontend/src/components/series/PostSeriesCard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { PostSeries } from '../../types/post';
-import { cardPaddedClass } from '../../constants/styles';
+import { cardPaddedClass, iconButtonClass } from '../../constants/styles';
 
 interface PostSeriesCardProps {
   series: PostSeries;
@@ -29,7 +29,7 @@ export default function PostSeriesCard({ series, onEdit, onDelete, isOwner }: Po
           <div className="flex gap-1">
             <button
               onClick={onEdit}
-              className="p-1.5 text-gray-400 hover:text-white transition-colors"
+              className={iconButtonClass}
               aria-label={t('common.edit')}
               title={t('common.edit')}
             >

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -43,6 +43,9 @@ export const labelClass =
 export const emptyStateClass =
   'bg-gray-900 border border-gray-800 rounded-md p-12 text-center';
 
+export const iconButtonClass =
+  'p-1.5 text-gray-400 hover:text-white transition-colors';
+
 export const modalOverlayClass =
   'fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4';
 


### PR DESCRIPTION
## 概要
- 7ファイルで重複していた `p-1.5 text-gray-400 hover:text-white transition-colors` を `constants/styles.ts` の `iconButtonClass` 定数に抽出
- 対象: PostCard, PostSeriesCard, QuestionCard, AnswerCard, ProjectCard, ResourceCard, BookReviewCard

Closes #1545