### PR TITLE
refactor: NotesPageのソートオプション配列をconstantsに移動 (#1793)

### DIFF
--- a/frontend/src/constants/notes.ts
+++ b/frontend/src/constants/notes.ts
@@ -1,0 +1,9 @@
+// ノートのソートオプション定義
+export const NOTES_SORT_OPTIONS = [
+  { value: 'latest' as const, label: 'notes.sortLatest' },
+  { value: 'oldest' as const, label: 'notes.sortOldest' },
+  { value: 'updated' as const, label: 'notes.sortUpdated' },
+  { value: 'favorites_first' as const, label: 'notes.sortFavorites' },
+] as const;
+
+export type NoteSortValue = typeof NOTES_SORT_OPTIONS[number]['value'];

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -7,6 +7,7 @@ import EmptyState from '../components/common/EmptyState';
 import NoteFormPanel from '../components/notes/NoteFormPanel';
 import NoteCard from '../components/notes/NoteCard';
 import { buttonPrimaryClass } from '../constants/styles';
+import { NOTES_SORT_OPTIONS } from '../constants/notes';
 
 export default function NotesPage() {
   const { t } = useTranslation();
@@ -55,12 +56,7 @@ export default function NotesPage() {
         <div className="flex items-center gap-3">
           <ArrowDownWideNarrow className="w-4 h-4 text-gray-400" />
           <div className="flex flex-wrap gap-2">
-            {([
-              { value: 'latest', label: 'notes.sortLatest' },
-              { value: 'oldest', label: 'notes.sortOldest' },
-              { value: 'updated', label: 'notes.sortUpdated' },
-              { value: 'favorites_first', label: 'notes.sortFavorites' },
-            ] as const).map((opt) => (
+            {NOTES_SORT_OPTIONS.map((opt) => (
               <button
                 key={opt.value}
                 onClick={() => setSortBy(opt.value)}


### PR DESCRIPTION
## 概要
NotesPageコンポーネント内に直接定義されていたソートオプション配列を`constants/notes.ts`に移動し、コードの可読性と保守性を向上させる。

## 変更内容
- `constants/notes.ts` を新規作成し、NOTES_SORT_OPTIONS を定義
- NoteSortValue 型を追加
- NotesPage.tsx から配列定義をインポートに変更

## リファクタリングの効果
- コンポーネントコードがシンプルになる（7行削減）
- ソートオプションの変更が容易になる
- 定数の再利用が可能になる（他のページでも利用可能）

## テスト
- [x] TypeScript型チェック成功

## 関連Issue
Closes #1793