### PR TITLE
ChatRoomService.SendMessageにメッセージ内容のバリデーション追加

### DIFF
--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -169,6 +169,10 @@ func (s *ChatRoomService) GetMessages(roomID, userID uint, page, limit int) ([]m
 // SendMessage はメンバーシップを検証した後、メッセージを送信する。
 // WebSocket経由でルーム内の他メンバーにリアルタイム配信する。
 func (s *ChatRoomService) SendMessage(roomID, userID uint, content string) (*model.GroupMessage, error) {
+	if err := domain.ValidateStringLength(content, 1, 5000, "メッセージ内容"); err != nil {
+		return nil, err
+	}
+	content = strings.TrimSpace(content)
 	if err := s.checkMembership(roomID, userID); err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -486,6 +487,26 @@ func TestChatRoomSendMessage_CreateError(t *testing.T) {
 	assert.Nil(t, result)
 	roomRepo.AssertExpectations(t)
 	msgRepo.AssertExpectations(t)
+}
+
+func TestChatRoomSendMessage_EmptyContent(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	result, err := svc.SendMessage(10, 1, "   ")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "メッセージ内容を入力してください")
+	roomRepo.AssertNotCalled(t, "IsMember")
+}
+
+func TestChatRoomSendMessage_ContentTooLong(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	result, err := svc.SendMessage(10, 1, strings.Repeat("あ", 5001))
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "メッセージ内容は5000文字以下")
+	roomRepo.AssertNotCalled(t, "IsMember")
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
- グループチャットメッセージ送信時に`domain.ValidateStringLength`でメッセージ内容を1〜5000文字に制限
- `strings.TrimSpace`でcontent正規化
- 空白メッセージ・文字数超過テスト2件追加

## テスト
- `TestChatRoomSendMessage_EmptyContent` — 空白のみでエラー
- `TestChatRoomSendMessage_ContentTooLong` — 5001文字でエラー
- 既存テスト全件合格

Closes #1686