### PR TITLE
security: AIチャットメッセージの空白チェック・文字数制限追加

### DIFF
--- a/backend/internal/service/ai_advice_test.go
+++ b/backend/internal/service/ai_advice_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -423,6 +424,25 @@ func TestChat_LLMNotConfigured(t *testing.T) {
 	conv, err := svc.Chat(1, "質問", 0)
 	assert.ErrorIs(t, err, ErrLLMNotConfigured)
 	assert.Nil(t, conv)
+}
+
+func TestChat_EmptyMessage(t *testing.T) {
+	svc, _ := newTestAIAdviceService(true)
+
+	conv, err := svc.Chat(1, "   ", 0)
+	assert.Error(t, err)
+	assert.Nil(t, conv)
+	assert.Contains(t, err.Error(), "メッセージを入力してください")
+}
+
+func TestChat_MessageTooLong(t *testing.T) {
+	svc, _ := newTestAIAdviceService(true)
+
+	longMsg := strings.Repeat("あ", MaxChatMessageLength+1)
+	conv, err := svc.Chat(1, longMsg, 0)
+	assert.Error(t, err)
+	assert.Nil(t, conv)
+	assert.Contains(t, err.Error(), "メッセージは5000文字以内で入力してください")
 }
 
 func TestIsLLMAvailable(t *testing.T) {

--- a/backend/internal/service/ai_chat.go
+++ b/backend/internal/service/ai_chat.go
@@ -4,15 +4,29 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
 // DailyChatLimit は1日あたりのLLMチャット回数制限。
 const DailyChatLimit = 5
 
+// MaxChatMessageLength はチャットメッセージの最大文字数。
+const MaxChatMessageLength = 5000
+
 // Chat はLLMとの会話を行い、結果を保存して返す。
 // conversationID が0の場合は新規会話を作成する。
 func (s *AIAdviceService) Chat(userID uint, message string, conversationID uint) (*model.AIConversation, error) {
+	// メッセージバリデーション
+	trimmed := strings.TrimSpace(message)
+	if trimmed == "" {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "メッセージを入力してください", nil)
+	}
+	if len(trimmed) > MaxChatMessageLength {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "メッセージは5000文字以内で入力してください", nil)
+	}
+	message = trimmed
+
 	// LLM利用可否チェック
 	if s.llmClient == nil {
 		return nil, ErrLLMNotConfigured


### PR DESCRIPTION
## 概要
- `AIAdviceService.Chat()` にメッセージバリデーションを追加
- 空白のみのメッセージはBadRequestエラーで拒否
- 5000文字を超えるメッセージはBadRequestエラーで拒否
- `strings.TrimSpace()` で前後の空白を除去してからLLMに送信

## リスク軽減
- 巨大テキストによるLLM APIコスト増加を防止
- 空白メッセージによる無駄なAPI呼び出しを防止

## テスト
- `TestChat_EmptyMessage` / `TestChat_MessageTooLong` 追加、全テスト合格

closes #1654