### PR TITLE
refactor: analytics/learning-logsのインラインpanelスタイルをpanelClassに統一

### DIFF
--- a/frontend/src/components/analytics/AIInsightCard.tsx
+++ b/frontend/src/components/analytics/AIInsightCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Lightbulb, Clock, TrendingUp, TrendingDown, Flame, LayoutGrid } from 'lucide-react';
 import type { AIInsight } from '../../types/analytics';
+import { panelClass } from '../../constants/styles';
 
 interface Props {
   insights: AIInsight[];
@@ -30,7 +31,7 @@ export default function AIInsightCard({ insights, loading }: Props) {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className={panelClass}>
         <div className="h-5 bg-gray-800 rounded animate-pulse w-1/3 mb-4" />
         <div className="space-y-3">
           <div className="h-16 bg-gray-800 rounded animate-pulse" />
@@ -51,7 +52,7 @@ export default function AIInsightCard({ insights, loading }: Props) {
   };
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <h3 className="flex items-center gap-2 text-sm font-medium text-white mb-4">
         <Lightbulb className="w-4 h-4 text-yellow-400" />
         {t('analytics.insightsTitle')}

--- a/frontend/src/components/analytics/CategoryPieChart.tsx
+++ b/frontend/src/components/analytics/CategoryPieChart.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { CategoryBreakdown } from '../../types/analytics';
+import { panelClass } from '../../constants/styles';
 
 interface Props {
   data: CategoryBreakdown[];
@@ -27,7 +28,7 @@ export default function CategoryPieChart({ data, loading }: Props) {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className={panelClass}>
         <div className="h-5 bg-gray-800 rounded animate-pulse w-1/3 mb-4" />
         <div className="h-32 bg-gray-800 rounded animate-pulse" />
       </div>
@@ -39,7 +40,7 @@ export default function CategoryPieChart({ data, loading }: Props) {
   const remainMinutes = totalMinutes % 60;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <h3 className="text-sm font-medium text-white mb-4">{t('analytics.categoryTitle')}</h3>
 
       {data.length === 0 ? (

--- a/frontend/src/components/analytics/HeatmapChart.tsx
+++ b/frontend/src/components/analytics/HeatmapChart.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { HeatmapEntry } from '../../types/analytics';
+import { panelClass } from '../../constants/styles';
 
 interface Props {
   data: HeatmapEntry[];
@@ -24,7 +25,7 @@ export default function HeatmapChart({ data, loading }: Props) {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className={panelClass}>
         <div className="h-5 bg-gray-800 rounded animate-pulse w-1/3 mb-4" />
         <div className="h-40 bg-gray-800 rounded animate-pulse" />
       </div>
@@ -41,7 +42,7 @@ export default function HeatmapChart({ data, loading }: Props) {
   }
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <h3 className="text-sm font-medium text-white mb-4">{t('analytics.heatmapTitle')}</h3>
 
       <div className="overflow-x-auto">

--- a/frontend/src/components/analytics/ProductivityScoreCard.tsx
+++ b/frontend/src/components/analytics/ProductivityScoreCard.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { ProductivityScore } from '../../types/analytics';
+import { panelClass } from '../../constants/styles';
 
 interface Props {
   score: ProductivityScore | null;
@@ -25,7 +26,7 @@ export default function ProductivityScoreCard({ score, loading }: Props) {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className={panelClass}>
         <div className="h-5 bg-gray-800 rounded animate-pulse w-1/3 mb-4" />
         <div className="h-24 bg-gray-800 rounded animate-pulse" />
       </div>
@@ -41,7 +42,7 @@ export default function ProductivityScoreCard({ score, loading }: Props) {
   ];
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <h3 className="text-sm font-medium text-white mb-4">{t('analytics.productivityTitle')}</h3>
 
       {/* 総合スコア */}

--- a/frontend/src/components/analytics/WeeklyTrendChart.tsx
+++ b/frontend/src/components/analytics/WeeklyTrendChart.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { WeeklyTrend } from '../../types/analytics';
+import { panelClass } from '../../constants/styles';
 
 interface Props {
   data: WeeklyTrend[];
@@ -11,7 +12,7 @@ export default function WeeklyTrendChart({ data, loading }: Props) {
 
   if (loading) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className={panelClass}>
         <div className="h-5 bg-gray-800 rounded animate-pulse w-1/3 mb-4" />
         <div className="h-40 bg-gray-800 rounded animate-pulse" />
       </div>
@@ -20,7 +21,7 @@ export default function WeeklyTrendChart({ data, loading }: Props) {
 
   if (data.length === 0) {
     return (
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+      <div className={panelClass}>
         <h3 className="text-sm font-medium text-white mb-4">{t('analytics.trendTitle')}</h3>
         <p className="text-xs text-gray-500 text-center py-6">{t('analytics.noData')}</p>
       </div>
@@ -38,7 +39,7 @@ export default function WeeklyTrendChart({ data, loading }: Props) {
   }
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <div className="flex items-center justify-between mb-4">
         <h3 className="text-sm font-medium text-white">{t('analytics.trendTitle')}</h3>
         {growthRate !== null && (

--- a/frontend/src/components/learning-logs/LogCard.tsx
+++ b/frontend/src/components/learning-logs/LogCard.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Code, BookOpen, GraduationCap, Users, FileText, Star, type LucideIcon } from 'lucide-react';
 import type { LearningLog, LogCategory } from '../../types/learningLog';
 import { formatDate } from '../../utils/timeFormat';
+import { panelClass } from '../../constants/styles';
 
 export const CATEGORIES: { value: LogCategory; label: string; Icon: LucideIcon }[] = [
   { value: 'coding', label: 'learningLogs.categoryCoding', Icon: Code },
@@ -37,7 +38,7 @@ export default function LogCard({ log, onEdit, onDelete, onToggleFavorite }: Log
   const CatIcon = catInfo.Icon;
 
   return (
-    <div className="bg-gray-900 border border-gray-800 rounded-md p-4">
+    <div className={panelClass}>
       <div className="flex items-start justify-between gap-4">
         <div className="flex items-start gap-3 min-w-0 flex-1">
           <CatIcon className="w-5 h-5 text-purple-400 flex-shrink-0 mt-0.5" />

--- a/frontend/src/components/learning-logs/WeeklySummaryCard.tsx
+++ b/frontend/src/components/learning-logs/WeeklySummaryCard.tsx
@@ -1,6 +1,7 @@
 import { Clock, Calendar, FileText } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { StreakInfo } from '../../types/learningLog';
+import { panelClass } from '../../constants/styles';
 
 interface WeeklySummaryCardProps {
   weeklyDuration: number;
@@ -17,7 +18,7 @@ export default function WeeklySummaryCard({
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-3 gap-3">
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4 flex items-center gap-3">
+      <div className={`${panelClass} flex items-center gap-3`}>
         <Clock className="w-8 h-8 text-blue-400" />
         <div>
           <p className="text-xs text-gray-400">{t('learningLogs.weeklyDuration')}</p>
@@ -28,14 +29,14 @@ export default function WeeklySummaryCard({
           </p>
         </div>
       </div>
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4 flex items-center gap-3">
+      <div className={`${panelClass} flex items-center gap-3`}>
         <Calendar className="w-8 h-8 text-orange-400" />
         <div>
           <p className="text-xs text-gray-400">{t('learningLogs.currentStreak')}</p>
           <p className="text-lg font-bold text-white">{streakInfo?.current_streak ?? 0}{t('learningLogs.days')}</p>
         </div>
       </div>
-      <div className="bg-gray-900 border border-gray-800 rounded-md p-4 flex items-center gap-3 col-span-2 md:col-span-1">
+      <div className={`${panelClass} flex items-center gap-3 col-span-2 md:col-span-1`}>
         <FileText className="w-8 h-8 text-green-400" />
         <div>
           <p className="text-xs text-gray-400">{t('learningLogs.logCount')}</p>


### PR DESCRIPTION
## 概要
- 7ファイル・15箇所のインラインパネルスタイルを `panelClass` 定数に統一

## 変更内容
- **analytics** (5ファイル/11箇所): CategoryPieChart, AIInsightCard, WeeklyTrendChart, ProductivityScoreCard, HeatmapChart
- **learning-logs** (2ファイル/4箇所): WeeklySummaryCard, LogCard

Closes #1593