### PR TITLE
security: ReminderSettings.UpdateSettingsにバリデーション追加

### DIFF
--- a/backend/internal/handler/reminder_settings_test.go
+++ b/backend/internal/handler/reminder_settings_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/mock"
 )
@@ -75,5 +76,21 @@ func TestReminderSettings_UpdateSettings_ServiceError(t *testing.T) {
 		"enabled": false,
 	})
 	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestReminderSettings_UpdateSettings_ValidationError(t *testing.T) {
+	h, svc := setupReminderSettingsHandler()
+	svc.On("UpdateSettings", uint(1), mock.AnythingOfType("*model.ReminderSettings")).Return(
+		nil, domain.NewError(domain.ErrCodeBadRequest, "頻度はdailyまたはweeklyのみ有効です", nil),
+	)
+
+	r := newRouter(1)
+	r.PUT("/reminder-settings", h.UpdateSettings)
+
+	w := doRequest(r, http.MethodPut, "/reminder-settings", map[string]interface{}{
+		"frequency": "hourly",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
 	svc.AssertExpectations(t)
 }

--- a/backend/internal/service/reminder_settings.go
+++ b/backend/internal/service/reminder_settings.go
@@ -1,11 +1,22 @@
 package service
 
 import (
+	"regexp"
 	"time"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
+
+// validFrequencies は有効なリマインダー頻度の集合。
+var validFrequencies = map[string]bool{
+	string(model.ReminderFrequencyDaily):  true,
+	string(model.ReminderFrequencyWeekly): true,
+}
+
+// timeFormatRegex はHH:MM形式の正規表現。
+var timeFormatRegex = regexp.MustCompile(`^([01]\d|2[0-3]):[0-5]\d$`)
 
 // ReminderSettingsService は学習リマインダー設定のビジネスロジックを提供する。
 type ReminderSettingsService struct {
@@ -30,14 +41,23 @@ func (s *ReminderSettingsService) UpdateSettings(userID uint, updates *model.Rem
 		return nil, err
 	}
 
-	// 更新内容を反映
+	// 更新内容を反映（バリデーション付き）
 	if updates.Frequency != "" {
+		if !validFrequencies[string(updates.Frequency)] {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "頻度はdailyまたはweeklyのみ有効です", nil)
+		}
 		settings.Frequency = updates.Frequency
 	}
 	if updates.NotificationTime != "" {
+		if !timeFormatRegex.MatchString(updates.NotificationTime) {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "通知時間はHH:MM形式で指定してください", nil)
+		}
 		settings.NotificationTime = updates.NotificationTime
 	}
 	if updates.InactiveDays > 0 {
+		if updates.InactiveDays > 30 {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "非活動日数は1〜30の範囲で指定してください", nil)
+		}
 		settings.InactiveDays = updates.InactiveDays
 	}
 	settings.Enabled = updates.Enabled

--- a/backend/internal/service/reminder_settings_test.go
+++ b/backend/internal/service/reminder_settings_test.go
@@ -244,6 +244,54 @@ func TestReminderSettingsService_SendReminder_Error(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestReminderSettingsService_UpdateSettings_InvalidFrequency(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	existing := &model.ReminderSettings{
+		ID:     1,
+		UserID: 1,
+	}
+	repo.On("GetByUserID", uint(1)).Return(existing, nil)
+
+	updates := &model.ReminderSettings{Frequency: "hourly"}
+	result, err := svc.UpdateSettings(1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "頻度はdailyまたはweeklyのみ有効です")
+}
+
+func TestReminderSettingsService_UpdateSettings_InvalidNotificationTime(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	existing := &model.ReminderSettings{
+		ID:     1,
+		UserID: 1,
+	}
+	repo.On("GetByUserID", uint(1)).Return(existing, nil)
+
+	updates := &model.ReminderSettings{NotificationTime: "25:00"}
+	result, err := svc.UpdateSettings(1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "通知時間はHH:MM形式で指定してください")
+}
+
+func TestReminderSettingsService_UpdateSettings_InactiveDaysExceedsMax(t *testing.T) {
+	svc, repo := newTestReminderSettingsService()
+
+	existing := &model.ReminderSettings{
+		ID:     1,
+		UserID: 1,
+	}
+	repo.On("GetByUserID", uint(1)).Return(existing, nil)
+
+	updates := &model.ReminderSettings{InactiveDays: 31}
+	result, err := svc.UpdateSettings(1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "非活動日数は1〜30の範囲で指定してください")
+}
+
 func TestReminderSettingsService_UpdateSettings_WithNotificationTimeAndInactiveDays(t *testing.T) {
 	svc, repo := newTestReminderSettingsService()
 


### PR DESCRIPTION
## 概要
- `ReminderSettings.UpdateSettings` に入力値バリデーションを追加
- `Frequency`: daily/weeklyのみ許可（不正値はBadRequestエラー）
- `NotificationTime`: HH:MM形式の正規表現チェック
- `InactiveDays`: 1〜30の範囲チェック

## テスト
- Service層: 3つのバリデーションエラーケーステスト追加（InvalidFrequency, InvalidNotificationTime, InactiveDaysExceedsMax）
- Handler層: ValidationError（BadRequest返却）テスト追加
- 全テスト合格確認済み

closes #1646