### PR TITLE
fix: LearningGoalServiceにValidateStringLength統一バリデーション追加

### DIFF
--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -22,9 +22,10 @@ func NewLearningGoalService(repo repository.LearningGoalRepositoryInterface) *Le
 
 // Create は新しい学習目標を作成する。
 func (s *LearningGoalService) Create(goal *model.LearningGoal) error {
-	if strings.TrimSpace(goal.Title) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "タイトルは必須です", nil)
+	if err := domain.ValidateStringLength(goal.Title, 1, 200, "タイトル"); err != nil {
+		return err
 	}
+	goal.Title = strings.TrimSpace(goal.Title)
 	return s.repo.Create(goal)
 }
 
@@ -101,10 +102,16 @@ func (s *LearningGoalService) Update(id, userID uint, updates *model.LearningGoa
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		goal.Title = updates.Title
+		if len(strings.TrimSpace(updates.Title)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		}
+		goal.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		goal.Description = updates.Description
+		if len(strings.TrimSpace(updates.Description)) > 1000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		}
+		goal.Description = strings.TrimSpace(updates.Description)
 	}
 	if strings.TrimSpace(string(updates.Category)) != "" {
 		goal.Category = updates.Category

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -679,6 +680,39 @@ func TestLearningGoalUpdate_WhitespaceStatus(t *testing.T) {
 	result, err := svc.Update(1, 1, &model.LearningGoal{Status: "   "})
 	assert.NoError(t, err)
 	assert.Equal(t, model.GoalStatusActive, result.Status)
+}
+
+func TestLearningGoalCreate_TitleTooLong(t *testing.T) {
+	svc, _ := newTestLearningGoalService()
+
+	goal := &model.LearningGoal{UserID: 1, Title: strings.Repeat("あ", 201)}
+	err := svc.Create(goal)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "タイトルは200文字以下")
+}
+
+func TestLearningGoalUpdate_TitleTooLong(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	existing := &model.LearningGoal{Title: "Title", Status: model.GoalStatusActive, UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	result, err := svc.Update(1, 1, &model.LearningGoal{Title: strings.Repeat("あ", 201)})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトルは200文字以下")
+}
+
+func TestLearningGoalUpdate_DescriptionTooLong(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	existing := &model.LearningGoal{Title: "Title", Status: model.GoalStatusActive, UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	result, err := svc.Update(1, 1, &model.LearningGoal{Description: strings.Repeat("あ", 1001)})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "説明は1000文字以下")
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
- Create: タイトルに `ValidateStringLength(1-200)` を適用
- Update: タイトル200文字、説明1000文字の上限チェック追加
- 3テスト追加（Create タイトル超過、Update タイトル超過、Update 説明超過）

## テスト計画
- [x] `go test ./internal/service/... -run TestLearningGoal` — 全テストパス

closes #1726