### PR TITLE
fix: MarkdownEditor画像URLサニタイズとlocalStorage型検証追加

### DIFF
--- a/frontend/src/components/posts/MarkdownEditor.tsx
+++ b/frontend/src/components/posts/MarkdownEditor.tsx
@@ -6,6 +6,7 @@ import rehypeSanitize from 'rehype-sanitize';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { uploadImage } from '../../api/posts';
+import { sanitizeUrl } from '../../utils/url';
 import MarkdownToolbar from './MarkdownToolbar';
 
 interface MarkdownEditorProps {
@@ -280,7 +281,7 @@ export default function MarkdownEditor({
             {uploadedImages.map((url, i) => (
               <div key={i} className="relative group">
                 <img
-                  src={url}
+                  src={sanitizeUrl(url) ?? ''}
                   alt={t('editor.uploadedImage', { number: i + 1 })}
                   className="w-16 h-16 object-cover rounded border border-gray-600"
                 />

--- a/frontend/src/hooks/useBadgeNotifier.ts
+++ b/frontend/src/hooks/useBadgeNotifier.ts
@@ -21,7 +21,10 @@ export function useBadgeNotifier(badges: BadgeResult[]) {
     let previousIds: string[] = [];
     if (stored) {
       try {
-        previousIds = JSON.parse(stored);
+        const parsed: unknown = JSON.parse(stored);
+        if (Array.isArray(parsed) && parsed.every((v) => typeof v === 'string')) {
+          previousIds = parsed;
+        }
       } catch {
         localStorage.removeItem(STORAGE_KEY);
       }


### PR DESCRIPTION
## 概要
- MarkdownEditorのアップロード画像プレビューのセキュリティ強化
- useBadgeNotifierのlocalStorageデータの型安全性向上

## 変更内容
- **MarkdownEditor.tsx**: `src={url}` → `src={sanitizeUrl(url) ?? ''}` で不正URLを防止
- **useBadgeNotifier.ts**: `JSON.parse()` 結果に `Array.isArray` + `typeof === 'string'` チェック追加

Closes #1589