### PR TITLE
feat: ProjectCardに進行中/完了ステータスバッジ追加

### DIFF
--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Trash2, CircleDot, CheckCircle2 } from 'lucide-react';
 import type { Project } from '../../types/project';
 import { cardClass, iconButtonClass, deleteIconButtonClass, badgeBaseClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
@@ -39,6 +39,17 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
               {project.featured && (
                 <span className={`${badgeBaseClass} bg-yellow-500/20 text-yellow-400`}>
                   {t('projects.featured')}
+                </span>
+              )}
+              {project.end_date ? (
+                <span className={`${badgeBaseClass} inline-flex items-center gap-0.5 bg-blue-400/10 text-blue-400`}>
+                  <CheckCircle2 className="w-3 h-3" />
+                  {t('projects.statusCompleted')}
+                </span>
+              ) : (
+                <span className={`${badgeBaseClass} inline-flex items-center gap-0.5 bg-green-400/10 text-green-400`}>
+                  <CircleDot className="w-3 h-3" />
+                  {t('projects.statusInProgress')}
                 </span>
               )}
             </div>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -779,7 +779,9 @@
     "createFailed": "Projekt konnte nicht erstellt werden",
     "updateFailed": "Projekt konnte nicht aktualisiert werden",
     "deleteFailed": "Projekt konnte nicht gelöscht werden",
-    "confirmDelete": "Bist du sicher, dass du dieses Projekt löschen möchtest?"
+    "confirmDelete": "Bist du sicher, dass du dieses Projekt löschen möchtest?",
+    "statusInProgress": "In Arbeit",
+    "statusCompleted": "Abgeschlossen"
   },
   "resources": {
     "pageTitle": "Lernressourcen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -779,7 +779,9 @@
     "createFailed": "Failed to create project",
     "updateFailed": "Failed to update project",
     "deleteFailed": "Failed to delete project",
-    "confirmDelete": "Are you sure you want to delete this project?"
+    "confirmDelete": "Are you sure you want to delete this project?",
+    "statusInProgress": "In Progress",
+    "statusCompleted": "Completed"
   },
   "resources": {
     "pageTitle": "Learning Resources",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -779,7 +779,9 @@
     "createFailed": "Error al crear proyecto",
     "updateFailed": "Error al actualizar proyecto",
     "deleteFailed": "Error al eliminar proyecto",
-    "confirmDelete": "¿Estás seguro de que deseas eliminar este proyecto?"
+    "confirmDelete": "¿Estás seguro de que deseas eliminar este proyecto?",
+    "statusInProgress": "En curso",
+    "statusCompleted": "Completado"
   },
   "resources": {
     "pageTitle": "Recursos de Aprendizaje",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -779,7 +779,9 @@
     "createFailed": "Échec de la création du projet",
     "updateFailed": "Échec de la mise à jour du projet",
     "deleteFailed": "Échec de la suppression du projet",
-    "confirmDelete": "Êtes-vous sûr de vouloir supprimer ce projet ?"
+    "confirmDelete": "Êtes-vous sûr de vouloir supprimer ce projet ?",
+    "statusInProgress": "En cours",
+    "statusCompleted": "Terminé"
   },
   "resources": {
     "pageTitle": "Ressources d'Apprentissage",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -748,7 +748,9 @@
     "createFailed": "プロジェクトの作成に失敗しました",
     "updateFailed": "プロジェクトの更新に失敗しました",
     "deleteFailed": "プロジェクトの削除に失敗しました",
-    "confirmDelete": "このプロジェクトを削除してもよろしいですか？"
+    "confirmDelete": "このプロジェクトを削除してもよろしいですか？",
+    "statusInProgress": "進行中",
+    "statusCompleted": "完了"
   },
   "resources": {
     "pageTitle": "学習教材",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -779,7 +779,9 @@
     "createFailed": "프로젝트 생성에 실패했습니다",
     "updateFailed": "프로젝트 업데이트에 실패했습니다",
     "deleteFailed": "프로젝트 삭제에 실패했습니다",
-    "confirmDelete": "이 프로젝트를 삭제하시겠습니까?"
+    "confirmDelete": "이 프로젝트를 삭제하시겠습니까?",
+    "statusInProgress": "진행 중",
+    "statusCompleted": "완료"
   },
   "resources": {
     "pageTitle": "학습 리소스",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -779,7 +779,9 @@
     "createFailed": "Falha ao criar projeto",
     "updateFailed": "Falha ao atualizar projeto",
     "deleteFailed": "Falha ao excluir projeto",
-    "confirmDelete": "Tem certeza de que deseja excluir este projeto?"
+    "confirmDelete": "Tem certeza de que deseja excluir este projeto?",
+    "statusInProgress": "Em andamento",
+    "statusCompleted": "Concluído"
   },
   "resources": {
     "pageTitle": "Recursos de Aprendizado",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -779,7 +779,9 @@
     "createFailed": "Не удалось создать проект",
     "updateFailed": "Не удалось обновить проект",
     "deleteFailed": "Не удалось удалить проект",
-    "confirmDelete": "Вы уверены, что хотите удалить этот проект?"
+    "confirmDelete": "Вы уверены, что хотите удалить этот проект?",
+    "statusInProgress": "В процессе",
+    "statusCompleted": "Завершён"
   },
   "resources": {
     "pageTitle": "Учебные ресурсы",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -779,7 +779,9 @@
     "createFailed": "创建项目失败",
     "updateFailed": "更新项目失败",
     "deleteFailed": "删除项目失败",
-    "confirmDelete": "确定要删除这个项目吗？"
+    "confirmDelete": "确定要删除这个项目吗？",
+    "statusInProgress": "进行中",
+    "statusCompleted": "已完成"
   },
   "resources": {
     "pageTitle": "学习资源",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -779,7 +779,9 @@
     "createFailed": "建立專案失敗",
     "updateFailed": "更新專案失敗",
     "deleteFailed": "刪除專案失敗",
-    "confirmDelete": "確定要刪除這個專案嗎？"
+    "confirmDelete": "確定要刪除這個專案嗎？",
+    "statusInProgress": "進行中",
+    "statusCompleted": "已完成"
   },
   "resources": {
     "pageTitle": "學習資源",


### PR DESCRIPTION
## 概要
- ProjectCardにプロジェクトの進行状態を視覚的に表示するステータスバッジを追加
- end_dateの有無で状態を判定

## 表示仕様
- end_dateがnull → 緑色「進行中」バッジ（CircleDotアイコン）
- end_dateがある → 青色「完了」バッジ（CheckCircle2アイコン）
- featuredバッジの横に配置

## 変更ファイル
- ProjectCard.tsx: ステータスバッジUI追加
- 10言語ファイル: `projects.statusInProgress`, `projects.statusCompleted`キー追加

Closes #1615