### PR TITLE
security: LearningGoal GetByIDにIDOR脆弱性修正

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -11,7 +11,7 @@ import (
 // LearningGoalServiceInterface はLearningGoalServiceが実装すべきインターフェース。
 type LearningGoalServiceInterface interface {
 	Create(goal *model.LearningGoal) error
-	GetByID(id uint) (*model.LearningGoal, error)
+	GetByID(id, userID uint) (*model.LearningGoal, error)
 	GetByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error)
 	GetByCategory(userID uint, category string) ([]model.LearningGoal, error)
 	GetByStatus(userID uint, status string) ([]model.LearningGoal, error)
@@ -137,16 +137,17 @@ func (h *LearningGoalHandler) Delete(c *gin.Context) {
 	respondDeleted(c)
 }
 
-// GetByID は指定されたIDの学習目標を取得する。
+// GetByID は指定されたIDの学習目標を取得する。所有者のみ取得可能。
 func (h *LearningGoalHandler) GetByID(c *gin.Context) {
+	userID := c.GetUint("userID")
 	goalID, ok := parseID(c, "id")
 	if !ok {
 		return
 	}
 
-	goal, err := h.service.GetByID(goalID)
+	goal, err := h.service.GetByID(goalID, userID)
 	if err != nil {
-		respondNotFound(c, "goal not found")
+		respondError(c, err)
 		return
 	}
 

--- a/backend/internal/handler/learning_goal_test.go
+++ b/backend/internal/handler/learning_goal_test.go
@@ -215,12 +215,28 @@ func TestLearningGoalGetByID_Success(t *testing.T) {
 
 	goal := &model.LearningGoal{}
 	goal.ID = 10
+	goal.UserID = 1
 	goal.Title = "Test Goal"
 
 	repo.On("FindByID", uint(10)).Return(goal, nil)
 
 	w := doRequest(r, http.MethodGet, "/goals/10", nil)
 	assertStatus(t, w, http.StatusOK)
+}
+
+func TestLearningGoalGetByID_Forbidden(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.GET("/goals/:id", h.GetByID)
+
+	goal := &model.LearningGoal{}
+	goal.ID = 10
+	goal.UserID = 999 // 別のユーザー
+
+	repo.On("FindByID", uint(10)).Return(goal, nil)
+
+	w := doRequest(r, http.MethodGet, "/goals/10", nil)
+	assertStatus(t, w, http.StatusForbidden)
 }
 
 func TestLearningGoalGetByID_NotFound(t *testing.T) {

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -28,9 +28,9 @@ func (s *LearningGoalService) Create(goal *model.LearningGoal) error {
 	return s.repo.Create(goal)
 }
 
-// GetByID は指定IDの学習目標を取得する。
-func (s *LearningGoalService) GetByID(id uint) (*model.LearningGoal, error) {
-	return s.repo.FindByID(id)
+// GetByID は指定IDの学習目標を取得する。所有権を検証する。
+func (s *LearningGoalService) GetByID(id, userID uint) (*model.LearningGoal, error) {
+	return s.findAndCheckOwnership(id, userID)
 }
 
 // GetByUserID は指定ユーザーの学習目標をページネーション付きで取得する。

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -77,9 +77,23 @@ func TestLearningGoalGetByID_Success(t *testing.T) {
 	expected.ID = 1
 	repo.On("FindByID", uint(1)).Return(expected, nil)
 
-	result, err := svc.GetByID(1)
+	result, err := svc.GetByID(1, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, "Go学習", result.Title)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalGetByID_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	goal := &model.LearningGoal{Title: "Go学習", UserID: 1}
+	goal.ID = 1
+	repo.On("FindByID", uint(1)).Return(goal, nil)
+
+	result, err := svc.GetByID(1, 999)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, ErrForbidden, err)
 	repo.AssertExpectations(t)
 }
 
@@ -88,7 +102,7 @@ func TestLearningGoalGetByID_NotFound(t *testing.T) {
 
 	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
 
-	result, err := svc.GetByID(999)
+	result, err := svc.GetByID(999, 1)
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)


### PR DESCRIPTION
## 概要
- LearningGoal.GetByIDにuserIDパラメータを追加し、findAndCheckOwnershipで所有権チェックを実施
- 他ユーザーの学習目標への不正アクセスを防止
- Handler・Serviceの両テストにForbiddenケースを追加

## テスト計画
- [x] Service層テスト全通過（GetByID_Forbidden追加）
- [x] Handler層テスト全通過（GetByID_Forbidden追加）

Closes #1630