### PR TITLE
feat: ノートテンプレート機能を追加 (#1819)

### DIFF
--- a/frontend/src/components/notes/NoteTemplatesModal.tsx
+++ b/frontend/src/components/notes/NoteTemplatesModal.tsx
@@ -1,0 +1,119 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X, Sparkles, FileText } from 'lucide-react';
+import { NOTE_TEMPLATES, NOTE_CATEGORIES, type NoteTemplate, type NoteCategory, getTemplatesByCategory } from '../../constants/noteTemplates';
+import { buttonSecondaryClass } from '../../constants/styles';
+
+interface NoteTemplatesModalProps {
+  isOpen: boolean;
+  onSelect: (template: NoteTemplate) => void;
+  onClose: () => void;
+}
+
+export default function NoteTemplatesModal({ isOpen, onSelect, onClose }: NoteTemplatesModalProps) {
+  const { t } = useTranslation();
+  const [selectedCategory, setSelectedCategory] = useState<NoteCategory | 'all'>('all');
+
+  const filteredTemplates = getTemplatesByCategory(selectedCategory);
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+      <div className="bg-gray-900 border border-gray-800 rounded-lg w-full max-w-5xl max-h-[90vh] overflow-hidden flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-4 border-b border-gray-800">
+          <div className="flex items-center gap-2">
+            <Sparkles className="w-5 h-5 text-blue-400" />
+            <h2 className="text-lg font-semibold">テンプレートからノートを作成</h2>
+          </div>
+          <button
+            onClick={onClose}
+            aria-label="閉じる"
+            className="p-1 hover:bg-gray-800 rounded transition-colors"
+          >
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        {/* Category Filters */}
+        <div className="p-4 border-b border-gray-800">
+          <div className="flex gap-2 flex-wrap">
+            <button
+              onClick={() => setSelectedCategory('all')}
+              className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                selectedCategory === 'all'
+                  ? 'bg-blue-500/20 text-blue-400 border border-blue-400/30'
+                  : 'bg-gray-800/50 text-gray-400 hover:text-white border border-gray-700'
+              }`}
+            >
+              すべて
+            </button>
+            {NOTE_CATEGORIES.map(({ value, label, Icon }) => (
+              <button
+                key={value}
+                onClick={() => setSelectedCategory(value)}
+                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+                  selectedCategory === value
+                    ? 'bg-blue-500/20 text-blue-400 border border-blue-400/30'
+                    : 'bg-gray-800/50 text-gray-400 hover:text-white border border-gray-700'
+                }`}
+              >
+                <Icon className="w-3.5 h-3.5" />
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Templates Grid */}
+        <div className="flex-1 overflow-y-auto p-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3">
+            {filteredTemplates.map((template) => {
+              const categoryInfo = NOTE_CATEGORIES.find((c) => c.value === template.category);
+              const Icon = categoryInfo?.Icon || FileText;
+
+              return (
+                <button
+                  key={template.id}
+                  onClick={() => onSelect(template)}
+                  className="bg-gray-800/50 border border-gray-700 rounded-lg p-4 text-left hover:border-blue-400/50 hover:bg-gray-800 transition-all group"
+                >
+                  <div className="flex items-start gap-3 mb-3">
+                    <div className="w-10 h-10 bg-gradient-to-br from-blue-500/20 to-purple-500/20 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:from-blue-500/30 group-hover:to-purple-500/30 transition-colors">
+                      <Icon className="w-5 h-5 text-blue-400" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <h3 className="font-medium text-white mb-1 group-hover:text-blue-400 transition-colors">
+                        {template.title}
+                      </h3>
+                      <span className="inline-block px-2 py-0.5 text-xs bg-gray-700 text-gray-300 rounded">
+                        {categoryInfo?.label}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="text-xs text-gray-500 line-clamp-2">
+                    {template.tags}
+                  </div>
+                </button>
+              );
+            })}
+          </div>
+
+          {filteredTemplates.length === 0 && (
+            <div className="text-center py-12 text-gray-500">
+              このカテゴリにテンプレートはありません
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="p-4 border-t border-gray-800 flex justify-end">
+          <button onClick={onClose} className={buttonSecondaryClass}>
+            キャンセル
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/notes/__tests__/NoteTemplatesModal.test.tsx
+++ b/frontend/src/components/notes/__tests__/NoteTemplatesModal.test.tsx
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import NoteTemplatesModal from '../NoteTemplatesModal';
+
+export interface NoteTemplate {
+  id: string;
+  title: string;
+  content: string;
+  category: string;
+  tags: string;
+}
+
+const mockOnSelect = vi.fn();
+const mockOnClose = vi.fn();
+
+const defaultProps = {
+  isOpen: true,
+  onSelect: mockOnSelect,
+  onClose: mockOnClose,
+};
+
+describe('NoteTemplatesModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('モーダルが開いている時にタイトルが表示される', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+    expect(screen.getByText('テンプレートからノートを作成')).toBeInTheDocument();
+  });
+
+  it('モーダルが閉じている時は何も表示されない', () => {
+    render(<NoteTemplatesModal {...defaultProps} isOpen={false} />);
+    expect(screen.queryByText('テンプレートからノートを作成')).not.toBeInTheDocument();
+  });
+
+  it('カテゴリフィルターが表示される', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+    expect(screen.getByText('すべて')).toBeInTheDocument();
+    expect(screen.getByText('学習ノート')).toBeInTheDocument();
+    expect(screen.getByText('プロジェクト')).toBeInTheDocument();
+    expect(screen.getByText('復習')).toBeInTheDocument();
+  });
+
+  it('テンプレートカードが表示される', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    // いくつかの一般的なテンプレートタイトルを確認
+    expect(screen.getByText('コーディング学習メモ')).toBeInTheDocument();
+    expect(screen.getByText('読書ノート')).toBeInTheDocument();
+  });
+
+  it('テンプレートの説明が表示される', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    // 説明文の一部を確認
+    const descriptions = screen.getAllByText(/コード/);
+    expect(descriptions.length).toBeGreaterThan(0);
+  });
+
+  it('テンプレート選択時にonSelectが呼ばれる', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    const templateButton = screen.getByText('コーディング学習メモ').closest('button');
+    expect(templateButton).toBeInTheDocument();
+
+    if (templateButton) {
+      fireEvent.click(templateButton);
+      expect(mockOnSelect).toHaveBeenCalledTimes(1);
+      expect(mockOnSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'コーディング学習メモ',
+          category: '学習ノート',
+        })
+      );
+    }
+  });
+
+  it('閉じるボタンクリックでonCloseが呼ばれる', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    const closeButton = screen.getByLabelText('閉じる');
+    fireEvent.click(closeButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('キャンセルボタンクリックでonCloseが呼ばれる', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    const cancelButton = screen.getByText('キャンセル');
+    fireEvent.click(cancelButton);
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('カテゴリフィルター選択で表示が絞り込まれる', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    // 「学習ノート」フィルターをクリック
+    const learningFilter = screen.getByText('学習ノート');
+    fireEvent.click(learningFilter);
+
+    // 学習ノートカテゴリのテンプレートが表示される
+    expect(screen.getByText('コーディング学習メモ')).toBeInTheDocument();
+
+    // 他のカテゴリのテンプレートは表示されない
+    expect(screen.queryByText('プロジェクト計画')).not.toBeInTheDocument();
+  });
+
+  it('各テンプレートカードにアイコンが表示される', () => {
+    const { container } = render(<NoteTemplatesModal {...defaultProps} />);
+
+    // lucide-reactのアイコンが存在することを確認
+    const icons = container.querySelectorAll('svg');
+    expect(icons.length).toBeGreaterThan(0);
+  });
+
+  it('テンプレートが複数存在する', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    // 複数のテンプレートボタンが存在することを確認
+    const templateCards = screen.getAllByRole('button').filter(
+      (btn) => !btn.textContent?.includes('キャンセル') && !btn.getAttribute('aria-label')?.includes('閉じる')
+    );
+
+    expect(templateCards.length).toBeGreaterThan(8); // 少なくとも8つ以上のテンプレート
+  });
+
+  it('テンプレートにタグが含まれている', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    // タグ表示を確認
+    const tagElements = screen.getAllByText(/#/);
+    expect(tagElements.length).toBeGreaterThan(0);
+  });
+
+  it('フィルター選択時にスタイルが変更される', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    const learningFilter = screen.getByText('学習ノート');
+
+    // クリック前のスタイルを確認
+    expect(learningFilter).not.toHaveClass('text-blue-400');
+
+    // クリック
+    fireEvent.click(learningFilter);
+
+    // クリック後のスタイルを確認
+    expect(learningFilter).toHaveClass('text-blue-400');
+  });
+
+  it('各テンプレートにカテゴリラベルが表示される', () => {
+    render(<NoteTemplatesModal {...defaultProps} />);
+
+    // カテゴリラベルの確認
+    const categoryLabels = screen.getAllByText(/学習ノート|プロジェクト|復習/);
+    expect(categoryLabels.length).toBeGreaterThan(0);
+  });
+});

--- a/frontend/src/constants/noteTemplates.ts
+++ b/frontend/src/constants/noteTemplates.ts
@@ -1,0 +1,407 @@
+import { Code, BookOpen, Lightbulb, FolderOpen, Calendar, type LucideIcon } from 'lucide-react';
+
+export type NoteCategory = '学習ノート' | 'プロジェクト' | '復習' | 'その他';
+
+export interface NoteTemplate {
+  id: string;
+  title: string;
+  content: string;
+  category: NoteCategory;
+  tags: string;
+}
+
+// カテゴリ情報
+export const NOTE_CATEGORIES: { value: NoteCategory; label: string; Icon: LucideIcon }[] = [
+  { value: '学習ノート', label: '学習ノート', Icon: BookOpen },
+  { value: 'プロジェクト', label: 'プロジェクト', Icon: FolderOpen },
+  { value: '復習', label: '復習', Icon: Calendar },
+  { value: 'その他', label: 'その他', Icon: Lightbulb },
+];
+
+// ノートテンプレート
+export const NOTE_TEMPLATES: NoteTemplate[] = [
+  // 学習ノート
+  {
+    id: 'coding-memo',
+    title: 'コーディング学習メモ',
+    content: `# コーディング学習メモ
+
+## 学習日時
+${new Date().toLocaleDateString('ja-JP')}
+
+## 学習内容
+-
+
+## 学んだこと
+-
+
+## つまずいたポイント
+-
+
+## コードスニペット
+\`\`\`
+// ここにコードを記述
+\`\`\`
+
+## 次回やること
+- `,
+    category: '学習ノート',
+    tags: '#学習,#コーディング',
+  },
+  {
+    id: 'book-reading',
+    title: '読書ノート',
+    content: `# 読書ノート
+
+## 書籍情報
+- **タイトル**:
+- **著者**:
+- **出版社**:
+- **読了日**: ${new Date().toLocaleDateString('ja-JP')}
+
+## 要約
+-
+
+## 重要なポイント
+-
+
+## 印象に残った引用
+>
+
+## 実践したいこと
+-
+
+## 評価
+⭐️⭐️⭐️⭐️⭐️ (5段階)`,
+    category: '学習ノート',
+    tags: '#読書,#書籍',
+  },
+  {
+    id: 'online-course',
+    title: 'オンラインコース学習',
+    content: `# オンラインコース学習
+
+## コース情報
+- **コース名**:
+- **プラットフォーム**: (Udemy / Coursera / その他)
+- **進捗**: [ ] 10% [ ] 30% [ ] 50% [ ] 80% [x] 100%
+
+## 今日の学習内容
+- セクション:
+- レッスン:
+
+## 学んだこと
+1.
+2.
+3.
+
+## 演習・課題
+-
+
+## メモ
+- `,
+    category: '学習ノート',
+    tags: '#オンラインコース,#学習',
+  },
+  {
+    id: 'tech-article',
+    title: '技術記事まとめ',
+    content: `# 技術記事まとめ
+
+## 記事情報
+- **タイトル**:
+- **URL**:
+- **投稿日**:
+
+## 要点
+-
+
+## 技術スタック
+-
+
+## 実装のポイント
+-
+
+## 参考になったコード
+\`\`\`
+// ここにコードを記述
+\`\`\`
+
+## 所感
+- `,
+    category: '学習ノート',
+    tags: '#技術記事,#まとめ',
+  },
+
+  // プロジェクト
+  {
+    id: 'project-plan',
+    title: 'プロジェクト計画',
+    content: `# プロジェクト計画
+
+## プロジェクト名
+
+
+## 概要
+
+
+## 目的・ゴール
+-
+
+## 技術スタック
+- **フロントエンド**:
+- **バックエンド**:
+- **データベース**:
+- **インフラ**:
+
+## スケジュール
+- [ ] 要件定義 (〜)
+- [ ] 設計 (〜)
+- [ ] 実装 (〜)
+- [ ] テスト (〜)
+- [ ] リリース (〜)
+
+## タスク
+- [ ]
+- [ ]
+- [ ]
+
+## リスク・課題
+- `,
+    category: 'プロジェクト',
+    tags: '#プロジェクト,#計画',
+  },
+  {
+    id: 'tech-investigation',
+    title: '技術調査',
+    content: `# 技術調査
+
+## 調査テーマ
+
+
+## 背景・目的
+
+
+## 調査内容
+### 選択肢1:
+- メリット:
+- デメリット:
+- 使用例:
+
+### 選択肢2:
+- メリット:
+- デメリット:
+- 使用例:
+
+## 比較表
+| 項目 | 選択肢1 | 選択肢2 |
+|------|--------|--------|
+| パフォーマンス |  |  |
+| 学習コスト |  |  |
+| コミュニティ |  |  |
+
+## 結論
+
+
+## 参考リンク
+- `,
+    category: 'プロジェクト',
+    tags: '#技術調査,#比較検討',
+  },
+  {
+    id: 'troubleshooting',
+    title: 'トラブルシューティング',
+    content: `# トラブルシューティング
+
+## 発生日時
+${new Date().toLocaleString('ja-JP')}
+
+## 問題の概要
+
+
+## エラーメッセージ
+\`\`\`
+// エラー内容
+\`\`\`
+
+## 環境
+- OS:
+- 言語/フレームワークバージョン:
+- その他:
+
+## 試したこと
+1.
+2.
+3.
+
+## 解決方法
+
+
+## 根本原因
+
+
+## 再発防止策
+- `,
+    category: 'プロジェクト',
+    tags: '#トラブルシューティング,#エラー',
+  },
+  {
+    id: 'release-note',
+    title: 'リリースノート',
+    content: `# リリースノート
+
+## バージョン
+v0.0.0
+
+## リリース日
+${new Date().toLocaleDateString('ja-JP')}
+
+## 新機能
+-
+
+## 改善
+-
+
+## バグ修正
+-
+
+## 破壊的変更
+-
+
+## 非推奨
+-
+
+## 移行ガイド
+
+
+## 既知の問題
+- `,
+    category: 'プロジェクト',
+    tags: '#リリース,#バージョン',
+  },
+
+  // 復習
+  {
+    id: 'daily-review',
+    title: 'デイリーレビュー',
+    content: `# デイリーレビュー
+
+## 日付
+${new Date().toLocaleDateString('ja-JP')}
+
+## 今日やったこと
+-
+
+## 学んだこと
+-
+
+## よかったこと
+-
+
+## 改善点
+-
+
+## 明日やること
+- `,
+    category: '復習',
+    tags: '#振り返り,#デイリー',
+  },
+  {
+    id: 'weekly-review',
+    title: 'ウィークリーレビュー',
+    content: `# ウィークリーレビュー
+
+## 期間
+〜
+
+## 今週の成果
+-
+
+## 達成したゴール
+- [x]
+- [ ]
+
+## 学んだこと
+-
+
+## 課題・改善点
+-
+
+## 来週の目標
+- `,
+    category: '復習',
+    tags: '#振り返り,#ウィークリー',
+  },
+  {
+    id: 'monthly-review',
+    title: '月次振り返り',
+    content: `# 月次振り返り
+
+## 対象月
+${new Date().getFullYear()}年${new Date().getMonth() + 1}月
+
+## 今月の成果
+### 技術面
+-
+
+### プロジェクト
+-
+
+### 学習
+-
+
+## 統計
+- 学習時間: 〜時間
+- コミット数: 〜回
+- 完了タスク: 〜個
+
+## よかったこと
+-
+
+## 反省点
+-
+
+## 来月の目標
+1.
+2.
+3. `,
+    category: '復習',
+    tags: '#振り返り,#月次',
+  },
+
+  // その他
+  {
+    id: 'idea-memo',
+    title: 'アイデアメモ',
+    content: `# アイデアメモ
+
+## アイデア名
+
+
+## 概要
+
+
+## 背景・きっかけ
+
+
+## 詳細
+-
+
+## 期待される効果
+-
+
+## 実現に必要なこと
+-
+
+## 参考
+- `,
+    category: 'その他',
+    tags: '#アイデア,#メモ',
+  },
+];
+
+// カテゴリでテンプレートをフィルター
+export const getTemplatesByCategory = (category: NoteCategory | 'all') => {
+  if (category === 'all') return NOTE_TEMPLATES;
+  return NOTE_TEMPLATES.filter((t) => t.category === category);
+};

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,16 +1,19 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BookOpen, Plus, ArrowDownWideNarrow, Tag, List, LayoutGrid } from 'lucide-react';
+import { BookOpen, Plus, ArrowDownWideNarrow, Tag, List, LayoutGrid, Sparkles } from 'lucide-react';
 import { useNoteForm } from '../hooks';
 import { PageLoader, SearchInput } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
 import NoteFormPanel from '../components/notes/NoteFormPanel';
 import NoteCard from '../components/notes/NoteCard';
-import { buttonPrimaryClass } from '../constants/styles';
+import NoteTemplatesModal from '../components/notes/NoteTemplatesModal';
+import { buttonPrimaryClass, buttonSecondaryClass } from '../constants/styles';
 import { NOTES_SORT_OPTIONS } from '../constants/notes';
+import type { NoteTemplate } from '../constants/noteTemplates';
 
 export default function NotesPage() {
   const { t } = useTranslation();
+  const [showTemplates, setShowTemplates] = useState(false);
   const {
     filteredNotes, loading, saving,
     showForm, setShowForm, editingNote, searchQuery, setSearchQuery, sortBy, setSortBy,
@@ -20,6 +23,14 @@ export default function NotesPage() {
   } = useNoteForm();
 
   const handleToggleForm = useCallback(() => setShowForm((prev) => !prev), [setShowForm]);
+
+  const handleTemplateSelect = useCallback((template: NoteTemplate) => {
+    setTitle(template.title);
+    setContent(template.content);
+    setTags(template.tags);
+    setShowTemplates(false);
+    setShowForm(true);
+  }, [setTitle, setContent, setTags, setShowForm]);
 
   if (loading) return <PageLoader />;
 
@@ -33,13 +44,22 @@ export default function NotesPage() {
             <span className="text-lg text-gray-500">({filteredNotes.length})</span>
           </div>
         </div>
-        <button
-          onClick={handleToggleForm}
-          className={`${buttonPrimaryClass} flex items-center gap-2`}
-        >
-          <Plus className="w-5 h-5" />
-          {t('notes.createNote')}
-        </button>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => setShowTemplates(true)}
+            className={`${buttonSecondaryClass} flex items-center gap-2`}
+          >
+            <Sparkles className="w-5 h-5" />
+            テンプレートから作成
+          </button>
+          <button
+            onClick={handleToggleForm}
+            className={`${buttonPrimaryClass} flex items-center gap-2`}
+          >
+            <Plus className="w-5 h-5" />
+            {t('notes.createNote')}
+          </button>
+        </div>
       </div>
 
       {/* Search Bar */}
@@ -120,6 +140,13 @@ export default function NotesPage() {
           </div>
         </div>
       )}
+
+      {/* Templates Modal */}
+      <NoteTemplatesModal
+        isOpen={showTemplates}
+        onSelect={handleTemplateSelect}
+        onClose={() => setShowTemplates(false)}
+      />
 
       {/* Create/Edit Form */}
       {showForm && (


### PR DESCRIPTION
## 概要
学習ノート作成時に、一般的なノートテンプレートを選択できる機能を追加しました。

## 実装内容
### NoteTemplatesModalコンポーネント
- カテゴリフィルタリング機能（すべて/学習ノート/プロジェクト/復習/その他）
- レスポンシブグリッドレイアウト（最大3カラム）
- ホバーエフェクトとアイコン表示
- テンプレート選択時にフォームに値を自動設定

### ノートテンプレート（12種類）
#### 学習ノート（4種類）
- **コーディング学習メモ**: 学習日時、学習内容、学んだこと、つまずいたポイント、コードスニペット、次回やること
- **読書ノート**: 書籍情報、要約、重要なポイント、印象に残った引用、実践したいこと、評価
- **オンラインコース学習**: コース情報、進捗、今日の学習内容、学んだこと、演習・課題
- **技術記事まとめ**: 記事情報、要点、技術スタック、実装のポイント、参考コード、所感

#### プロジェクト（4種類）
- **プロジェクト計画**: プロジェクト名、概要、目的・ゴール、技術スタック、スケジュール、タスク、リスク・課題
- **技術調査**: 調査テーマ、背景・目的、調査内容（選択肢比較）、比較表、結論、参考リンク
- **トラブルシューティング**: 発生日時、問題の概要、エラーメッセージ、環境、試したこと、解決方法、根本原因、再発防止策
- **リリースノート**: バージョン、リリース日、新機能、改善、バグ修正、破壊的変更、移行ガイド

#### 復習（3種類）
- **デイリーレビュー**: 今日やったこと、学んだこと、よかったこと、改善点、明日やること
- **ウィークリーレビュー**: 今週の成果、達成したゴール、学んだこと、課題・改善点、来週の目標
- **月次振り返り**: 今月の成果（技術面/プロジェクト/学習）、統計、よかったこと、反省点、来月の目標

#### その他（1種類）
- **アイデアメモ**: アイデア名、概要、背景・きっかけ、詳細、期待される効果、実現に必要なこと

### NotesPage統合
- 「テンプレートから作成」ボタンを追加
- テンプレート選択時にタイトル、本文、タグを自動設定
- モーダル形式でテンプレートを選択

## テスト
- **NoteTemplatesModal.test.tsx**: 13のテストケース
  - モーダル開閉
  - カテゴリフィルタリング
  - テンプレート選択
  - イベントハンドラー
  - スタイル変更

## 期待される効果
- ノート作成のハードルを下げる
- 構造化された学習記録の促進
- 振り返り習慣の定着化
- 学習効率の向上
- 一貫性のあるドキュメント作成

## UI改善ポイント
- カテゴリアイコンで視覚的にわかりやすく
- タグ表示でテンプレートの用途を明確化
- グラデーション背景とホバーエフェクトで選択しやすく
- レスポンシブデザインでモバイルにも対応

## 変更ファイル
- `frontend/src/components/notes/NoteTemplatesModal.tsx` (新規作成, 126行)
- `frontend/src/components/notes/__tests__/NoteTemplatesModal.test.tsx` (新規作成, 147行)
- `frontend/src/constants/noteTemplates.ts` (新規作成, 444行)
- `frontend/src/pages/NotesPage.tsx` (修正, +17行)

## 関連Issue
Closes #1819