### PR TITLE
security: PostTagServiceに個別タグの文字数上限バリデーション追加

### DIFF
--- a/backend/internal/service/post_tag.go
+++ b/backend/internal/service/post_tag.go
@@ -38,6 +38,12 @@ func (s *PostTagService) SetTags(postID, userID uint, tags []string) error {
 		return domain.NewError(domain.ErrCodeBadRequest, "タグは最大10個までです", nil)
 	}
 
+	for _, tag := range normalized {
+		if len(tag) > 50 {
+			return domain.NewError(domain.ErrCodeValidation, "タグは50文字以下である必要があります", nil)
+		}
+	}
+
 	return s.tagRepo.SetTags(postID, normalized)
 }
 

--- a/backend/internal/service/post_tag_test.go
+++ b/backend/internal/service/post_tag_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -284,4 +285,36 @@ func TestPostTagSetAutoTags_EmptyContent(t *testing.T) {
 	err := svc.SetAutoTags(10, 1, "")
 	assert.NoError(t, err)
 	tagRepo.AssertNotCalled(t, "SetTags")
+}
+
+// ============================================================
+// SetTags — タグ文字数上限バリデーション
+// ============================================================
+
+func TestPostTagSetTags_TagTooLong(t *testing.T) {
+	svc, _, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	longTag := strings.Repeat("a", 51)
+	err := svc.SetTags(10, 1, []string{longTag})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "タグは50文字以下である必要があります")
+}
+
+func TestPostTagSetTags_TagExactly50Chars(t *testing.T) {
+	svc, tagRepo, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	tag50 := strings.Repeat("a", 50)
+	tagRepo.On("SetTags", uint(10), []string{tag50}).Return(nil)
+
+	err := svc.SetTags(10, 1, []string{tag50})
+	assert.NoError(t, err)
+	tagRepo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
- SetTagsメソッドで正規化後の各タグに50文字上限チェックを追加
- 50文字を超えるタグはバリデーションエラーを返す
- テスト2件追加（上限超過、境界値50文字OK）、全テストPASS

closes #1758