### PR TITLE
feat: NotesPageにノート数カウンター表示追加

### DIFF
--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -27,7 +27,10 @@ export default function NotesPage() {
       <div className="flex items-center justify-between mb-8">
         <div className="flex items-center gap-3">
           <BookOpen className="w-8 h-8 text-blue-500" />
-          <h1 className="text-3xl font-bold">{t('notes.title')}</h1>
+          <div className="flex items-baseline gap-2">
+            <h1 className="text-3xl font-bold">{t('notes.title')}</h1>
+            <span className="text-lg text-gray-500">({filteredNotes.length})</span>
+          </div>
         </div>
         <button
           onClick={handleToggleForm}


### PR DESCRIPTION
## 概要
NotesPageのタイトルに全ノート数を表示する小さなカウンターを追加しました。

## 変更内容
- NotesPageのタイトルに`(ノート数)`を表示
- `filteredNotes.length`を使用して動的に表示
- 検索・フィルタリング時も正確な件数を表示

## テスト結果
- TypeScript型チェック通過

## UXへの影響
- ユーザーが全ノート数を一目で確認可能
- 検索結果の件数も同時に確認可能

closes #1784