### PR TITLE
refactor: toLocaleDateString()呼び出しをformatDateユーティリティに統一

### DIFF
--- a/frontend/src/components/advice/ConversationList.tsx
+++ b/frontend/src/components/advice/ConversationList.tsx
@@ -3,6 +3,7 @@ import { MessageSquare, Clock, Trash2 } from 'lucide-react';
 import { useConfirm } from '../../hooks';
 import ConfirmDialog from '../common/ConfirmDialog';
 import type { AIConversation } from '../../api/advice';
+import { formatDate } from '../../utils/timeFormat';
 
 interface ConversationListProps {
   conversations: AIConversation[];
@@ -62,7 +63,7 @@ export default function ConversationList({
             <div className="flex items-center gap-1 mt-1">
               <Clock size={12} className="text-gray-500" />
               <span className="text-xs text-gray-500">
-                {new Date(conv.updated_at).toLocaleDateString()}
+                {formatDate(conv.updated_at)}
               </span>
               {conv.messages && (
                 <span className="text-xs text-gray-500 ml-2">

--- a/frontend/src/components/goals/GoalCard.tsx
+++ b/frontend/src/components/goals/GoalCard.tsx
@@ -2,6 +2,7 @@ import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Monitor, Rocket, Target, FolderOpen, FileText, Copy, type LucideIcon } from 'lucide-react';
 import { type GoalCategory, type GoalStatus, type LearningGoal } from '../../api/goals';
+import { formatDate } from '../../utils/timeFormat';
 
 export const CATEGORIES: { value: GoalCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'goals.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -77,7 +78,7 @@ const GoalCard = memo(function GoalCard({
               <span>{t(categoryInfo.label)}</span>
               {goal.target_date && (
                 <span>
-                  {t('goals.targetDateLabel')}: {new Date(goal.target_date).toLocaleDateString()}
+                  {t('goals.targetDateLabel')}: {formatDate(goal.target_date)}
                 </span>
               )}
               {(() => {

--- a/frontend/src/components/learning-logs/LogCard.tsx
+++ b/frontend/src/components/learning-logs/LogCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Code, BookOpen, GraduationCap, Users, FileText, Star, type LucideIcon } from 'lucide-react';
 import type { LearningLog, LogCategory } from '../../types/learningLog';
+import { formatDate } from '../../utils/timeFormat';
 
 export const CATEGORIES: { value: LogCategory; label: string; Icon: LucideIcon }[] = [
   { value: 'coding', label: 'learningLogs.categoryCoding', Icon: Code },
@@ -49,7 +50,7 @@ export default function LogCard({ log, onEdit, onDelete, onToggleFavorite }: Log
             </div>
             <p className="text-sm text-gray-400 mt-1 whitespace-pre-wrap">{log.content}</p>
             <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
-              <span>{new Date(log.created_at).toLocaleDateString()}</span>
+              <span>{formatDate(log.created_at)}</span>
               {log.duration > 0 && (
                 <span>
                   {log.duration >= 60

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -3,6 +3,7 @@ import type { Project } from '../../types/project';
 import { cardClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
 import { sanitizeUrl } from '../../utils/url';
+import { formatDate } from '../../utils/timeFormat';
 
 interface ProjectCardProps {
   project: Project;
@@ -15,11 +16,6 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
   const { t } = useTranslation();
 
   const techStack = parseJsonArray(project.tech_stack);
-
-  const formatDate = (dateStr: string | null) => {
-    if (!dateStr) return null;
-    return new Date(dateStr).toLocaleDateString();
-  };
 
   return (
     <div className={cardClass}>

--- a/frontend/src/components/qa/AnswerCard.tsx
+++ b/frontend/src/components/qa/AnswerCard.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import type { Answer } from '../../types/qa';
 import Avatar from '../common/Avatar';
 import { iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
+import { formatDate } from '../../utils/timeFormat';
 
 interface AnswerCardProps {
   answer: Answer;
@@ -99,7 +100,7 @@ export default function AnswerCard({
                 </Link>
               )}
               <span className="text-xs text-gray-500">
-                {new Date(answer.created_at).toLocaleDateString()}
+                {formatDate(answer.created_at)}
               </span>
             </div>
 

--- a/frontend/src/components/qa/QuestionCard.tsx
+++ b/frontend/src/components/qa/QuestionCard.tsx
@@ -4,6 +4,7 @@ import type { Question } from '../../types/qa';
 import Avatar from '../common/Avatar';
 import { cardPaddedClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
+import { formatDate } from '../../utils/timeFormat';
 
 interface QuestionCardProps {
   question: Question;
@@ -110,7 +111,7 @@ export default function QuestionCard({ question, isOwner = false, onEdit, onDele
               </Link>
             )}
             <span className="text-xs text-gray-500">
-              {new Date(question.created_at).toLocaleDateString()}
+              {formatDate(question.created_at)}
             </span>
           </div>
         </div>

--- a/frontend/src/components/roadmaps/RoadmapStepList.tsx
+++ b/frontend/src/components/roadmaps/RoadmapStepList.tsx
@@ -4,6 +4,7 @@ import { type RoadmapStep } from '../../api/roadmaps';
 import EmptyState from '../common/EmptyState';
 import { sanitizeUrl } from '../../utils/url';
 import { deleteIconButtonClass } from '../../constants/styles';
+import { formatDate } from '../../utils/timeFormat';
 
 interface RoadmapStepListProps {
   steps: RoadmapStep[] | undefined;
@@ -74,7 +75,7 @@ export default function RoadmapStepList({
                   </div>
                   {step.is_completed && step.completed_at && (
                     <p className="text-xs text-green-400 mt-0.5">
-                      {t('roadmaps.completedOn', { date: new Date(step.completed_at).toLocaleDateString() })}
+                      {t('roadmaps.completedOn', { date: formatDate(step.completed_at) })}
                     </p>
                   )}
                   {step.description && (

--- a/frontend/src/components/search/PostSearchCard.tsx
+++ b/frontend/src/components/search/PostSearchCard.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import type { Post } from '../../types/post';
 import Avatar from '../common/Avatar';
+import { formatDate } from '../../utils/timeFormat';
 
 interface PostSearchCardProps {
   post: Post;
@@ -21,7 +22,7 @@ export default function PostSearchCard({ post }: PostSearchCardProps) {
           <div className="flex items-center gap-2 text-xs text-gray-500 mb-1">
             <span className="font-medium text-gray-300">{post.user?.name}</span>
             <span>•</span>
-            <span>{new Date(post.created_at).toLocaleDateString()}</span>
+            <span>{formatDate(post.created_at)}</span>
           </div>
           <h3 className="font-semibold text-white mb-1">{post.title}</h3>
           <p className="text-sm text-gray-400 line-clamp-2">{post.content}</p>

--- a/frontend/src/components/series/PostSeriesCard.tsx
+++ b/frontend/src/components/series/PostSeriesCard.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import type { PostSeries } from '../../types/post';
 import { cardPaddedClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
+import { formatDate } from '../../utils/timeFormat';
 
 interface PostSeriesCardProps {
   series: PostSeries;
@@ -56,7 +57,7 @@ export default function PostSeriesCard({ series, onEdit, onDelete, isOwner }: Po
       )}
 
       <p className="text-xs text-gray-500 mt-3">
-        {new Date(series.created_at).toLocaleDateString()}
+        {formatDate(series.created_at)}
       </p>
     </div>
   );

--- a/frontend/src/components/youtube/YouTubeVideoCard.tsx
+++ b/frontend/src/components/youtube/YouTubeVideoCard.tsx
@@ -3,6 +3,7 @@ import { ExternalLink, Play } from 'lucide-react';
 import type { YouTubeVideo } from '../../types/youtube';
 import { cardClass } from '../../constants/styles';
 import { sanitizeUrl } from '../../utils/url';
+import { formatDate } from '../../utils/timeFormat';
 
 interface YouTubeVideoCardProps {
   video: YouTubeVideo;
@@ -47,7 +48,7 @@ export default function YouTubeVideoCard({ video }: YouTubeVideoCardProps) {
 
         <div className="flex items-center justify-between mt-3 pt-2 border-t border-gray-700">
           <span className="text-xs text-gray-500">
-            {new Date(video.published_at).toLocaleDateString()}
+            {formatDate(video.published_at)}
           </span>
           <a href={videoURL} target="_blank" rel="noopener noreferrer"
              className="text-gray-400 hover:text-red-400 transition-colors"

--- a/frontend/src/pages/PostCollectionDetailPage.tsx
+++ b/frontend/src/pages/PostCollectionDetailPage.tsx
@@ -9,6 +9,7 @@ import PostCard from '../components/posts/PostCard';
 import { useAuthStore } from '../store/authStore';
 import { Globe, Lock } from 'lucide-react';
 import { emptyStateClass } from '../constants/styles';
+import { formatDate } from '../utils/timeFormat';
 
 export default function PostCollectionDetailPage() {
   const { t } = useTranslation();
@@ -52,7 +53,7 @@ export default function PostCollectionDetailPage() {
           </Link>
         )}
         <p className="text-xs text-gray-500 mt-2">
-          {new Date(collection.created_at).toLocaleDateString()}
+          {formatDate(collection.created_at)}
         </p>
       </div>
 

--- a/frontend/src/pages/PostSeriesDetailPage.tsx
+++ b/frontend/src/pages/PostSeriesDetailPage.tsx
@@ -8,6 +8,7 @@ import { PageLoader } from '../components/common';
 import PostCard from '../components/posts/PostCard';
 import { useAuthStore } from '../store/authStore';
 import { emptyStateClass } from '../constants/styles';
+import { formatDate } from '../utils/timeFormat';
 
 export default function PostSeriesDetailPage() {
   const { t } = useTranslation();
@@ -44,7 +45,7 @@ export default function PostSeriesDetailPage() {
           </Link>
         )}
         <p className="text-xs text-gray-500 mt-2">
-          {new Date(series.created_at).toLocaleDateString()}
+          {formatDate(series.created_at)}
         </p>
       </div>
 

--- a/frontend/src/pages/QADetailPage.tsx
+++ b/frontend/src/pages/QADetailPage.tsx
@@ -9,6 +9,7 @@ import AnswerForm from '../components/qa/AnswerForm';
 import Avatar from '../components/common/Avatar';
 import { PageLoader } from '../components/common';
 import { parseJsonArray } from '../utils/json';
+import { formatDate } from '../utils/timeFormat';
 
 export default function QADetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -135,7 +136,7 @@ export default function QADetailPage() {
                   <div>
                     <span className="text-sm text-gray-300">{question.user.name}</span>
                     <span className="text-xs text-gray-500 ml-2">
-                      {new Date(question.created_at).toLocaleDateString()}
+                      {formatDate(question.created_at)}
                     </span>
                   </div>
                 </Link>

--- a/frontend/src/utils/timeFormat.ts
+++ b/frontend/src/utils/timeFormat.ts
@@ -1,5 +1,10 @@
 import i18n from '../i18n';
 
+export function formatDate(dateStr: string | null | undefined): string | null {
+  if (!dateStr) return null;
+  return new Date(dateStr).toLocaleDateString();
+}
+
 export function formatDistanceToNow(dateString: string): string {
   const t = i18n.t.bind(i18n);
   const date = new Date(dateString);


### PR DESCRIPTION
## 概要
13ファイルで重複していた`new Date(xxx).toLocaleDateString()`パターンを共通ユーティリティに集約。

## 変更内容
- `utils/timeFormat.ts`に`formatDate`関数を追加（null/undefined安全）
- 13ファイルのインライン`toLocaleDateString()`呼び出しを`formatDate()`に置換
- `ProjectCard`のローカル`formatDate`関数を削除し共通版に統一

## 対象ファイル
PostSeriesCard, QuestionCard, AnswerCard, PostSearchCard, LogCard, YouTubeVideoCard, ConversationList, RoadmapStepList, PostSeriesDetailPage, PostCollectionDetailPage, QADetailPage, ProjectCard, GoalCard

Closes #1569