### PR TITLE
feat: 学習統計の可視化を強化 (#1823)

### DIFF
--- a/frontend/src/components/learningLogs/LearningStatsCards.tsx
+++ b/frontend/src/components/learningLogs/LearningStatsCards.tsx
@@ -1,0 +1,187 @@
+import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Clock, BookOpen, TrendingUp, PieChart } from 'lucide-react';
+import { useAuthStore } from '../../store/authStore';
+import { useAsyncData } from '../../hooks/useAsyncData';
+import { getMyLogs } from '../../api/learningLogs';
+import { getCategoryInfo, getCategoryColor } from '../../constants/learningLogs';
+import type { LearningLog, LogCategory } from '../../types/learningLog';
+
+export default function LearningStatsCards() {
+  const { t } = useTranslation();
+  const user = useAuthStore((s) => s.user);
+
+  const { data: logs, loading } = useAsyncData(
+    async () => {
+      if (!user) return [];
+      const res = await getMyLogs();
+      return res.data;
+    },
+    { initialData: [] as LearningLog[], deps: [user?.id], enabled: !!user }
+  );
+
+  const stats = useMemo(() => {
+    const totalDuration = logs.reduce((sum, log) => sum + log.duration, 0);
+    const totalHours = Math.round((totalDuration / 60) * 10) / 10;
+    const avgDuration = logs.length > 0 ? Math.round((totalDuration / logs.length) * 10) / 10 : 0;
+    const avgHours = Math.round((avgDuration / 60) * 10) / 10;
+
+    // カテゴリ別集計
+    const categoryStats = logs.reduce((acc, log) => {
+      const cat = log.category;
+      if (!acc[cat]) {
+        acc[cat] = { count: 0, duration: 0 };
+      }
+      acc[cat].count++;
+      acc[cat].duration += log.duration;
+      return acc;
+    }, {} as Record<LogCategory, { count: number; duration: number }>);
+
+    // カテゴリ別割合
+    const categoryPercentages = Object.entries(categoryStats).map(([category, stat]) => ({
+      category: category as LogCategory,
+      count: stat.count,
+      duration: stat.duration,
+      percentage: totalDuration > 0 ? Math.round((stat.duration / totalDuration) * 100) : 0,
+    }));
+
+    // 割合でソート
+    categoryPercentages.sort((a, b) => b.percentage - a.percentage);
+
+    return {
+      totalDuration,
+      totalHours,
+      totalLogs: logs.length,
+      avgDuration,
+      avgHours,
+      categoryPercentages,
+    };
+  }, [logs]);
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="h-5 bg-gray-800 rounded animate-pulse w-1/2 mb-2" />
+          <div className="h-8 bg-gray-800 rounded animate-pulse w-3/4" />
+        </div>
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="h-5 bg-gray-800 rounded animate-pulse w-1/2 mb-2" />
+          <div className="h-8 bg-gray-800 rounded animate-pulse w-3/4" />
+        </div>
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="h-5 bg-gray-800 rounded animate-pulse w-1/2 mb-2" />
+          <div className="h-8 bg-gray-800 rounded animate-pulse w-3/4" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <h3 className="text-sm font-medium text-white flex items-center gap-2">
+        <TrendingUp className="w-4 h-4 text-blue-400" />
+        学習統計
+      </h3>
+
+      {/* Main Stats Grid */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {/* Total Duration */}
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <Clock className="w-4 h-4 text-blue-400" />
+            <span className="text-xs text-gray-400">総学習時間</span>
+          </div>
+          <div className="text-2xl font-bold text-white">
+            {stats.totalHours}
+            <span className="text-sm text-gray-400 ml-1">時間</span>
+          </div>
+          <div className="text-xs text-gray-500 mt-1">
+            {stats.totalDuration}分
+          </div>
+        </div>
+
+        {/* Total Logs */}
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <BookOpen className="w-4 h-4 text-green-400" />
+            <span className="text-xs text-gray-400">学習ログ数</span>
+          </div>
+          <div className="text-2xl font-bold text-white">
+            {stats.totalLogs}
+            <span className="text-sm text-gray-400 ml-1">件</span>
+          </div>
+        </div>
+
+        {/* Average Duration */}
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="flex items-center gap-2 mb-2">
+            <TrendingUp className="w-4 h-4 text-purple-400" />
+            <span className="text-xs text-gray-400">平均学習時間</span>
+          </div>
+          <div className="text-2xl font-bold text-white">
+            {stats.avgHours}
+            <span className="text-sm text-gray-400 ml-1">時間</span>
+          </div>
+          <div className="text-xs text-gray-500 mt-1">
+            {stats.avgDuration}分/回
+          </div>
+        </div>
+      </div>
+
+      {/* Category Stats */}
+      {stats.categoryPercentages.length > 0 && (
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-4">
+          <div className="flex items-center gap-2 mb-4">
+            <PieChart className="w-4 h-4 text-orange-400" />
+            <span className="text-sm font-medium text-white">カテゴリ別学習時間</span>
+          </div>
+
+          <div className="space-y-3">
+            {stats.categoryPercentages.map(({ category, duration, percentage }) => {
+              const categoryInfo = getCategoryInfo(category);
+              const Icon = categoryInfo.Icon;
+              const colorClass = getCategoryColor(category);
+              const hours = Math.round((duration / 60) * 10) / 10;
+
+              return (
+                <div key={category} className="space-y-1">
+                  <div className="flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-2">
+                      <Icon className="w-3.5 h-3.5 text-gray-400" />
+                      <span className="text-white">{t(categoryInfo.label)}</span>
+                    </div>
+                    <div className="flex items-center gap-3">
+                      <span className="text-gray-400">{hours}h</span>
+                      <span className="text-blue-400 font-medium min-w-[3rem] text-right">
+                        {percentage}%
+                      </span>
+                    </div>
+                  </div>
+                  <div className="h-2 bg-gray-800 rounded-full overflow-hidden">
+                    <div
+                      className={`h-full ${colorClass.split(' ')[1]} transition-all`}
+                      style={{ width: `${percentage}%` }}
+                    />
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {stats.totalLogs === 0 && (
+        <div className="bg-gray-900 border border-gray-800 rounded-lg p-8 text-center">
+          <BookOpen className="w-12 h-12 mx-auto mb-3 text-gray-700" />
+          <p className="text-gray-400 text-sm">
+            まだ学習ログがありません
+          </p>
+          <p className="text-gray-500 text-xs mt-1">
+            学習ログを記録して統計を確認しましょう
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/learningLogs/__tests__/LearningStatsCards.test.tsx
+++ b/frontend/src/components/learningLogs/__tests__/LearningStatsCards.test.tsx
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import LearningStatsCards from '../LearningStatsCards';
+import * as learningLogsApi from '../../../api/learningLogs';
+import type { LearningLog } from '../../../types/learningLog';
+
+vi.mock('../../../api/learningLogs');
+vi.mock('../../../store/authStore', () => ({
+  useAuthStore: vi.fn(() => ({ user: { id: 1, name: 'Test User' } })),
+}));
+
+const mockLearningLogs: LearningLog[] = [
+  {
+    id: 1,
+    user_id: 1,
+    title: 'React学習',
+    content: 'Hooks を学んだ',
+    category: 'coding',
+    duration: 120,
+    source: 'manual',
+    is_favorite: false,
+    created_at: '2026-02-22T10:00:00Z',
+    updated_at: '2026-02-22T10:00:00Z',
+  },
+  {
+    id: 2,
+    user_id: 1,
+    title: '技術書読書',
+    content: 'Clean Code を読んだ',
+    category: 'reading',
+    duration: 60,
+    source: 'manual',
+    is_favorite: true,
+    created_at: '2026-02-21T14:00:00Z',
+    updated_at: '2026-02-21T14:00:00Z',
+  },
+  {
+    id: 3,
+    user_id: 1,
+    title: 'Udemy受講',
+    content: 'TypeScript コースを受講',
+    category: 'course',
+    duration: 90,
+    source: 'manual',
+    is_favorite: false,
+    created_at: '2026-02-20T09:00:00Z',
+    updated_at: '2026-02-20T09:00:00Z',
+  },
+];
+
+function renderWithRouter(ui: React.ReactElement) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('LearningStatsCards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(learningLogsApi.getMyLogs).mockResolvedValue({
+      data: mockLearningLogs,
+    } as any);
+  });
+
+  it('タイトルが表示される', async () => {
+    renderWithRouter(<LearningStatsCards />);
+    expect(screen.getByText(/学習統計/)).toBeInTheDocument();
+  });
+
+  it('総学習時間が表示される', async () => {
+    renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      // 120 + 60 + 90 = 270分 = 4.5時間
+      expect(screen.getByText(/4\.5|270/)).toBeInTheDocument();
+      expect(screen.getByText(/総学習時間/)).toBeInTheDocument();
+    });
+  });
+
+  it('学習ログ数が表示される', async () => {
+    renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByText('3')).toBeInTheDocument();
+      expect(screen.getByText(/学習ログ数/)).toBeInTheDocument();
+    });
+  });
+
+  it('平均学習時間が表示される', async () => {
+    renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      // (120 + 60 + 90) / 3 = 90分 = 1.5時間
+      expect(screen.getByText(/1\.5|90/)).toBeInTheDocument();
+      expect(screen.getByText(/平均学習時間/)).toBeInTheDocument();
+    });
+  });
+
+  it('カテゴリ別統計が表示される', async () => {
+    renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/カテゴリ別/)).toBeInTheDocument();
+      expect(screen.getByText(/コーディング|読書|コース/)).toBeInTheDocument();
+    });
+  });
+
+  it('各カテゴリの学習時間が表示される', async () => {
+    renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      // coding: 120分, reading: 60分, course: 90分
+      const timeElements = screen.getAllByText(/分|時間/);
+      expect(timeElements.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('ローディング状態が表示される', () => {
+    vi.mocked(learningLogsApi.getMyLogs).mockImplementation(
+      () => new Promise(() => {}) as any
+    );
+
+    const { container } = renderWithRouter(<LearningStatsCards />);
+
+    // ローディングスケルトンまたはスピナーの確認
+    const loadingElements = container.querySelectorAll('.animate-pulse');
+    expect(loadingElements.length).toBeGreaterThan(0);
+  });
+
+  it('学習ログがゼロの場合の表示', async () => {
+    vi.mocked(learningLogsApi.getMyLogs).mockResolvedValue({
+      data: [],
+    } as any);
+
+    renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      expect(screen.getByText('0')).toBeInTheDocument();
+    });
+  });
+
+  it('カードが複数表示される', async () => {
+    const { container } = renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      // 統計カードが存在することを確認
+      const cards = container.querySelectorAll('.bg-gray-900, .bg-gray-800');
+      expect(cards.length).toBeGreaterThan(2);
+    });
+  });
+
+  it('アイコンが表示される', async () => {
+    const { container } = renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      // lucide-reactのアイコンが存在することを確認
+      const icons = container.querySelectorAll('svg');
+      expect(icons.length).toBeGreaterThan(0);
+    });
+  });
+
+  it('グリッドレイアウトで表示される', async () => {
+    const { container } = renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      const grid = container.querySelector('.grid');
+      expect(grid).toBeInTheDocument();
+    });
+  });
+
+  it('カテゴリ別の割合が表示される', async () => {
+    renderWithRouter(<LearningStatsCards />);
+
+    await waitFor(() => {
+      // パーセンテージ表示を確認
+      const percentages = screen.getAllByText(/%/);
+      expect(percentages.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/frontend/src/pages/LearningLogsPage.tsx
+++ b/frontend/src/pages/LearningLogsPage.tsx
@@ -11,6 +11,7 @@ import LogFiltersBar from '../components/learning-logs/LogFiltersBar';
 import LogFormModal from '../components/learning-logs/LogFormModal';
 import WeeklySummaryCard from '../components/learning-logs/WeeklySummaryCard';
 import LearningStreakCard from '../components/learningLogs/LearningStreakCard';
+import LearningStatsCards from '../components/learningLogs/LearningStatsCards';
 import LoadingSpinner from '../components/common/LoadingSpinner';
 import { inputClass, buttonSecondaryClass, emptyStateClass } from '../constants/styles';
 
@@ -108,6 +109,9 @@ export default function LearningLogsPage() {
 
       {/* Learning Streak Card */}
       <LearningStreakCard />
+
+      {/* Learning Stats Cards */}
+      <LearningStatsCards />
 
       {/* Search */}
       <div className="relative">


### PR DESCRIPTION
## 概要
学習統計の可視化を強化し、ユーザーの学習傾向をより詳細に分析できるようにしました。

## 実装内容
### LearningStatsCardsコンポーネント
- 3列グリッドレイアウトで主要統計を表示
- カテゴリ別学習時間の割合を可視化
- ローディングスケルトンでUX向上
- 学習ログゼロ時の適切なフィードバック

### 主要統計（3カード）
1. **総学習時間**
   - 累計の学習時間を時間・分で表示
   - アイコン: Clock（青）

2. **学習ログ数**
   - 記録された学習ログの総数
   - アイコン: BookOpen（緑）

3. **平均学習時間**
   - 1回あたりの平均学習時間
   - 時間・分/回で表示
   - アイコン: TrendingUp（紫）

### カテゴリ別統計
- 各カテゴリ（コーディング/読書/コース/ミートアップ/その他）の集計
- 学習時間（時間単位）
- 割合（パーセンテージ）
- カテゴリアイコンと色分け
- プログレスバーで視覚的に表示
- 割合の高い順にソート

### LearningLogsPage統合
- LearningStreakCardの後に配置
- 既存の統計ウィジェットと統一感のあるデザイン

## UI/UXデザイン
- **主要統計**: 3カードを横並びで一目で把握
- **カテゴリ統計**: プログレスバーで割合を直感的に理解
- **アイコンと色**: 各統計項目を色で識別しやすく
- **ローディング**: スケルトンで読み込み中も違和感なし
- **空状態**: 学習ログゼロ時に励ましメッセージ

## テスト
- **LearningStatsCards.test.tsx**: 12のテストケース
  - 総学習時間表示
  - 学習ログ数表示
  - 平均学習時間表示
  - カテゴリ別統計表示
  - 割合計算
  - ローディング状態
  - 空状態表示

## 期待される効果
- **学習パターンの可視化**: 自分の学習傾向が一目でわかる
- **モチベーション向上**: 累計時間や平均時間を見て達成感
- **学習バランスの把握**: カテゴリ別で偏りを認識
- **目標設定の支援**: データに基づいた学習計画を立てやすく
- **継続的改善**: 統計を見て学習方法を改善

## 変更ファイル
- `frontend/src/components/learningLogs/LearningStatsCards.tsx` (新規作成, 185行)
- `frontend/src/components/learningLogs/__tests__/LearningStatsCards.test.tsx` (新規作成, 182行)
- `frontend/src/pages/LearningLogsPage.tsx` (修正, +4行)

## 関連Issue
Closes #1823