### PR TITLE
feat: ProfileCompletenessCardに完成度マイルストーンバッジを追加

### DIFF
--- a/frontend/src/components/profile/ProfileCompletenessCard.tsx
+++ b/frontend/src/components/profile/ProfileCompletenessCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { CheckCircle } from 'lucide-react';
+import { CheckCircle, Zap, TrendingUp, Trophy } from 'lucide-react';
 
 interface ProfileCompletenessCardProps {
   percentage: number;
@@ -27,6 +27,22 @@ export default function ProfileCompletenessCard({ percentage, missingFields }: P
           style={{ width: `${percentage}%` }}
         />
       </div>
+      {percentage >= 75 ? (
+        <div className="flex items-center gap-1.5 mb-3 text-xs">
+          <Trophy className="w-3.5 h-3.5 text-green-400" />
+          <span className="text-green-400 font-medium">{t('profile.milestoneAlmost')}</span>
+        </div>
+      ) : percentage >= 50 ? (
+        <div className="flex items-center gap-1.5 mb-3 text-xs">
+          <TrendingUp className="w-3.5 h-3.5 text-blue-400" />
+          <span className="text-blue-400 font-medium">{t('profile.milestoneHalf')}</span>
+        </div>
+      ) : percentage >= 25 ? (
+        <div className="flex items-center gap-1.5 mb-3 text-xs">
+          <Zap className="w-3.5 h-3.5 text-yellow-400" />
+          <span className="text-yellow-400 font-medium">{t('profile.milestoneStarted')}</span>
+        </div>
+      ) : null}
       <div className="flex flex-wrap gap-2">
         {missingFields.map((field) => (
           <Link

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -234,6 +234,9 @@
     "editProfile": "Profil bearbeiten",
     "posts": "Beiträge",
     "completeness": "Profilvollständigkeit",
+    "milestoneAlmost": "Fast fertig!",
+    "milestoneHalf": "Halb fertig!",
+    "milestoneStarted": "Guter Fortschritt!",
     "missing": {
       "avatar": "Avatar hinzufügen",
       "bio": "Bio hinzufügen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -234,6 +234,9 @@
     "editProfile": "Edit Profile",
     "posts": "Posts",
     "completeness": "Profile Completeness",
+    "milestoneAlmost": "Almost There!",
+    "milestoneHalf": "Halfway Done!",
+    "milestoneStarted": "Good Progress!",
     "missing": {
       "avatar": "Add avatar",
       "bio": "Add bio",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -234,6 +234,9 @@
     "editProfile": "Editar perfil",
     "posts": "Publicaciones",
     "completeness": "Perfil completo",
+    "milestoneAlmost": "¡Casi listo!",
+    "milestoneHalf": "¡Mitad completado!",
+    "milestoneStarted": "¡Buen progreso!",
     "missing": {
       "avatar": "Agregar avatar",
       "bio": "Agregar biografía",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -234,6 +234,9 @@
     "editProfile": "Modifier le profil",
     "posts": "Publications",
     "completeness": "Complétude du profil",
+    "milestoneAlmost": "Presque terminé !",
+    "milestoneHalf": "À moitié fait !",
+    "milestoneStarted": "Bon progrès !",
     "missing": {
       "avatar": "Ajouter un avatar",
       "bio": "Ajouter une bio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -251,6 +251,9 @@
     "editProfile": "プロフィール編集",
     "posts": "投稿",
     "completeness": "プロフィール完成度",
+    "milestoneAlmost": "もうすぐ完成！",
+    "milestoneHalf": "半分完成！",
+    "milestoneStarted": "順調です！",
     "missing": {
       "avatar": "アバター画像を設定",
       "bio": "自己紹介を追加",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -234,6 +234,9 @@
     "editProfile": "프로필 편집",
     "posts": "게시물",
     "completeness": "프로필 완성도",
+    "milestoneAlmost": "거의 다 왔어요!",
+    "milestoneHalf": "절반 완성!",
+    "milestoneStarted": "순조롭습니다!",
     "missing": {
       "avatar": "아바타 설정",
       "bio": "자기소개 추가",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -234,6 +234,9 @@
     "editProfile": "Editar perfil",
     "posts": "Postagens",
     "completeness": "Completude do perfil",
+    "milestoneAlmost": "Quase lá!",
+    "milestoneHalf": "Metade feito!",
+    "milestoneStarted": "Bom progresso!",
     "missing": {
       "avatar": "Adicionar avatar",
       "bio": "Adicionar bio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -234,6 +234,9 @@
     "editProfile": "Редактировать профиль",
     "posts": "Посты",
     "completeness": "Заполненность профиля",
+    "milestoneAlmost": "Почти готово!",
+    "milestoneHalf": "Половина сделана!",
+    "milestoneStarted": "Хороший прогресс!",
     "missing": {
       "avatar": "Добавить аватар",
       "bio": "Добавить описание",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -234,6 +234,9 @@
     "editProfile": "编辑资料",
     "posts": "帖子",
     "completeness": "资料完成度",
+    "milestoneAlmost": "快完成了！",
+    "milestoneHalf": "完成一半！",
+    "milestoneStarted": "进展顺利！",
     "missing": {
       "avatar": "设置头像",
       "bio": "添加简介",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -234,6 +234,9 @@
     "editProfile": "編輯資料",
     "posts": "貼文",
     "completeness": "資料完成度",
+    "milestoneAlmost": "快完成了！",
+    "milestoneHalf": "完成一半！",
+    "milestoneStarted": "進展順利！",
     "missing": {
       "avatar": "設定頭像",
       "bio": "新增簡介",


### PR DESCRIPTION
## 概要
- ProfileCompletenessCardに進捗率に応じた3段階のマイルストーンバッジを表示
- ≥75%: もうすぐ完成(Trophy), ≥50%: 半分完成(TrendingUp), ≥25%: 順調(Zap)
- 10言語対応のi18nキー3件追加

closes #1768