### PR TITLE
feat: BookReviewCardに高評価おすすめバッジを追加

### DIFF
--- a/frontend/src/components/bookReviews/BookReviewCard.tsx
+++ b/frontend/src/components/bookReviews/BookReviewCard.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { Pencil, Trash2 } from 'lucide-react';
+import { Pencil, Trash2, ThumbsUp, Flame } from 'lucide-react';
 import type { BookReview, ReviewStatus } from '../../types/bookReview';
 import Avatar from '../common/Avatar';
 import StarRating from '../common/StarRating';
@@ -84,6 +84,17 @@ export default function BookReviewCard({
           {/* Status & Rating */}
           <div className="mt-2 flex items-center gap-3">
             <StarRating rating={review.rating} />
+            {review.rating >= 5 ? (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs rounded bg-red-400/10 text-red-400">
+                <Flame className="w-3 h-3" />
+                {t('bookReviews.mustRead')}
+              </span>
+            ) : review.rating >= 4 ? (
+              <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs rounded bg-orange-400/10 text-orange-400">
+                <ThumbsUp className="w-3 h-3" />
+                {t('bookReviews.recommended')}
+              </span>
+            ) : null}
             {review.status && (
               <span className={`text-xs px-2 py-0.5 rounded-full ${statusColors[review.status]}`}>
                 {t(`bookReviews.status.${review.status}`)}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -907,6 +907,8 @@
     },
     "statusAll": "Alle",
     "archivedLabel": "Archiviert",
+    "recommended": "Empfohlen",
+    "mustRead": "Pflichtlektüre",
     "archive": "Archivieren",
     "unarchive": "Entarchivieren",
     "archived": "Rezension archiviert",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -907,6 +907,8 @@
     },
     "statusAll": "All",
     "archivedLabel": "Archived",
+    "recommended": "Recommended",
+    "mustRead": "Must Read",
     "archive": "Archive",
     "unarchive": "Unarchive",
     "archived": "Review archived",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -907,6 +907,8 @@
     },
     "statusAll": "Todos",
     "archivedLabel": "Archivado",
+    "recommended": "Recomendado",
+    "mustRead": "Lectura obligatoria",
     "archive": "Archivar",
     "unarchive": "Desarchivar",
     "archived": "Reseña archivada",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -907,6 +907,8 @@
     },
     "statusAll": "Tous",
     "archivedLabel": "Archivé",
+    "recommended": "Recommandé",
+    "mustRead": "Incontournable",
     "archive": "Archiver",
     "unarchive": "Désarchiver",
     "archived": "Avis archivé",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -861,6 +861,8 @@
     },
     "statusAll": "すべて",
     "archivedLabel": "アーカイブ済み",
+    "recommended": "おすすめ",
+    "mustRead": "必読",
     "archive": "アーカイブ",
     "unarchive": "アーカイブ解除",
     "archived": "アーカイブしました",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -907,6 +907,8 @@
     },
     "statusAll": "전체",
     "archivedLabel": "보관됨",
+    "recommended": "추천",
+    "mustRead": "필독",
     "archive": "보관",
     "unarchive": "보관 해제",
     "archived": "보관되었습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -907,6 +907,8 @@
     },
     "statusAll": "Todos",
     "archivedLabel": "Arquivado",
+    "recommended": "Recomendado",
+    "mustRead": "Leitura obrigatória",
     "archive": "Arquivar",
     "unarchive": "Desarquivar",
     "archived": "Resenha arquivada",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -907,6 +907,8 @@
     },
     "statusAll": "Все",
     "archivedLabel": "В архиве",
+    "recommended": "Рекомендовано",
+    "mustRead": "Обязательно к прочтению",
     "archive": "Архивировать",
     "unarchive": "Разархивировать",
     "archived": "Отзыв архивирован",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -907,6 +907,8 @@
     },
     "statusAll": "全部",
     "archivedLabel": "已归档",
+    "recommended": "推荐",
+    "mustRead": "必读",
     "archive": "归档",
     "unarchive": "取消归档",
     "archived": "已归档",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -907,6 +907,8 @@
     },
     "statusAll": "全部",
     "archivedLabel": "已封存",
+    "recommended": "推薦",
+    "mustRead": "必讀",
     "archive": "封存",
     "unarchive": "取消封存",
     "archived": "已封存",


### PR DESCRIPTION
## 概要
- BookReviewCardにrating値に応じたバッジを追加
  - rating >= 5: Flameアイコン「必読」バッジ（赤）
  - rating >= 4: ThumbsUpアイコン「おすすめ」バッジ（オレンジ）
- StarRatingの横に表示

## i18n
10言語に `bookReviews.recommended` / `bookReviews.mustRead` キーを追加

closes #1664