### PR TITLE
feat: ポモドーロタイマー機能を追加 (#1827)

### DIFF
--- a/frontend/src/components/pomodoro/PomodoroTimer.tsx
+++ b/frontend/src/components/pomodoro/PomodoroTimer.tsx
@@ -1,0 +1,178 @@
+import { useState, useEffect, useRef } from 'react';
+import { Play, Pause, RotateCcw, Timer } from 'lucide-react';
+
+interface PomodoroTimerProps {
+  workMinutes?: number;
+  breakMinutes?: number;
+  onComplete?: (duration: number) => void;
+}
+
+type TimerMode = 'work' | 'break';
+
+export default function PomodoroTimer({
+  workMinutes = 25,
+  breakMinutes = 5,
+  onComplete,
+}: PomodoroTimerProps) {
+  const [mode, setMode] = useState<TimerMode>('work');
+  const [timeLeft, setTimeLeft] = useState(workMinutes * 60);
+  const [isRunning, setIsRunning] = useState(false);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const startTimeRef = useRef<number>(0);
+
+  const totalTime = mode === 'work' ? workMinutes * 60 : breakMinutes * 60;
+  const progress = ((totalTime - timeLeft) / totalTime) * 100;
+
+  useEffect(() => {
+    if (isRunning) {
+      startTimeRef.current = Date.now();
+      intervalRef.current = setInterval(() => {
+        setTimeLeft((prev) => {
+          if (prev <= 1) {
+            setIsRunning(false);
+            if (onComplete && mode === 'work') {
+              onComplete(mode === 'work' ? workMinutes : breakMinutes);
+            }
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    } else {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, [isRunning, mode, workMinutes, breakMinutes, onComplete]);
+
+  useEffect(() => {
+    setTimeLeft(mode === 'work' ? workMinutes * 60 : breakMinutes * 60);
+    setIsRunning(false);
+  }, [mode, workMinutes, breakMinutes]);
+
+  const handleStart = () => {
+    setIsRunning(true);
+  };
+
+  const handlePause = () => {
+    setIsRunning(false);
+  };
+
+  const handleReset = () => {
+    setIsRunning(false);
+    setTimeLeft(mode === 'work' ? workMinutes * 60 : breakMinutes * 60);
+  };
+
+  const handleModeChange = (newMode: TimerMode) => {
+    setMode(newMode);
+  };
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = seconds % 60;
+    return `${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`;
+  };
+
+  return (
+    <div className="bg-gray-900 border border-gray-800 rounded-lg p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <Timer className="w-5 h-5 text-blue-400" />
+        <h3 className="text-lg font-semibold text-white">ポモドーロタイマー</h3>
+      </div>
+
+      {/* Mode Tabs */}
+      <div className="flex gap-2">
+        <button
+          onClick={() => handleModeChange('work')}
+          className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
+            mode === 'work'
+              ? 'bg-blue-500/20 text-blue-400 border border-blue-400/30'
+              : 'bg-gray-800/50 text-gray-400 hover:text-white border border-gray-700'
+          }`}
+        >
+          作業
+        </button>
+        <button
+          onClick={() => handleModeChange('break')}
+          className={`flex-1 py-2 px-4 rounded-lg text-sm font-medium transition-colors ${
+            mode === 'break'
+              ? 'bg-green-500/20 text-green-400 border border-green-400/30'
+              : 'bg-gray-800/50 text-gray-400 hover:text-white border border-gray-700'
+          }`}
+        >
+          休憩
+        </button>
+      </div>
+
+      {/* Timer Display */}
+      <div className="text-center py-8">
+        <div
+          className={`text-6xl font-bold ${
+            mode === 'work' ? 'text-blue-400' : 'text-green-400'
+          }`}
+        >
+          {formatTime(timeLeft)}
+        </div>
+        <div className="text-sm text-gray-400 mt-2">
+          {mode === 'work' ? '作業時間' : '休憩時間'}
+        </div>
+      </div>
+
+      {/* Progress Bar */}
+      <div className="space-y-2">
+        <div className="h-2 bg-gray-800 rounded-full overflow-hidden" role="progressbar">
+          <div
+            className={`h-full transition-all ${
+              mode === 'work' ? 'bg-blue-500' : 'bg-green-500'
+            }`}
+            style={{ width: `${progress}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Controls */}
+      <div className="flex gap-3">
+        {!isRunning ? (
+          <button
+            onClick={handleStart}
+            className="flex-1 flex items-center justify-center gap-2 py-3 bg-blue-500 hover:bg-blue-600 text-white rounded-lg font-medium transition-colors"
+          >
+            <Play className="w-5 h-5" />
+            {timeLeft === totalTime ? '開始' : '再開'}
+          </button>
+        ) : (
+          <button
+            onClick={handlePause}
+            className="flex-1 flex items-center justify-center gap-2 py-3 bg-orange-500 hover:bg-orange-600 text-white rounded-lg font-medium transition-colors"
+          >
+            <Pause className="w-5 h-5" />
+            一時停止
+          </button>
+        )}
+
+        <button
+          onClick={handleReset}
+          className="px-6 py-3 bg-gray-700 hover:bg-gray-600 text-white rounded-lg font-medium transition-colors flex items-center gap-2"
+        >
+          <RotateCcw className="w-5 h-5" />
+          リセット
+        </button>
+      </div>
+
+      {/* Hint */}
+      <div className="text-xs text-gray-500 text-center">
+        {mode === 'work'
+          ? `${workMinutes}分間集中して作業しましょう`
+          : `${breakMinutes}分間リラックスしましょう`}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/pomodoro/__tests__/PomodoroTimer.test.tsx
+++ b/frontend/src/components/pomodoro/__tests__/PomodoroTimer.test.tsx
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import PomodoroTimer from '../PomodoroTimer';
+
+vi.useFakeTimers();
+
+describe('PomodoroTimer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it('タイマーが表示される', () => {
+    render(<PomodoroTimer />);
+    expect(screen.getByText(/25:00/)).toBeInTheDocument();
+  });
+
+  it('開始ボタンが表示される', () => {
+    render(<PomodoroTimer />);
+    expect(screen.getByText('開始')).toBeInTheDocument();
+  });
+
+  it('開始ボタンをクリックするとタイマーが開始する', () => {
+    render(<PomodoroTimer />);
+
+    const startButton = screen.getByText('開始');
+    fireEvent.click(startButton);
+
+    expect(screen.getByText('一時停止')).toBeInTheDocument();
+  });
+
+  it('タイマーが1秒ごとにカウントダウンする', () => {
+    render(<PomodoroTimer />);
+
+    const startButton = screen.getByText('開始');
+    fireEvent.click(startButton);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(screen.getByText(/24:59/)).toBeInTheDocument();
+  });
+
+  it('一時停止ボタンをクリックするとタイマーが停止する', () => {
+    render(<PomodoroTimer />);
+
+    const startButton = screen.getByText('開始');
+    fireEvent.click(startButton);
+
+    const pauseButton = screen.getByText('一時停止');
+    fireEvent.click(pauseButton);
+
+    expect(screen.getByText('再開')).toBeInTheDocument();
+  });
+
+  it('リセットボタンが表示される', () => {
+    render(<PomodoroTimer />);
+    expect(screen.getByText('リセット')).toBeInTheDocument();
+  });
+
+  it('リセットボタンをクリックするとタイマーが初期化される', () => {
+    render(<PomodoroTimer />);
+
+    const startButton = screen.getByText('開始');
+    fireEvent.click(startButton);
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    const resetButton = screen.getByText('リセット');
+    fireEvent.click(resetButton);
+
+    expect(screen.getByText(/25:00/)).toBeInTheDocument();
+    expect(screen.getByText('開始')).toBeInTheDocument();
+  });
+
+  it('作業時間と休憩時間のタブが表示される', () => {
+    render(<PomodoroTimer />);
+    expect(screen.getByText('作業')).toBeInTheDocument();
+    expect(screen.getByText('休憩')).toBeInTheDocument();
+  });
+
+  it('休憩タブをクリックすると休憩時間が表示される', () => {
+    render(<PomodoroTimer />);
+
+    const breakTab = screen.getByText('休憩');
+    fireEvent.click(breakTab);
+
+    expect(screen.getByText(/05:00/)).toBeInTheDocument();
+  });
+
+  it('進捗バーが表示される', () => {
+    const { container } = render(<PomodoroTimer />);
+
+    const progressBar = container.querySelector('[role="progressbar"]');
+    expect(progressBar).toBeInTheDocument();
+  });
+
+  it('タイマーアイコンが表示される', () => {
+    const { container } = render(<PomodoroTimer />);
+
+    const icons = container.querySelectorAll('svg');
+    expect(icons.length).toBeGreaterThan(0);
+  });
+
+  it('タイマー終了時にコールバックが呼ばれる', async () => {
+    const onComplete = vi.fn();
+    render(<PomodoroTimer onComplete={onComplete} />);
+
+    const startButton = screen.getByText('開始');
+    fireEvent.click(startButton);
+
+    // 25分 = 1500秒
+    act(() => {
+      vi.advanceTimersByTime(1500 * 1000);
+    });
+
+    await waitFor(() => {
+      expect(onComplete).toHaveBeenCalledWith(25);
+    });
+  });
+
+  it('作業中はタイマーが青色で表示される', () => {
+    const { container } = render(<PomodoroTimer />);
+
+    const timer = container.querySelector('.text-blue-400');
+    expect(timer).toBeInTheDocument();
+  });
+
+  it('タイマーのカスタマイズが可能', () => {
+    render(<PomodoroTimer workMinutes={30} breakMinutes={10} />);
+
+    expect(screen.getByText(/30:00/)).toBeInTheDocument();
+
+    const breakTab = screen.getByText('休憩');
+    fireEvent.click(breakTab);
+
+    expect(screen.getByText(/10:00/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
学習時間を計測するポモドーロタイマー機能を追加しました。

## 実装内容
### PomodoroTimerコンポーネント
- 25分作業 + 5分休憩のポモドーロサイクル
- 開始/一時停止/リセット機能
- 進捗バー表示
- 作業時間と休憩時間の切り替えタブ
- カスタマイズ可能な時間設定

### 主な機能
#### タイマー機能
- **作業時間**: 25分（workMinutesプロップでカスタマイズ可能）
- **休憩時間**: 5分（breakMinutesプロップでカスタマイズ可能）
- **開始/再開**: タイマーを開始または再開
- **一時停止**: タイマーを一時停止
- **リセット**: タイマーを初期状態に戻す
- **進捗バー**: 残り時間を視覚的に表示

#### UI/UXデザイン
- **タブ切り替え**: 作業モードと休憩モードを切り替え
- **大きな時刻表示**: MM:SS形式で見やすく表示
- **色分け**: 
  - 作業モード: 青（集中を表現）
  - 休憩モード: 緑（リラックスを表現）
- **進捗バー**: カラーバーで残り時間を視覚化
- **ヒントメッセージ**: 各モードに応じたメッセージ

#### コールバック
- **onComplete**: タイマー終了時に呼ばれるコールバック
  - 引数: 経過時間（分）
  - 用途: 学習ログの自動作成など

### Props
```typescript
interface PomodoroTimerProps {
  workMinutes?: number;      // 作業時間（デフォルト: 25分）
  breakMinutes?: number;     // 休憩時間（デフォルト: 5分）
  onComplete?: (duration: number) => void;  // 終了時コールバック
}
```

## テスト
- **PomodoroTimer.test.tsx**: 14のテストケース
  - タイマー表示
  - 開始/一時停止/リセット
  - カウントダウン動作
  - モード切り替え
  - 進捗バー
  - カスタマイズ
  - コールバック実行

## 期待される効果
- **集中力の向上**: ポモドーロテクニックで集中時間を確保
- **学習時間の可視化**: タイマーで実際の学習時間を把握
- **タイムマネジメント改善**: 25分単位での時間管理
- **学習ログとの連携**: 終了時に自動で学習ログを作成（将来実装）
- **休憩の習慣化**: 定期的な休憩でリフレッシュ

## 今後の拡張予定
1. タイマー終了時に学習ログ作成フォームを表示
2. 通知音の追加
3. 完了したポモドーロ数の表示
4. 統計機能（1日のポモドーロ数など）
5. DashboardPageへの統合

## 変更ファイル
- `frontend/src/components/pomodoro/PomodoroTimer.tsx` (新規作成, 167行)
- `frontend/src/components/pomodoro/__tests__/PomodoroTimer.test.tsx` (新規作成, 156行)

## 関連Issue
Closes #1827