### PR TITLE
QuestionCardの解決済みチェックSVGをlucide-react CheckCircle2に置換

### DIFF
--- a/frontend/src/components/qa/QuestionCard.tsx
+++ b/frontend/src/components/qa/QuestionCard.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { TrendingUp, Clock, Pencil, Trash2 } from 'lucide-react';
+import { TrendingUp, Clock, CheckCircle2, Pencil, Trash2 } from 'lucide-react';
 import type { Question } from '../../types/qa';
 import Avatar from '../common/Avatar';
 import { cardPaddedClass, iconButtonClass, deleteIconButtonClass } from '../../constants/styles';
@@ -56,9 +56,7 @@ export default function QuestionCard({ question, isOwner = false, onEdit, onDele
             >
               {question.is_solved && (
                 <span className="inline-flex items-center mr-2 text-green-400">
-                  <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20">
-                    <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-                  </svg>
+                  <CheckCircle2 className="w-4 h-4" aria-hidden="true" />
                 </span>
               )}
               {question.title}


### PR DESCRIPTION
## 概要
- QuestionCard.tsxの解決済みチェックマークのインラインSVG（3行）をCheckCircle2コンポーネント（1行）に置換
- lucide-reactアイコン統一パターンに準拠

## テスト
- TypeScript型チェック通過

Closes #1682