### PR TITLE
fix: AdviceCard/AIAdviceWidgetのJSON.parseにtry-catch保護追加

### DIFF
--- a/frontend/src/components/advice/AdviceCard.tsx
+++ b/frontend/src/components/advice/AdviceCard.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Check } from 'lucide-react';
 import AdviceIcon from './AdviceIcon';
 import type { AIAdvice } from '../../api/advice';
+import { parseJsonObject } from '../../utils/json';
 
 interface AdviceCardProps {
   advice: AIAdvice;
@@ -13,7 +14,7 @@ export default function AdviceCard({ advice, onMarkRead }: AdviceCardProps) {
   const { t } = useTranslation();
   const navigate = useNavigate();
 
-  const params = advice.params ? JSON.parse(advice.params) : {};
+  const params = parseJsonObject(advice.params);
 
   const priorityBorder: Record<number, string> = {
     1: 'border-l-red-500',

--- a/frontend/src/components/dashboard/AIAdviceWidget.tsx
+++ b/frontend/src/components/dashboard/AIAdviceWidget.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { Lightbulb, ChevronRight, MessageSquare } from 'lucide-react';
 import { useAdvice } from '../../hooks/useAdvice';
 import AdviceIcon from '../advice/AdviceIcon';
+import { parseJsonObject } from '../../utils/json';
 
 export default function AIAdviceWidget() {
   const { t } = useTranslation();
@@ -45,7 +46,7 @@ export default function AIAdviceWidget() {
       ) : (
         <div className="space-y-2">
           {topAdvices.map((advice) => {
-            const params = advice.params ? JSON.parse(advice.params) : {};
+            const params = parseJsonObject(advice.params);
             return (
               <div
                 key={advice.id}

--- a/frontend/src/utils/json.ts
+++ b/frontend/src/utils/json.ts
@@ -6,3 +6,13 @@ export function parseJsonArray<T = string>(json: string | undefined | null): T[]
     return [];
   }
 }
+
+export function parseJsonObject(json: string | undefined | null): Record<string, unknown> {
+  if (!json) return {};
+  try {
+    const parsed = JSON.parse(json);
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}


### PR DESCRIPTION
## 概要
不正なJSONでコンポーネントがクラッシュする可能性があったJSON.parseを安全なパース関数に置換。

## 変更内容
- `utils/json.ts`に`parseJsonObject`関数を追加（配列やnullも安全に処理）
- `AdviceCard`と`AIAdviceWidget`の`JSON.parse(advice.params)`を`parseJsonObject(advice.params)`に置換
- パース失敗時は空オブジェクト`{}`にフォールバック

Closes #1573