### PR TITLE
security: PostSeriesServiceの文字列長バリデーション強化

### DIFF
--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -21,9 +21,10 @@ func NewPostSeriesService(repo repository.PostSeriesRepositoryInterface) *PostSe
 
 // Create は新しい投稿シリーズを作成する。
 func (s *PostSeriesService) Create(series *model.PostSeries) error {
-	if strings.TrimSpace(series.Title) == "" {
-		return domain.NewError(domain.ErrCodeValidation, "タイトルは必須です", nil)
+	if err := domain.ValidateStringLength(series.Title, 1, 200, "タイトル"); err != nil {
+		return err
 	}
+	series.Title = strings.TrimSpace(series.Title)
 	return s.repo.Create(series)
 }
 
@@ -66,13 +67,19 @@ func (s *PostSeriesService) Update(id, userID uint, updates *model.PostSeries) (
 		if strings.TrimSpace(updates.Title) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみでは入力できません", nil)
 		}
-		series.Title = updates.Title
+		if len(strings.TrimSpace(updates.Title)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		}
+		series.Title = strings.TrimSpace(updates.Title)
 	}
 	if updates.Description != "" {
 		if strings.TrimSpace(updates.Description) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "説明は空白のみでは入力できません", nil)
 		}
-		series.Description = updates.Description
+		if len(strings.TrimSpace(updates.Description)) > 1000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		}
+		series.Description = strings.TrimSpace(updates.Description)
 	}
 
 	if err := s.repo.Update(series); err != nil {

--- a/backend/internal/service/post_series_test.go
+++ b/backend/internal/service/post_series_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -417,6 +418,49 @@ func TestPostSeriesRemovePost_NotFound(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestPostSeriesCreate_TitleTooLong(t *testing.T) {
+	svc, _ := newTestPostSeriesService()
+
+	series := &model.PostSeries{
+		Title:  strings.Repeat("あ", 201),
+		UserID: 1,
+	}
+
+	err := svc.Create(series)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "200文字以下")
+}
+
+func TestPostSeriesUpdate_TitleTooLong(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	existing := &model.PostSeries{Title: "Old Title", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.PostSeries{Title: strings.Repeat("あ", 201)}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "200文字以下")
+}
+
+func TestPostSeriesUpdate_DescriptionTooLong(t *testing.T) {
+	svc, repo := newTestPostSeriesService()
+
+	existing := &model.PostSeries{Title: "Title", Description: "Old Desc", UserID: 1}
+	existing.ID = 1
+
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.PostSeries{Description: strings.Repeat("あ", 1001)}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "1000文字以下")
+}
+
 func TestPostSeriesCreate_WhitespaceTitle(t *testing.T) {
 	svc, _ := newTestPostSeriesService()
 
@@ -427,7 +471,7 @@ func TestPostSeriesCreate_WhitespaceTitle(t *testing.T) {
 
 	err := svc.Create(series)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "タイトルは必須です")
+	assert.Contains(t, err.Error(), "タイトルを入力してください")
 }
 
 func TestPostSeriesUpdate_WhitespaceTitle(t *testing.T) {


### PR DESCRIPTION
## 概要
- Create: 手動空白チェック → `ValidateStringLength(Title, 1-200)` に統一
- Update: タイトル200文字・説明1000文字の上限チェック追加
- テスト3件追加（Create長すぎ、Update Title長すぎ、Update Description長すぎ）

## テスト計画
- [x] 既存テスト全通過
- [x] 新規テスト3件通過

closes #1734