### PR TITLE
refactor: text-blue-400リンクスタイルをlinkSmallClassに統一

### DIFF
--- a/frontend/src/components/advice/AIChatPanel.tsx
+++ b/frontend/src/components/advice/AIChatPanel.tsx
@@ -4,6 +4,7 @@ import { Send, Loader2, Plus, MessageSquare, Trash2 } from 'lucide-react';
 import { useConfirm } from '../../hooks';
 import ConfirmDialog from '../common/ConfirmDialog';
 import type { AIMessage } from '../../api/advice';
+import { linkSmallClass } from '../../constants/styles';
 
 interface AIChatPanelProps {
   messages: AIMessage[];
@@ -71,7 +72,7 @@ export default function AIChatPanel({
           )}
           <button
             onClick={onNewChat}
-            className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+            className={`${linkSmallClass} flex items-center gap-1`}
           >
             <Plus size={14} />
             {t('advice.newChat')}

--- a/frontend/src/components/advice/AdviceCard.tsx
+++ b/frontend/src/components/advice/AdviceCard.tsx
@@ -4,6 +4,7 @@ import { Check } from 'lucide-react';
 import AdviceIcon from './AdviceIcon';
 import type { AIAdvice } from '../../api/advice';
 import { parseJsonObject } from '../../utils/json';
+import { linkSmallClass } from '../../constants/styles';
 
 interface AdviceCardProps {
   advice: AIAdvice;
@@ -43,7 +44,7 @@ export default function AdviceCard({ advice, onMarkRead }: AdviceCardProps) {
             {advice.action_url?.startsWith('/') && (
               <button
                 onClick={() => navigate(advice.action_url)}
-                className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+                className={linkSmallClass}
               >
                 {t('advice.viewAll')} &rarr;
               </button>

--- a/frontend/src/components/chat/ChatRoomMemberSection.tsx
+++ b/frontend/src/components/chat/ChatRoomMemberSection.tsx
@@ -4,6 +4,7 @@ import { UserPlus, UserMinus } from 'lucide-react';
 import type { User } from '../../types/user';
 import type { ChatRoomMember } from '../../types/chat';
 import Avatar from '../common/Avatar';
+import { linkSmallClass } from '../../constants/styles';
 
 interface ChatRoomMemberSectionProps {
   members: ChatRoomMember[];
@@ -35,7 +36,7 @@ export default function ChatRoomMemberSection({
         </h3>
         <button
           onClick={() => setShowAddMember(!showAddMember)}
-          className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+          className={`${linkSmallClass} flex items-center gap-1`}
         >
           <UserPlus className="w-3.5 h-3.5" />
           {t('chat.addMember')}

--- a/frontend/src/components/dashboard/AIAdviceWidget.tsx
+++ b/frontend/src/components/dashboard/AIAdviceWidget.tsx
@@ -4,6 +4,7 @@ import { Lightbulb, ChevronRight, MessageSquare } from 'lucide-react';
 import { useAdvice } from '../../hooks/useAdvice';
 import AdviceIcon from '../advice/AdviceIcon';
 import { parseJsonObject } from '../../utils/json';
+import { linkSmallClass } from '../../constants/styles';
 
 export default function AIAdviceWidget() {
   const { t } = useTranslation();
@@ -34,7 +35,7 @@ export default function AIAdviceWidget() {
         </div>
         <button
           onClick={() => navigate('/advice')}
-          className="text-xs text-blue-400 hover:text-blue-300 flex items-center gap-1"
+          className={`${linkSmallClass} flex items-center gap-1`}
         >
           {t('advice.viewAll')}
           <ChevronRight size={14} />

--- a/frontend/src/components/dashboard/GoalsProgressWidget.tsx
+++ b/frontend/src/components/dashboard/GoalsProgressWidget.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Target, ChevronRight } from 'lucide-react';
 import type { LearningGoal } from '../../api/goals';
-import { panelClass } from '../../constants/styles';
+import { panelClass, linkSmallClass } from '../../constants/styles';
 
 interface GoalsProgressWidgetProps {
   activeGoals: LearningGoal[];
@@ -36,7 +36,7 @@ export default function GoalsProgressWidget({ activeGoals, completedGoals, avgPr
           <p className="text-xs text-gray-500 mb-2">{t('dashboard.noActiveGoals')}</p>
           <Link
             to="/goals"
-            className="text-xs text-blue-400 hover:text-blue-300 transition-colors"
+            className={linkSmallClass}
           >
             {t('dashboard.createGoal')}
           </Link>

--- a/frontend/src/components/notes/NoteCard.tsx
+++ b/frontend/src/components/notes/NoteCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Star, Edit, Trash2 } from 'lucide-react';
 import type { Note } from '../../api/notes';
 import { formatDistanceToNow } from '../../utils/timeFormat';
+import { linkSmallClass } from '../../constants/styles';
 
 interface NoteCardProps {
   note: Note;
@@ -30,7 +31,7 @@ export default function NoteCard({ note, onToggleFavorite, onEdit, onDelete }: N
           {isLong && (
             <button
               onClick={() => setExpanded(!expanded)}
-              className="text-xs text-blue-400 hover:text-blue-300 transition-colors mb-2"
+              className={`${linkSmallClass} mb-2`}
             >
               {expanded ? t('notes.collapse') : t('notes.expand')}
             </button>

--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -5,6 +5,7 @@ import { useNotifications } from '../../hooks';
 import Avatar from '../common/Avatar';
 import { getNotificationLink, getNotificationMessage } from './NotificationItem';
 import { formatDistanceToNow } from '../../utils/timeFormat';
+import { linkSmallClass } from '../../constants/styles';
 
 export default function NotificationDropdown() {
   const { t } = useTranslation();
@@ -64,7 +65,7 @@ export default function NotificationDropdown() {
             {unreadCount > 0 && (
               <button
                 onClick={markAllAsRead}
-                className="text-xs text-blue-400 hover:text-blue-300"
+                className={linkSmallClass}
               >
                 {t('notifications.markAllRead')}
               </button>

--- a/frontend/src/components/roadmaps/RoadmapStepList.tsx
+++ b/frontend/src/components/roadmaps/RoadmapStepList.tsx
@@ -3,7 +3,7 @@ import { List } from 'lucide-react';
 import { type RoadmapStep } from '../../api/roadmaps';
 import EmptyState from '../common/EmptyState';
 import { sanitizeUrl } from '../../utils/url';
-import { deleteIconButtonClass } from '../../constants/styles';
+import { deleteIconButtonClass, linkSmallClass } from '../../constants/styles';
 import { formatDate } from '../../utils/timeFormat';
 
 interface RoadmapStepListProps {
@@ -86,7 +86,7 @@ export default function RoadmapStepList({
                       href={sanitizeUrl(step.resource_url)!}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-xs text-blue-400 hover:text-blue-300 mt-2 inline-flex items-center gap-1"
+                      className={`${linkSmallClass} mt-2 inline-flex items-center gap-1`}
                     >
                       {t('roadmaps.viewResource')}
                       <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">

--- a/frontend/src/components/studyCircles/CircleRoadmapTab.tsx
+++ b/frontend/src/components/studyCircles/CircleRoadmapTab.tsx
@@ -4,6 +4,7 @@ import { Plus, Trash2, Check, ExternalLink } from 'lucide-react';
 import type { StudyCircle, StudyCircleMemberProgress } from '../../types/studyCircle';
 import type { User } from '../../types/user';
 import { sanitizeUrl } from '../../utils/url';
+import { linkSmallClass } from '../../constants/styles';
 
 interface CircleRoadmapTabProps {
   circle: StudyCircle;
@@ -89,7 +90,7 @@ export default function CircleRoadmapTab({
                         href={sanitizeUrl(step.resource_url)!}
                         target="_blank"
                         rel="noopener noreferrer"
-                        className="inline-flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300 mt-1"
+                        className={`${linkSmallClass} inline-flex items-center gap-1 mt-1`}
                       >
                         <ExternalLink className="w-3 h-3" />
                         {t('studyCircle.steps.resourceUrl')}

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -60,3 +60,6 @@ export const modalOverlayClass =
 
 export const modalContentClass =
   'bg-gray-800 rounded-md p-6 w-full max-h-[90vh] overflow-y-auto';
+
+export const linkSmallClass =
+  'text-xs text-blue-400 hover:text-blue-300 transition-colors';


### PR DESCRIPTION
## 概要
- 9コンポーネントで重複していた `text-xs text-blue-400 hover:text-blue-300 transition-colors` パターンを `linkSmallClass` 定数に統一

## 変更内容
- `constants/styles.ts` に `linkSmallClass` 定数を追加
- 9コンポーネント（AdviceCard, AIChatPanel, GoalsProgressWidget, AIAdviceWidget, NoteCard, NotificationDropdown, ChatRoomMemberSection, RoadmapStepList, CircleRoadmapTab）のインラインクラスを置換

Closes #1585