### PR TITLE
feat: DraftsPageに古い下書きの視覚的警告インジケーター追加

### DIFF
--- a/frontend/src/pages/DraftsPage.tsx
+++ b/frontend/src/pages/DraftsPage.tsx
@@ -11,6 +11,13 @@ import ConfirmDialog from '../components/common/ConfirmDialog';
 import { formatDistanceToNow } from '../utils/timeFormat';
 import { emptyStateClass } from '../constants/styles';
 
+const getDraftAgeClass = (updatedAt: string): string => {
+  const diffDays = Math.floor((Date.now() - new Date(updatedAt).getTime()) / 86400000);
+  if (diffDays >= 30) return 'text-orange-400';
+  if (diffDays >= 7) return 'text-yellow-500';
+  return 'text-gray-500';
+};
+
 export default function DraftsPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
@@ -134,7 +141,7 @@ export default function DraftsPage() {
               </div>
 
               <div className="flex items-center justify-between mt-4 pt-3 border-t border-gray-800">
-                <span className="text-xs text-gray-500">
+                <span className={`text-xs ${getDraftAgeClass(draft.updated_at)}`}>
                   {t('post.lastEdited')}: {formatDistanceToNow(draft.updated_at)}
                 </span>
 


### PR DESCRIPTION
## 概要
下書き一覧で長期間放置された下書きの最終更新日時を色分け表示する。

## 変更内容
- `getDraftAgeClass`関数を追加（更新日からの経過日数で色を判定）
  - 7日未満: グレー（従来通り）
  - 7-30日: 黄色（`text-yellow-500`）
  - 30日以上: オレンジ（`text-orange-400`）
- i18nキー追加不要、既存表示の色変更のみ

Closes #1575