### PR TITLE
security: ValidateURLにnet/url.Parse検証とSSRF対策を追加

### DIFF
--- a/backend/internal/domain/validators.go
+++ b/backend/internal/domain/validators.go
@@ -3,6 +3,8 @@ package domain
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"regexp"
 	"strings"
 	"unicode"
@@ -137,22 +139,52 @@ func ValidateContent(content string) error {
 }
 
 // ValidateURL はURLの形式をチェックする
-func ValidateURL(url string) error {
-	if url == "" {
+func ValidateURL(rawURL string) error {
+	if rawURL == "" {
 		return nil // 空の場合は許可（オプショナル）
 	}
 
-	url = strings.TrimSpace(url)
+	rawURL = strings.TrimSpace(rawURL)
 
-	if !strings.HasPrefix(url, "http://") && !strings.HasPrefix(url, "https://") {
-		return NewError(ErrCodeValidation, "URLはhttp://またはhttps://で始まる必要があります", nil)
-	}
-
-	if len(url) > 2048 {
+	if len(rawURL) > 2048 {
 		return NewError(ErrCodeValidation, "URLが長すぎます", nil)
 	}
 
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return NewError(ErrCodeValidation, "URLの形式が不正です", nil)
+	}
+
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return NewError(ErrCodeValidation, "URLはhttp://またはhttps://で始まる必要があります", nil)
+	}
+
+	if parsed.Host == "" {
+		return NewError(ErrCodeValidation, "URLにホスト名が必要です", nil)
+	}
+
+	// SSRF対策: ローカルホスト・プライベートIPを拒否
+	hostname := parsed.Hostname()
+	if isBlockedHost(hostname) {
+		return NewError(ErrCodeValidation, "内部ネットワークのURLは許可されていません", nil)
+	}
+
 	return nil
+}
+
+// isBlockedHost はSSRF対策として内部ネットワークのホストを検出する
+func isBlockedHost(hostname string) bool {
+	lower := strings.ToLower(hostname)
+	if lower == "localhost" || lower == "0.0.0.0" {
+		return true
+	}
+
+	ip := net.ParseIP(hostname)
+	if ip == nil {
+		return false // ドメイン名の場合はDNS解決前なので許可
+	}
+
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
 }
 
 // ValidateTags はタグのバリデーションを行う

--- a/backend/internal/domain/validators_test.go
+++ b/backend/internal/domain/validators_test.go
@@ -153,9 +153,20 @@ func TestValidateURL(t *testing.T) {
 	}{
 		{"有効なURL（https）", "https://example.com", false},
 		{"有効なURL（http）", "http://example.com/path", false},
+		{"有効なURL（クエリ付き）", "https://example.com/search?q=test", false},
 		{"有効なURL（空・オプショナル）", "", false},
 		{"無効なURL（httpなし）", "example.com", true},
+		{"無効なURL（ftpスキーム）", "ftp://example.com", true},
+		{"無効なURL（javascriptスキーム）", "javascript:alert(1)", true},
+		{"無効なURL（ホスト名なし）", "https://", true},
 		{"無効なURL（長すぎる）", "https://" + strings.Repeat("a", 2050), true},
+		{"SSRF: localhost", "https://localhost/admin", true},
+		{"SSRF: 127.0.0.1", "http://127.0.0.1:8080", true},
+		{"SSRF: プライベートIP(10.x)", "http://10.0.0.1", true},
+		{"SSRF: プライベートIP(192.168.x)", "http://192.168.1.1", true},
+		{"SSRF: プライベートIP(172.16.x)", "http://172.16.0.1", true},
+		{"SSRF: 0.0.0.0", "http://0.0.0.0", true},
+		{"SSRF: IPv6ループバック", "http://[::1]/path", true},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## 概要
- `ValidateURL`関数を`net/url.Parse()`ベースに改善し、URL構文の正式検証を追加
- スキーム検証（http/httpsのみ許可）、ホスト名存在確認を追加
- SSRF対策: localhost、ループバックIP、プライベートIP範囲（10.x、172.16.x、192.168.x）、リンクローカルアドレスを拒否
- テストケースを5件→17件に拡充

## テスト計画
- [x] `go test ./internal/domain/... -v` — 全テスト通過確認済み

Closes #1597