### PR TITLE
feat: ProjectCardにプロジェクト期間（日数）バッジを追加

### DIFF
--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Pencil, Trash2, CircleDot, CheckCircle2, ExternalLink } from 'lucide-react';
+import { Pencil, Trash2, CircleDot, CheckCircle2, ExternalLink, Calendar } from 'lucide-react';
 import type { Project } from '../../types/project';
 import { cardClass, iconButtonClass, deleteIconButtonClass, badgeBaseClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
@@ -17,6 +17,13 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
   const { t } = useTranslation();
 
   const techStack = parseJsonArray(project.tech_stack);
+
+  const durationDays = (() => {
+    if (!project.start_date) return null;
+    const start = new Date(project.start_date).getTime();
+    const end = project.end_date ? new Date(project.end_date).getTime() : Date.now();
+    return Math.max(1, Math.ceil((end - start) / (1000 * 60 * 60 * 24)));
+  })();
 
   return (
     <div className={cardClass}>
@@ -101,9 +108,19 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
         )}
 
         {(project.start_date || project.end_date) && (
-          <p className="text-xs text-gray-500 mt-2">
-            {formatDate(project.start_date)} - {project.end_date ? formatDate(project.end_date) : t('projects.present')}
-          </p>
+          <div className="flex items-center gap-2 mt-2">
+            <p className="text-xs text-gray-500">
+              {formatDate(project.start_date)} - {project.end_date ? formatDate(project.end_date) : t('projects.present')}
+            </p>
+            {durationDays && (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs rounded bg-cyan-400/10 text-cyan-400">
+                <Calendar className="w-3 h-3" />
+                {project.end_date
+                  ? t('projects.durationCompleted', { days: durationDays })
+                  : t('projects.durationOngoing', { days: durationDays })}
+              </span>
+            )}
+          </div>
         )}
 
         <div className="flex gap-2 mt-4">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -769,6 +769,8 @@
     "startDate": "Startdatum",
     "endDate": "Enddatum",
     "present": "Aktuell",
+    "durationCompleted": "{{days}} Tage",
+    "durationOngoing": "Tag {{days}}",
     "markFeatured": "Dieses Projekt hervorheben",
     "featured": "Hervorgehoben",
     "liveDemo": "Live-Demo",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -769,6 +769,8 @@
     "startDate": "Start Date",
     "endDate": "End Date",
     "present": "Present",
+    "durationCompleted": "{{days}} days",
+    "durationOngoing": "Day {{days}}",
     "markFeatured": "Feature this project",
     "featured": "Featured",
     "liveDemo": "Live Demo",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -769,6 +769,8 @@
     "startDate": "Fecha de Inicio",
     "endDate": "Fecha de Fin",
     "present": "Presente",
+    "durationCompleted": "{{days}} días",
+    "durationOngoing": "Día {{days}}",
     "markFeatured": "Destacar este proyecto",
     "featured": "Destacado",
     "liveDemo": "Demo en Vivo",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -769,6 +769,8 @@
     "startDate": "Date de Début",
     "endDate": "Date de Fin",
     "present": "Présent",
+    "durationCompleted": "{{days}} jours",
+    "durationOngoing": "Jour {{days}}",
     "markFeatured": "Mettre en avant ce projet",
     "featured": "En Vedette",
     "liveDemo": "Démo en Direct",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -738,6 +738,8 @@
     "startDate": "開始日",
     "endDate": "終了日",
     "present": "現在",
+    "durationCompleted": "{{days}}日間",
+    "durationOngoing": "{{days}}日目",
     "markFeatured": "このプロジェクトを注目に設定",
     "featured": "注目",
     "liveDemo": "デモを見る",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -769,6 +769,8 @@
     "startDate": "시작 날짜",
     "endDate": "종료 날짜",
     "present": "현재",
+    "durationCompleted": "{{days}}일간",
+    "durationOngoing": "{{days}}일째",
     "markFeatured": "이 프로젝트를 추천",
     "featured": "추천",
     "liveDemo": "라이브 데모",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -769,6 +769,8 @@
     "startDate": "Data de Início",
     "endDate": "Data de Término",
     "present": "Presente",
+    "durationCompleted": "{{days}} dias",
+    "durationOngoing": "Dia {{days}}",
     "markFeatured": "Destacar este projeto",
     "featured": "Destaque",
     "liveDemo": "Demo ao Vivo",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -769,6 +769,8 @@
     "startDate": "Дата начала",
     "endDate": "Дата окончания",
     "present": "По настоящее время",
+    "durationCompleted": "{{days}} дн.",
+    "durationOngoing": "День {{days}}",
     "markFeatured": "Выделить этот проект",
     "featured": "Избранное",
     "liveDemo": "Живая демо",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -769,6 +769,8 @@
     "startDate": "开始日期",
     "endDate": "结束日期",
     "present": "至今",
+    "durationCompleted": "{{days}}天",
+    "durationOngoing": "第{{days}}天",
     "markFeatured": "设为精选项目",
     "featured": "精选",
     "liveDemo": "在线演示",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -769,6 +769,8 @@
     "startDate": "開始日期",
     "endDate": "結束日期",
     "present": "至今",
+    "durationCompleted": "{{days}}天",
+    "durationOngoing": "第{{days}}天",
     "markFeatured": "設為精選專案",
     "featured": "精選",
     "liveDemo": "線上演示",


### PR DESCRIPTION
## 概要
- ProjectCardにプロジェクト期間を日数で表示するバッジを追加
- 進行中プロジェクト: 「○日目」（開始日からの経過日数）
- 完了プロジェクト: 「○日間」（開始日〜終了日の日数）
- Calendarアイコン付きシアンカラーバッジ
- start_dateがない場合は非表示

## i18n
10言語に `projects.durationCompleted` / `projects.durationOngoing` キーを追加

closes #1648