### PR TITLE
fix: ChatRoomServiceにValidateStringLength統一バリデーション追加

### DIFF
--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -24,9 +24,10 @@ func NewChatRoomService(roomRepo repository.ChatRoomRepositoryInterface, message
 
 // Create は新しいチャットルームを作成し、オーナーと指定メンバーを追加する。
 func (s *ChatRoomService) Create(room *model.ChatRoom, memberIDs []uint) (*model.ChatRoom, error) {
-	if strings.TrimSpace(room.Name) == "" {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "チャットルーム名は空白のみでは入力できません", nil)
+	if err := domain.ValidateStringLength(room.Name, 1, 100, "チャットルーム名"); err != nil {
+		return nil, err
 	}
+	room.Name = strings.TrimSpace(room.Name)
 	if err := s.roomRepo.Create(room); err != nil {
 		return nil, err
 	}
@@ -96,12 +97,18 @@ func (s *ChatRoomService) Update(roomID, userID uint, name, description string) 
 		if strings.TrimSpace(name) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "チャットルーム名は空白のみでは入力できません", nil)
 		}
-		room.Name = name
+		if len(strings.TrimSpace(name)) > 100 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "チャットルーム名は100文字以下である必要があります", nil)
+		}
+		room.Name = strings.TrimSpace(name)
 	}
 	if description != "" && strings.TrimSpace(description) == "" {
 		return nil, domain.NewError(domain.ErrCodeBadRequest, "説明は空白のみでは入力できません", nil)
 	}
-	room.Description = description
+	if len(strings.TrimSpace(description)) > 500 {
+		return nil, domain.NewError(domain.ErrCodeValidation, "説明は500文字以下である必要があります", nil)
+	}
+	room.Description = strings.TrimSpace(description)
 
 	if err := s.roomRepo.Update(room); err != nil {
 		return nil, err

--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -589,7 +589,42 @@ func TestChatRoomCreate_WhitespaceName(t *testing.T) {
 	room := &model.ChatRoom{Name: "   ", OwnerID: 1}
 	_, err := svc.Create(room, nil)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "空白のみ")
+	assert.Contains(t, err.Error(), "チャットルーム名を入力してください")
+}
+
+func TestChatRoomCreate_NameTooLong(t *testing.T) {
+	svc, _, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{Name: strings.Repeat("あ", 101), OwnerID: 1}
+	_, err := svc.Create(room, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "チャットルーム名は100文字以下")
+}
+
+func TestChatRoomUpdate_NameTooLong(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{Name: "Room", OwnerID: 1}
+	room.ID = 10
+	roomRepo.On("FindByID", uint(10)).Return(room, nil)
+
+	result, err := svc.Update(10, 1, strings.Repeat("あ", 101), "")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "チャットルーム名は100文字以下")
+}
+
+func TestChatRoomUpdate_DescriptionTooLong(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	room := &model.ChatRoom{Name: "Room", OwnerID: 1}
+	room.ID = 10
+	roomRepo.On("FindByID", uint(10)).Return(room, nil)
+
+	result, err := svc.Update(10, 1, "", strings.Repeat("あ", 501))
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "説明は500文字以下")
 }
 
 func TestChatRoomUpdate_WhitespaceName(t *testing.T) {


### PR DESCRIPTION
## 概要
- Create: ルーム名に `ValidateStringLength(1-100)` を適用（手動空白チェック → 統一バリデーション）
- Update: ルーム名100文字、説明500文字の上限チェック追加
- 既存テストのエラーメッセージ更新 + 4テスト追加（Create名前超過、Update名前超過、Update説明超過）

## テスト計画
- [x] `go test ./internal/service/... -run TestChatRoom` — 全テストパス

closes #1718