### PR TITLE
security: Note GetByIDに所有権チェック追加（IDOR対策）

### DIFF
--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -11,7 +11,7 @@ import (
 // テスト時のモック化を容易にするため、インターフェースとして定義する。
 type NoteServiceInterface interface {
 	Create(note *model.Note) error
-	GetByID(id uint) (*model.Note, error)
+	GetByID(id, userID uint) (*model.Note, error)
 	GetByUserID(userID uint, page, limit int) ([]model.Note, error)
 	GetByFolderID(folderID uint) ([]model.Note, error)
 	Update(id, userID uint, title, content, tags string, folderID *uint) (*model.Note, error)
@@ -63,14 +63,15 @@ func (h *NoteHandler) Create(c *gin.Context) {
 	respondCreated(c, note)
 }
 
-// GetByID は指定IDのノートを取得する。
+// GetByID は指定IDのノートを所有権検証付きで取得する。
 func (h *NoteHandler) GetByID(c *gin.Context) {
+	userID := c.GetUint("userID")
 	id, ok := parseID(c, "id")
 	if !ok {
 		return
 	}
 
-	note, err := h.service.GetByID(id)
+	note, err := h.service.GetByID(id, userID)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -18,8 +18,8 @@ func (m *MockNoteService) Create(note *model.Note) error {
 	return m.Called(note).Error(0)
 }
 
-func (m *MockNoteService) GetByID(id uint) (*model.Note, error) {
-	args := m.Called(id)
+func (m *MockNoteService) GetByID(id, userID uint) (*model.Note, error) {
+	args := m.Called(id, userID)
 	if note := args.Get(0); note != nil {
 		return note.(*model.Note), args.Error(1)
 	}
@@ -141,7 +141,7 @@ func TestNoteHandler_GetByID(t *testing.T) {
 		Content: "内容",
 	}
 
-	svc.On("GetByID", uint(1)).Return(note, nil)
+	svc.On("GetByID", uint(1), uint(1)).Return(note, nil)
 
 	w := doRequest(r, "GET", "/notes/1", nil)
 	assertStatus(t, w, http.StatusOK)
@@ -511,7 +511,7 @@ func TestNoteHandler_GetByID_ServiceError(t *testing.T) {
 	r := newRouter(1)
 	r.GET("/notes/:id", h.GetByID)
 
-	svc.On("GetByID", uint(1)).Return(nil, errors.New("error"))
+	svc.On("GetByID", uint(1), uint(1)).Return(nil, errors.New("error"))
 
 	w := doRequest(r, "GET", "/notes/1", nil)
 	assertStatus(t, w, http.StatusInternalServerError)

--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -30,9 +30,9 @@ func (s *NoteService) Create(note *model.Note) error {
 	return s.repo.Create(note)
 }
 
-// GetByID は指定IDのノートを取得する。
-func (s *NoteService) GetByID(id uint) (*model.Note, error) {
-	return s.repo.FindByID(id)
+// GetByID は指定IDのノートを所有権検証付きで取得する。
+func (s *NoteService) GetByID(id, userID uint) (*model.Note, error) {
+	return s.findAndCheckOwnership(id, userID)
 }
 
 // GetByUserID は指定ユーザーのノート一覧を取得する。

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -160,7 +160,7 @@ func TestNoteService_GetByID(t *testing.T) {
 
 	repo.On("FindByID", uint(1)).Return(note, nil)
 
-	result, err := svc.GetByID(1)
+	result, err := svc.GetByID(1, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, note, result)
 	repo.AssertExpectations(t)
@@ -171,7 +171,25 @@ func TestNoteService_GetByID_NotFound(t *testing.T) {
 
 	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
 
-	result, err := svc.GetByID(999)
+	result, err := svc.GetByID(999, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteService_GetByID_Forbidden(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	note := &model.Note{
+		ID:      1,
+		UserID:  1,
+		Title:   "他人のノート",
+		Content: "内容",
+	}
+
+	repo.On("FindByID", uint(1)).Return(note, nil)
+
+	result, err := svc.GetByID(1, 999) // 別ユーザーがアクセス
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)


### PR DESCRIPTION
## 概要
- NoteのGetByIDエンドポイントに所有権チェックが欠落していたIDOR脆弱性を修正
- Service層の`GetByID`に`userID`パラメータを追加し、既存の`findAndCheckOwnership`ヘルパーを活用
- Handler層で認証済みユーザーのIDを取得してServiceに渡すように変更
- 禁止アクセス時のテストケースを追加（計3テスト: 正常取得、NotFound、Forbidden）

## テスト計画
- [x] `go test ./internal/service/... -run TestNote -v` — 全Service層テスト通過
- [x] `go test ./internal/handler/... -run TestNote -v` — 全Handler層テスト通過

Closes #1605