### PR TITLE
feat: GoalCardに完了日時を表示

### DIFF
--- a/frontend/src/components/goals/GoalCard.tsx
+++ b/frontend/src/components/goals/GoalCard.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Monitor, Rocket, Target, FolderOpen, FileText, Copy, Pencil, Trash2, type LucideIcon } from 'lucide-react';
+import { Monitor, Rocket, Target, FolderOpen, FileText, Copy, Pencil, Trash2, CheckCircle2, type LucideIcon } from 'lucide-react';
 import { type GoalCategory, type GoalStatus, type LearningGoal } from '../../api/goals';
 import { formatDate } from '../../utils/timeFormat';
 import { badgeBaseClass } from '../../constants/styles';
@@ -80,6 +80,12 @@ const GoalCard = memo(function GoalCard({
               {goal.target_date && (
                 <span>
                   {t('goals.targetDateLabel')}: {formatDate(goal.target_date)}
+                </span>
+              )}
+              {goal.status === 'completed' && goal.completed_at && (
+                <span className="inline-flex items-center gap-0.5 text-green-400">
+                  <CheckCircle2 className="w-3 h-3" />
+                  {t('goals.completedAt')}: {formatDate(goal.completed_at)}
                 </span>
               )}
               {(() => {

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -634,6 +634,7 @@
     "categorySkill": "Fähigkeit",
     "categoryProject": "Projekt",
     "categoryOther": "Sonstiges",
+    "completedAt": "Abgeschlossen am",
     "stats": {
       "total": "Gesamtziele",
       "activeCount": "Aktiv",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -634,6 +634,7 @@
     "categorySkill": "Skill",
     "categoryProject": "Project",
     "categoryOther": "Other",
+    "completedAt": "Completed",
     "stats": {
       "total": "Total Goals",
       "activeCount": "Active",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -634,6 +634,7 @@
     "categorySkill": "Habilidad",
     "categoryProject": "Proyecto",
     "categoryOther": "Otro",
+    "completedAt": "Completado",
     "stats": {
       "total": "Total de Objetivos",
       "activeCount": "Activos",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -634,6 +634,7 @@
     "categorySkill": "Compétence",
     "categoryProject": "Projet",
     "categoryOther": "Autre",
+    "completedAt": "Terminé le",
     "stats": {
       "total": "Total des objectifs",
       "activeCount": "Actifs",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -623,6 +623,7 @@
     "categorySkill": "スキル",
     "categoryProject": "プロジェクト",
     "categoryOther": "その他",
+    "completedAt": "完了日",
     "stats": {
       "total": "合計目標",
       "activeCount": "進行中",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -634,6 +634,7 @@
     "categorySkill": "스킬",
     "categoryProject": "프로젝트",
     "categoryOther": "기타",
+    "completedAt": "완료일",
     "stats": {
       "total": "총 목표",
       "activeCount": "진행 중",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -634,6 +634,7 @@
     "categorySkill": "Habilidade",
     "categoryProject": "Projeto",
     "categoryOther": "Outro",
+    "completedAt": "Concluído em",
     "stats": {
       "total": "Total de Metas",
       "activeCount": "Ativas",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -634,6 +634,7 @@
     "categorySkill": "Навык",
     "categoryProject": "Проект",
     "categoryOther": "Другое",
+    "completedAt": "Завершено",
     "stats": {
       "total": "Всего целей",
       "activeCount": "Активных",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -634,6 +634,7 @@
     "categorySkill": "技能",
     "categoryProject": "项目",
     "categoryOther": "其他",
+    "completedAt": "完成日",
     "stats": {
       "total": "总目标",
       "activeCount": "进行中",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -634,6 +634,7 @@
     "categorySkill": "技能",
     "categoryProject": "專案",
     "categoryOther": "其他",
+    "completedAt": "完成日",
     "stats": {
       "total": "總目標",
       "activeCount": "進行中",


### PR DESCRIPTION
## 概要
- GoalCardコンポーネントに、完了済み目標の完了日時を表示する機能を追加
- `status === 'completed'` かつ `completed_at` が存在する場合、緑色のCheckCircle2アイコン付きで完了日を表示
- 10言語ファイルに `goals.completedAt` キーを追加

## テスト計画
- [ ] 完了済み目標カードに完了日が表示されることを確認
- [ ] 未完了目標には完了日が表示されないことを確認
- [ ] 各言語で適切なラベルが表示されることを確認

Closes #1623