### PR TITLE
feat: PostForm執筆中に推定読了時間をリアルタイム表示

### DIFF
--- a/frontend/src/components/posts/PostForm.tsx
+++ b/frontend/src/components/posts/PostForm.tsx
@@ -34,6 +34,8 @@ export default function PostForm({ post, onSubmit, onCancel, loading: externalLo
   const [expanded, setExpanded] = useState(!!post);
   const { confirm, dialogProps } = useConfirm();
 
+  const estimatedReadMinutes = Math.max(1, Math.ceil(content.length / 500));
+
   const addSnippet = () => {
     setSnippets([...snippets, { language: '', file_name: '', code: '' }]);
   };
@@ -99,6 +101,11 @@ export default function PostForm({ post, onSubmit, onCancel, loading: externalLo
               minHeight="150px"
               onImagesChange={setImageUrls}
             />
+            {content.length > 0 && (
+              <p className="text-xs text-gray-500 text-right mt-1">
+                {t('post.readTime', { minutes: estimatedReadMinutes })}
+              </p>
+            )}
           </div>
 
           {/* Code Snippets Section */}


### PR DESCRIPTION
## 概要
- PostFormのMarkdownEditor下に推定読了時間をリアルタイム表示
- 500文字/分で計算（最低1分）
- コンテンツ入力開始後に表示、空の場合は非表示
- 既存の`post.readTime` i18nキーを再利用

Closes #1551