### PR TITLE
feat: WeeklySummaryCardにストリーク達成バッジを追加

### DIFF
--- a/frontend/src/components/learning-logs/WeeklySummaryCard.tsx
+++ b/frontend/src/components/learning-logs/WeeklySummaryCard.tsx
@@ -1,4 +1,4 @@
-import { Clock, Calendar, FileText } from 'lucide-react';
+import { Clock, Calendar, FileText, Flame } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { StreakInfo } from '../../types/learningLog';
 import { panelClass } from '../../constants/styles';
@@ -33,7 +33,15 @@ export default function WeeklySummaryCard({
         <Calendar className="w-8 h-8 text-orange-400" />
         <div>
           <p className="text-xs text-gray-400">{t('learningLogs.currentStreak')}</p>
-          <p className="text-lg font-bold text-white">{streakInfo?.current_streak ?? 0}{t('learningLogs.days')}</p>
+          <p className="text-lg font-bold text-white">
+            {streakInfo?.current_streak ?? 0}{t('learningLogs.days')}
+            {(streakInfo?.current_streak ?? 0) >= 7 && (
+              <span className="inline-flex items-center gap-0.5 ml-2 px-1.5 py-0.5 text-xs rounded bg-orange-400/10 text-orange-400 font-medium align-middle">
+                <Flame className="w-3 h-3" />
+                {t('learningLogs.streakAchieved')}
+              </span>
+            )}
+          </p>
         </div>
       </div>
       <div className={`${panelClass} flex items-center gap-3 col-span-2 md:col-span-1`}>

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -697,6 +697,7 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Aktuelle Serie",
     "days": " Tage",
+    "streakAchieved": "Serie!",
     "logCount": "Gesamteinträge",
     "favorites": "Favoriten",
     "toggleFavorite": "Favorit umschalten"

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -697,6 +697,7 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Current Streak",
     "days": " days",
+    "streakAchieved": "Streak!",
     "logCount": "Total Logs",
     "favorites": "Favorites",
     "toggleFavorite": "Toggle Favorite"

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -697,6 +697,7 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Racha actual",
     "days": " días",
+    "streakAchieved": "¡Racha!",
     "logCount": "Total de registros",
     "favorites": "Favoritos",
     "toggleFavorite": "Alternar favorito"

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -697,6 +697,7 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Série en cours",
     "days": " jours",
+    "streakAchieved": "Série !",
     "logCount": "Total des entrées",
     "favorites": "Favoris",
     "toggleFavorite": "Basculer le favori"

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -681,6 +681,7 @@
     "hoursMinutes": "{{hours}}時間{{minutes}}分",
     "currentStreak": "連続学習日数",
     "days": "日",
+    "streakAchieved": "連続達成",
     "logCount": "ログ件数",
     "favorites": "お気に入り",
     "toggleFavorite": "お気に入り切替"

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -697,6 +697,7 @@
     "hoursMinutes": "{{hours}}시간 {{minutes}}분",
     "currentStreak": "연속 학습일",
     "days": "일",
+    "streakAchieved": "연속 달성",
     "logCount": "로그 수",
     "favorites": "즐겨찾기",
     "toggleFavorite": "즐겨찾기 전환"

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -697,6 +697,7 @@
     "hoursMinutes": "{{hours}}h {{minutes}}m",
     "currentStreak": "Sequência atual",
     "days": " dias",
+    "streakAchieved": "Sequência!",
     "logCount": "Total de registros",
     "favorites": "Favoritos",
     "toggleFavorite": "Alternar favorito"

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -697,6 +697,7 @@
     "hoursMinutes": "{{hours}}ч {{minutes}}м",
     "currentStreak": "Текущая серия",
     "days": " дн.",
+    "streakAchieved": "Серия!",
     "logCount": "Всего записей",
     "favorites": "Избранное",
     "toggleFavorite": "Переключить избранное"

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -697,6 +697,7 @@
     "hoursMinutes": "{{hours}}小时{{minutes}}分钟",
     "currentStreak": "连续学习天数",
     "days": "天",
+    "streakAchieved": "连续达成",
     "logCount": "日志数量",
     "favorites": "收藏",
     "toggleFavorite": "切换收藏"

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -697,6 +697,7 @@
     "hoursMinutes": "{{hours}}小時{{minutes}}分鐘",
     "currentStreak": "連續學習天數",
     "days": "天",
+    "streakAchieved": "連續達成",
     "logCount": "日誌數量",
     "favorites": "收藏",
     "toggleFavorite": "切換收藏"


### PR DESCRIPTION
## 概要
- 連続学習7日以上の場合、Flameアイコン付き「連続達成」バッジをストリーク欄に表示
- 10言語対応のi18nキー（streakAchieved）追加

## テスト計画
- [x] TypeScript型チェック通過
- [ ] 連続7日以上のストリークでバッジが表示される
- [ ] 連続7日未満ではバッジが非表示

closes #1736