### PR TITLE
fix: sessionStorage値の厳密な値チェックに変更

### DIFF
--- a/frontend/src/pages/GitHubCallbackPage.tsx
+++ b/frontend/src/pages/GitHubCallbackPage.tsx
@@ -59,7 +59,7 @@ export default function GitHubCallbackPage() {
           await loadUser();
           toast.success(t('githubCallback.connectSuccess'));
           const onboardingRedirect = sessionStorage.getItem('onboarding_redirect');
-          if (onboardingRedirect) {
+          if (onboardingRedirect === 'true') {
             sessionStorage.removeItem('onboarding_redirect');
             navigate('/onboarding');
           } else {


### PR DESCRIPTION
## 概要
- GitHubCallbackPageの`onboarding_redirect` sessionStorage値をtruthyチェックから `=== 'true'` の厳密比較に変更
- 任意の文字列値による意図しないリダイレクトを防止

Closes #1557