### PR TITLE
security: BookReviewService Create/Updateの文字数バリデーション強化

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -28,12 +28,17 @@ func validateRating(rating int) error {
 
 // Create は新しい書籍レビューを作成する。
 func (s *BookReviewService) Create(review *model.BookReview) error {
-	if strings.TrimSpace(review.Title) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "タイトルは必須です", nil)
+	if err := domain.ValidateStringLength(review.Title, 1, 200, "タイトル"); err != nil {
+		return err
 	}
 	if err := validateRating(review.Rating); err != nil {
 		return err
 	}
+	if len(strings.TrimSpace(review.Review)) > 10000 {
+		return domain.NewError(domain.ErrCodeValidation, "レビュー本文は10000文字以下である必要があります", nil)
+	}
+	review.Title = strings.TrimSpace(review.Title)
+	review.Review = strings.TrimSpace(review.Review)
 	return s.repo.Create(review)
 }
 
@@ -88,6 +93,9 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
+		if len(strings.TrimSpace(updates.Title)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		}
 		review.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Author) != "" {
@@ -103,6 +111,9 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		review.Rating = updates.Rating
 	}
 	if strings.TrimSpace(updates.Review) != "" {
+		if len(strings.TrimSpace(updates.Review)) > 10000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "レビュー本文は10000文字以下である必要があります", nil)
+		}
 		review.Review = strings.TrimSpace(updates.Review)
 	}
 	if strings.TrimSpace(updates.ImageURL) != "" {

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -44,7 +45,7 @@ func TestBookReviewCreate_WhitespaceTitle(t *testing.T) {
 	review := &model.BookReview{UserID: 1, Title: "   \t  ", Rating: 4}
 	err := svc.Create(review)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "タイトルは必須です")
+	assert.Contains(t, err.Error(), "タイトルを入力してください")
 }
 
 func TestBookReviewCreate_EmptyTitle(t *testing.T) {
@@ -572,4 +573,54 @@ func TestBookReviewSearch_RepoError(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// タイトル・レビュー本文の文字数バリデーションテスト
+// ============================================================
+
+func TestBookReviewCreate_TitleTooLong(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{Title: strings.Repeat("あ", 201), UserID: 1, Rating: 4}
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "タイトルは200文字以下")
+}
+
+func TestBookReviewCreate_ReviewTooLong(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{Title: "テスト本", UserID: 1, Rating: 4, Review: strings.Repeat("あ", 10001)}
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "レビュー本文は10000文字以下")
+}
+
+func TestBookReviewUpdate_TitleTooLong(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Old", Rating: 3}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.BookReview{Title: strings.Repeat("あ", 201)}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトルは200文字以下")
+}
+
+func TestBookReviewUpdate_ReviewTooLong(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Old", Rating: 3}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.BookReview{Review: strings.Repeat("あ", 10001)}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "レビュー本文は10000文字以下")
 }


### PR DESCRIPTION
## 概要
- BookReviewServiceのCreate/Updateに文字数バリデーションを追加
- タイトル: 1-200文字（CreateはValidateStringLength、Updateはlen()チェック）
- レビュー本文: 10000文字以下

## 変更内容
- `book_review.go`: Create/Updateにバリデーション追加
- `book_review_test.go`: 既存テストのエラーメッセージ更新 + 4テスト追加

## テスト
- 全BookReviewテスト通過

Closes #1702