### PR TITLE
feat: プロフィールページにハイライトカード追加

### DIFF
--- a/frontend/src/components/profile/ProfileHighlightCard.tsx
+++ b/frontend/src/components/profile/ProfileHighlightCard.tsx
@@ -1,0 +1,84 @@
+import { useTranslation } from 'react-i18next';
+import { Trophy, Flame, TrendingUp } from 'lucide-react';
+import { Post, Badge } from '../../types';
+import { Link } from 'react-router-dom';
+
+interface ProfileHighlightCardProps {
+  posts: Post[];
+  badges: Badge[];
+  streakDays: number;
+}
+
+export default function ProfileHighlightCard({ posts, badges, streakDays }: ProfileHighlightCardProps) {
+  const { t } = useTranslation();
+
+  // 最も反応が多い投稿を取得（いいね+コメント数）
+  const topPost = posts.reduce<Post | null>((best, post) => {
+    const score = (post.likes_count || 0) + (post.comments_count || 0);
+    const bestScore = best ? (best.likes_count || 0) + (best.comments_count || 0) : 0;
+    return score > bestScore ? post : best;
+  }, null);
+
+  // 最新バッジを取得
+  const latestBadge = badges[0]; // バッジは新しい順にソートされていると仮定
+
+  // ハイライトが何もない場合は表示しない
+  if (!topPost && !latestBadge && streakDays === 0) {
+    return null;
+  }
+
+  return (
+    <div className="bg-gradient-to-br from-gray-900 to-gray-800 border border-gray-700 rounded-md p-5">
+      <h3 className="text-sm font-semibold text-gray-200 mb-4 flex items-center gap-2">
+        <Trophy className="w-4 h-4 text-yellow-400" aria-hidden="true" />
+        {t('profile.highlights.title')}
+      </h3>
+
+      <div className="space-y-3">
+        {/* 人気の投稿 */}
+        {topPost && (
+          <div className="flex items-start gap-3 p-3 bg-gray-800/50 rounded-lg">
+            <TrendingUp className="w-4 h-4 text-blue-400 mt-1 shrink-0" aria-hidden="true" />
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-gray-400 mb-1">{t('profile.highlights.topPost')}</p>
+              <Link
+                to={`/posts/${topPost.id}`}
+                className="text-sm text-gray-200 hover:text-white transition-colors line-clamp-2"
+              >
+                {topPost.title}
+              </Link>
+              <p className="text-xs text-gray-500 mt-1">
+                {topPost.likes_count || 0} {t('common.likes')} · {topPost.comments_count || 0} {t('common.comments')}
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* 最新バッジ */}
+        {latestBadge && (
+          <div className="flex items-start gap-3 p-3 bg-gray-800/50 rounded-lg">
+            <span className="text-2xl shrink-0" aria-hidden="true">{latestBadge.icon}</span>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-gray-400 mb-1">{t('profile.highlights.latestBadge')}</p>
+              <p className="text-sm text-gray-200 font-medium">{latestBadge.name}</p>
+              <p className="text-xs text-gray-500 mt-1">{latestBadge.description}</p>
+            </div>
+          </div>
+        )}
+
+        {/* 連続学習日数 */}
+        {streakDays > 0 && (
+          <div className="flex items-start gap-3 p-3 bg-gray-800/50 rounded-lg">
+            <Flame className="w-4 h-4 text-orange-400 mt-1 shrink-0" aria-hidden="true" />
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-gray-400 mb-1">{t('profile.highlights.streak')}</p>
+              <p className="text-sm text-gray-200 font-medium">
+                {streakDays} {t('profile.highlights.streakDays')}
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -237,6 +237,13 @@
     "milestoneAlmost": "Fast fertig!",
     "milestoneHalf": "Halb fertig!",
     "milestoneStarted": "Guter Fortschritt!",
+    "highlights": {
+      "title": "Highlights",
+      "topPost": "Beliebtester Beitrag",
+      "latestBadge": "Neuestes Abzeichen",
+      "streak": "Lernsträhne",
+      "streakDays": "Tage"
+    },
     "missing": {
       "avatar": "Avatar hinzufügen",
       "bio": "Bio hinzufügen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -237,6 +237,13 @@
     "milestoneAlmost": "Almost There!",
     "milestoneHalf": "Halfway Done!",
     "milestoneStarted": "Good Progress!",
+    "highlights": {
+      "title": "Highlights",
+      "topPost": "Most Popular Post",
+      "latestBadge": "Latest Badge",
+      "streak": "Learning Streak",
+      "streakDays": "days"
+    },
     "missing": {
       "avatar": "Add avatar",
       "bio": "Add bio",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -237,6 +237,13 @@
     "milestoneAlmost": "¡Casi listo!",
     "milestoneHalf": "¡Mitad completado!",
     "milestoneStarted": "¡Buen progreso!",
+    "highlights": {
+      "title": "Destacados",
+      "topPost": "Publicación Más Popular",
+      "latestBadge": "Última Insignia",
+      "streak": "Racha de Aprendizaje",
+      "streakDays": "días"
+    },
     "missing": {
       "avatar": "Agregar avatar",
       "bio": "Agregar biografía",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -237,6 +237,13 @@
     "milestoneAlmost": "Presque terminé !",
     "milestoneHalf": "À moitié fait !",
     "milestoneStarted": "Bon progrès !",
+    "highlights": {
+      "title": "Points Forts",
+      "topPost": "Article Le Plus Populaire",
+      "latestBadge": "Dernier Badge",
+      "streak": "Série d'Apprentissage",
+      "streakDays": "jours"
+    },
     "missing": {
       "avatar": "Ajouter un avatar",
       "bio": "Ajouter une bio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -254,6 +254,13 @@
     "milestoneAlmost": "もうすぐ完成！",
     "milestoneHalf": "半分完成！",
     "milestoneStarted": "順調です！",
+    "highlights": {
+      "title": "ハイライト",
+      "topPost": "人気の投稿",
+      "latestBadge": "最新のバッジ",
+      "streak": "連続学習日数",
+      "streakDays": "日間"
+    },
     "missing": {
       "avatar": "アバター画像を設定",
       "bio": "自己紹介を追加",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -237,6 +237,13 @@
     "milestoneAlmost": "거의 다 왔어요!",
     "milestoneHalf": "절반 완성!",
     "milestoneStarted": "순조롭습니다!",
+    "highlights": {
+      "title": "하이라이트",
+      "topPost": "인기 게시물",
+      "latestBadge": "최신 뱃지",
+      "streak": "연속 학습 일수",
+      "streakDays": "일"
+    },
     "missing": {
       "avatar": "아바타 설정",
       "bio": "자기소개 추가",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -237,6 +237,13 @@
     "milestoneAlmost": "Quase lá!",
     "milestoneHalf": "Metade feito!",
     "milestoneStarted": "Bom progresso!",
+    "highlights": {
+      "title": "Destaques",
+      "topPost": "Postagem Mais Popular",
+      "latestBadge": "Último Emblema",
+      "streak": "Sequência de Aprendizado",
+      "streakDays": "dias"
+    },
     "missing": {
       "avatar": "Adicionar avatar",
       "bio": "Adicionar bio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -237,6 +237,13 @@
     "milestoneAlmost": "Почти готово!",
     "milestoneHalf": "Половина сделана!",
     "milestoneStarted": "Хороший прогресс!",
+    "highlights": {
+      "title": "Основные моменты",
+      "topPost": "Самый популярный пост",
+      "latestBadge": "Последний значок",
+      "streak": "Непрерывная учебная полоса",
+      "streakDays": "дней"
+    },
     "missing": {
       "avatar": "Добавить аватар",
       "bio": "Добавить описание",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -237,6 +237,13 @@
     "milestoneAlmost": "快完成了！",
     "milestoneHalf": "完成一半！",
     "milestoneStarted": "进展顺利！",
+    "highlights": {
+      "title": "亮点",
+      "topPost": "最受欢迎的帖子",
+      "latestBadge": "最新徽章",
+      "streak": "连续学习天数",
+      "streakDays": "天"
+    },
     "missing": {
       "avatar": "设置头像",
       "bio": "添加简介",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -237,6 +237,13 @@
     "milestoneAlmost": "快完成了！",
     "milestoneHalf": "完成一半！",
     "milestoneStarted": "進展順利！",
+    "highlights": {
+      "title": "亮點",
+      "topPost": "最受歡迎的貼文",
+      "latestBadge": "最新徽章",
+      "streak": "連續學習天數",
+      "streakDays": "天"
+    },
     "missing": {
       "avatar": "設定頭像",
       "bio": "新增簡介",

--- a/frontend/src/pages/ProfilePage.tsx
+++ b/frontend/src/pages/ProfilePage.tsx
@@ -15,6 +15,7 @@ import LevelDisplay from '../components/profile/LevelDisplay';
 import PostCard from '../components/posts/PostCard';
 import PostSeriesCard from '../components/series/PostSeriesCard';
 import ProfileCompletenessCard from '../components/profile/ProfileCompletenessCard';
+import ProfileHighlightCard from '../components/profile/ProfileHighlightCard';
 import CompetitiveProgrammingCard from '../components/profile/CompetitiveProgrammingCard';
 import ShareModal from '../components/profile/ShareModal';
 import PortfolioModal from '../components/profile/PortfolioModal';
@@ -62,6 +63,13 @@ export default function ProfilePage() {
       {isOwnProfile && (
         <ProfileCompletenessCard percentage={percentage} missingFields={missingFields} />
       )}
+
+      {/* Profile Highlights */}
+      <ProfileHighlightCard
+        posts={posts}
+        badges={badges}
+        streakDays={streakInfo?.current_streak || 0}
+      />
 
       {/* Skills */}
       {(user.skills_languages || user.skills_frameworks) && (


### PR DESCRIPTION
## 概要
プロフィールページに、ユーザーの主要な成果を一目で確認できる「ハイライトカード」を追加しました。訪問者がユーザーの実績を瞬時に理解できるようになります。

## 変更内容
- **新コンポーネント**: `ProfileHighlightCard.tsx`
  - 最も反応が多い投稿（いいね+コメント数で算出）
  - 最新バッジ
  - 連続学習日数（ストリーク）
- `ProfilePage.tsx`にハイライトカードを追加（ProfileCompletenessCardの直後に配置）
- 10言語すべてに`profile.highlights`キーを追加（title, topPost, latestBadge, streak, streakDays）

## テスト結果
- TypeScript型チェック通過
- JSONファイルのフォーマット確認済み

## UXへの影響
- プロフィール訪問時の第一印象が向上
- ユーザーの主要な実績が一目で分かる
- SNS的な華やかさが増し、ユーザーエンゲージメント向上

closes #1776