### PR TITLE
security: StudyCircle.CreateCheckinのcontentバリデーション追加

### DIFF
--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -298,6 +298,11 @@ func (s *StudyCircleService) GetProgress(circleID, userID uint) ([]model.StudyCi
 
 // CreateCheckin は日次チェックインを作成する。1日1回制限。
 func (s *StudyCircleService) CreateCheckin(circleID, userID uint, content string) (*model.StudyCircleCheckin, error) {
+	if err := domain.ValidateStringLength(content, 1, 5000, "チェックイン内容"); err != nil {
+		return nil, err
+	}
+	content = strings.TrimSpace(content)
+
 	isMember, err := s.repo.IsMember(circleID, userID)
 	if err != nil {
 		return nil, err

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -792,6 +793,25 @@ func TestStudyCircleCreateCheckin_RepoError(t *testing.T) {
 	result, err := svc.CreateCheckin(1, 2, "test")
 	assert.Nil(t, result)
 	assert.Error(t, err)
+}
+
+func TestStudyCircleCreateCheckin_EmptyContent(t *testing.T) {
+	svc, _ := newTestStudyCircleService()
+
+	result, err := svc.CreateCheckin(1, 2, "   ")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "チェックイン内容を入力してください")
+}
+
+func TestStudyCircleCreateCheckin_ContentTooLong(t *testing.T) {
+	svc, _ := newTestStudyCircleService()
+
+	longContent := strings.Repeat("あ", 5001)
+	result, err := svc.CreateCheckin(1, 2, longContent)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "チェックイン内容は5000文字以下")
 }
 
 func TestStudyCircleCreateStep_NotFound(t *testing.T) {


### PR DESCRIPTION
## 概要
- `StudyCircleService.CreateCheckin()` のcontentパラメータにService層でのバリデーションを追加
- `domain.ValidateStringLength` で空白チェック（1文字以上）と最大5000文字の文字数制限
- `strings.TrimSpace` で前後の空白を除去

## テスト
- `TestStudyCircleCreateCheckin_EmptyContent` / `TestStudyCircleCreateCheckin_ContentTooLong` 追加
- 全テスト合格

closes #1662