### PR TITLE
refactor: LogCardのカテゴリ定義をconstantsに移動 (#1809)

### DIFF
--- a/frontend/src/components/learning-logs/LogCard.tsx
+++ b/frontend/src/components/learning-logs/LogCard.tsx
@@ -1,29 +1,9 @@
 import { useTranslation } from 'react-i18next';
-import { Code, BookOpen, GraduationCap, Users, FileText, Star, Timer, Zap, Pencil, Trash2, type LucideIcon } from 'lucide-react';
-import type { LearningLog, LogCategory } from '../../types/learningLog';
+import { Star, Timer, Zap, Pencil, Trash2 } from 'lucide-react';
+import type { LearningLog } from '../../types/learningLog';
 import { formatDate } from '../../utils/timeFormat';
 import { panelClass, badgeBaseClass, editIconButtonClass, deleteIconButtonLargeClass } from '../../constants/styles';
-
-export const CATEGORIES: { value: LogCategory; label: string; Icon: LucideIcon }[] = [
-  { value: 'coding', label: 'learningLogs.categoryCoding', Icon: Code },
-  { value: 'reading', label: 'learningLogs.categoryReading', Icon: BookOpen },
-  { value: 'course', label: 'learningLogs.categoryCourse', Icon: GraduationCap },
-  { value: 'meetup', label: 'learningLogs.categoryMeetup', Icon: Users },
-  { value: 'other', label: 'learningLogs.categoryOther', Icon: FileText },
-];
-
-export const getCategoryInfo = (cat: LogCategory) =>
-  CATEGORIES.find((c) => c.value === cat) || CATEGORIES[4];
-
-export const getCategoryColor = (cat: LogCategory) => {
-  switch (cat) {
-    case 'coding': return 'text-blue-400 bg-blue-400/10';
-    case 'reading': return 'text-green-400 bg-green-400/10';
-    case 'course': return 'text-purple-400 bg-purple-400/10';
-    case 'meetup': return 'text-orange-400 bg-orange-400/10';
-    default: return 'text-gray-400 bg-gray-400/10';
-  }
-};
+import { getCategoryInfo, getCategoryColor } from '../../constants/learningLogs';
 
 interface LogCardProps {
   log: LearningLog;

--- a/frontend/src/constants/learningLogs.ts
+++ b/frontend/src/constants/learningLogs.ts
@@ -1,0 +1,31 @@
+import { Code, BookOpen, GraduationCap, Users, FileText, type LucideIcon } from 'lucide-react';
+import type { LogCategory } from '../types/learningLog';
+
+// 学習ログのカテゴリ定義
+export const LOG_CATEGORIES: { value: LogCategory; label: string; Icon: LucideIcon }[] = [
+  { value: 'coding', label: 'learningLogs.categoryCoding', Icon: Code },
+  { value: 'reading', label: 'learningLogs.categoryReading', Icon: BookOpen },
+  { value: 'course', label: 'learningLogs.categoryCourse', Icon: GraduationCap },
+  { value: 'meetup', label: 'learningLogs.categoryMeetup', Icon: Users },
+  { value: 'other', label: 'learningLogs.categoryOther', Icon: FileText },
+];
+
+// カテゴリ情報を取得する
+export const getCategoryInfo = (cat: LogCategory) =>
+  LOG_CATEGORIES.find((c) => c.value === cat) || LOG_CATEGORIES[4];
+
+// カテゴリの色クラスを取得する
+export const getCategoryColor = (cat: LogCategory) => {
+  switch (cat) {
+    case 'coding':
+      return 'text-blue-400 bg-blue-400/10';
+    case 'reading':
+      return 'text-green-400 bg-green-400/10';
+    case 'course':
+      return 'text-purple-400 bg-purple-400/10';
+    case 'meetup':
+      return 'text-orange-400 bg-orange-400/10';
+    default:
+      return 'text-gray-400 bg-gray-400/10';
+  }
+};


### PR DESCRIPTION
## 概要
LogCardコンポーネント内に定義されていたカテゴリ関連の定数と関数を`constants/learningLogs.ts`に移動し、再利用性を向上させる。

## 変更内容
- `constants/learningLogs.ts` を新規作成
- LOG_CATEGORIES, getCategoryInfo, getCategoryColor を移動
- LogCard.tsx から不要なインポートを削除し、定数をインポートに変更

## リファクタリングの効果
- カテゴリ定義が一元管理される
- 他のコンポーネント（フィルターなど）でも再利用可能
- コンポーネントコードがシンプルになる（約25行削減）

## テスト
- [x] TypeScript型チェック成功

## 関連Issue
Closes #1809