### PR TITLE
feat: LogCardにポモドーロソースバッジ表示を追加

### DIFF
--- a/frontend/src/components/learning-logs/LogCard.tsx
+++ b/frontend/src/components/learning-logs/LogCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Code, BookOpen, GraduationCap, Users, FileText, Star, type LucideIcon } from 'lucide-react';
+import { Code, BookOpen, GraduationCap, Users, FileText, Star, Timer, type LucideIcon } from 'lucide-react';
 import type { LearningLog, LogCategory } from '../../types/learningLog';
 import { formatDate } from '../../utils/timeFormat';
 import { panelClass, badgeBaseClass } from '../../constants/styles';
@@ -48,6 +48,12 @@ export default function LogCard({ log, onEdit, onDelete, onToggleFavorite }: Log
               <span className={`${badgeBaseClass} ${getCategoryColor(log.category)}`}>
                 {t(catInfo.label)}
               </span>
+              {log.source === 'pomodoro' && (
+                <span className={`${badgeBaseClass} inline-flex items-center gap-0.5 text-red-400 bg-red-400/10`}>
+                  <Timer className="w-3 h-3" />
+                  {t('learningLogs.sourcePomodoro')}
+                </span>
+              )}
             </div>
             <p className="text-sm text-gray-400 mt-1 whitespace-pre-wrap">{log.content}</p>
             <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -664,6 +664,7 @@
     "duration": "Lernzeit",
     "durationMinutes": "{{minutes}} Min.",
     "durationHoursMinutes": "{{hours}} Std. {{minutes}} Min.",
+    "sourcePomodoro": "Pomodoro",
     "durationPlaceholder": "Minuten",
     "calendar": "Kalender",
     "list": "Liste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -664,6 +664,7 @@
     "duration": "Study Time",
     "durationMinutes": "{{minutes}} min",
     "durationHoursMinutes": "{{hours}}h {{minutes}}m",
+    "sourcePomodoro": "Pomodoro",
     "durationPlaceholder": "minutes",
     "calendar": "Calendar",
     "list": "List",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -664,6 +664,7 @@
     "duration": "Tiempo de estudio",
     "durationMinutes": "{{minutes}} min",
     "durationHoursMinutes": "{{hours}}h {{minutes}}m",
+    "sourcePomodoro": "Pomodoro",
     "durationPlaceholder": "minutos",
     "calendar": "Calendario",
     "list": "Lista",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -664,6 +664,7 @@
     "duration": "Temps d'étude",
     "durationMinutes": "{{minutes}} min",
     "durationHoursMinutes": "{{hours}}h {{minutes}}m",
+    "sourcePomodoro": "Pomodoro",
     "durationPlaceholder": "minutes",
     "calendar": "Calendrier",
     "list": "Liste",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -648,6 +648,7 @@
     "duration": "学習時間",
     "durationMinutes": "{{minutes}}分",
     "durationHoursMinutes": "{{hours}}時間{{minutes}}分",
+    "sourcePomodoro": "ポモドーロ",
     "durationPlaceholder": "分",
     "calendar": "カレンダー",
     "list": "リスト",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -664,6 +664,7 @@
     "duration": "학습 시간",
     "durationMinutes": "{{minutes}}분",
     "durationHoursMinutes": "{{hours}}시간 {{minutes}}분",
+    "sourcePomodoro": "포모도로",
     "durationPlaceholder": "분",
     "calendar": "캘린더",
     "list": "목록",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -664,6 +664,7 @@
     "duration": "Tempo de estudo",
     "durationMinutes": "{{minutes}} min",
     "durationHoursMinutes": "{{hours}}h {{minutes}}m",
+    "sourcePomodoro": "Pomodoro",
     "durationPlaceholder": "minutos",
     "calendar": "Calendário",
     "list": "Lista",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -664,6 +664,7 @@
     "duration": "Время обучения",
     "durationMinutes": "{{minutes}} мин",
     "durationHoursMinutes": "{{hours}} ч {{minutes}} мин",
+    "sourcePomodoro": "Помодоро",
     "durationPlaceholder": "минуты",
     "calendar": "Календарь",
     "list": "Список",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -664,6 +664,7 @@
     "duration": "学习时长",
     "durationMinutes": "{{minutes}}分钟",
     "durationHoursMinutes": "{{hours}}小时{{minutes}}分钟",
+    "sourcePomodoro": "番茄钟",
     "durationPlaceholder": "分钟",
     "calendar": "日历",
     "list": "列表",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -664,6 +664,7 @@
     "duration": "學習時間",
     "durationMinutes": "{{minutes}}分鐘",
     "durationHoursMinutes": "{{hours}}小時{{minutes}}分鐘",
+    "sourcePomodoro": "番茄鐘",
     "durationPlaceholder": "分鐘",
     "calendar": "日曆",
     "list": "列表",


### PR DESCRIPTION
## 概要
- 学習ログのLogCardで、ポモドーロタイマーから記録されたログにTimerアイコン付き赤色バッジを表示
- sourceが'pomodoro'の場合のみ表示（manualはデフォルトのため非表示）
- 全10言語のi18nファイルに`learningLogs.sourcePomodoro`キーを追加

## テスト計画
- [x] `npx tsc --noEmit` — 型チェック通過確認済み

Closes #1607