### PR TITLE
refactor: スキル選択ボタンの基本スタイルをchipButtonClass定数に抽出

### DIFF
--- a/frontend/src/components/onboarding/OnboardingSkillsStep.tsx
+++ b/frontend/src/components/onboarding/OnboardingSkillsStep.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { LANGUAGES, FRAMEWORKS } from '../../constants/skills';
+import { chipButtonClass } from '../../constants/styles';
 
 interface OnboardingSkillsStepProps {
   selectedLanguages: string[];
@@ -41,7 +42,7 @@ export default function OnboardingSkillsStep({
                 key={lang}
                 type="button"
                 onClick={() => toggleLanguage(lang)}
-                className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all border ${
+                className={`${chipButtonClass} ${
                   selectedLanguages.includes(lang)
                     ? 'bg-blue-600/20 text-blue-300 border-blue-500/50'
                     : 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-500'
@@ -73,7 +74,7 @@ export default function OnboardingSkillsStep({
                 key={fw}
                 type="button"
                 onClick={() => toggleFramework(fw)}
-                className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all border ${
+                className={`${chipButtonClass} ${
                   selectedFrameworks.includes(fw)
                     ? 'bg-purple-600/20 text-purple-300 border-purple-500/50'
                     : 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-500'

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -43,6 +43,9 @@ export const labelClass =
 export const emptyStateClass =
   'bg-gray-900 border border-gray-800 rounded-md p-12 text-center';
 
+export const chipButtonClass =
+  'px-3 py-1.5 rounded-lg text-xs font-medium transition-all border';
+
 export const iconButtonClass =
   'p-1.5 text-gray-400 hover:text-white transition-colors';
 

--- a/frontend/src/pages/RankingsPage.tsx
+++ b/frontend/src/pages/RankingsPage.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Search } from 'lucide-react';
 import { useRankings } from '../hooks';
-import { sectionContainerClass, inputClass, emptyStateClass } from '../constants/styles';
+import { sectionContainerClass, inputClass, emptyStateClass, chipButtonClass } from '../constants/styles';
 import Avatar from '../components/common/Avatar';
 import { PageLoader } from '../components/common';
 
@@ -111,7 +111,7 @@ export default function RankingsPage() {
               <button
                 key={lang}
                 onClick={() => setLanguage(lang)}
-                className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all border ${
+                className={`${chipButtonClass} ${
                   language === lang
                     ? 'bg-purple-600 text-white border-purple-500 shadow-sm shadow-purple-500/20'
                     : 'bg-gray-800 text-gray-400 border-gray-700 hover:text-white hover:border-gray-500 hover:bg-gray-700'

--- a/frontend/src/pages/settings/SkillsSection.tsx
+++ b/frontend/src/pages/settings/SkillsSection.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Sparkles } from 'lucide-react';
-import { buttonSecondaryClass, sectionContainerClass } from '../../constants/styles';
+import { buttonSecondaryClass, sectionContainerClass, chipButtonClass } from '../../constants/styles';
 import { LANGUAGES, FRAMEWORKS } from '../../constants/skills';
 
 interface Props {
@@ -41,7 +41,7 @@ export default function SkillsSection({
                 key={lang}
                 type="button"
                 onClick={() => toggleLanguage(lang)}
-                className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all border ${
+                className={`${chipButtonClass} ${
                   selectedLanguages.includes(lang)
                     ? 'bg-blue-600/20 text-blue-300 border-blue-500/50'
                     : 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-500'
@@ -77,7 +77,7 @@ export default function SkillsSection({
                 key={fw}
                 type="button"
                 onClick={() => toggleFramework(fw)}
-                className={`px-3 py-1.5 rounded-lg text-xs font-medium transition-all border ${
+                className={`${chipButtonClass} ${
                   selectedFrameworks.includes(fw)
                     ? 'bg-purple-600/20 text-purple-300 border-purple-500/50'
                     : 'bg-gray-800 text-gray-400 border-gray-700 hover:border-gray-500'


### PR DESCRIPTION
## 概要
- 5箇所で重複していた `px-3 py-1.5 rounded-lg text-xs font-medium transition-all border` を `constants/styles.ts` の `chipButtonClass` に抽出
- 対象: SkillsSection（2箇所）、OnboardingSkillsStep（2箇所）、RankingsPage（1箇所）

Closes #1553