### PR TITLE
refactor: LanguageSelectorのインラインSVGをlucide-reactに統一

### DIFF
--- a/frontend/src/components/common/LanguageSelector.tsx
+++ b/frontend/src/components/common/LanguageSelector.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Globe, ChevronDown, Check } from 'lucide-react';
 import { languages } from '../../i18n';
 
 export default function LanguageSelector() {
@@ -34,13 +35,9 @@ export default function LanguageSelector() {
         aria-expanded={isOpen}
         aria-haspopup="listbox"
       >
-        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24" aria-hidden="true">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" />
-        </svg>
+        <Globe className="w-4 h-4" aria-hidden="true" />
         <span className="hidden sm:inline">{currentLanguage.nativeName}</span>
-        <svg className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" aria-hidden="true">
-          <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
-        </svg>
+        <ChevronDown className={`w-3 h-3 transition-transform ${isOpen ? 'rotate-180' : ''}`} aria-hidden="true" />
       </button>
 
       {isOpen && (
@@ -61,9 +58,7 @@ export default function LanguageSelector() {
             >
               <span>{lang.nativeName}</span>
               {lang.code === i18n.language && (
-                <svg className="w-4 h-4" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true">
-                  <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
-                </svg>
+                <Check className="w-4 h-4" aria-hidden="true" />
               )}
             </button>
           ))}


### PR DESCRIPTION
## 概要
- LanguageSelectorコンポーネントの3つのインラインSVGをlucide-reactに置換
- Globe（グローブ）、ChevronDown（下矢印）、Check（チェックマーク）

## 変更内容
- `LanguageSelector.tsx`: 9行のインラインSVGを4行のlucide-reactコンポーネントに簡素化

## テスト
- TypeScript型チェック通過

Closes #1698