### PR TITLE
fix: action_urlのナビゲーション前に内部パス検証を追加

### DIFF
--- a/frontend/src/components/advice/AdviceCard.tsx
+++ b/frontend/src/components/advice/AdviceCard.tsx
@@ -39,7 +39,7 @@ export default function AdviceCard({ advice, onMarkRead }: AdviceCardProps) {
             {t(advice.message_key, params)}
           </p>
           <div className="flex items-center gap-2 mt-3">
-            {advice.action_url && (
+            {advice.action_url?.startsWith('/') && (
               <button
                 onClick={() => navigate(advice.action_url)}
                 className="text-xs text-blue-400 hover:text-blue-300 transition-colors"

--- a/frontend/src/components/dashboard/AIAdviceWidget.tsx
+++ b/frontend/src/components/dashboard/AIAdviceWidget.tsx
@@ -51,7 +51,7 @@ export default function AIAdviceWidget() {
                 key={advice.id}
                 className="flex items-start gap-2 p-2 rounded-lg hover:bg-gray-700/30 cursor-pointer transition-colors"
                 onClick={() => {
-                  if (advice.action_url) navigate(advice.action_url);
+                  if (advice.action_url?.startsWith('/')) navigate(advice.action_url);
                 }}
               >
                 <AdviceIcon type={advice.type} size={16} className="mt-0.5" />


### PR DESCRIPTION
## 概要
- AdviceCard.tsx / AIAdviceWidget.tsx で、APIから返される`action_url`が`/`で始まる内部パスであることを検証
- 外部URLやjavascript:プロトコル等による不正なナビゲーションを防止

Closes #1549