### PR TITLE
PostCollectionService Create/Updateにタイトル・説明の文字数上限追加

### DIFF
--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -21,9 +21,13 @@ func NewPostCollectionService(repo repository.PostCollectionRepositoryInterface)
 
 // Create は新しい投稿コレクションを作成する。
 func (s *PostCollectionService) Create(collection *model.PostCollection) (*model.PostCollection, error) {
-	if strings.TrimSpace(collection.Title) == "" {
-		return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは必須です", nil)
+	if err := domain.ValidateStringLength(collection.Title, 1, 200, "タイトル"); err != nil {
+		return nil, err
 	}
+	if len(strings.TrimSpace(collection.Description)) > 1000 {
+		return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+	}
+	collection.Title = strings.TrimSpace(collection.Title)
 	if err := s.repo.Create(collection); err != nil {
 		return nil, err
 	}
@@ -59,8 +63,11 @@ func (s *PostCollectionService) findAndCheckOwnership(id, userID uint) (*model.P
 
 // Update は所有権を検証した後、コレクションを更新する。
 func (s *PostCollectionService) Update(id, userID uint, title, description string, isPublic bool) (*model.PostCollection, error) {
-	if strings.TrimSpace(title) == "" {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは必須です", nil)
+	if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
+		return nil, err
+	}
+	if len(strings.TrimSpace(description)) > 1000 {
+		return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
 	}
 	collection, err := s.findAndCheckOwnership(id, userID)
 	if err != nil {

--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -66,7 +67,7 @@ func TestPostCollectionCreate_WhitespaceTitle(t *testing.T) {
 	result, err := svc.Create(collection)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "タイトルは必須です")
+	assert.Contains(t, err.Error(), "タイトルを入力してください")
 }
 
 func TestPostCollectionCreate_RepoError(t *testing.T) {
@@ -229,7 +230,7 @@ func TestPostCollectionUpdate_EmptyTitle(t *testing.T) {
 	result, err := svc.Update(10, 1, "", "desc", false)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "タイトルは必須です")
+	assert.Contains(t, err.Error(), "タイトルを入力してください")
 }
 
 func TestPostCollectionUpdate_WhitespaceTitle(t *testing.T) {
@@ -238,7 +239,7 @@ func TestPostCollectionUpdate_WhitespaceTitle(t *testing.T) {
 	result, err := svc.Update(10, 1, "   ", "desc", false)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "タイトルは必須です")
+	assert.Contains(t, err.Error(), "タイトルを入力してください")
 }
 
 // ============================================================
@@ -418,4 +419,46 @@ func TestPostCollectionRemovePost_NotFound(t *testing.T) {
 	err := svc.RemovePost(99, 1, 5)
 	assert.Error(t, err)
 	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// タイトル・説明文字数バリデーションテスト
+// ============================================================
+
+func TestPostCollectionCreate_TitleTooLong(t *testing.T) {
+	svc, _ := newTestPostCollectionService()
+
+	collection := &model.PostCollection{Title: strings.Repeat("あ", 201), UserID: 1}
+	result, err := svc.Create(collection)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトルは200文字以下")
+}
+
+func TestPostCollectionCreate_DescriptionTooLong(t *testing.T) {
+	svc, _ := newTestPostCollectionService()
+
+	collection := &model.PostCollection{Title: "テスト", Description: strings.Repeat("あ", 1001), UserID: 1}
+	result, err := svc.Create(collection)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "説明は1000文字以下")
+}
+
+func TestPostCollectionUpdate_TitleTooLong(t *testing.T) {
+	svc, _ := newTestPostCollectionService()
+
+	result, err := svc.Update(1, 1, strings.Repeat("あ", 201), "説明", true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトルは200文字以下")
+}
+
+func TestPostCollectionUpdate_DescriptionTooLong(t *testing.T) {
+	svc, _ := newTestPostCollectionService()
+
+	result, err := svc.Update(1, 1, "タイトル", strings.Repeat("あ", 1001), true)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "説明は1000文字以下")
 }


### PR DESCRIPTION
## 概要
- `domain.ValidateStringLength`でタイトルを1〜200文字に制限
- 説明を0〜1000文字に制限
- Create/Update両方に適用
- 文字数超過テスト4件追加

## テスト
- `TestPostCollectionCreate_TitleTooLong` — 201文字でエラー
- `TestPostCollectionCreate_DescriptionTooLong` — 1001文字でエラー
- `TestPostCollectionUpdate_TitleTooLong` — 201文字でエラー
- `TestPostCollectionUpdate_DescriptionTooLong` — 1001文字でエラー
- 既存テスト全件合格

Closes #1694