### PR TITLE
test: GoalCardのプログレスバー色分けテストを追加 (#1811)

### DIFF
--- a/frontend/src/components/goals/__tests__/GoalCard.test.tsx
+++ b/frontend/src/components/goals/__tests__/GoalCard.test.tsx
@@ -118,4 +118,39 @@ describe('GoalCard', () => {
     render(<GoalCard {...defaultProps} goal={goalWithDate} />);
     expect(screen.getByText(/目標日/)).toBeInTheDocument();
   });
+
+  it('0-24%の進捗で赤色のプログレスバーが表示される', () => {
+    const lowProgressGoal = { ...baseGoal, progress: 20 };
+    const { container } = render(<GoalCard {...defaultProps} goal={lowProgressGoal} />);
+    const progressBar = container.querySelector('.bg-red-500');
+    expect(progressBar).toBeInTheDocument();
+  });
+
+  it('25-49%の進捗でオレンジ色のプログレスバーが表示される', () => {
+    const mediumLowProgressGoal = { ...baseGoal, progress: 30 };
+    const { container } = render(<GoalCard {...defaultProps} goal={mediumLowProgressGoal} />);
+    const progressBar = container.querySelector('.bg-orange-500');
+    expect(progressBar).toBeInTheDocument();
+  });
+
+  it('50-74%の進捗で黄色のプログレスバーが表示される', () => {
+    const mediumProgressGoal = { ...baseGoal, progress: 60 };
+    const { container } = render(<GoalCard {...defaultProps} goal={mediumProgressGoal} />);
+    const progressBar = container.querySelector('.bg-yellow-500');
+    expect(progressBar).toBeInTheDocument();
+  });
+
+  it('75-99%の進捗で青色のプログレスバーが表示される', () => {
+    const highProgressGoal = { ...baseGoal, progress: 80 };
+    const { container } = render(<GoalCard {...defaultProps} goal={highProgressGoal} />);
+    const progressBar = container.querySelector('.bg-blue-500');
+    expect(progressBar).toBeInTheDocument();
+  });
+
+  it('100%の進捗で緑色のプログレスバーが表示される', () => {
+    const completedGoal = { ...baseGoal, status: 'completed' as const, progress: 100 };
+    const { container } = render(<GoalCard {...defaultProps} goal={completedGoal} />);
+    const progressBar = container.querySelector('.bg-green-500');
+    expect(progressBar).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## 概要
GoalCardコンポーネントに最近追加されたプログレスバーの進捗率に応じた色分け機能のテストケースを追加する。

## 追加テスト
- 0-24%の進捗で赤色が適用されるか
- 25-49%の進捗でオレンジ色が適用されるか
- 50-74%の進捗で黄色が適用されるか
- 75-99%の進捗で青色が適用されるか
- 100%の進捗で緑色が適用されるか

## カバレッジ向上
既存テストケースに5テストケースを追加し、プログレスバーの色分けロジックを完全にカバー。

## テスト
- [x] TypeScript型チェック成功

## 関連Issue
Closes #1811、関連 #1807 (プログレスバー色分けPR)