### PR TITLE
test: parseJsonObjectとformatDateのユニットテスト追加

### DIFF
--- a/frontend/src/utils/__tests__/json.test.ts
+++ b/frontend/src/utils/__tests__/json.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseJsonArray } from '../json';
+import { parseJsonArray, parseJsonObject } from '../json';
 
 describe('parseJsonArray', () => {
   it('正常なJSON配列文字列をパースする', () => {
@@ -41,5 +41,47 @@ describe('parseJsonArray', () => {
 
   it('日本語を含む配列をパースする', () => {
     expect(parseJsonArray('["タグ1","タグ2"]')).toEqual(['タグ1', 'タグ2']);
+  });
+});
+
+describe('parseJsonObject', () => {
+  it('正常なJSONオブジェクトをパースする', () => {
+    expect(parseJsonObject('{"key":"value"}')).toEqual({ key: 'value' });
+  });
+
+  it('ネストされたオブジェクトをパースする', () => {
+    expect(parseJsonObject('{"a":{"b":1}}')).toEqual({ a: { b: 1 } });
+  });
+
+  it('undefinedの場合に空オブジェクトを返す', () => {
+    expect(parseJsonObject(undefined)).toEqual({});
+  });
+
+  it('nullの場合に空オブジェクトを返す', () => {
+    expect(parseJsonObject(null)).toEqual({});
+  });
+
+  it('空文字列の場合に空オブジェクトを返す', () => {
+    expect(parseJsonObject('')).toEqual({});
+  });
+
+  it('不正なJSONの場合に空オブジェクトを返す', () => {
+    expect(parseJsonObject('invalid json')).toEqual({});
+  });
+
+  it('JSON配列の場合に空オブジェクトを返す', () => {
+    expect(parseJsonObject('[1,2,3]')).toEqual({});
+  });
+
+  it('JSON文字列リテラルの場合に空オブジェクトを返す', () => {
+    expect(parseJsonObject('"hello"')).toEqual({});
+  });
+
+  it('JSON nullの場合に空オブジェクトを返す', () => {
+    expect(parseJsonObject('null')).toEqual({});
+  });
+
+  it('数値のみの場合に空オブジェクトを返す', () => {
+    expect(parseJsonObject('42')).toEqual({});
   });
 });

--- a/frontend/src/utils/__tests__/timeFormat.test.ts
+++ b/frontend/src/utils/__tests__/timeFormat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { formatDistanceToNow } from '../timeFormat';
+import { formatDistanceToNow, formatDate } from '../timeFormat';
 
 describe('formatDistanceToNow', () => {
   const NOW = new Date('2026-02-19T12:00:00Z');
@@ -51,5 +51,31 @@ describe('formatDistanceToNow', () => {
   it('1日前の場合「1日前」を返す', () => {
     const result = formatDistanceToNow('2026-02-18T12:00:00Z');
     expect(result).toBe('1日前');
+  });
+});
+
+describe('formatDate', () => {
+  it('日付文字列をローカライズされた文字列に変換する', () => {
+    const result = formatDate('2026-01-15T00:00:00Z');
+    expect(result).toBeTruthy();
+    expect(typeof result).toBe('string');
+  });
+
+  it('nullの場合にnullを返す', () => {
+    expect(formatDate(null)).toBeNull();
+  });
+
+  it('undefinedの場合にnullを返す', () => {
+    expect(formatDate(undefined)).toBeNull();
+  });
+
+  it('空文字列の場合にnullを返す', () => {
+    expect(formatDate('')).toBeNull();
+  });
+
+  it('異なる日付フォーマットを処理できる', () => {
+    const result = formatDate('2026-06-30');
+    expect(result).toBeTruthy();
+    expect(typeof result).toBe('string');
   });
 });


### PR DESCRIPTION
## 概要
- `parseJsonObject` の10件のユニットテストを追加
- `formatDate` の5件のユニットテストを追加

## 変更内容
- `json.test.ts`: parseJsonObjectの正常系・異常系テスト（正常パース、ネスト、null/undefined/空文字列、不正JSON、配列・文字列リテラル・null・数値の拒否）
- `timeFormat.test.ts`: formatDateの正常系・異常系テスト（ローカライズ変換、null/undefined/空文字列、異なるフォーマット）

## テスト結果
全33テスト通過（json 20件 + timeFormat 13件）

Closes #1579