### PR TITLE
useBadgeNotifierフックのユニットテスト追加

### DIFF
--- a/frontend/src/hooks/__tests__/useBadgeNotifier.test.ts
+++ b/frontend/src/hooks/__tests__/useBadgeNotifier.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useBadgeNotifier } from '../useBadgeNotifier';
+import { notifyBadgeEarned } from '../../api/badges';
+import type { BadgeResult } from '../../types/badge';
+
+const mockShowToast = vi.fn();
+
+vi.mock('../../contexts/ToastContext', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+vi.mock('../../api/badges', () => ({
+  notifyBadgeEarned: vi.fn().mockResolvedValue({}),
+}));
+
+const badge1 = { id: 'b1', name: 'badges.firstPost', earned: true, earned_at: '2026-02-19' } as BadgeResult;
+const badge2 = { id: 'b2', name: 'badges.tenPosts', earned: true, earned_at: '2026-02-19' } as BadgeResult;
+const badge3 = { id: 'b3', name: 'badges.hundredPosts', earned: false } as BadgeResult;
+
+// localStorage mock
+const store: Record<string, string> = {};
+const mockGetItem = vi.fn((key: string) => store[key] ?? null);
+const mockSetItem = vi.fn((key: string, value: string) => { store[key] = value; });
+const mockRemoveItem = vi.fn((key: string) => { delete store[key]; });
+
+Object.defineProperty(globalThis, 'localStorage', {
+  value: {
+    getItem: mockGetItem,
+    setItem: mockSetItem,
+    removeItem: mockRemoveItem,
+  },
+  writable: true,
+});
+
+describe('useBadgeNotifier', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(store).forEach((k) => delete store[k]);
+  });
+
+  it('空バッジ配列では何もしないこと', () => {
+    renderHook(() => useBadgeNotifier([]));
+
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
+
+  it('初回ロード時はToast表示せずlocalStorageに保存すること', () => {
+    renderHook(() => useBadgeNotifier([badge1, badge2, badge3]));
+
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith('devsync_earned_badges', JSON.stringify(['b1', 'b2']));
+  });
+
+  it('新規バッジ検出時にToast表示とAPI通知が行われること', () => {
+    store['devsync_earned_badges'] = JSON.stringify(['b1']);
+
+    renderHook(() => useBadgeNotifier([badge1, badge2, badge3]));
+
+    expect(mockShowToast).toHaveBeenCalledTimes(1);
+    expect(notifyBadgeEarned).toHaveBeenCalledWith('b2');
+    expect(mockSetItem).toHaveBeenCalledWith('devsync_earned_badges', JSON.stringify(['b1', 'b2']));
+  });
+
+  it('既存バッジのみの場合はToast表示しないこと', () => {
+    store['devsync_earned_badges'] = JSON.stringify(['b1', 'b2']);
+
+    renderHook(() => useBadgeNotifier([badge1, badge2]));
+
+    expect(mockShowToast).not.toHaveBeenCalled();
+  });
+
+  it('localStorageの不正JSONでエラーハンドリングすること', () => {
+    store['devsync_earned_badges'] = 'invalid-json';
+
+    renderHook(() => useBadgeNotifier([badge1]));
+
+    expect(mockRemoveItem).toHaveBeenCalledWith('devsync_earned_badges');
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith('devsync_earned_badges', JSON.stringify(['b1']));
+  });
+
+  it('localStorageに不正な型が保存されている場合は無視すること', () => {
+    store['devsync_earned_badges'] = JSON.stringify({ not: 'array' });
+
+    renderHook(() => useBadgeNotifier([badge1]));
+
+    // 不正な型は空配列として扱われ、初回ロードとして処理
+    expect(mockShowToast).not.toHaveBeenCalled();
+    expect(mockSetItem).toHaveBeenCalledWith('devsync_earned_badges', JSON.stringify(['b1']));
+  });
+});


### PR DESCRIPTION
## 概要
- localStorage永続化・新規バッジ検出・Toast通知フック`useBadgeNotifier`のテスト6件を追加

## テストケース
- 空バッジ配列では何もしない
- 初回ロード時はToast表示せずlocalStorageに保存
- 新規バッジ検出時にToast表示とAPI通知
- 既存バッジのみの場合はToast表示なし
- localStorageの不正JSONでエラーハンドリング
- localStorageの不正な型で適切にフォールバック

Closes #1684