### PR TITLE
refactor: ScrollToTopのインラインSVGをlucide-reactに置換

### DIFF
--- a/frontend/src/components/common/ScrollToTop.tsx
+++ b/frontend/src/components/common/ScrollToTop.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { ChevronUp } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 export default function ScrollToTop() {
@@ -19,9 +20,7 @@ export default function ScrollToTop() {
       className="fixed bottom-6 right-6 z-40 p-3 bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-white border border-gray-700 rounded-full shadow-sm transition-all duration-200"
       aria-label={t('common.scrollToTop')}
     >
-      <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
-      </svg>
+      <ChevronUp className="w-5 h-5" />
     </button>
   );
 }


### PR DESCRIPTION
## 概要
- ScrollToTop.tsxの上向き矢印インラインSVGをlucide-reactのChevronUpに置換
- 3行のSVGコードを1行に削減

## テスト計画
- [ ] スクロール時に「トップへ戻る」ボタンのアイコンが正しく表示されることを確認

Closes #1642