### PR TITLE
feat: リソースカードに人気リソースバッジを追加

### DIFF
--- a/frontend/src/components/resources/ResourceCard.tsx
+++ b/frontend/src/components/resources/ResourceCard.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
-import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin, Pencil, Trash2, ExternalLink, type LucideIcon } from 'lucide-react';
+import { BookOpen, Video, FileText, GraduationCap, BookMarked, Mic, Wrench, Pin, Pencil, Trash2, ExternalLink, Flame, type LucideIcon } from 'lucide-react';
 import type { LearningResource, ResourceCategory, ResourceDifficulty } from '../../types/resource';
 import { parseJsonArray } from '../../utils/json';
 import Avatar from '../common/Avatar';
@@ -127,20 +127,28 @@ export default function ResourceCard({
         </div>
 
         {/* Title & Description */}
-        <h3 className="text-lg font-semibold text-white mt-3">
-          {sanitizeUrl(resource.url) ? (
-            <a
-              href={sanitizeUrl(resource.url)}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-green-400 transition-colors"
-            >
-              {resource.title}
-            </a>
-          ) : (
-            resource.title
+        <div className="flex items-center gap-2 mt-3">
+          <h3 className="text-lg font-semibold text-white">
+            {sanitizeUrl(resource.url) ? (
+              <a
+                href={sanitizeUrl(resource.url)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="hover:text-green-400 transition-colors"
+              >
+                {resource.title}
+              </a>
+            ) : (
+              resource.title
+            )}
+          </h3>
+          {resource.like_count >= 10 && (
+            <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 rounded bg-orange-400/10 text-orange-400 shrink-0">
+              <Flame className="w-3 h-3" />
+              {t('resources.popular')}
+            </span>
           )}
-        </h3>
+        </div>
 
         {resource.description && (
           <p className="text-gray-300 text-sm mt-2 line-clamp-2">{resource.description}</p>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -797,6 +797,7 @@
     "explore": "Entdecken",
     "savedTab": "Gespeichert",
     "myResources": "Meine Ressourcen",
+    "popular": "Beliebt",
     "noResources": "Keine Ressourcen gefunden",
     "noSavedResources": "Noch keine gespeicherten Ressourcen",
     "noMyResources": "Du hast noch keine Ressourcen geteilt",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -797,6 +797,7 @@
     "explore": "Explore",
     "savedTab": "Saved",
     "myResources": "My Resources",
+    "popular": "Popular",
     "noResources": "No resources found",
     "noSavedResources": "No saved resources yet",
     "noMyResources": "You haven't shared any resources yet",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -797,6 +797,7 @@
     "explore": "Explorar",
     "savedTab": "Guardados",
     "myResources": "Mis Recursos",
+    "popular": "Popular",
     "noResources": "No se encontraron recursos",
     "noSavedResources": "Aún no hay recursos guardados",
     "noMyResources": "Aún no has compartido ningún recurso",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -797,6 +797,7 @@
     "explore": "Explorer",
     "savedTab": "Enregistrés",
     "myResources": "Mes Ressources",
+    "popular": "Populaire",
     "noResources": "Aucune ressource trouvée",
     "noSavedResources": "Pas encore de ressources enregistrées",
     "noMyResources": "Vous n'avez pas encore partagé de ressources",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -766,6 +766,7 @@
     "explore": "みんなの教材",
     "savedTab": "保存済み",
     "myResources": "自分の教材",
+    "popular": "人気",
     "noResources": "教材が見つかりませんでした",
     "noSavedResources": "保存済みの教材がありません",
     "noMyResources": "まだ教材を共有していません",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -797,6 +797,7 @@
     "explore": "탐색",
     "savedTab": "저장됨",
     "myResources": "내 리소스",
+    "popular": "인기",
     "noResources": "리소스를 찾을 수 없습니다",
     "noSavedResources": "저장된 리소스가 없습니다",
     "noMyResources": "아직 공유한 리소스가 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -797,6 +797,7 @@
     "explore": "Explorar",
     "savedTab": "Salvos",
     "myResources": "Meus Recursos",
+    "popular": "Popular",
     "noResources": "Nenhum recurso encontrado",
     "noSavedResources": "Nenhum recurso salvo ainda",
     "noMyResources": "Você ainda não compartilhou nenhum recurso",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -797,6 +797,7 @@
     "explore": "Обзор",
     "savedTab": "Сохранённые",
     "myResources": "Мои ресурсы",
+    "popular": "Популярное",
     "noResources": "Ресурсы не найдены",
     "noSavedResources": "Пока нет сохранённых ресурсов",
     "noMyResources": "Вы ещё не поделились ресурсами",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -797,6 +797,7 @@
     "explore": "探索",
     "savedTab": "已保存",
     "myResources": "我的资源",
+    "popular": "热门",
     "noResources": "未找到资源",
     "noSavedResources": "暂无保存的资源",
     "noMyResources": "你还没有分享任何资源",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -797,6 +797,7 @@
     "explore": "探索",
     "savedTab": "已儲存",
     "myResources": "我的資源",
+    "popular": "熱門",
     "noResources": "未找到資源",
     "noSavedResources": "暫無儲存的資源",
     "noMyResources": "你還沒有分享任何資源",


### PR DESCRIPTION
## 概要
- ResourceCardにいいね数10以上で人気バッジを表示
- Flameアイコン付きオレンジバッジをタイトル横に配置
- 10言語対応（`resources.popular`キー追加）

## 変更内容
- `ResourceCard.tsx`: Flame import、バッジ表示ロジック追加
- 10言語ファイル: `resources.popular`キー追加

## テスト
- TypeScript型チェック通過

Closes #1704