### PR TITLE
security: CodeSnippetService Create/Update/CreateCommentの文字数バリデーション強化

### DIFF
--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -25,12 +25,14 @@ func NewCodeSnippetService(
 // Create は新しいコードスニペットを作成する。
 // 投稿の存在を確認してからスニペットを作成する。
 func (s *CodeSnippetService) Create(snippet *model.CodeSnippet) (*model.CodeSnippet, error) {
-	if strings.TrimSpace(snippet.Language) == "" {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "言語は空白のみでは入力できません", nil)
+	if err := domain.ValidateStringLength(snippet.Language, 1, 100, "言語"); err != nil {
+		return nil, err
 	}
-	if strings.TrimSpace(snippet.Code) == "" {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "コードは空白のみでは入力できません", nil)
+	if err := domain.ValidateStringLength(snippet.Code, 1, 50000, "コード"); err != nil {
+		return nil, err
 	}
+	snippet.Language = strings.TrimSpace(snippet.Language)
+	snippet.Code = strings.TrimSpace(snippet.Code)
 
 	// 投稿の存在確認
 	if _, err := s.postRepo.FindByID(snippet.PostID); err != nil {
@@ -82,13 +84,19 @@ func (s *CodeSnippetService) Update(id, userID uint, language, fileName, code st
 	}
 
 	if strings.TrimSpace(language) != "" {
-		snippet.Language = language
+		if len(strings.TrimSpace(language)) > 100 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "言語は100文字以下である必要があります", nil)
+		}
+		snippet.Language = strings.TrimSpace(language)
 	}
 	if strings.TrimSpace(fileName) != "" {
-		snippet.FileName = fileName
+		snippet.FileName = strings.TrimSpace(fileName)
 	}
 	if strings.TrimSpace(code) != "" {
-		snippet.Code = code
+		if len(strings.TrimSpace(code)) > 50000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "コードは50000文字以下である必要があります", nil)
+		}
+		snippet.Code = strings.TrimSpace(code)
 	}
 
 	if err := s.repo.Update(snippet); err != nil {
@@ -108,9 +116,10 @@ func (s *CodeSnippetService) Delete(id, userID uint) error {
 // CreateComment はスニペットへのインラインコメントを作成する。
 // スニペットの存在を確認してからコメントを作成する。
 func (s *CodeSnippetService) CreateComment(comment *model.SnippetComment) error {
-	if strings.TrimSpace(comment.Content) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "コメント内容は必須です", nil)
+	if err := domain.ValidateStringLength(comment.Content, 1, 2000, "コメント内容"); err != nil {
+		return err
 	}
+	comment.Content = strings.TrimSpace(comment.Content)
 	if _, err := s.repo.FindByID(comment.SnippetID); err != nil {
 		return err
 	}

--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -171,7 +172,7 @@ func TestSnippetCommentCreate_EmptyContent(t *testing.T) {
 
 	err := svc.CreateComment(comment)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "コメント内容は必須です")
+	assert.Contains(t, err.Error(), "コメント内容を入力してください")
 }
 
 func TestSnippetCommentCreate_WhitespaceContent(t *testing.T) {
@@ -186,7 +187,7 @@ func TestSnippetCommentCreate_WhitespaceContent(t *testing.T) {
 
 	err := svc.CreateComment(comment)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "コメント内容は必須です")
+	assert.Contains(t, err.Error(), "コメント内容を入力してください")
 }
 
 func TestSnippetCommentCreate_SnippetNotFound(t *testing.T) {
@@ -428,7 +429,7 @@ func TestSnippetCreate_WhitespaceCode(t *testing.T) {
 	snippet := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", Code: "   "}
 	_, err := svc.Create(snippet)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "コードは空白のみでは入力できません")
+	assert.Contains(t, err.Error(), "コードを入力してください")
 }
 
 func TestSnippetCreate_WhitespaceLanguage(t *testing.T) {
@@ -440,5 +441,60 @@ func TestSnippetCreate_WhitespaceLanguage(t *testing.T) {
 	snippet := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "   ", Code: "package main"}
 	_, err := svc.Create(snippet)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "言語は空白のみでは入力できません")
+	assert.Contains(t, err.Error(), "言語を入力してください")
+}
+
+// ============================================================
+// 文字数バリデーションテスト
+// ============================================================
+
+func TestSnippetCreate_LanguageTooLong(t *testing.T) {
+	svc, _, _ := newTestCodeSnippetService()
+
+	snippet := &model.CodeSnippet{PostID: 5, UserID: 1, Language: strings.Repeat("a", 101), Code: "package main"}
+	_, err := svc.Create(snippet)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "言語は100文字以下")
+}
+
+func TestSnippetCreate_CodeTooLong(t *testing.T) {
+	svc, _, _ := newTestCodeSnippetService()
+
+	snippet := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", Code: strings.Repeat("a", 50001)}
+	_, err := svc.Create(snippet)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "コードは50000文字以下")
+}
+
+func TestSnippetUpdate_LanguageTooLong(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+	existing := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", Code: "package main"}
+	existing.ID = 10
+	snippetRepo.On("FindByID", uint(10)).Return(existing, nil)
+
+	result, err := svc.Update(10, 1, strings.Repeat("a", 101), "", "")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "言語は100文字以下")
+}
+
+func TestSnippetUpdate_CodeTooLong(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+	existing := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", Code: "package main"}
+	existing.ID = 10
+	snippetRepo.On("FindByID", uint(10)).Return(existing, nil)
+
+	result, err := svc.Update(10, 1, "", "", strings.Repeat("a", 50001))
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "コードは50000文字以下")
+}
+
+func TestSnippetCreateComment_ContentTooLong(t *testing.T) {
+	svc, _, _ := newTestCodeSnippetService()
+
+	comment := &model.SnippetComment{SnippetID: 10, UserID: 1, Content: strings.Repeat("あ", 2001)}
+	err := svc.CreateComment(comment)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "コメント内容は2000文字以下")
 }


### PR DESCRIPTION
## 概要
- CodeSnippetServiceの各メソッドに文字数バリデーションを追加
- 言語: 1-100文字、コード: 1-50000文字、コメント: 1-2000文字

## 変更内容
- `code_snippet.go`: Create/Update/CreateCommentにバリデーション追加
- `code_snippet_test.go`: 既存テストのエラーメッセージ更新 + 5テスト追加

## テスト
- 全CodeSnippetテスト通過

Closes #1710