### PR TITLE
feat: LogCardに集中学習バッジ（120分以上）を追加

### DIFF
--- a/frontend/src/components/learning-logs/LogCard.tsx
+++ b/frontend/src/components/learning-logs/LogCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Code, BookOpen, GraduationCap, Users, FileText, Star, Timer, Pencil, Trash2, type LucideIcon } from 'lucide-react';
+import { Code, BookOpen, GraduationCap, Users, FileText, Star, Timer, Zap, Pencil, Trash2, type LucideIcon } from 'lucide-react';
 import type { LearningLog, LogCategory } from '../../types/learningLog';
 import { formatDate } from '../../utils/timeFormat';
 import { panelClass, badgeBaseClass } from '../../constants/styles';
@@ -63,6 +63,12 @@ export default function LogCard({ log, onEdit, onDelete, onToggleFavorite }: Log
                   {log.duration >= 60
                     ? t('learningLogs.durationHoursMinutes', { hours: Math.floor(log.duration / 60), minutes: log.duration % 60 })
                     : t('learningLogs.durationMinutes', { minutes: log.duration })}
+                </span>
+              )}
+              {log.duration >= 120 && (
+                <span className="inline-flex items-center gap-0.5 px-1.5 py-0.5 text-xs rounded bg-purple-400/10 text-purple-400">
+                  <Zap className="w-3 h-3" />
+                  {t('learningLogs.deepFocus')}
                 </span>
               )}
             </div>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -668,6 +668,7 @@
     "durationMinutes": "{{minutes}} Min.",
     "durationHoursMinutes": "{{hours}} Std. {{minutes}} Min.",
     "sourcePomodoro": "Pomodoro",
+    "deepFocus": "Tiefes Fokus",
     "durationPlaceholder": "Minuten",
     "calendar": "Kalender",
     "list": "Liste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -668,6 +668,7 @@
     "durationMinutes": "{{minutes}} min",
     "durationHoursMinutes": "{{hours}}h {{minutes}}m",
     "sourcePomodoro": "Pomodoro",
+    "deepFocus": "Deep Focus",
     "durationPlaceholder": "minutes",
     "calendar": "Calendar",
     "list": "List",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -668,6 +668,7 @@
     "durationMinutes": "{{minutes}} min",
     "durationHoursMinutes": "{{hours}}h {{minutes}}m",
     "sourcePomodoro": "Pomodoro",
+    "deepFocus": "Enfoque profundo",
     "durationPlaceholder": "minutos",
     "calendar": "Calendario",
     "list": "Lista",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -668,6 +668,7 @@
     "durationMinutes": "{{minutes}} min",
     "durationHoursMinutes": "{{hours}}h {{minutes}}m",
     "sourcePomodoro": "Pomodoro",
+    "deepFocus": "Concentration intense",
     "durationPlaceholder": "minutes",
     "calendar": "Calendrier",
     "list": "Liste",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -652,6 +652,7 @@
     "durationMinutes": "{{minutes}}分",
     "durationHoursMinutes": "{{hours}}時間{{minutes}}分",
     "sourcePomodoro": "ポモドーロ",
+    "deepFocus": "集中学習",
     "durationPlaceholder": "分",
     "calendar": "カレンダー",
     "list": "リスト",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -668,6 +668,7 @@
     "durationMinutes": "{{minutes}}분",
     "durationHoursMinutes": "{{hours}}시간 {{minutes}}분",
     "sourcePomodoro": "포모도로",
+    "deepFocus": "집중 학습",
     "durationPlaceholder": "분",
     "calendar": "캘린더",
     "list": "목록",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -668,6 +668,7 @@
     "durationMinutes": "{{minutes}} min",
     "durationHoursMinutes": "{{hours}}h {{minutes}}m",
     "sourcePomodoro": "Pomodoro",
+    "deepFocus": "Foco profundo",
     "durationPlaceholder": "minutos",
     "calendar": "Calendário",
     "list": "Lista",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -668,6 +668,7 @@
     "durationMinutes": "{{minutes}} мин",
     "durationHoursMinutes": "{{hours}} ч {{minutes}} мин",
     "sourcePomodoro": "Помодоро",
+    "deepFocus": "Глубокий фокус",
     "durationPlaceholder": "минуты",
     "calendar": "Календарь",
     "list": "Список",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -668,6 +668,7 @@
     "durationMinutes": "{{minutes}}分钟",
     "durationHoursMinutes": "{{hours}}小时{{minutes}}分钟",
     "sourcePomodoro": "番茄钟",
+    "deepFocus": "深度专注",
     "durationPlaceholder": "分钟",
     "calendar": "日历",
     "list": "列表",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -668,6 +668,7 @@
     "durationMinutes": "{{minutes}}分鐘",
     "durationHoursMinutes": "{{hours}}小時{{minutes}}分鐘",
     "sourcePomodoro": "番茄鐘",
+    "deepFocus": "深度專注",
     "durationPlaceholder": "分鐘",
     "calendar": "日曆",
     "list": "列表",


### PR DESCRIPTION
## 概要
- 学習ログカード（LogCard）で duration >= 120分のログに Zap アイコン + 紫色の「集中学習」バッジを表示
- NoteCard の volume badge と同じ UI パターンで統一感を持たせる
- 10言語の i18n 対応（`learningLogs.deepFocus`）

## テスト計画
- [ ] 120分以上の学習ログに集中学習バッジが表示されること
- [ ] 120分未満の学習ログにバッジが表示されないこと
- [ ] 各言語で正しい翻訳が表示されること

closes #1712