### PR TITLE
security: NoteTemplate GetByIDにIDOR脆弱性修正

### DIFF
--- a/backend/internal/handler/note_template.go
+++ b/backend/internal/handler/note_template.go
@@ -9,7 +9,7 @@ import (
 // NoteTemplateServiceInterface はNoteTemplateServiceのインターフェース。
 type NoteTemplateServiceInterface interface {
 	Create(template *model.NoteTemplate) error
-	GetByID(id uint) (*model.NoteTemplate, error)
+	GetByID(id, userID uint) (*model.NoteTemplate, error)
 	GetByUserID(userID uint) ([]model.NoteTemplate, error)
 	GetDefaultByUserID(userID uint) (*model.NoteTemplate, error)
 	Update(id, userID uint, name, description, defaultTitle, contentTemplate, defaultTags string, isDefault *bool) (*model.NoteTemplate, error)
@@ -53,14 +53,15 @@ func (h *NoteTemplateHandler) Create(c *gin.Context) {
 	respondCreated(c, template)
 }
 
-// GetByID は指定IDのテンプレートを取得する。
+// GetByID は指定IDのテンプレートを取得する。所有者のみ取得可能。
 func (h *NoteTemplateHandler) GetByID(c *gin.Context) {
+	userID := c.GetUint("userID")
 	id, ok := parseID(c, "id")
 	if !ok {
 		return
 	}
 
-	template, err := h.service.GetByID(id)
+	template, err := h.service.GetByID(id, userID)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/note_template_test.go
+++ b/backend/internal/handler/note_template_test.go
@@ -43,7 +43,7 @@ func TestNoteTemplateCreate_ServiceError(t *testing.T) {
 func TestNoteTemplateGetByID_Success(t *testing.T) {
 	h, svc := setupNoteTemplateHandler()
 	tmpl := &model.NoteTemplate{ID: 1, UserID: 1, Name: "テスト"}
-	svc.On("GetByID", uint(1)).Return(tmpl, nil)
+	svc.On("GetByID", uint(1), uint(1)).Return(tmpl, nil)
 
 	r := newRouter(1)
 	r.GET("/note-templates/:id", h.GetByID)
@@ -53,9 +53,21 @@ func TestNoteTemplateGetByID_Success(t *testing.T) {
 	svc.AssertExpectations(t)
 }
 
+func TestNoteTemplateGetByID_Forbidden(t *testing.T) {
+	h, svc := setupNoteTemplateHandler()
+	svc.On("GetByID", uint(1), uint(1)).Return(nil, service.ErrForbidden)
+
+	r := newRouter(1)
+	r.GET("/note-templates/:id", h.GetByID)
+	w := doRequest(r, "GET", "/note-templates/1", nil)
+
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
 func TestNoteTemplateGetByID_NotFound(t *testing.T) {
 	h, svc := setupNoteTemplateHandler()
-	svc.On("GetByID", uint(99)).Return(nil, service.ErrNotFound)
+	svc.On("GetByID", uint(99), uint(1)).Return(nil, service.ErrNotFound)
 
 	r := newRouter(1)
 	r.GET("/note-templates/:id", h.GetByID)

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1730,8 +1730,8 @@ type MockNoteTemplateService struct{ mock.Mock }
 func (m *MockNoteTemplateService) Create(template *model.NoteTemplate) error {
 	return m.Called(template).Error(0)
 }
-func (m *MockNoteTemplateService) GetByID(id uint) (*model.NoteTemplate, error) {
-	args := m.Called(id)
+func (m *MockNoteTemplateService) GetByID(id, userID uint) (*model.NoteTemplate, error) {
+	args := m.Called(id, userID)
 	if t := args.Get(0); t != nil {
 		return t.(*model.NoteTemplate), args.Error(1)
 	}

--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -61,9 +61,9 @@ func (s *NoteTemplateService) Create(template *model.NoteTemplate) error {
 	return s.repo.Create(template)
 }
 
-// GetByID は指定IDのテンプレートを取得する。
-func (s *NoteTemplateService) GetByID(id uint) (*model.NoteTemplate, error) {
-	return s.repo.FindByID(id)
+// GetByID は指定IDのテンプレートを取得する。所有権を検証する。
+func (s *NoteTemplateService) GetByID(id, userID uint) (*model.NoteTemplate, error) {
+	return s.findAndCheckOwnership(id, userID)
 }
 
 // GetByUserID は指定ユーザーの全テンプレートを取得する。

--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -178,9 +178,28 @@ func TestNoteTemplateService_GetByID(t *testing.T) {
 
 	repo.On("FindByID", uint(1)).Return(template, nil)
 
-	result, err := svc.GetByID(1)
+	result, err := svc.GetByID(1, 1)
 	assert.NoError(t, err)
 	assert.Equal(t, template, result)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateService_GetByID_Forbidden(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	template := &model.NoteTemplate{
+		ID:              1,
+		UserID:          1,
+		Name:            "テンプレート1",
+		ContentTemplate: "本文",
+	}
+
+	repo.On("FindByID", uint(1)).Return(template, nil)
+
+	result, err := svc.GetByID(1, 999)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, ErrForbidden, err)
 	repo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
- NoteTemplate.GetByIDにuserIDパラメータを追加し、findAndCheckOwnershipで所有権チェックを実施
- 他ユーザーのノートテンプレートへの不正アクセスを防止
- Handler・Serviceの両テストにForbiddenケースを追加

## テスト計画
- [x] Service層テスト全通過（GetByID_Forbidden追加）
- [x] Handler層テスト全通過（GetByID_Forbidden追加）

Closes #1638