### PR TITLE
refactor: バッジスタイルをbadgeBaseClass定数に統一

### DIFF
--- a/frontend/src/components/goals/GoalCard.tsx
+++ b/frontend/src/components/goals/GoalCard.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Monitor, Rocket, Target, FolderOpen, FileText, Copy, type LucideIcon } from 'lucide-react';
 import { type GoalCategory, type GoalStatus, type LearningGoal } from '../../api/goals';
 import { formatDate } from '../../utils/timeFormat';
+import { badgeBaseClass } from '../../constants/styles';
 
 export const CATEGORIES: { value: GoalCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'goals.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -67,7 +68,7 @@ const GoalCard = memo(function GoalCard({
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 flex-wrap">
               <h3 className="font-medium">{goal.title}</h3>
-              <span className={`px-2 py-0.5 text-xs rounded-full ${getStatusColor(goal.status)}`}>
+              <span className={`${badgeBaseClass} ${getStatusColor(goal.status)}`}>
                 {t(`goals.status${goal.status.charAt(0).toUpperCase() + goal.status.slice(1)}`)}
               </span>
             </div>

--- a/frontend/src/components/learning-logs/LogCard.tsx
+++ b/frontend/src/components/learning-logs/LogCard.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Code, BookOpen, GraduationCap, Users, FileText, Star, type LucideIcon } from 'lucide-react';
 import type { LearningLog, LogCategory } from '../../types/learningLog';
 import { formatDate } from '../../utils/timeFormat';
-import { panelClass } from '../../constants/styles';
+import { panelClass, badgeBaseClass } from '../../constants/styles';
 
 export const CATEGORIES: { value: LogCategory; label: string; Icon: LucideIcon }[] = [
   { value: 'coding', label: 'learningLogs.categoryCoding', Icon: Code },
@@ -45,7 +45,7 @@ export default function LogCard({ log, onEdit, onDelete, onToggleFavorite }: Log
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 flex-wrap">
               <h3 className="font-medium">{log.title}</h3>
-              <span className={`px-2 py-0.5 text-xs rounded-full ${getCategoryColor(log.category)}`}>
+              <span className={`${badgeBaseClass} ${getCategoryColor(log.category)}`}>
                 {t(catInfo.label)}
               </span>
             </div>

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import type { Project } from '../../types/project';
-import { cardClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
+import { cardClass, iconButtonClass, deleteIconButtonClass, badgeBaseClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
 import { sanitizeUrl } from '../../utils/url';
 import { formatDate } from '../../utils/timeFormat';
@@ -36,7 +36,7 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
             <div className="flex items-center gap-2">
               <h3 className="text-lg font-semibold text-white">{project.title}</h3>
               {project.featured && (
-                <span className="px-2 py-0.5 bg-yellow-500/20 text-yellow-400 text-xs rounded-full">
+                <span className={`${badgeBaseClass} bg-yellow-500/20 text-yellow-400`}>
                   {t('projects.featured')}
                 </span>
               )}

--- a/frontend/src/components/resources/ResourceCard.tsx
+++ b/frontend/src/components/resources/ResourceCard.tsx
@@ -5,7 +5,7 @@ import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin,
 import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import { parseJsonArray } from '../../utils/json';
 import Avatar from '../common/Avatar';
-import { cardClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
+import { cardClass, iconButtonClass, deleteIconButtonClass, badgeBaseClass } from '../../constants/styles';
 import { sanitizeUrl } from '../../utils/url';
 
 interface ResourceCardProps {
@@ -96,7 +96,7 @@ export default function ResourceCard({
                 {t(`resources.categories.${resource.category}`)}
               </span>
               {resource.difficulty && (
-                <span className={`ml-2 px-2 py-0.5 text-xs rounded-full ${difficultyColors[resource.difficulty]}`}>
+                <span className={`ml-2 ${badgeBaseClass} ${difficultyColors[resource.difficulty]}`}>
                   {t(`resources.difficulty.${resource.difficulty}`)}
                 </span>
               )}

--- a/frontend/src/components/roadmaps/RoadmapCard.tsx
+++ b/frontend/src/components/roadmaps/RoadmapCard.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Monitor, Rocket, Target, FolderOpen, FileText, type LucideIcon } from 'lucide-react';
 import { type Roadmap, type RoadmapCategory } from '../../api/roadmaps';
+import { badgeBaseClass } from '../../constants/styles';
 
 const CATEGORIES: { value: RoadmapCategory; label: string; icon: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'roadmaps.categoryLanguage', icon: '💻', Icon: Monitor },
@@ -37,12 +38,12 @@ export default function RoadmapCard({ roadmap, onView, onEdit, onDelete }: Roadm
             <div className="flex items-center gap-2 flex-wrap">
               <h3 className="font-medium text-white">{roadmap.title}</h3>
               {roadmap.is_public && (
-                <span className="px-2 py-0.5 text-xs rounded-full bg-blue-500/10 text-blue-400">
+                <span className={`${badgeBaseClass} bg-blue-500/10 text-blue-400`}>
                   {t('roadmaps.public')}
                 </span>
               )}
               {roadmap.status === 'completed' && (
-                <span className="px-2 py-0.5 text-xs rounded-full bg-green-500/10 text-green-400">
+                <span className={`${badgeBaseClass} bg-green-500/10 text-green-400`}>
                   {t('roadmaps.completed')}
                 </span>
               )}

--- a/frontend/src/components/roadmaps/RoadmapTemplatesSection.tsx
+++ b/frontend/src/components/roadmaps/RoadmapTemplatesSection.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from 'react-i18next';
 import { Monitor, Rocket, Target, FolderOpen, FileText, BookOpen, ChevronDown, ChevronUp, type LucideIcon } from 'lucide-react';
 import { type RoadmapCategory, type Roadmap } from '../../api/roadmaps';
+import { badgeBaseClass } from '../../constants/styles';
 
 const CATEGORIES: { value: RoadmapCategory; label: string; Icon: LucideIcon }[] = [
   { value: 'language', label: 'roadmaps.categoryLanguage', Icon: Monitor },
@@ -80,7 +81,7 @@ export default function RoadmapTemplatesSection({
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2 flex-wrap">
                           <h3 className="font-medium text-white">{template.title}</h3>
-                          <span className="px-2 py-0.5 text-xs rounded-full bg-purple-500/10 text-purple-400">
+                          <span className={`${badgeBaseClass} bg-purple-500/10 text-purple-400`}>
                             {t('roadmaps.template')}
                           </span>
                         </div>

--- a/frontend/src/constants/styles.ts
+++ b/frontend/src/constants/styles.ts
@@ -63,3 +63,6 @@ export const modalContentClass =
 
 export const linkSmallClass =
   'text-xs text-blue-400 hover:text-blue-300 transition-colors';
+
+export const badgeBaseClass =
+  'px-2 py-0.5 text-xs rounded-full';


### PR DESCRIPTION
## 概要
- `px-2 py-0.5 text-xs rounded-full` パターンを `badgeBaseClass` 定数としてconstants/styles.tsに追加
- 6コンポーネント・7箇所のインラインバッジスタイルを定数参照に置換

## 対象ファイル
- ResourceCard.tsx
- LogCard.tsx
- GoalCard.tsx
- RoadmapTemplatesSection.tsx
- RoadmapCard.tsx（2箇所）
- ProjectCard.tsx

## テスト計画
- [x] `npx tsc --noEmit` — 型チェック通過確認済み

Closes #1601