### PR TITLE
feat: GoalCardのプログレスバーに進捗率に応じた色分けを追加 (#1807)

### DIFF
--- a/frontend/src/components/goals/GoalCard.tsx
+++ b/frontend/src/components/goals/GoalCard.tsx
@@ -39,6 +39,14 @@ const getDeadlineInfo = (goal: LearningGoal): { status: 'overdue' | 'approaching
   return { status: '', daysLeft: days };
 };
 
+const getProgressBarColor = (progress: number, status: GoalStatus) => {
+  if (status === 'completed') return 'bg-green-500';
+  if (progress >= 75) return 'bg-blue-500';
+  if (progress >= 50) return 'bg-yellow-500';
+  if (progress >= 25) return 'bg-orange-500';
+  return 'bg-red-500';
+};
+
 interface GoalCardProps {
   goal: LearningGoal;
   onEdit: (goal: LearningGoal) => void;
@@ -116,9 +124,7 @@ const GoalCard = memo(function GoalCard({
               </div>
               <div className="h-2 bg-gray-700 rounded-full overflow-hidden">
                 <div
-                  className={`h-full transition-all ${
-                    goal.status === 'completed' ? 'bg-green-500' : 'bg-blue-500'
-                  }`}
+                  className={`h-full transition-all ${getProgressBarColor(goal.progress, goal.status)}`}
                   style={{ width: `${goal.progress}%` }}
                 />
               </div>


### PR DESCRIPTION
## 概要
GoalCardコンポーネントのプログレスバーに進捗率に応じた色分けを追加し、視覚的にモチベーションを向上させる。

## 変更内容
- `getProgressBarColor` ヘルパー関数を追加
- プログレスバーの色を進捗率に応じて動的に変更

## 色分けルール
- 🔴 0-24%: 赤色（開始したばかり）
- 🟠 25-49%: オレンジ色（1/4完了）
- 🟡 50-74%: 黄色（半分完了）
- 🔵 75-99%: 青色（もうすぐ完了）
- 🟢 100%: 緑色（完了）

## 期待効果
- 進捗状況が一目でわかりやすくなる
- 色の変化がモチベーション向上につながる
- ユーザーエクスペリエンスの向上

## テスト
- [x] TypeScript型チェック成功

## 関連Issue
Closes #1807