### PR TITLE
security: コメント・メッセージの最小長バリデーション追加

### DIFF
--- a/backend/internal/dto/message_dto.go
+++ b/backend/internal/dto/message_dto.go
@@ -2,5 +2,5 @@ package dto
 
 // SendMessageRequest はDMメッセージ送信リクエスト。
 type SendMessageRequest struct {
-	Content string `json:"content" binding:"required,max=5000" validate:"required,max=5000"`
+	Content string `json:"content" binding:"required,min=1,max=5000" validate:"required,min=1,max=5000"`
 }

--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -28,7 +28,7 @@ type UpdatePostRequest struct {
 // CreateCommentRequest はコメント作成リクエスト。
 // ParentIDが指定された場合は返信コメントとして作成する。
 type CreateCommentRequest struct {
-	Content  string `json:"content" binding:"required,max=5000"`
+	Content  string `json:"content" binding:"required,min=1,max=5000"`
 	ParentID *uint  `json:"parent_id,omitempty"`
 }
 

--- a/backend/internal/handler/message_test.go
+++ b/backend/internal/handler/message_test.go
@@ -86,6 +86,17 @@ func TestMessage_SendMessage_ValidationError(t *testing.T) {
 	assertStatus(t, w, http.StatusBadRequest)
 }
 
+func TestMessage_SendMessage_EmptyContent(t *testing.T) {
+	h, _ := setupMessageHandler()
+
+	r := newRouter(1)
+	r.POST("/messages/:userId", h.SendMessage)
+
+	// 空文字列は min=1 でエラー
+	w := doRequest(r, http.MethodPost, "/messages/5", map[string]string{"content": ""})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
 func TestMessage_SendMessage_ServiceError(t *testing.T) {
 	h, svc := setupMessageHandler()
 	svc.On("SendMessage", mock.AnythingOfType("*model.Message")).Return(errors.New("send failed"))

--- a/backend/internal/handler/post_test.go
+++ b/backend/internal/handler/post_test.go
@@ -293,6 +293,16 @@ func TestPostCreateComment_ValidationError(t *testing.T) {
 	assertStatus(t, w, http.StatusBadRequest)
 }
 
+func TestPostCreateComment_EmptyContent(t *testing.T) {
+	h, _, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/:id/comments", h.CreateComment)
+
+	// 空文字列は min=1 でエラー
+	w := doRequest(r, http.MethodPost, "/posts/5/comments", map[string]string{"content": ""})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
 func TestPostCreateReply_Success(t *testing.T) {
 	h, postRepo, _, _ := setupPostHandler()
 	r := newRouter(1)


### PR DESCRIPTION
## 概要
コメントとDMメッセージの作成時に、空文字列のみのコンテンツを防ぐため、最小長バリデーションを追加しました。

## 問題点
- `CreateCommentRequest`: `binding:"required,max=5000"`（最小長チェックなし）
- `SendMessageRequest`: `binding:"required,max=5000"`（最小長チェックなし）
- 空白のみのコメント・メッセージ送信が可能
- スパムやDBリソースの無駄遣いリスク

## 変更内容
- **DTO修正**:
  - `dto/post_dto.go`: CreateCommentRequestに`min=1`追加
  - `dto/message_dto.go`: SendMessageRequestに`min=1`追加
- **テスト追加**:
  - `TestPostCreateComment_EmptyContent`: 空文字列コメントで400エラー
  - `TestMessage_SendMessage_EmptyContent`: 空文字列メッセージで400エラー

## テスト結果
- 新規2テスト通過
- 既存のバリデーションテストも正常動作

## セキュリティへの影響
- 空コンテンツのスパム投稿を防止
- DBリソースの無駄遣いを軽減

closes #1782