### PR TITLE
feat: PostSearchCardにタグプレビュー表示を追加

### DIFF
--- a/frontend/src/components/search/PostSearchCard.tsx
+++ b/frontend/src/components/search/PostSearchCard.tsx
@@ -25,6 +25,18 @@ export default function PostSearchCard({ post }: PostSearchCardProps) {
           </div>
           <h3 className="font-semibold text-white mb-1">{post.title}</h3>
           <p className="text-sm text-gray-400 line-clamp-2">{post.content}</p>
+          {post.tags && post.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {post.tags.slice(0, 3).map((tag) => (
+                <span key={tag} className="text-xs px-2 py-0.5 bg-blue-500/10 text-blue-400 rounded">
+                  {tag}
+                </span>
+              ))}
+              {post.tags.length > 3 && (
+                <span className="text-xs text-gray-500">+{post.tags.length - 3}</span>
+              )}
+            </div>
+          )}
           <div className="flex items-center gap-4 mt-3 text-xs text-gray-500">
             <span>{t('search.likesCount', { count: post.like_count || 0 })}</span>
             <span>{t('search.commentsCount', { count: post.comment_count || 0 })}</span>


### PR DESCRIPTION
## 概要
- 検索結果のPostSearchCardにタグバッジを最大3つ表示
- PostCardと同じスタイル（bg-blue-500/10 text-blue-400）で統一
- 4つ以上のタグは「+N」表示

Closes #1559