### PR TITLE
fix: img src URLのサニタイズとURL構築のエンコード漏れ修正

### DIFF
--- a/frontend/src/components/posts/PostCardContent.tsx
+++ b/frontend/src/components/posts/PostCardContent.tsx
@@ -7,6 +7,7 @@ import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { useTranslation } from 'react-i18next';
 import { Code2 } from 'lucide-react';
 import type { Post } from '../../types/post';
+import { sanitizeUrl } from '../../utils/url';
 
 interface PostCardContentProps {
   post: Post;
@@ -60,7 +61,7 @@ export default function PostCardContent({ post, imageUrls }: PostCardContentProp
           {imageUrls.slice(0, 4).map((url, i) => (
             <div key={i} className="relative">
               <img
-                src={url}
+                src={sanitizeUrl(url) ?? ''}
                 alt=""
                 className="w-20 h-20 object-cover rounded-lg border border-gray-700"
               />

--- a/frontend/src/components/profile/SpotifyNowPlaying.tsx
+++ b/frontend/src/components/profile/SpotifyNowPlaying.tsx
@@ -67,7 +67,7 @@ export default function SpotifyNowPlaying({ userId }: Props) {
         >
           {currentTrack.album_image && (
             <img
-              src={currentTrack.album_image}
+              src={sanitizeUrl(currentTrack.album_image) ?? ''}
               alt={currentTrack.album_name}
               referrerPolicy="no-referrer"
               className="w-16 h-16 rounded-lg object-cover"
@@ -112,7 +112,7 @@ export default function SpotifyNowPlaying({ userId }: Props) {
             >
               {track.album_image && (
                 <img
-                  src={track.album_image}
+                  src={sanitizeUrl(track.album_image) ?? ''}
                   alt={track.album_name}
                   referrerPolicy="no-referrer"
                   className="w-10 h-10 rounded object-cover"

--- a/frontend/src/components/youtube/YouTubeVideoCard.tsx
+++ b/frontend/src/components/youtube/YouTubeVideoCard.tsx
@@ -11,8 +11,8 @@ interface YouTubeVideoCardProps {
 
 export default function YouTubeVideoCard({ video }: YouTubeVideoCardProps) {
   const { t } = useTranslation();
-  const videoURL = `https://www.youtube.com/watch?v=${video.video_id}`;
-  const channelURL = `https://www.youtube.com/channel/${video.channel_id}`;
+  const videoURL = `https://www.youtube.com/watch?v=${encodeURIComponent(video.video_id)}`;
+  const channelURL = `https://www.youtube.com/channel/${encodeURIComponent(video.channel_id)}`;
 
   return (
     <div className={cardClass}>


### PR DESCRIPTION
## 概要
- 複数コンポーネントで `<img>` の `src` 属性に渡すURLのサニタイズ漏れを修正
- URL構築時のパラメータエンコード漏れを修正

## 変更内容
- **PostCardContent.tsx**: ユーザー投稿の画像URLに `sanitizeUrl()` を適用（`javascript:` / `data:` URI防止）
- **SpotifyNowPlaying.tsx**: `album_image` URLに `sanitizeUrl()` を適用（2箇所）
- **YouTubeVideoCard.tsx**: `video_id` / `channel_id` に `encodeURIComponent()` を適用（URL構造の破壊防止）

Closes #1581