### PR TITLE
security: LearningLog GetByIDに認可チェック追加（IDOR修正）

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -12,7 +12,7 @@ import (
 // LearningLogServiceInterface はLearningLogHandlerが依存するサービスのインターフェース。
 type LearningLogServiceInterface interface {
 	Create(log *model.LearningLog) error
-	GetByID(id uint) (*model.LearningLog, error)
+	GetByID(id, userID uint) (*model.LearningLog, error)
 	GetByUserID(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	Update(id, userID uint, updates *model.LearningLog) (*model.LearningLog, error)
 	Delete(id, userID uint) error
@@ -122,12 +122,13 @@ func (h *LearningLogHandler) Delete(c *gin.Context) {
 
 // GetByID は指定されたIDの学習ログを取得する。
 func (h *LearningLogHandler) GetByID(c *gin.Context) {
+	userID := c.GetUint("userID")
 	logID, ok := parseID(c, "id")
 	if !ok {
 		return
 	}
 
-	log, err := h.service.GetByID(logID)
+	log, err := h.service.GetByID(logID, userID)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -49,30 +49,24 @@ func TestLearningLog_Create_ValidationError(t *testing.T) {
 func TestLearningLog_GetByID_Success(t *testing.T) {
 	h, svc := setupLearningLogHandler()
 	log := &model.LearningLog{Title: "Test", Content: "Content"}
-	svc.On("GetByID", uint(1)).Return(log, nil)
+	svc.On("GetByID", uint(1), uint(1)).Return(log, nil)
 
-	r := gin.New()
+	r := newRouter(1)
 	r.GET("/logs/:id", h.GetByID)
 
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/logs/1", nil)
-	r.ServeHTTP(w, req)
-
+	w := doRequest(r, http.MethodGet, "/logs/1", nil)
 	assertStatus(t, w, http.StatusOK)
 	svc.AssertExpectations(t)
 }
 
 func TestLearningLog_GetByID_ServiceError(t *testing.T) {
 	h, svc := setupLearningLogHandler()
-	svc.On("GetByID", uint(99)).Return(nil, errors.New("not found"))
+	svc.On("GetByID", uint(99), uint(1)).Return(nil, errors.New("not found"))
 
-	r := gin.New()
+	r := newRouter(1)
 	r.GET("/logs/:id", h.GetByID)
 
-	w := httptest.NewRecorder()
-	req, _ := http.NewRequest("GET", "/logs/99", nil)
-	r.ServeHTTP(w, req)
-
+	w := doRequest(r, http.MethodGet, "/logs/99", nil)
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1273,8 +1273,8 @@ type MockLearningLogService struct{ mock.Mock }
 func (m *MockLearningLogService) Create(log *model.LearningLog) error {
 	return m.Called(log).Error(0)
 }
-func (m *MockLearningLogService) GetByID(id uint) (*model.LearningLog, error) {
-	args := m.Called(id)
+func (m *MockLearningLogService) GetByID(id, userID uint) (*model.LearningLog, error) {
+	args := m.Called(id, userID)
 	if l := args.Get(0); l != nil {
 		return l.(*model.LearningLog), args.Error(1)
 	}

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -40,9 +40,9 @@ func (s *LearningLogService) Create(log *model.LearningLog) error {
 	return s.repo.Create(log)
 }
 
-// GetByID は指定IDの学習ログを取得する。
-func (s *LearningLogService) GetByID(id uint) (*model.LearningLog, error) {
-	return s.repo.FindByID(id)
+// GetByID は指定IDの学習ログを取得する。所有権を検証する。
+func (s *LearningLogService) GetByID(id, userID uint) (*model.LearningLog, error) {
+	return s.findAndCheckOwnership(id, userID)
 }
 
 // GetByUserID は指定ユーザーの学習ログをページネーション付きで取得する。

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -231,7 +231,7 @@ func TestLearningLogGetByID_Success(t *testing.T) {
 	log.ID = 1
 	repo.On("FindByID", uint(1)).Return(log, nil)
 
-	result, err := svc.GetByID(1)
+	result, err := svc.GetByID(1, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, "Go Study", result.Title)
 	repo.AssertExpectations(t)
@@ -242,8 +242,21 @@ func TestLearningLogGetByID_NotFound(t *testing.T) {
 
 	repo.On("FindByID", uint(999)).Return((*model.LearningLog)(nil), errors.New("not found"))
 
-	_, err := svc.GetByID(999)
+	_, err := svc.GetByID(999, 1)
 	assert.Error(t, err)
+}
+
+func TestLearningLogGetByID_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	log := &model.LearningLog{Title: "Go Study", UserID: 1}
+	log.ID = 1
+	repo.On("FindByID", uint(1)).Return(log, nil)
+
+	result, err := svc.GetByID(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
- LearningLog GetByIDエンドポイントのIDOR脆弱性を修正
- 認証済みユーザーが他ユーザーの学習ログにIDを推測してアクセスできる問題を解消

## 変更内容
- Service層: `GetByID(id uint)` → `GetByID(id, userID uint)` に変更、`findAndCheckOwnership`で所有権検証
- Handler層: インターフェース更新、`userID`をサービスに渡すよう修正
- テスト: `TestLearningLogGetByID_Forbidden`テスト追加、既存テストの引数更新

## テスト結果
Service層・Handler層ともに全テスト通過

Closes #1613