### PR TITLE
security: UserService Updateメソッドにバリデーション追加

### DIFF
--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -40,6 +41,21 @@ func (s *UserService) FindByID(id uint) (*model.User, error) {
 
 // Update はユーザー情報を更新する。
 func (s *UserService) Update(user *model.User) error {
+	if err := domain.ValidateStringLength(user.Name, 1, 100, "名前"); err != nil {
+		return err
+	}
+	if len(user.Bio) > 500 {
+		return domain.NewError(domain.ErrCodeValidation, "自己紹介は500文字以下である必要があります", nil)
+	}
+	if len(user.SkillsLanguages) > 500 {
+		return domain.NewError(domain.ErrCodeValidation, "プログラミング言語スキルは500文字以下である必要があります", nil)
+	}
+	if len(user.SkillsFrameworks) > 500 {
+		return domain.NewError(domain.ErrCodeValidation, "フレームワークスキルは500文字以下である必要があります", nil)
+	}
+	if len(user.AvatarURL) > 2000 {
+		return domain.NewError(domain.ErrCodeValidation, "アバターURLは2000文字以下である必要があります", nil)
+	}
 	return s.repo.Update(user)
 }
 

--- a/backend/internal/service/user_test.go
+++ b/backend/internal/service/user_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -286,4 +287,53 @@ func TestGetProfileCompleteness_OnlyFrameworks(t *testing.T) {
 	assert.Contains(t, result.MissingFields, "avatar")
 	assert.Contains(t, result.MissingFields, "bio")
 	assert.Contains(t, result.MissingFields, "github")
+}
+
+// ============================================================
+// Update — バリデーションテスト
+// ============================================================
+
+func TestUserUpdate_NameTooLong(t *testing.T) {
+	svc, _ := newTestUserService()
+
+	user := &model.User{Name: strings.Repeat("あ", 101)}
+	err := svc.Update(user)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "名前は100文字以下である必要があります")
+}
+
+func TestUserUpdate_BioTooLong(t *testing.T) {
+	svc, _ := newTestUserService()
+
+	user := &model.User{Name: "Alice", Bio: strings.Repeat("a", 501)}
+	err := svc.Update(user)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "自己紹介は500文字以下である必要があります")
+}
+
+func TestUserUpdate_SkillsLanguagesTooLong(t *testing.T) {
+	svc, _ := newTestUserService()
+
+	user := &model.User{Name: "Alice", SkillsLanguages: strings.Repeat("a", 501)}
+	err := svc.Update(user)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "プログラミング言語スキルは500文字以下である必要があります")
+}
+
+func TestUserUpdate_SkillsFrameworksTooLong(t *testing.T) {
+	svc, _ := newTestUserService()
+
+	user := &model.User{Name: "Alice", SkillsFrameworks: strings.Repeat("a", 501)}
+	err := svc.Update(user)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "フレームワークスキルは500文字以下である必要があります")
+}
+
+func TestUserUpdate_AvatarURLTooLong(t *testing.T) {
+	svc, _ := newTestUserService()
+
+	user := &model.User{Name: "Alice", AvatarURL: strings.Repeat("a", 2001)}
+	err := svc.Update(user)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "アバターURLは2000文字以下である必要があります")
 }


### PR DESCRIPTION
## 概要
- UserService Updateメソッドに名前・Bio・スキル・AvatarURLの文字数上限チェックを追加
- 名前100文字、Bio/スキル500文字、AvatarURL 2000文字の上限
- テスト5件追加、全テストPASS

closes #1766