### PR TITLE
NotificationDropdownのベルSVGをlucide-react Bellに置換

### DIFF
--- a/frontend/src/components/notifications/NotificationDropdown.tsx
+++ b/frontend/src/components/notifications/NotificationDropdown.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Bell } from 'lucide-react';
 import { useNotifications } from '../../hooks';
 import Avatar from '../common/Avatar';
 import { getNotificationLink, getNotificationMessage } from './NotificationItem';
@@ -44,9 +45,7 @@ export default function NotificationDropdown() {
         aria-expanded={isOpen}
         aria-haspopup="dialog"
       >
-        <svg className="w-5 h-5" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24" aria-hidden="true">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M14.857 17.082a23.848 23.848 0 0 0 5.454-1.31A8.967 8.967 0 0 1 18 9.75V9A6 6 0 0 0 6 9v.75a8.967 8.967 0 0 1-2.312 6.022c1.733.64 3.56 1.085 5.455 1.31m5.714 0a24.255 24.255 0 0 1-5.714 0m5.714 0a3 3 0 1 1-5.714 0" />
-        </svg>
+        <Bell className="w-5 h-5" aria-hidden="true" />
         {unreadCount > 0 && (
           <span className="absolute -top-0.5 -right-0.5 bg-red-500 text-white text-xs w-5 h-5 flex items-center justify-center rounded-full font-medium">
             {unreadCount > 9 ? '9+' : unreadCount}


### PR DESCRIPTION
## 概要
- NotificationDropdown.tsxのインラインSVG（ベルアイコン3行）をlucide-reactのBellコンポーネント（1行）に置換
- lucide-reactアイコン統一パターンに準拠

## テスト
- TypeScript型チェック通過

Closes #1674