### PR TITLE
feat: NoteCardに文字数ボリュームバッジを表示

### DIFF
--- a/frontend/src/components/notes/NoteCard.tsx
+++ b/frontend/src/components/notes/NoteCard.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Star, Edit, Trash2 } from 'lucide-react';
+import { Star, Edit, Trash2, FileText, BookOpen } from 'lucide-react';
 import type { Note } from '../../api/notes';
 import { formatDistanceToNow } from '../../utils/timeFormat';
 import { linkSmallClass } from '../../constants/styles';
@@ -53,6 +53,17 @@ export default function NoteCard({ note, onToggleFavorite, onEdit, onDelete }: N
             <span>{t('notes.lastUpdated')}: {formatDistanceToNow(note.updated_at)}</span>
             <span className="text-gray-600">·</span>
             <span>{note.content.length.toLocaleString()} {t('notes.chars')}</span>
+            {note.content.length >= 500 ? (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs rounded bg-purple-400/10 text-purple-400">
+                <BookOpen className="w-3 h-3" />
+                {t('notes.volumeDetailed')}
+              </span>
+            ) : note.content.length >= 200 ? (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs rounded bg-yellow-400/10 text-yellow-400">
+                <FileText className="w-3 h-3" />
+                {t('notes.volumeRegular')}
+              </span>
+            ) : null}
           </div>
         </div>
         <div className="flex gap-2 ml-4">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1405,7 +1405,9 @@
     "collapse": "Weniger anzeigen",
     "createdAt": "Erstellt am",
     "tagsPlaceholder": "z.B. React, TypeScript, Go",
-    "allTags": "Alle Tags"
+    "allTags": "Alle Tags",
+    "volumeRegular": "Standard",
+    "volumeDetailed": "Ausführlich"
   },
   "githubCallback": {
     "missingOAuthParams": "Fehlende OAuth-Parameter",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1405,7 +1405,9 @@
     "collapse": "Show less",
     "createdAt": "Created at",
     "tagsPlaceholder": "e.g., React, TypeScript, Go",
-    "allTags": "All Tags"
+    "allTags": "All Tags",
+    "volumeRegular": "Regular",
+    "volumeDetailed": "Detailed"
   },
   "githubCallback": {
     "missingOAuthParams": "Missing OAuth parameters",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1405,7 +1405,9 @@
     "collapse": "Ver menos",
     "createdAt": "Creado el",
     "tagsPlaceholder": "Ej: React, TypeScript, Go",
-    "allTags": "Todas las etiquetas"
+    "allTags": "Todas las etiquetas",
+    "volumeRegular": "Normal",
+    "volumeDetailed": "Detallado"
   },
   "githubCallback": {
     "missingOAuthParams": "Faltan parámetros OAuth",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1405,7 +1405,9 @@
     "collapse": "Voir moins",
     "createdAt": "Créé le",
     "tagsPlaceholder": "Ex : React, TypeScript, Go",
-    "allTags": "Tous les tags"
+    "allTags": "Tous les tags",
+    "volumeRegular": "Standard",
+    "volumeDetailed": "Détaillé"
   },
   "githubCallback": {
     "missingOAuthParams": "Paramètres OAuth manquants",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1306,7 +1306,9 @@
     "collapse": "折りたたむ",
     "createdAt": "作成日時",
     "tagsPlaceholder": "例: React, TypeScript, Go",
-    "allTags": "すべてのタグ"
+    "allTags": "すべてのタグ",
+    "volumeRegular": "標準",
+    "volumeDetailed": "充実"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuthパラメータが不足しています",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1405,7 +1405,9 @@
     "collapse": "접기",
     "createdAt": "생성일",
     "tagsPlaceholder": "예: React, TypeScript, Go",
-    "allTags": "모든 태그"
+    "allTags": "모든 태그",
+    "volumeRegular": "보통",
+    "volumeDetailed": "상세"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuth 매개변수가 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1405,7 +1405,9 @@
     "collapse": "Ver menos",
     "createdAt": "Criado em",
     "tagsPlaceholder": "Ex: React, TypeScript, Go",
-    "allTags": "Todas as tags"
+    "allTags": "Todas as tags",
+    "volumeRegular": "Regular",
+    "volumeDetailed": "Detalhado"
   },
   "githubCallback": {
     "missingOAuthParams": "Parâmetros OAuth ausentes",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1405,7 +1405,9 @@
     "collapse": "Свернуть",
     "createdAt": "Создано",
     "tagsPlaceholder": "Напр.: React, TypeScript, Go",
-    "allTags": "Все теги"
+    "allTags": "Все теги",
+    "volumeRegular": "Обычная",
+    "volumeDetailed": "Подробная"
   },
   "githubCallback": {
     "missingOAuthParams": "Отсутствуют параметры OAuth",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1405,7 +1405,9 @@
     "collapse": "收起",
     "createdAt": "创建时间",
     "tagsPlaceholder": "例如：React, TypeScript, Go",
-    "allTags": "所有标签"
+    "allTags": "所有标签",
+    "volumeRegular": "标准",
+    "volumeDetailed": "详细"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth参数",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1405,7 +1405,9 @@
     "collapse": "收起",
     "createdAt": "創建時間",
     "tagsPlaceholder": "例如：React, TypeScript, Go",
-    "allTags": "所有標籤"
+    "allTags": "所有標籤",
+    "volumeRegular": "標準",
+    "volumeDetailed": "詳細"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth參數",


### PR DESCRIPTION
## 概要
- NoteCardコンポーネントに、ノートの文字数に応じたボリュームバッジを追加
- 200字以上500字未満: 黄色のFileTextアイコン付き「標準」バッジ
- 500字以上: 紫色のBookOpenアイコン付き「充実」バッジ
- 10言語ファイルに `notes.volumeRegular`, `notes.volumeDetailed` キーを追加

## テスト計画
- [ ] 200字未満のノートにバッジが表示されないことを確認
- [ ] 200字以上のノートに黄色バッジが表示されることを確認
- [ ] 500字以上のノートに紫色バッジが表示されることを確認

Closes #1632