### PR TITLE
refactor: 削除アイコンボタンスタイルをdeleteIconButtonClass定数に統一

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewCard.tsx
+++ b/frontend/src/components/bookReviews/BookReviewCard.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 import type { BookReview, ReviewStatus } from '../../types/bookReview';
 import Avatar from '../common/Avatar';
 import StarRating from '../common/StarRating';
-import { cardClass, iconButtonClass } from '../../constants/styles';
+import { cardClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
 
 const statusColors: Record<ReviewStatus, string> = {
   not_started: 'bg-gray-600 text-gray-200',
@@ -72,7 +72,7 @@ export default function BookReviewCard({
                 </button>
                 <button
                   onClick={onDelete}
-                  className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+                  className={deleteIconButtonClass}
                   aria-label={t('common.delete')}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">

--- a/frontend/src/components/posts/PostCard.tsx
+++ b/frontend/src/components/posts/PostCard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { Post } from '../../types/post';
 import Avatar from '../common/Avatar';
 import { format } from 'date-fns';
-import { cardDarkClass, iconButtonClass } from '../../constants/styles';
+import { cardDarkClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
 import PostCardContent from './PostCardContent';
 import PostCardActions from './PostCardActions';
@@ -66,7 +66,7 @@ export default function PostCard({ post, isOwner = false, onEdit, onDelete, onUp
             </button>
             <button
               onClick={onDelete}
-              className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+              className={deleteIconButtonClass}
               aria-label={t('common.delete')}
             >
               <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { Project } from '../../types/project';
-import { cardClass, iconButtonClass } from '../../constants/styles';
+import { cardClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
 import { sanitizeUrl } from '../../utils/url';
 
@@ -63,7 +63,7 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
               </button>
               <button
                 onClick={onDelete}
-                className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+                className={deleteIconButtonClass}
                 aria-label={t('common.delete')}
               >
                 <svg aria-hidden="true" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">

--- a/frontend/src/components/qa/AnswerCard.tsx
+++ b/frontend/src/components/qa/AnswerCard.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { Answer } from '../../types/qa';
 import Avatar from '../common/Avatar';
-import { iconButtonClass } from '../../constants/styles';
+import { iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
 
 interface AnswerCardProps {
   answer: Answer;
@@ -125,7 +125,7 @@ export default function AnswerCard({
                   </button>
                   <button
                     onClick={onDelete}
-                    className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+                    className={deleteIconButtonClass}
                     title={t('common.delete')}
                   >
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">

--- a/frontend/src/components/qa/QuestionCard.tsx
+++ b/frontend/src/components/qa/QuestionCard.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { Question } from '../../types/qa';
 import Avatar from '../common/Avatar';
-import { cardPaddedClass, iconButtonClass } from '../../constants/styles';
+import { cardPaddedClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
 
 interface QuestionCardProps {
@@ -74,7 +74,7 @@ export default function QuestionCard({ question, isOwner = false, onEdit, onDele
                 </button>
                 <button
                   onClick={onDelete}
-                  className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+                  className={deleteIconButtonClass}
                   title={t('common.delete')}
                 >
                   <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">

--- a/frontend/src/components/resources/ResourceCard.tsx
+++ b/frontend/src/components/resources/ResourceCard.tsx
@@ -5,7 +5,7 @@ import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin,
 import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import { parseJsonArray } from '../../utils/json';
 import Avatar from '../common/Avatar';
-import { cardClass, iconButtonClass } from '../../constants/styles';
+import { cardClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
 import { sanitizeUrl } from '../../utils/url';
 
 interface ResourceCardProps {
@@ -116,7 +116,7 @@ export default function ResourceCard({
               </button>
               <button
                 onClick={onDelete}
-                className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+                className={deleteIconButtonClass}
                 title={t('common.delete')}
               >
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">

--- a/frontend/src/components/roadmaps/RoadmapStepList.tsx
+++ b/frontend/src/components/roadmaps/RoadmapStepList.tsx
@@ -3,6 +3,7 @@ import { List } from 'lucide-react';
 import { type RoadmapStep } from '../../api/roadmaps';
 import EmptyState from '../common/EmptyState';
 import { sanitizeUrl } from '../../utils/url';
+import { deleteIconButtonClass } from '../../constants/styles';
 
 interface RoadmapStepListProps {
   steps: RoadmapStep[] | undefined;
@@ -106,7 +107,7 @@ export default function RoadmapStepList({
                     </button>
                     <button
                       onClick={() => onDelete(step.id)}
-                      className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+                      className={deleteIconButtonClass}
                     >
                       <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
                         <path strokeLinecap="round" strokeLinejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 00-7.5 0" />

--- a/frontend/src/components/series/PostSeriesCard.tsx
+++ b/frontend/src/components/series/PostSeriesCard.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { PostSeries } from '../../types/post';
-import { cardPaddedClass, iconButtonClass } from '../../constants/styles';
+import { cardPaddedClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
 
 interface PostSeriesCardProps {
   series: PostSeries;
@@ -39,7 +39,7 @@ export default function PostSeriesCard({ series, onEdit, onDelete, isOwner }: Po
             </button>
             <button
               onClick={onDelete}
-              className="p-1.5 text-gray-400 hover:text-red-400 transition-colors"
+              className={deleteIconButtonClass}
               aria-label={t('common.delete')}
               title={t('common.delete')}
             >

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -49,6 +49,9 @@ export const chipButtonClass =
 export const iconButtonClass =
   'p-1.5 text-gray-400 hover:text-white transition-colors';
 
+export const deleteIconButtonClass =
+  'p-1.5 text-gray-400 hover:text-red-400 transition-colors';
+
 export const modalOverlayClass =
   'fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4';
 


### PR DESCRIPTION
## 概要
- 8ファイルで重複していた `p-1.5 text-gray-400 hover:text-red-400 transition-colors` を `constants/styles.ts` の `deleteIconButtonClass` に抽出
- 対象: PostCard, PostSeriesCard, QuestionCard, AnswerCard, ProjectCard, ResourceCard, BookReviewCard, RoadmapStepList

Closes #1561