### PR TITLE
security: RoadmapServiceの文字列長バリデーション強化

### DIFF
--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -29,9 +29,10 @@ func NewRoadmapService(repo repository.RoadmapRepositoryInterface) *RoadmapServi
 
 // Create は新しいロードマップを作成する。
 func (s *RoadmapService) Create(roadmap *model.Roadmap) error {
-	if strings.TrimSpace(roadmap.Title) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "タイトルは必須です", nil)
+	if err := domain.ValidateStringLength(roadmap.Title, 1, 200, "タイトル"); err != nil {
+		return err
 	}
+	roadmap.Title = strings.TrimSpace(roadmap.Title)
 	return s.repo.Create(roadmap)
 }
 
@@ -107,10 +108,16 @@ func (s *RoadmapService) Update(id, userID uint, updates *model.Roadmap) (*model
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		roadmap.Title = updates.Title
+		if len(strings.TrimSpace(updates.Title)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		}
+		roadmap.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		roadmap.Description = updates.Description
+		if len(strings.TrimSpace(updates.Description)) > 1000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		}
+		roadmap.Description = strings.TrimSpace(updates.Description)
 	}
 	if strings.TrimSpace(string(updates.Category)) != "" {
 		roadmap.Category = updates.Category
@@ -183,12 +190,21 @@ func (s *RoadmapService) UpdateStep(roadmapID, stepID, userID uint, updates *mod
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
+		if len(strings.TrimSpace(updates.Title)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		}
 		step.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
+		if len(strings.TrimSpace(updates.Description)) > 1000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		}
 		step.Description = strings.TrimSpace(updates.Description)
 	}
 	if strings.TrimSpace(updates.ResourceURL) != "" {
+		if len(strings.TrimSpace(updates.ResourceURL)) > 500 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "リソースURLは500文字以下である必要があります", nil)
+		}
 		step.ResourceURL = strings.TrimSpace(updates.ResourceURL)
 	}
 

--- a/backend/internal/service/roadmap_test.go
+++ b/backend/internal/service/roadmap_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -590,7 +591,7 @@ func TestRoadmapCreate_WhitespaceTitle(t *testing.T) {
 	roadmap := &model.Roadmap{Title: "   \t\n  ", UserID: 1}
 	err := svc.Create(roadmap)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "タイトルは必須です")
+	assert.Contains(t, err.Error(), "タイトルを入力してください")
 }
 
 func TestRoadmapCreate_EmptyTitle(t *testing.T) {
@@ -1247,4 +1248,93 @@ func TestRoadmapUpdateStep_TrimsPaddedTitle(t *testing.T) {
 	result, err := svc.UpdateStep(1, 10, 1, &model.RoadmapStep{Title: "  New Title  "})
 	assert.NoError(t, err)
 	assert.Equal(t, "New Title", result.Title)
+}
+
+// ============================================================
+// 文字列長バリデーションテスト
+// ============================================================
+
+func TestRoadmapCreate_TitleTooLong(t *testing.T) {
+	svc, _ := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{Title: strings.Repeat("あ", 201), UserID: 1}
+	err := svc.Create(roadmap)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "200文字以下")
+}
+
+func TestRoadmapUpdate_TitleTooLong(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	existing := &model.Roadmap{Title: "Old", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.Roadmap{Title: strings.Repeat("あ", 201)}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "200文字以下")
+}
+
+func TestRoadmapUpdate_DescriptionTooLong(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	existing := &model.Roadmap{Title: "Title", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.Roadmap{Description: strings.Repeat("あ", 1001)}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "1000文字以下")
+}
+
+func TestRoadmapUpdateStep_TitleTooLong(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 1
+	step := &model.RoadmapStep{RoadmapID: 1, Title: "Old"}
+	step.ID = 10
+	repo.On("FindByID", uint(1)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(10)).Return(step, nil)
+
+	result, err := svc.UpdateStep(1, 10, 1, &model.RoadmapStep{Title: strings.Repeat("あ", 201)})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "200文字以下")
+}
+
+func TestRoadmapUpdateStep_DescriptionTooLong(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 1
+	step := &model.RoadmapStep{RoadmapID: 1, Title: "Step"}
+	step.ID = 10
+	repo.On("FindByID", uint(1)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(10)).Return(step, nil)
+
+	result, err := svc.UpdateStep(1, 10, 1, &model.RoadmapStep{Description: strings.Repeat("あ", 1001)})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "1000文字以下")
+}
+
+func TestRoadmapUpdateStep_ResourceURLTooLong(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 1
+	step := &model.RoadmapStep{RoadmapID: 1, Title: "Step"}
+	step.ID = 10
+	repo.On("FindByID", uint(1)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(10)).Return(step, nil)
+
+	result, err := svc.UpdateStep(1, 10, 1, &model.RoadmapStep{ResourceURL: strings.Repeat("a", 501)})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "500文字以下")
 }


### PR DESCRIPTION
## 概要
- Create: 手動空白チェック → `ValidateStringLength(Title, 1-200)` に統一
- Update: タイトル200文字・説明1000文字の上限チェック追加
- UpdateStep: タイトル200文字・説明1000文字・ResourceURL500文字の上限チェック追加
- テスト6件追加

## テスト計画
- [x] 既存テスト全通過
- [x] 新規テスト6件通過

closes #1742