### PR TITLE
refactor: AnswerCardのインラインSVGをlucide-reactに置換

### DIFF
--- a/frontend/src/components/qa/AnswerCard.tsx
+++ b/frontend/src/components/qa/AnswerCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Pencil, Trash2, Sparkles } from 'lucide-react';
+import { Pencil, Trash2, Sparkles, CheckCircle2, ChevronUp, ChevronDown } from 'lucide-react';
 import type { Answer } from '../../types/qa';
 import Avatar from '../common/Avatar';
 import { iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
@@ -48,9 +48,7 @@ export default function AnswerCard({
     }`}>
       {answer.is_best && (
         <div className="flex items-center gap-1.5 mb-3 text-green-400 text-sm font-medium">
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-          </svg>
+          <CheckCircle2 className="w-5 h-5" />
           {t('qa.bestAnswer')}
         </div>
       )}
@@ -64,9 +62,7 @@ export default function AnswerCard({
             className="p-1 text-gray-400 hover:text-green-400 transition-colors disabled:opacity-50"
             title={t('qa.upvote')}
           >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" />
-            </svg>
+            <ChevronUp className="w-6 h-6" />
           </button>
           <span className={`text-sm font-bold ${
             answer.vote_count > 0 ? 'text-green-400' : answer.vote_count < 0 ? 'text-red-400' : 'text-gray-400'
@@ -79,9 +75,7 @@ export default function AnswerCard({
             className="p-1 text-gray-400 hover:text-red-400 transition-colors disabled:opacity-50"
             title={t('qa.downvote')}
           >
-            <svg className="w-6 h-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
-            </svg>
+            <ChevronDown className="w-6 h-6" />
           </button>
         </div>
 


### PR DESCRIPTION
## 概要
- AnswerCard.tsxの3つのインラインSVGをlucide-reactコンポーネントに置換
  - ベストアンサーアイコン → CheckCircle2
  - 上投票アイコン → ChevronUp
  - 下投票アイコン → ChevronDown
- 10行のSVGコードを4行に削減

closes #1658