### PR TITLE
CommentSectionのコメントSVGをlucide-react MessageCircleに置換

### DIFF
--- a/frontend/src/components/posts/CommentSection.tsx
+++ b/frontend/src/components/posts/CommentSection.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import { MessageCircle } from 'lucide-react';
 import { sectionContainerClass, messageInputClass } from '../../constants/styles';
 import type { Comment } from '../../types/post';
 import CommentItem from './CommentItem';
@@ -42,9 +43,7 @@ export default function CommentSection({ comments, submitting, onSubmitComment }
   return (
     <div className={sectionContainerClass}>
       <div className="px-6 py-4 border-b border-gray-800 flex items-center gap-2">
-        <svg aria-hidden="true" className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 20.25c4.97 0 9-3.694 9-8.25s-4.03-8.25-9-8.25S3 7.444 3 12c0 2.104.859 4.023 2.273 5.48.432.447.74 1.04.586 1.641a4.483 4.483 0 0 1-.923 1.785A5.969 5.969 0 0 0 6 21c1.282 0 2.47-.402 3.445-1.087.81.22 1.668.337 2.555.337Z" />
-        </svg>
+        <MessageCircle className="w-4 h-4 text-gray-400" aria-hidden="true" />
         <h3 className="text-sm font-semibold">{t('post.comments')} ({comments.length})</h3>
       </div>
 


### PR DESCRIPTION
## 概要
- CommentSection.tsxのインラインSVG（コメントアイコン3行）をMessageCircleコンポーネント（1行）に置換
- lucide-reactアイコン統一パターンに準拠

## テスト
- TypeScript型チェック通過

Closes #1690