### PR TITLE
QuestionCardに24時間以内の新着質問バッジを追加

### DIFF
--- a/frontend/src/components/qa/QuestionCard.tsx
+++ b/frontend/src/components/qa/QuestionCard.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { TrendingUp, Pencil, Trash2 } from 'lucide-react';
+import { TrendingUp, Clock, Pencil, Trash2 } from 'lucide-react';
 import type { Question } from '../../types/qa';
 import Avatar from '../common/Avatar';
 import { cardPaddedClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
@@ -18,6 +18,7 @@ export default function QuestionCard({ question, isOwner = false, onEdit, onDele
   const { t } = useTranslation();
 
   const tags = parseJsonArray(question.tags);
+  const isNew = Date.now() - new Date(question.created_at).getTime() < 24 * 60 * 60 * 1000;
 
   const statusBorderClass = question.is_solved
     ? 'border-l-4 border-l-green-500'
@@ -85,9 +86,15 @@ export default function QuestionCard({ question, isOwner = false, onEdit, onDele
 
           <p className="text-gray-400 text-sm mt-1 line-clamp-2">{question.body}</p>
 
-          {/* Tags & Popular badge */}
-          {(tags.length > 0 || question.vote_count >= 5) && (
+          {/* Tags & Badges */}
+          {(tags.length > 0 || question.vote_count >= 5 || isNew) && (
             <div className="flex flex-wrap gap-1.5 mt-2">
+              {isNew && (
+                <span className="inline-flex items-center gap-0.5 px-2 py-0.5 bg-cyan-400/10 text-cyan-400 text-xs rounded-md font-medium">
+                  <Clock className="w-3 h-3" />
+                  {t('qa.newQuestion')}
+                </span>
+              )}
               {question.vote_count >= 5 && (
                 <span className="inline-flex items-center gap-0.5 px-2 py-0.5 bg-yellow-400/10 text-yellow-400 text-xs rounded-md font-medium">
                   <TrendingUp className="w-3 h-3" />

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -986,7 +986,8 @@
     "bestAnswerSet": "Beste Antwort festgelegt",
     "bestAnswerFailed": "Beste Antwort konnte nicht festgelegt werden",
     "voteFailed": "Abstimmung fehlgeschlagen",
-    "popularBadge": "Beliebt"
+    "popularBadge": "Beliebt",
+    "newQuestion": "Neu"
   },
   "roadmaps": {
     "title": "Lern-Roadmaps",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -986,7 +986,8 @@
     "bestAnswerSet": "Best answer set",
     "bestAnswerFailed": "Failed to set best answer",
     "voteFailed": "Failed to vote",
-    "popularBadge": "Popular"
+    "popularBadge": "Popular",
+    "newQuestion": "New"
   },
   "roadmaps": {
     "title": "Learning Roadmaps",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -986,7 +986,8 @@
     "bestAnswerSet": "Mejor respuesta establecida",
     "bestAnswerFailed": "Error al establecer la mejor respuesta",
     "voteFailed": "Error al votar",
-    "popularBadge": "Popular"
+    "popularBadge": "Popular",
+    "newQuestion": "Nuevo"
   },
   "roadmaps": {
     "title": "Hojas de Ruta de Aprendizaje",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -986,7 +986,8 @@
     "bestAnswerSet": "Meilleure réponse définie",
     "bestAnswerFailed": "Échec de la définition de la meilleure réponse",
     "voteFailed": "Échec du vote",
-    "popularBadge": "Populaire"
+    "popularBadge": "Populaire",
+    "newQuestion": "Nouveau"
   },
   "roadmaps": {
     "title": "Feuilles de Route d'Apprentissage",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -940,7 +940,8 @@
     "bestAnswerSet": "ベストアンサーを設定しました",
     "bestAnswerFailed": "ベストアンサーの設定に失敗しました",
     "voteFailed": "投票に失敗しました",
-    "popularBadge": "人気"
+    "popularBadge": "人気",
+    "newQuestion": "新着"
   },
   "roadmaps": {
     "title": "学習ロードマップ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -986,7 +986,8 @@
     "bestAnswerSet": "채택 답변이 설정되었습니다",
     "bestAnswerFailed": "채택 답변 설정에 실패했습니다",
     "voteFailed": "투표에 실패했습니다",
-    "popularBadge": "인기"
+    "popularBadge": "인기",
+    "newQuestion": "신규"
   },
   "roadmaps": {
     "title": "학습 로드맵",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -986,7 +986,8 @@
     "bestAnswerSet": "Melhor resposta definida",
     "bestAnswerFailed": "Falha ao definir melhor resposta",
     "voteFailed": "Falha ao votar",
-    "popularBadge": "Popular"
+    "popularBadge": "Popular",
+    "newQuestion": "Novo"
   },
   "roadmaps": {
     "title": "Roteiros de Aprendizado",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -986,7 +986,8 @@
     "bestAnswerSet": "Лучший ответ установлен",
     "bestAnswerFailed": "Не удалось установить лучший ответ",
     "voteFailed": "Не удалось проголосовать",
-    "popularBadge": "Популярное"
+    "popularBadge": "Популярное",
+    "newQuestion": "Новый"
   },
   "roadmaps": {
     "title": "Дорожные карты обучения",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -986,7 +986,8 @@
     "bestAnswerSet": "已设置最佳答案",
     "bestAnswerFailed": "设置最佳答案失败",
     "voteFailed": "投票失败",
-    "popularBadge": "热门"
+    "popularBadge": "热门",
+    "newQuestion": "最新"
   },
   "roadmaps": {
     "title": "学习路线图",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -986,7 +986,8 @@
     "bestAnswerSet": "已設定最佳答案",
     "bestAnswerFailed": "設定最佳答案失敗",
     "voteFailed": "投票失敗",
-    "popularBadge": "熱門"
+    "popularBadge": "熱門",
+    "newQuestion": "最新"
   },
   "roadmaps": {
     "title": "學習路線圖",


### PR DESCRIPTION
## 概要
- QuestionCardに`created_at`から24時間以内の質問にClockアイコン+シアンの「新着」バッジを表示
- 既存の人気バッジの隣に配置
- 10言語対応（qa.newQuestionキー追加）

## テスト
- TypeScript型チェック通過

Closes #1680