### PR TITLE
security: ユーザー検索クエリに長さ制限を追加（DoS対策）

### DIFF
--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -53,6 +53,9 @@ func parseLimitOffset(c *gin.Context) (limit, offset int) {
 // maxSearchQueryLen は検索クエリの最大文字数（ルーン数）。
 const maxSearchQueryLen = 500
 
+// maxUserSearchQueryLen はユーザー検索クエリの最大文字数（ルーン数）。
+const maxUserSearchQueryLen = 100
+
 // parseSearchQuery はクエリパラメータ "q" を取得・検証する共通ヘルパー。
 // 未指定・空文字列・500文字超の場合は400を返しfalseを返す。
 // 前後の空白はTrimSpaceで除去して返す。
@@ -64,6 +67,22 @@ func parseSearchQuery(c *gin.Context) (string, bool) {
 	}
 	if len([]rune(query)) > maxSearchQueryLen {
 		respondBadRequest(c, "検索クエリは500文字以下である必要があります")
+		return "", false
+	}
+	return strings.TrimSpace(query), true
+}
+
+// parseOptionalSearchQuery はクエリパラメータ "q" をオプションとして取得・検証する。
+// 未指定・空文字列の場合は空文字列を返す（エラーなし）。
+// maxLen文字超の場合は400を返しfalseを返す。
+// 前後の空白はTrimSpaceで除去して返す。
+func parseOptionalSearchQuery(c *gin.Context, maxLen int) (string, bool) {
+	query := c.Query("q")
+	if query == "" {
+		return "", true
+	}
+	if len([]rune(query)) > maxLen {
+		respondBadRequest(c, "検索クエリは"+strconv.Itoa(maxLen)+"文字以下である必要があります")
 		return "", false
 	}
 	return strings.TrimSpace(query), true

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -27,9 +27,12 @@ func NewUserHandler(s UserServiceInterface) *UserHandler {
 	return &UserHandler{service: s}
 }
 
-// GetAll はユーザー一覧を返す。クエリパラメータqで検索可能。
+// GetAll はユーザー一覧を返す。クエリパラメータqで検索可能（最大100文字）。
 func (h *UserHandler) GetAll(c *gin.Context) {
-	q := c.Query("q")
+	q, ok := parseOptionalSearchQuery(c, maxUserSearchQueryLen)
+	if !ok {
+		return
+	}
 	users, err := h.service.GetAll(q)
 	if err != nil {
 		respondError(c, err)

--- a/backend/internal/handler/user_test.go
+++ b/backend/internal/handler/user_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -99,6 +100,42 @@ func TestUserHandler_GetAll(t *testing.T) {
 
 		w := doRequest(r, "GET", "/users", nil)
 		assertStatus(t, w, http.StatusInternalServerError)
+		svc.AssertExpectations(t)
+	})
+
+	t.Run("100文字超のクエリで400エラー", func(t *testing.T) {
+		h, _ := newTestUserHandler()
+		r := newRouter(1)
+		r.GET("/users", h.GetAll)
+
+		longQuery := strings.Repeat("あ", 101)
+		w := doRequest(r, "GET", "/users?q="+longQuery, nil)
+		assertStatus(t, w, http.StatusBadRequest)
+	})
+
+	t.Run("ちょうど100文字のクエリで成功", func(t *testing.T) {
+		h, svc := newTestUserHandler()
+		r := newRouter(1)
+		r.GET("/users", h.GetAll)
+
+		query100 := strings.Repeat("あ", 100)
+		svc.On("GetAll", query100).Return([]model.User{}, nil)
+
+		w := doRequest(r, "GET", "/users?q="+query100, nil)
+		assertStatus(t, w, http.StatusOK)
+		svc.AssertExpectations(t)
+	})
+
+	t.Run("前後の空白がTrimSpaceされる", func(t *testing.T) {
+		h, svc := newTestUserHandler()
+		r := newRouter(1)
+		r.GET("/users", h.GetAll)
+
+		svc.On("GetAll", "テスト").Return([]model.User{}, nil)
+
+		// 空白はURLエンコードする必要がある
+		w := doRequest(r, "GET", "/users?q=%20%20テスト%20%20", nil)
+		assertStatus(t, w, http.StatusOK)
 		svc.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
## 概要
ユーザー検索エンドポイント（`GET /api/v1/users`）のクエリパラメータ`q`に長さ制限がなく、長大なクエリによるDoS攻撃のリスクがありました。

## 変更内容
- `parseOptionalSearchQuery`ヘルパーを追加（オプショナルな検索クエリのバリデーション）
- `maxUserSearchQueryLen`定数を追加（100文字制限）
- `UserHandler.GetAll`で`parseOptionalSearchQuery`を使用してクエリ長をチェック
- 3つのテストケースを追加（100文字超でエラー、ちょうど100文字で成功、空白のTrimSpace）

## テスト結果
- 全6テスト通過（既存3 + 新規3）

## セキュリティへの影響
- 長大なクエリによるDB負荷を防止
- DoS攻撃のリスクを軽減
- 投稿検索（500文字制限）と同様のセキュリティレベルを確保

closes #1774