### PR TITLE
test: GoalStatsPanelのアイコンとカラースタイルのテストを追加 (#1795)

### DIFF
--- a/frontend/src/components/goals/__tests__/GoalStatsPanel.test.tsx
+++ b/frontend/src/components/goals/__tests__/GoalStatsPanel.test.tsx
@@ -43,4 +43,41 @@ describe('GoalStatsPanel', () => {
     const cards = container.querySelectorAll('.bg-gray-900');
     expect(cards.length).toBe(5);
   });
+
+  it('各統計にアイコンが表示される', () => {
+    const { container } = render(<GoalStatsPanel {...defaultProps} />);
+    const icons = container.querySelectorAll('svg');
+    // 5つの統計それぞれにアイコンがある
+    expect(icons.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('進行中の目標に青色のスタイルが適用される', () => {
+    const { container } = render(<GoalStatsPanel {...defaultProps} />);
+    const blueElements = container.querySelectorAll('.text-blue-400');
+    expect(blueElements.length).toBeGreaterThan(0);
+  });
+
+  it('完了の目標に緑色のスタイルが適用される', () => {
+    const { container } = render(<GoalStatsPanel {...defaultProps} />);
+    const greenElements = container.querySelectorAll('.text-green-400');
+    expect(greenElements.length).toBeGreaterThan(0);
+  });
+
+  it('一時停止の目標に黄色のスタイルが適用される', () => {
+    const { container } = render(<GoalStatsPanel {...defaultProps} />);
+    const yellowElements = container.querySelectorAll('.text-yellow-400');
+    expect(yellowElements.length).toBeGreaterThan(0);
+  });
+
+  it('期限超過の目標に赤色のスタイルが適用される', () => {
+    const { container } = render(<GoalStatsPanel {...defaultProps} />);
+    const redElements = container.querySelectorAll('.text-red-400');
+    expect(redElements.length).toBeGreaterThan(0);
+  });
+
+  it('0の統計値も正しく表示される', () => {
+    render(<GoalStatsPanel total={0} active={0} completed={0} paused={0} overdue={0} />);
+    const zeros = screen.getAllByText('0');
+    expect(zeros.length).toBe(5);
+  });
 });


### PR DESCRIPTION
## 概要
GoalStatsPanelコンポーネントに最近追加されたアイコンとカラースタイルに関するテストケースを追加する。

## 追加テスト
- 各統計にアイコンが表示されるか
- 進行中の目標に青色のスタイルが適用されるか
- 完了の目標に緑色のスタイルが適用されるか
- 一時停止の目標に黄色のスタイルが適用されるか
- 期限超過の目標に赤色のスタイルが適用されるか
- 0の統計値も正しく表示されるか

## カバレッジ向上
既存の6テストケースに6テストケースを追加し、合計12テストケースでコンポーネントの動作を検証。

## テスト
- [x] TypeScript型チェック成功

## 関連Issue
Closes #1795、関連 #1791 (アイコン追加PR)