### PR TITLE
Answer Create/Updateに本文の文字数上限バリデーション追加

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -28,9 +28,10 @@ func (s *AnswerService) GetByQuestionID(questionID uint) ([]model.Answer, error)
 
 // Create は質問の存在を確認した後、新しい回答を作成する。
 func (s *AnswerService) Create(answer *model.Answer) error {
-	if strings.TrimSpace(answer.Body) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "回答内容は必須です", nil)
+	if err := domain.ValidateStringLength(answer.Body, 1, 10000, "回答内容"); err != nil {
+		return err
 	}
+	answer.Body = strings.TrimSpace(answer.Body)
 	if _, err := s.questionRepo.FindByID(answer.QuestionID); err != nil {
 		return ErrNotFound
 	}
@@ -51,8 +52,8 @@ func (s *AnswerService) findAndCheckOwnership(answerID, userID uint) (*model.Ans
 
 // Update は所有権を検証した後、回答を更新する。
 func (s *AnswerService) Update(answerID, userID uint, body string) (*model.Answer, error) {
-	if strings.TrimSpace(body) == "" {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "回答内容は必須です", nil)
+	if err := domain.ValidateStringLength(body, 1, 10000, "回答内容"); err != nil {
+		return nil, err
 	}
 	answer, err := s.findAndCheckOwnership(answerID, userID)
 	if err != nil {

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -138,7 +139,7 @@ func TestAnswerUpdate_EmptyBody(t *testing.T) {
 	result, err := svc.Update(1, 1, "")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "回答内容は必須です")
+	assert.Contains(t, err.Error(), "回答内容を入力してください")
 }
 
 func TestAnswerUpdate_WhitespaceBody(t *testing.T) {
@@ -147,7 +148,7 @@ func TestAnswerUpdate_WhitespaceBody(t *testing.T) {
 	result, err := svc.Update(1, 1, "   ")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "回答内容は必須です")
+	assert.Contains(t, err.Error(), "回答内容を入力してください")
 }
 
 // ============================================================
@@ -552,6 +553,24 @@ func TestAnswerGetByVoteRange_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 	answerRepo.AssertExpectations(t)
+}
+
+func TestAnswerCreate_BodyTooLong(t *testing.T) {
+	svc, _, _ := newTestAnswerService()
+
+	answer := &model.Answer{QuestionID: 10, UserID: 2, Body: strings.Repeat("あ", 10001)}
+	err := svc.Create(answer)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "回答内容は10000文字以下")
+}
+
+func TestAnswerUpdate_BodyTooLong(t *testing.T) {
+	svc, _, _ := newTestAnswerService()
+
+	result, err := svc.Update(1, 1, strings.Repeat("あ", 10001))
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "回答内容は10000文字以下")
 }
 
 func TestAnswerUpdate_TrimsPaddedBody(t *testing.T) {


### PR DESCRIPTION
## 概要
- Answer ServiceのCreate/Updateに`domain.ValidateStringLength`を使用した文字数上限チェック（1〜10000文字）を追加
- 既存の空白チェックを`ValidateStringLength`に統合
- Create/Update両方の文字数超過テストを追加

## テスト
- `TestAnswerCreate_BodyTooLong` — 10001文字でエラー確認
- `TestAnswerUpdate_BodyTooLong` — 10001文字でエラー確認
- 既存テスト全38件合格

Closes #1670