### PR TITLE
refactor: ダッシュボードウィジェットのカードクラスをpanelClassに統一

### DIFF
--- a/frontend/src/components/dashboard/DailyChallengeWidget.tsx
+++ b/frontend/src/components/dashboard/DailyChallengeWidget.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Sparkles, CheckCircle2 } from 'lucide-react';
 import { getDailyChallenge, isChallengeCompleted, markChallengeCompleted } from '../../utils/dailyChallenge';
+import { panelClass } from '../../constants/styles';
 
 export default function DailyChallengeWidget() {
   const { t } = useTranslation();
@@ -14,7 +15,7 @@ export default function DailyChallengeWidget() {
   };
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <h3 className="flex items-center gap-2 text-sm font-medium text-white mb-3">
         <Sparkles className="w-4 h-4 text-yellow-400" />
         {t('dailyChallenge.title')}

--- a/frontend/src/components/dashboard/GoalsProgressWidget.tsx
+++ b/frontend/src/components/dashboard/GoalsProgressWidget.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Target, ChevronRight } from 'lucide-react';
 import type { LearningGoal } from '../../api/goals';
+import { panelClass } from '../../constants/styles';
 
 interface GoalsProgressWidgetProps {
   activeGoals: LearningGoal[];
@@ -14,7 +15,7 @@ export default function GoalsProgressWidget({ activeGoals, completedGoals, avgPr
   const { t } = useTranslation();
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <div className="flex items-center justify-between mb-3">
         <h3 className="flex items-center gap-2 text-sm font-medium text-white">
           <Target className="w-4 h-4 text-blue-400" aria-hidden="true" />

--- a/frontend/src/components/dashboard/LevelWidget.tsx
+++ b/frontend/src/components/dashboard/LevelWidget.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Star } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useMyLevel } from '../../hooks';
+import { panelClass } from '../../constants/styles';
 
 function getLevelTitleKey(level: number): { key: string; params?: Record<string, unknown> } {
   if (level === 0) return { key: 'level.titleNewcomer' };
@@ -22,7 +23,7 @@ export default function LevelWidget() {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className={panelClass}>
         <div className="h-5 bg-gray-800 rounded animate-pulse w-1/2 mb-3" />
         <div className="h-12 bg-gray-800 rounded animate-pulse mb-3" />
         <div className="h-3 bg-gray-800 rounded animate-pulse" />
@@ -38,7 +39,7 @@ export default function LevelWidget() {
   const xpToNext = nextLevelXP - totalXP;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <h3 className="flex items-center gap-2 text-sm font-medium text-white mb-3">
         <Star className="w-4 h-4 text-gray-400" />
         {t('level.title')}

--- a/frontend/src/components/dashboard/QuickStatsWidget.tsx
+++ b/frontend/src/components/dashboard/QuickStatsWidget.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { TrendingUp, CheckCircle2, Clock } from 'lucide-react';
+import { panelClass } from '../../constants/styles';
 
 interface QuickStatsWidgetProps {
   activeCount: number;
@@ -11,7 +12,7 @@ export default function QuickStatsWidget({ activeCount, completedCount }: QuickS
   const { t } = useTranslation();
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <h3 className="flex items-center gap-2 text-sm font-medium text-white mb-3">
         <TrendingUp className="w-4 h-4 text-green-400" aria-hidden="true" />
         {t('dashboard.quickStats')}

--- a/frontend/src/components/dashboard/RecentNotificationsWidget.tsx
+++ b/frontend/src/components/dashboard/RecentNotificationsWidget.tsx
@@ -5,6 +5,7 @@ import { Bell } from 'lucide-react';
 import Avatar from '../common/Avatar';
 import { formatDistanceToNow } from '../../utils/timeFormat';
 import type { Notification } from '../../types/notification';
+import { panelClass } from '../../constants/styles';
 
 interface RecentNotificationsWidgetProps {
   notifications: Notification[];
@@ -31,7 +32,7 @@ export default function RecentNotificationsWidget({ notifications, loading }: Re
   }, [t, notificationNameMap]);
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <div className="flex items-center justify-between mb-3">
         <h3 className="flex items-center gap-2 text-sm font-medium text-white">
           <Bell className="w-4 h-4 text-yellow-400" aria-hidden="true" />

--- a/frontend/src/components/dashboard/RecommendedUsersWidget.tsx
+++ b/frontend/src/components/dashboard/RecommendedUsersWidget.tsx
@@ -5,6 +5,7 @@ import { Users, UserPlus, Check } from 'lucide-react';
 import { useRecommendedUsers } from '../../hooks';
 import { followUser } from '../../api/users';
 import Avatar from '../common/Avatar';
+import { panelClass } from '../../constants/styles';
 
 export default function RecommendedUsersWidget() {
   const { t } = useTranslation();
@@ -26,7 +27,7 @@ export default function RecommendedUsersWidget() {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className={panelClass}>
         <div className="h-5 bg-gray-800 rounded animate-pulse w-1/2 mb-3" />
         <div className="space-y-3">
           {[1, 2, 3].map((i) => (
@@ -46,7 +47,7 @@ export default function RecommendedUsersWidget() {
   if (!users || users.length === 0) return null;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <div className="flex items-center justify-between mb-3">
         <h3 className="flex items-center gap-2 text-sm font-medium text-white">
           <Users aria-hidden="true" className="w-4 h-4 text-purple-400" />

--- a/frontend/src/components/dashboard/StreakWidget.tsx
+++ b/frontend/src/components/dashboard/StreakWidget.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Flame, Trophy, Calendar } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useStreak } from '../../hooks';
+import { panelClass } from '../../constants/styles';
 
 export default function StreakWidget() {
   const { t } = useTranslation();
@@ -10,7 +11,7 @@ export default function StreakWidget() {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className={panelClass}>
         <div className="h-5 bg-gray-800 rounded animate-pulse w-1/2 mb-3" />
         <div className="h-12 bg-gray-800 rounded animate-pulse mb-3" />
         <div className="grid grid-cols-2 gap-2">
@@ -26,7 +27,7 @@ export default function StreakWidget() {
   const totalDays = streakInfo?.total_days ?? 0;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <h3 className="flex items-center gap-2 text-sm font-medium text-white mb-3">
         <Flame className="w-4 h-4 text-gray-400" />
         {t('streak.title')}

--- a/frontend/src/components/dashboard/StudyCircleWidget.tsx
+++ b/frontend/src/components/dashboard/StudyCircleWidget.tsx
@@ -3,13 +3,14 @@ import { useTranslation } from 'react-i18next';
 import { Users, ChevronRight } from 'lucide-react';
 import { useStudyCircles } from '../../hooks';
 import Avatar from '../common/Avatar';
+import { panelClass } from '../../constants/styles';
 
 export default function StudyCircleWidget() {
   const { t } = useTranslation();
   const { circles, loading } = useStudyCircles();
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <div className="flex items-center justify-between mb-3">
         <h3 className="flex items-center gap-2 text-sm font-medium text-white">
           <Users className="w-4 h-4 text-purple-400" />

--- a/frontend/src/components/dashboard/TrendingWidget.tsx
+++ b/frontend/src/components/dashboard/TrendingWidget.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { TrendingUp, Heart, MessageCircle, Bookmark } from 'lucide-react';
 import { useTrendingPosts, useTrendingResources } from '../../hooks';
+import { panelClass } from '../../constants/styles';
 
 export default function TrendingWidget() {
   const { t } = useTranslation();
@@ -13,7 +14,7 @@ export default function TrendingWidget() {
   const loading = tab === 'posts' ? postsLoading : resourcesLoading;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <h3 className="flex items-center gap-2 text-sm font-medium text-white mb-3">
         <TrendingUp className="w-4 h-4 text-orange-400" />
         {t('recommendations.trending')}

--- a/frontend/src/components/dashboard/UserProfileWidget.tsx
+++ b/frontend/src/components/dashboard/UserProfileWidget.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuthStore } from '../../store/authStore';
 import Avatar from '../common/Avatar';
+import { panelClass } from '../../constants/styles';
 
 export default function UserProfileWidget() {
   const { t } = useTranslation();
@@ -10,7 +11,7 @@ export default function UserProfileWidget() {
   if (!user) return null;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <div className="flex items-center gap-3 mb-3">
         <Avatar name={user.name} avatarUrl={user.avatar_url} size="md" />
         <div className="min-w-0">

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -28,6 +28,9 @@ export const cardPaddedClass =
 export const cardDarkClass =
   'bg-gray-900 border border-gray-800 rounded-md p-5 hover:border-gray-700 transition-colors';
 
+export const panelClass =
+  'bg-gray-900 border border-gray-800 rounded-md p-4';
+
 export const sectionContainerClass =
   'bg-gray-900 border border-gray-800 rounded-md overflow-hidden';
 


### PR DESCRIPTION
## 概要
ダッシュボードウィジェット群で重複していた`bg-gray-900 border border-gray-800 rounded-md p-4`パターンを`panelClass`定数に集約。

## 変更内容
- `constants/styles.ts`に`panelClass`定数を追加
- 10ウィジェットファイル・14箇所のインラインクラスを置換

## 対象ファイル
GoalsProgressWidget, DailyChallengeWidget, TrendingWidget, StudyCircleWidget, StreakWidget, RecommendedUsersWidget, RecentNotificationsWidget, LevelWidget, QuickStatsWidget, UserProfileWidget

Closes #1577