### PR TITLE
security: StudyCircleServiceのバリデーション強化

### DIFF
--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -46,9 +46,10 @@ func (s *StudyCircleService) findAndCheckStepOwnership(circleID, stepID, userID 
 
 // Create はサークルを作成し、オーナーをメンバーとして自動追加する。
 func (s *StudyCircleService) Create(circle *model.StudyCircle, memberIDs []uint) error {
-	if strings.TrimSpace(circle.Name) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "サークル名は必須です", nil)
+	if err := domain.ValidateStringLength(circle.Name, 1, 100, "サークル名"); err != nil {
+		return err
 	}
+	circle.Name = strings.TrimSpace(circle.Name)
 	if circle.MaxMembers < 3 || circle.MaxMembers > 10 {
 		circle.MaxMembers = 5
 	}
@@ -120,15 +121,24 @@ func (s *StudyCircleService) Update(id, userID uint, name, topic, description *s
 		if strings.TrimSpace(*name) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "サークル名は空白のみでは入力できません", nil)
 		}
-		circle.Name = *name
+		if len(strings.TrimSpace(*name)) > 100 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "サークル名は100文字以下である必要があります", nil)
+		}
+		circle.Name = strings.TrimSpace(*name)
 	}
 	if topic != nil {
 		if strings.TrimSpace(*topic) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "トピックは空白のみでは入力できません", nil)
 		}
-		circle.Topic = *topic
+		if len(strings.TrimSpace(*topic)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "トピックは200文字以下である必要があります", nil)
+		}
+		circle.Topic = strings.TrimSpace(*topic)
 	}
 	if description != nil {
+		if len(strings.TrimSpace(*description)) > 1000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		}
 		circle.Description = *description
 	}
 
@@ -232,9 +242,15 @@ func (s *StudyCircleService) UpdateStep(circleID, userID, stepID uint, title, de
 		if strings.TrimSpace(*title) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみでは入力できません", nil)
 		}
-		step.Title = *title
+		if len(strings.TrimSpace(*title)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		}
+		step.Title = strings.TrimSpace(*title)
 	}
 	if description != nil {
+		if len(strings.TrimSpace(*description)) > 1000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		}
 		step.Description = *description
 	}
 

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -38,7 +38,7 @@ func TestStudyCircleCreate_WhitespaceName(t *testing.T) {
 	circle := &model.StudyCircle{Name: "   \t  ", Topic: "Go", OwnerID: 1, MaxMembers: 5}
 	err := svc.Create(circle, nil)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "サークル名は必須です")
+	assert.Contains(t, err.Error(), "サークル名を入力してください")
 }
 
 func TestStudyCircleCreate_EmptyName(t *testing.T) {
@@ -1044,4 +1044,78 @@ func TestStudyCircleGetByStatus_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Empty(t, result)
 	repo.AssertExpectations(t)
+}
+
+// --- Validation Length Tests ---
+
+func TestStudyCircleCreate_NameTooLong(t *testing.T) {
+	svc, _ := newTestStudyCircleService()
+
+	longName := strings.Repeat("あ", 101)
+	circle := &model.StudyCircle{Name: longName, Topic: "Go", OwnerID: 1, MaxMembers: 5}
+	err := svc.Create(circle, nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "サークル名は100文字以下である必要があります")
+}
+
+func TestStudyCircleUpdate_NameTooLong(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("FindByID", uint(1)).Return(&model.StudyCircle{OwnerID: 1}, nil)
+
+	longName := strings.Repeat("あ", 101)
+	result, err := svc.Update(1, 1, &longName, nil, nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "サークル名は100文字以下である必要があります")
+}
+
+func TestStudyCircleUpdate_TopicTooLong(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("FindByID", uint(1)).Return(&model.StudyCircle{OwnerID: 1}, nil)
+
+	longTopic := strings.Repeat("あ", 201)
+	result, err := svc.Update(1, 1, nil, &longTopic, nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "トピックは200文字以下である必要があります")
+}
+
+func TestStudyCircleUpdate_DescriptionTooLong(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("FindByID", uint(1)).Return(&model.StudyCircle{OwnerID: 1}, nil)
+
+	longDesc := strings.Repeat("あ", 1001)
+	result, err := svc.Update(1, 1, nil, nil, &longDesc)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "説明は1000文字以下である必要があります")
+}
+
+func TestStudyCircleUpdateStep_TitleTooLong(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("FindByID", uint(1)).Return(&model.StudyCircle{OwnerID: 1}, nil)
+	repo.On("FindStepByID", uint(10)).Return(&model.StudyCircleStep{CircleID: 1}, nil)
+
+	longTitle := strings.Repeat("あ", 201)
+	result, err := svc.UpdateStep(1, 1, 10, &longTitle, nil)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "タイトルは200文字以下である必要があります")
+}
+
+func TestStudyCircleUpdateStep_DescriptionTooLong(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("FindByID", uint(1)).Return(&model.StudyCircle{OwnerID: 1}, nil)
+	repo.On("FindStepByID", uint(10)).Return(&model.StudyCircleStep{CircleID: 1}, nil)
+
+	longDesc := strings.Repeat("あ", 1001)
+	result, err := svc.UpdateStep(1, 1, 10, nil, &longDesc)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "説明は1000文字以下である必要があります")
 }


### PR DESCRIPTION
## 概要
- StudyCircleServiceのCreate/Update/UpdateStepメソッドにdomain.ValidateStringLengthによる統一的なバリデーションを追加
- Create: サークル名のバリデーションをValidateStringLength(1-100文字)に移行
- Update: サークル名100文字、トピック200文字、説明1000文字の上限チェック追加
- UpdateStep: タイトル200文字、説明1000文字の上限チェック追加
- 対応テスト6件追加（全テストPASS）

closes #1750