### PR TITLE
feat: AnswerCardに新着回答バッジを追加

### DIFF
--- a/frontend/src/components/qa/AnswerCard.tsx
+++ b/frontend/src/components/qa/AnswerCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Trash2, Sparkles } from 'lucide-react';
 import type { Answer } from '../../types/qa';
 import Avatar from '../common/Avatar';
 import { iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
@@ -30,6 +30,7 @@ export default function AnswerCard({
 }: AnswerCardProps) {
   const { t } = useTranslation();
   const [voting, setVoting] = useState(false);
+  const isNew = Date.now() - new Date(answer.created_at).getTime() < 24 * 60 * 60 * 1000;
 
   const handleVote = async (value: 1 | -1) => {
     if (voting) return;
@@ -103,6 +104,12 @@ export default function AnswerCard({
               <span className="text-xs text-gray-500">
                 {formatDate(answer.created_at)}
               </span>
+              {isNew && (
+                <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs rounded bg-green-400/10 text-green-400">
+                  <Sparkles className="w-3 h-3" />
+                  {t('qa.newAnswer')}
+                </span>
+              )}
             </div>
 
             <div className="flex items-center gap-2">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -947,6 +947,7 @@
     "upvote": "Positiv bewerten",
     "downvote": "Negativ bewerten",
     "bestAnswer": "Beste Antwort",
+    "newAnswer": "Neu",
     "markBest": "Als beste Antwort markieren",
     "yourAnswer": "Ihre Antwort",
     "postAnswer": "Antwort posten",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -947,6 +947,7 @@
     "upvote": "Upvote",
     "downvote": "Downvote",
     "bestAnswer": "Best Answer",
+    "newAnswer": "New",
     "markBest": "Mark as Best Answer",
     "yourAnswer": "Your Answer",
     "postAnswer": "Post Answer",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -947,6 +947,7 @@
     "upvote": "Votar a favor",
     "downvote": "Votar en contra",
     "bestAnswer": "Mejor respuesta",
+    "newAnswer": "Nueva",
     "markBest": "Marcar como mejor respuesta",
     "yourAnswer": "Tu respuesta",
     "postAnswer": "Publicar respuesta",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -947,6 +947,7 @@
     "upvote": "Vote positif",
     "downvote": "Vote négatif",
     "bestAnswer": "Meilleure réponse",
+    "newAnswer": "Nouvelle",
     "markBest": "Marquer comme meilleure réponse",
     "yourAnswer": "Votre réponse",
     "postAnswer": "Publier la réponse",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -901,6 +901,7 @@
     "upvote": "賛成",
     "downvote": "反対",
     "bestAnswer": "ベストアンサー",
+    "newAnswer": "新着",
     "markBest": "ベストアンサーに選ぶ",
     "yourAnswer": "あなたの回答",
     "postAnswer": "回答を投稿",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -947,6 +947,7 @@
     "upvote": "추천",
     "downvote": "비추천",
     "bestAnswer": "채택된 답변",
+    "newAnswer": "새 답변",
     "markBest": "채택하기",
     "yourAnswer": "답변 작성",
     "postAnswer": "답변 등록",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -947,6 +947,7 @@
     "upvote": "Votar a favor",
     "downvote": "Votar contra",
     "bestAnswer": "Melhor resposta",
+    "newAnswer": "Nova",
     "markBest": "Marcar como melhor resposta",
     "yourAnswer": "Sua resposta",
     "postAnswer": "Publicar resposta",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -947,6 +947,7 @@
     "upvote": "За",
     "downvote": "Против",
     "bestAnswer": "Лучший ответ",
+    "newAnswer": "Новый",
     "markBest": "Отметить как лучший ответ",
     "yourAnswer": "Ваш ответ",
     "postAnswer": "Опубликовать ответ",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -947,6 +947,7 @@
     "upvote": "赞同",
     "downvote": "反对",
     "bestAnswer": "最佳答案",
+    "newAnswer": "最新",
     "markBest": "采纳为最佳答案",
     "yourAnswer": "你的回答",
     "postAnswer": "发布回答",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -947,6 +947,7 @@
     "upvote": "贊同",
     "downvote": "反對",
     "bestAnswer": "最佳答案",
+    "newAnswer": "最新",
     "markBest": "採納為最佳答案",
     "yourAnswer": "你的回答",
     "postAnswer": "發布回答",


### PR DESCRIPTION
## 概要
- AnswerCardに投稿から24時間以内の回答に「新着」バッジを表示
- Sparklesアイコン付きの緑色バッジ
- フッター部分の投稿日時の横に配置

## i18n
10言語に `qa.newAnswer` キーを追加

closes #1656