### PR TITLE
feat: GoalsPageに期限切れ目標の警告パネル追加

### DIFF
--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -613,6 +613,7 @@
     "completedGoals": "Abgeschlossen",
     "pausedGoals": "Pausiert",
     "overdueGoals": "Überfällig",
+    "overdueWarning": "{{count}} Ziele haben ihre Frist überschritten",
     "sort": "Sortieren",
     "sortNewest": "Neueste",
     "sortOldest": "Älteste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -613,6 +613,7 @@
     "completedGoals": "Completed",
     "pausedGoals": "Paused",
     "overdueGoals": "Overdue",
+    "overdueWarning": "{{count}} goals are past their deadline",
     "sort": "Sort",
     "sortNewest": "Newest",
     "sortOldest": "Oldest",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -613,6 +613,7 @@
     "completedGoals": "Completados",
     "pausedGoals": "Pausados",
     "overdueGoals": "Vencidos",
+    "overdueWarning": "{{count}} objetivos han pasado su fecha límite",
     "sort": "Ordenar",
     "sortNewest": "Más reciente",
     "sortOldest": "Más antiguo",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -613,6 +613,7 @@
     "completedGoals": "Terminés",
     "pausedGoals": "En pause",
     "overdueGoals": "En retard",
+    "overdueWarning": "{{count}} objectifs ont dépassé leur échéance",
     "sort": "Trier",
     "sortNewest": "Plus récent",
     "sortOldest": "Plus ancien",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -602,6 +602,7 @@
     "completedGoals": "完了",
     "pausedGoals": "一時停止",
     "overdueGoals": "期限超過",
+    "overdueWarning": "{{count}}個の目標が期限を過ぎています",
     "sort": "並び替え",
     "sortNewest": "新しい順",
     "sortOldest": "古い順",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -613,6 +613,7 @@
     "completedGoals": "완료",
     "pausedGoals": "일시 중지",
     "overdueGoals": "기한 초과",
+    "overdueWarning": "{{count}}개의 목표가 기한을 초과했습니다",
     "sort": "정렬",
     "sortNewest": "최신순",
     "sortOldest": "오래된순",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -613,6 +613,7 @@
     "completedGoals": "Concluídas",
     "pausedGoals": "Pausadas",
     "overdueGoals": "Atrasadas",
+    "overdueWarning": "{{count}} metas ultrapassaram o prazo",
     "sort": "Ordenar",
     "sortNewest": "Mais recente",
     "sortOldest": "Mais antigo",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -613,6 +613,7 @@
     "completedGoals": "Завершённые",
     "pausedGoals": "Приостановленные",
     "overdueGoals": "Просроченные",
+    "overdueWarning": "{{count}} целей просрочены",
     "sort": "Сортировка",
     "sortNewest": "Новые",
     "sortOldest": "Старые",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -613,6 +613,7 @@
     "completedGoals": "已完成",
     "pausedGoals": "已暂停",
     "overdueGoals": "已逾期",
+    "overdueWarning": "{{count}}个目标已超过截止日期",
     "sort": "排序",
     "sortNewest": "最新",
     "sortOldest": "最早",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -613,6 +613,7 @@
     "completedGoals": "已完成",
     "pausedGoals": "已暫停",
     "overdueGoals": "已逾期",
+    "overdueWarning": "{{count}}個目標已超過截止日期",
     "sort": "排序",
     "sortNewest": "最新",
     "sortOldest": "最早",

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Target, Search } from 'lucide-react';
+import { Target, Search, AlertTriangle } from 'lucide-react';
 import { useGoalForm } from '../hooks';
 import { PageLoader } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
@@ -55,6 +55,16 @@ export default function GoalsPage() {
         paused={pausedGoals.length}
         overdue={overdueGoals.length}
       />
+
+      {/* Overdue Warning */}
+      {overdueGoals.length > 0 && (
+        <div className="flex items-center gap-3 px-4 py-3 bg-red-500/10 border border-red-500/30 rounded-lg">
+          <AlertTriangle className="w-5 h-5 text-red-400 shrink-0" />
+          <span className="text-sm text-red-400">
+            {t('goals.overdueWarning', { count: overdueGoals.length })}
+          </span>
+        </div>
+      )}
 
       {/* Search */}
       <div className="relative">


### PR DESCRIPTION
## 概要
- GoalsPageで期限切れの目標がある場合に警告バナーを表示

## 変更内容
- GoalStatsPanel下に赤い警告パネルを追加（AlertTriangleアイコン + メッセージ）
- 期限超過目標がない場合は非表示
- 全10言語のi18nキー `goals.overdueWarning` 追加

Closes #1583