### PR TITLE
MessageService.SendMessageにメッセージ内容のバリデーション追加

### DIFF
--- a/backend/internal/service/message.go
+++ b/backend/internal/service/message.go
@@ -1,6 +1,9 @@
 package service
 
 import (
+	"strings"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -34,6 +37,10 @@ func (s *MessageService) GetConversation(userID, otherUserID uint, page, limit i
 // SendMessage はメッセージを送信し、受信者に非同期で通知を作成する。
 // 自分自身へのメッセージ送信は許可しない。
 func (s *MessageService) SendMessage(msg *model.Message) error {
+	if err := domain.ValidateStringLength(msg.Content, 1, 5000, "メッセージ内容"); err != nil {
+		return err
+	}
+	msg.Content = strings.TrimSpace(msg.Content)
 	if msg.SenderID == msg.ReceiverID {
 		return ErrBadRequest
 	}

--- a/backend/internal/service/message_test.go
+++ b/backend/internal/service/message_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -176,6 +177,26 @@ func TestMessageSendMessage_CreateError(t *testing.T) {
 // ============================================================
 // 既読マークエラーテスト
 // ============================================================
+
+func TestMessageSendMessage_EmptyContent(t *testing.T) {
+	svc, msgRepo, _ := newTestMessageService()
+
+	msg := &model.Message{SenderID: 1, ReceiverID: 2, Content: "   "}
+	err := svc.SendMessage(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "メッセージ内容を入力してください")
+	msgRepo.AssertNotCalled(t, "Create")
+}
+
+func TestMessageSendMessage_ContentTooLong(t *testing.T) {
+	svc, msgRepo, _ := newTestMessageService()
+
+	msg := &model.Message{SenderID: 1, ReceiverID: 2, Content: strings.Repeat("あ", 5001)}
+	err := svc.SendMessage(msg)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "メッセージ内容は5000文字以下")
+	msgRepo.AssertNotCalled(t, "Create")
+}
 
 func TestMessageMarkAsRead_RepoError(t *testing.T) {
 	svc, msgRepo, _ := newTestMessageService()


### PR DESCRIPTION
## 概要
- DMメッセージ送信時に`domain.ValidateStringLength`でメッセージ内容を1〜5000文字に制限
- `strings.TrimSpace`でContent正規化
- 空白メッセージ・文字数超過テスト2件追加

## テスト
- `TestMessageSendMessage_EmptyContent` — 空白のみでエラー
- `TestMessageSendMessage_ContentTooLong` — 5001文字でエラー
- 既存テスト全14件合格

Closes #1678