### PR TITLE
PostSearchCardにいいね数ベースの人気バッジを追加

### DIFF
--- a/frontend/src/components/search/PostSearchCard.tsx
+++ b/frontend/src/components/search/PostSearchCard.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Flame } from 'lucide-react';
 import type { Post } from '../../types/post';
 import Avatar from '../common/Avatar';
 import { formatDate } from '../../utils/timeFormat';
@@ -24,7 +25,15 @@ export default function PostSearchCard({ post }: PostSearchCardProps) {
             <span>•</span>
             <span>{formatDate(post.created_at)}</span>
           </div>
-          <h3 className="font-semibold text-white mb-1">{post.title}</h3>
+          <div className="flex items-center gap-2 mb-1">
+            <h3 className="font-semibold text-white">{post.title}</h3>
+            {(post.like_count || 0) >= 10 && (
+              <span className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-orange-400/10 text-orange-400">
+                <Flame className="w-3 h-3" />
+                {t('search.popular')}
+              </span>
+            )}
+          </div>
           <p className="text-sm text-gray-400 line-clamp-2">{post.content}</p>
           {post.tags && post.tags.length > 0 && (
             <div className="flex flex-wrap gap-1.5 mt-2">

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -364,6 +364,7 @@
     "viewProfile": "Profil anzeigen",
     "likesCount": "{{count}} Likes",
     "commentsCount": "{{count}} Kommentare",
+    "popular": "Beliebt",
     "filters": "Filter",
     "sortBy": "Sortieren nach",
     "sortLatest": "Neueste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -364,6 +364,7 @@
     "viewProfile": "View Profile",
     "likesCount": "{{count}} likes",
     "commentsCount": "{{count}} comments",
+    "popular": "Popular",
     "filters": "Filters",
     "sortBy": "Sort by",
     "sortLatest": "Latest",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -364,6 +364,7 @@
     "viewProfile": "Ver perfil",
     "likesCount": "{{count}} me gusta",
     "commentsCount": "{{count}} comentarios",
+    "popular": "Popular",
     "filters": "Filtros",
     "sortBy": "Ordenar por",
     "sortLatest": "Más reciente",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -364,6 +364,7 @@
     "viewProfile": "Voir le profil",
     "likesCount": "{{count}} j'aime",
     "commentsCount": "{{count}} commentaires",
+    "popular": "Populaire",
     "filters": "Filtres",
     "sortBy": "Trier par",
     "sortLatest": "Plus récent",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -372,6 +372,7 @@
     "viewProfile": "プロフィール",
     "likesCount": "{{count}}件のいいね",
     "commentsCount": "{{count}}件のコメント",
+    "popular": "人気",
     "filters": "フィルター",
     "sortBy": "ソート順",
     "sortLatest": "最新順",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -364,6 +364,7 @@
     "viewProfile": "프로필 보기",
     "likesCount": "좋아요 {{count}}개",
     "commentsCount": "댓글 {{count}}개",
+    "popular": "인기",
     "filters": "필터",
     "sortBy": "정렬 순서",
     "sortLatest": "최신순",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -364,6 +364,7 @@
     "viewProfile": "Ver perfil",
     "likesCount": "{{count}} curtidas",
     "commentsCount": "{{count}} comentários",
+    "popular": "Popular",
     "filters": "Filtros",
     "sortBy": "Ordenar por",
     "sortLatest": "Mais recente",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -364,6 +364,7 @@
     "viewProfile": "Посмотреть профиль",
     "likesCount": "{{count}} лайков",
     "commentsCount": "{{count}} комментариев",
+    "popular": "Популярное",
     "filters": "Фильтры",
     "sortBy": "Сортировать по",
     "sortLatest": "Новейшие",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -364,6 +364,7 @@
     "viewProfile": "查看资料",
     "likesCount": "{{count}} 个赞",
     "commentsCount": "{{count}} 条评论",
+    "popular": "热门",
     "filters": "筛选",
     "sortBy": "排序",
     "sortLatest": "最新",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -364,6 +364,7 @@
     "viewProfile": "查看資料",
     "likesCount": "{{count}} 個讚",
     "commentsCount": "{{count}} 則留言",
+    "popular": "熱門",
     "filters": "篩選",
     "sortBy": "排序",
     "sortLatest": "最新",


### PR DESCRIPTION
## 概要
- 検索結果のPostSearchCardに、like_count >= 10の投稿にFlameアイコン+オレンジの「人気」バッジを表示
- 既存データのみ使用（バックエンド変更不要）
- 10言語対応（search.popularキー追加）

## テスト
- TypeScript型チェック通過

Closes #1672