### PR TITLE
refactor: インラインSVG外部リンクアイコンをlucide-react ExternalLinkに統一

### DIFF
--- a/frontend/src/components/profile/PortfolioModal.tsx
+++ b/frontend/src/components/profile/PortfolioModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import type { PortfolioTheme } from '../../utils/portfolioGenerator';
 import { generatePortfolioHTML, downloadPortfolio } from '../../utils/portfolioGenerator';
+import { ExternalLink } from 'lucide-react';
 import { buttonSecondaryClass, modalOverlayClass } from '../../constants/styles';
 import type { User } from '../../types/user';
 import type { GitHubLanguageStat, GitHubRepository } from '../../types/github';
@@ -145,9 +146,7 @@ export default function PortfolioModal({
             onClick={handleOpenInNewTab}
             className={`${buttonSecondaryClass} flex items-center gap-2`}
           >
-            <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-            </svg>
+            <ExternalLink className="w-4 h-4" />
             {t('portfolio.openInNewTab')}
           </button>
           <button

--- a/frontend/src/components/profile/ProfileArticlesSection.tsx
+++ b/frontend/src/components/profile/ProfileArticlesSection.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { FileText } from 'lucide-react';
+import { FileText, ExternalLink } from 'lucide-react';
 import { type ZennArticle, type ZennStats } from '../../api/zenn';
 import { type QiitaArticle, type QiitaStats } from '../../api/qiita';
 import { sanitizeUrl } from '../../utils/url';
@@ -34,7 +34,7 @@ export default function ProfileArticlesSection({
               {t('profile.zennArticles')}
               {zennStats && <span className="text-xs text-gray-500 font-normal ml-2">{zennStats.total_articles} {t('profile.articles')} · {zennStats.total_likes} {t('post.like')}s</span>}
             </h2>
-            <a href={`https://zenn.dev/${encodeURIComponent(zennUsername)}`} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1">{t('profile.viewAllOnZenn')}<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg></a>
+            <a href={`https://zenn.dev/${encodeURIComponent(zennUsername)}`} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1">{t('profile.viewAllOnZenn')}<ExternalLink className="w-3 h-3" /></a>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {zennArticles.slice(0, 6).map((article) => (
@@ -65,7 +65,7 @@ export default function ProfileArticlesSection({
               {t('profile.qiitaArticles')}
               {qiitaStats && <span className="text-xs text-gray-500 font-normal ml-2">{qiitaStats.total_articles} {t('profile.articles')} · {qiitaStats.total_likes} {t('post.like')}s</span>}
             </h2>
-            <a href={`https://qiita.com/${encodeURIComponent(qiitaUsername)}`} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-500 hover:text-green-400 transition-colors flex items-center gap-1">{t('profile.viewAllOnQiita')}<svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg></a>
+            <a href={`https://qiita.com/${encodeURIComponent(qiitaUsername)}`} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-500 hover:text-green-400 transition-colors flex items-center gap-1">{t('profile.viewAllOnQiita')}<ExternalLink className="w-3 h-3" /></a>
           </div>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {qiitaArticles.slice(0, 6).map((article) => (

--- a/frontend/src/components/profile/ProfileHeader.tsx
+++ b/frontend/src/components/profile/ProfileHeader.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { ExternalLink } from 'lucide-react';
 import type { User } from '../../types/user';
 import Avatar from '../common/Avatar';
 import FollowButton from './FollowButton';
@@ -30,9 +31,7 @@ export default function ProfileHeader({
     { key: 'atcoder', username: user.atcoder_username, href: `https://atcoder.jp/users/${encodeURIComponent(user.atcoder_username || '')}`, color: 'hover:text-cyan-400', badge: <span className="w-4 h-4 bg-gray-700 rounded text-white text-xs flex items-center justify-center font-bold">A</span> },
   ];
 
-  const externalLinkIcon = (
-    <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
-  );
+  const externalLinkIcon = <ExternalLink className="w-3 h-3" />;
 
   return (
     <div className="bg-gray-900 border border-gray-800 rounded-md p-6">

--- a/frontend/src/components/profile/ProfileRepositoriesSection.tsx
+++ b/frontend/src/components/profile/ProfileRepositoriesSection.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { ExternalLink } from 'lucide-react';
 
 interface Repo {
   id: number;
@@ -27,7 +28,7 @@ export default function ProfileRepositoriesSection({ repos, githubUsername }: Pr
         {githubUsername && (
           <a href={`https://github.com/${githubUsername}?tab=repositories`} target="_blank" rel="noopener noreferrer" className="text-xs text-gray-500 hover:text-blue-400 transition-colors flex items-center gap-1">
             {t('profile.viewAllOnGitHub')}
-            <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" /></svg>
+            <ExternalLink className="w-3 h-3" />
           </a>
         )}
       </div>

--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Pencil, Trash2, CircleDot, CheckCircle2 } from 'lucide-react';
+import { Pencil, Trash2, CircleDot, CheckCircle2, ExternalLink } from 'lucide-react';
 import type { Project } from '../../types/project';
 import { cardClass, iconButtonClass, deleteIconButtonClass, badgeBaseClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
@@ -114,9 +114,7 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
               rel="noopener noreferrer"
               className="flex-1 flex items-center justify-center gap-1.5 px-3 py-1.5 bg-gray-700 hover:bg-gray-600 text-white text-sm rounded-lg transition-colors"
             >
-              <svg aria-hidden="true" className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-              </svg>
+              <ExternalLink className="w-4 h-4" />
               {t('projects.liveDemo')}
             </a>
           )}

--- a/frontend/src/components/resources/ResourceCard.tsx
+++ b/frontend/src/components/resources/ResourceCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin, Pencil, Trash2, type LucideIcon } from 'lucide-react';
+import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin, Pencil, Trash2, ExternalLink, type LucideIcon } from 'lucide-react';
 import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import { parseJsonArray } from '../../utils/json';
 import Avatar from '../common/Avatar';
@@ -221,9 +221,7 @@ export default function ResourceCard({
                 rel="noopener noreferrer"
                 className="text-gray-400 hover:text-white transition-colors"
               >
-                <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-                </svg>
+                <ExternalLink className="w-5 h-5" />
               </a>
             )}
           </div>

--- a/frontend/src/components/roadmaps/RoadmapStepList.tsx
+++ b/frontend/src/components/roadmaps/RoadmapStepList.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { List, Pencil, Trash2 } from 'lucide-react';
+import { List, Pencil, Trash2, ExternalLink } from 'lucide-react';
 import { type RoadmapStep } from '../../api/roadmaps';
 import EmptyState from '../common/EmptyState';
 import { sanitizeUrl } from '../../utils/url';
@@ -89,9 +89,7 @@ export default function RoadmapStepList({
                       className={`${linkSmallClass} mt-2 inline-flex items-center gap-1`}
                     >
                       {t('roadmaps.viewResource')}
-                      <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
-                      </svg>
+                      <ExternalLink className="w-3 h-3" />
                     </a>
                   )}
                 </div>


### PR DESCRIPTION
## 概要
- 7ファイル8箇所のインラインSVG外部リンクアイコンをlucide-reactのExternalLinkコンポーネントに置換
- 前回のPencil/Trash2統一（#1610）に続くSVGアイコン整理

## 対象ファイル
- ResourceCard.tsx
- ProjectCard.tsx
- RoadmapStepList.tsx
- PortfolioModal.tsx
- ProfileArticlesSection.tsx（2箇所）
- ProfileHeader.tsx
- ProfileRepositoriesSection.tsx

## 結果
- 22行削減、15行追加（差引 -7行）
- 型チェック通過

Closes #1617