### PR TITLE
feat: GoalStatsPanelにアイコンを追加して視覚的改善 (#1791)

### DIFF
--- a/frontend/src/components/goals/GoalStatsPanel.tsx
+++ b/frontend/src/components/goals/GoalStatsPanel.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { Target, Play, CheckCircle, Pause, AlertTriangle } from 'lucide-react';
 
 interface GoalStatsPanelProps {
   total: number;
@@ -12,18 +13,21 @@ export default function GoalStatsPanel({ total, active, completed, paused, overd
   const { t } = useTranslation();
 
   const stats = [
-    { value: total, label: t('goals.totalGoals'), color: '' },
-    { value: active, label: t('goals.activeGoals'), color: 'text-blue-400' },
-    { value: completed, label: t('goals.completedGoals'), color: 'text-green-400' },
-    { value: paused, label: t('goals.pausedGoals'), color: 'text-yellow-400' },
-    { value: overdue, label: t('goals.overdueGoals'), color: 'text-red-400' },
+    { value: total, label: t('goals.totalGoals'), color: '', Icon: Target },
+    { value: active, label: t('goals.activeGoals'), color: 'text-blue-400', Icon: Play },
+    { value: completed, label: t('goals.completedGoals'), color: 'text-green-400', Icon: CheckCircle },
+    { value: paused, label: t('goals.pausedGoals'), color: 'text-yellow-400', Icon: Pause },
+    { value: overdue, label: t('goals.overdueGoals'), color: 'text-red-400', Icon: AlertTriangle },
   ];
 
   return (
     <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
       {stats.map((stat) => (
         <div key={stat.label} className="bg-gray-900 border border-gray-800 rounded-md p-4">
-          <p className={`text-2xl font-bold ${stat.color}`}>{stat.value}</p>
+          <div className="flex items-center gap-2 mb-1">
+            <stat.Icon className={`w-5 h-5 ${stat.color || 'text-gray-400'}`} />
+            <p className={`text-2xl font-bold ${stat.color}`}>{stat.value}</p>
+          </div>
           <p className="text-sm text-gray-400">{stat.label}</p>
         </div>
       ))}


### PR DESCRIPTION
## 概要
学習目標の統計パネル（GoalStatsPanel）に各統計項目を表すlucide-reactアイコンを追加し、視覚的にわかりやすくする。

## 変更内容
- Total Goals: Target アイコン追加
- Active Goals: Play アイコン追加
- Completed Goals: CheckCircle アイコン追加
- Paused Goals: Pause アイコン追加
- Overdue Goals: AlertTriangle アイコン追加

## スクリーンショット
各統計にアイコンが表示され、視覚的に区別しやすくなりました。

## 期待効果
- 視覚的な情報の識別が容易になる
- ユーザーエクスペリエンスの向上
- 一貫性のあるデザイン（他のウィジェットもアイコンを使用）

## テスト
- [x] TypeScript型チェック成功

## 関連Issue
Closes #1791