### PR TITLE
feat: UserSearchCardにスキルバッジを表示

### DIFF
--- a/frontend/src/components/search/UserSearchCard.tsx
+++ b/frontend/src/components/search/UserSearchCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import type { User } from '../../types/user';
 import Avatar from '../common/Avatar';
 import FollowButton from '../profile/FollowButton';
+import { parseJsonArray } from '../../utils/json';
 
 interface UserSearchCardProps {
   user: User;
@@ -11,6 +12,7 @@ interface UserSearchCardProps {
 
 export default function UserSearchCard({ user, currentUserId }: UserSearchCardProps) {
   const { t } = useTranslation();
+  const skills = parseJsonArray(user.skills_languages);
 
   return (
     <div className="bg-gray-900 border border-gray-800 rounded-md p-5 hover:border-gray-700 transition-colors">
@@ -23,6 +25,23 @@ export default function UserSearchCard({ user, currentUserId }: UserSearchCardPr
             {user.name}
           </Link>
           {user.bio && <p className="text-xs text-gray-400 mt-1 line-clamp-2">{user.bio}</p>}
+          {skills.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {skills.slice(0, 3).map((skill: string) => (
+                <span
+                  key={skill}
+                  className="px-2 py-0.5 bg-gray-700 text-gray-300 text-xs rounded"
+                >
+                  {skill}
+                </span>
+              ))}
+              {skills.length > 3 && (
+                <span className="px-2 py-0.5 text-gray-400 text-xs">
+                  +{skills.length - 3}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </div>
       <div className="flex items-center gap-2 mt-4 pt-3 border-t border-gray-800/50">


### PR DESCRIPTION
## 概要
検索結果のユーザーカードにスキル（skills_languages）をバッジとして表示する。

## 変更内容
- `UserSearchCard`にparseJsonArrayでskills_languagesをパースして表示
- 最大3つまでバッジ表示、4つ以上は+Nで省略
- ProjectCardのtechStackと同じスタイル（bg-gray-700 text-gray-300）で統一

Closes #1567