### PR TITLE
security: Project GetByIDに認可チェック追加（IDOR修正）

### DIFF
--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -16,7 +16,7 @@ func parseDate(dateStr string) (time.Time, error) {
 // ProjectServiceInterface はProjectHandlerが依存するサービスメソッドを定義する。
 type ProjectServiceInterface interface {
 	Create(project *model.Project) error
-	GetByID(id uint) (*model.Project, error)
+	GetByID(id, userID uint) (*model.Project, error)
 	GetByUserID(userID uint, limit, offset int) ([]model.Project, int64, error)
 	GetFeaturedByUserID(userID uint) ([]model.Project, error)
 	GetAll(limit, offset int) ([]model.Project, int64, error)
@@ -81,12 +81,13 @@ func (h *ProjectHandler) Create(c *gin.Context) {
 
 // GetByID は指定IDのプロジェクトを取得する。
 func (h *ProjectHandler) GetByID(c *gin.Context) {
+	userID := c.GetUint("userID")
 	id, ok := parseID(c, "id")
 	if !ok {
 		return
 	}
 
-	project, err := h.service.GetByID(id)
+	project, err := h.service.GetByID(id, userID)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/project_test.go
+++ b/backend/internal/handler/project_test.go
@@ -60,7 +60,7 @@ func TestProjectGetByID_Success(t *testing.T) {
 	h, svc := setupProjectHandler()
 	project := &model.Project{Title: "Test", UserID: 1}
 	project.ID = 1
-	svc.On("GetByID", uint(1)).Return(project, nil)
+	svc.On("GetByID", uint(1), uint(1)).Return(project, nil)
 
 	r := newRouter(1)
 	r.GET("/projects/:id", h.GetByID)
@@ -82,7 +82,7 @@ func TestProjectGetByID_InvalidID(t *testing.T) {
 
 func TestProjectGetByID_NotFound(t *testing.T) {
 	h, svc := setupProjectHandler()
-	svc.On("GetByID", uint(999)).Return(nil, service.ErrNotFound)
+	svc.On("GetByID", uint(999), uint(1)).Return(nil, service.ErrNotFound)
 
 	r := newRouter(1)
 	r.GET("/projects/:id", h.GetByID)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -886,8 +886,8 @@ type MockProjectService struct{ mock.Mock }
 func (m *MockProjectService) Create(project *model.Project) error {
 	return m.Called(project).Error(0)
 }
-func (m *MockProjectService) GetByID(id uint) (*model.Project, error) {
-	args := m.Called(id)
+func (m *MockProjectService) GetByID(id, userID uint) (*model.Project, error) {
+	args := m.Called(id, userID)
 	if p := args.Get(0); p != nil {
 		return p.(*model.Project), args.Error(1)
 	}

--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -28,9 +28,9 @@ func (s *ProjectService) Create(project *model.Project) error {
 	return s.repo.Create(project)
 }
 
-// GetByID は指定IDのプロジェクトを取得する。
-func (s *ProjectService) GetByID(id uint) (*model.Project, error) {
-	return s.repo.FindByID(id)
+// GetByID は指定IDのプロジェクトを取得する。所有権を検証する。
+func (s *ProjectService) GetByID(id, userID uint) (*model.Project, error) {
+	return s.findAndCheckOwnership(id, userID)
 }
 
 // GetByUserID は指定ユーザーのプロジェクトをページネーション付きで取得する。

--- a/backend/internal/service/project_test.go
+++ b/backend/internal/service/project_test.go
@@ -214,7 +214,7 @@ func TestProjectGetByID_Success(t *testing.T) {
 
 	repo.On("FindByID", uint(1)).Return(expected, nil)
 
-	result, err := svc.GetByID(1)
+	result, err := svc.GetByID(1, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, "Test", result.Title)
 	repo.AssertExpectations(t)
@@ -225,8 +225,21 @@ func TestProjectGetByID_NotFound(t *testing.T) {
 
 	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
 
-	result, err := svc.GetByID(999)
+	result, err := svc.GetByID(999, 1)
 	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectGetByID_Forbidden(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	project := &model.Project{Title: "Test", UserID: 1}
+	project.ID = 1
+	repo.On("FindByID", uint(1)).Return(project, nil)
+
+	result, err := svc.GetByID(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
- Project GetByIDエンドポイントのIDOR脆弱性を修正
- Note (#1606)、LearningLog (#1614) に続く同一パターンの修正

## 変更内容
- Service層: `GetByID(id uint)` → `GetByID(id, userID uint)` に変更
- Handler層: インターフェース更新、`userID`をサービスに渡す
- テスト: `TestProjectGetByID_Forbidden`テスト追加

## テスト結果
Service層・Handler層ともに全テスト通過

Closes #1621