### PR TITLE
feat: カスタムタグ管理機能を追加 (#1829)

### DIFF
--- a/frontend/src/components/common/TagSelector.tsx
+++ b/frontend/src/components/common/TagSelector.tsx
@@ -1,0 +1,134 @@
+import { useState, KeyboardEvent } from 'react';
+import { X, Hash } from 'lucide-react';
+
+interface TagSelectorProps {
+  value: string;
+  onChange: (value: string) => void;
+  suggestions?: string[];
+  maxTags?: number;
+}
+
+export default function TagSelector({
+  value,
+  onChange,
+  suggestions = [],
+  maxTags = 10,
+}: TagSelectorProps) {
+  const [inputValue, setInputValue] = useState('');
+
+  const selectedTags = value
+    ? value.split(',').filter((tag) => tag.trim() !== '')
+    : [];
+
+  const normalizeTag = (tag: string): string => {
+    const trimmed = tag.trim();
+    return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+  };
+
+  const addTags = (tagsToAdd: string[]) => {
+    const normalizedNewTags = tagsToAdd
+      .map((tag) => tag.trim())
+      .filter((tag) => tag !== '')
+      .map(normalizeTag);
+
+    const uniqueNewTags = normalizedNewTags.filter(
+      (tag) => !selectedTags.includes(tag)
+    );
+
+    if (uniqueNewTags.length === 0) return;
+
+    const totalTags = selectedTags.length + uniqueNewTags.length;
+    if (totalTags > maxTags) return;
+
+    const newValue = [...selectedTags, ...uniqueNewTags].join(',');
+    onChange(newValue);
+  };
+
+  const removeTag = (tagToRemove: string) => {
+    const newTags = selectedTags.filter((tag) => tag !== tagToRemove);
+    onChange(newTags.join(','));
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const tags = inputValue.split(',').map((t) => t.trim());
+      addTags(tags);
+      setInputValue('');
+    }
+  };
+
+  const handleSuggestionClick = (suggestion: string) => {
+    addTags([suggestion]);
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* 選択済みタグ */}
+      {selectedTags.length > 0 && (
+        <div className="flex flex-wrap gap-2">
+          {selectedTags.map((tag) => (
+            <button
+              key={tag}
+              onClick={() => removeTag(tag)}
+              className="bg-blue-500/20 text-blue-400 px-3 py-1.5 rounded-lg text-sm font-medium flex items-center gap-1.5 hover:bg-red-500/30 transition-colors border border-blue-400/30"
+            >
+              <Hash className="w-3.5 h-3.5" />
+              {tag.replace('#', '')}
+              <X className="w-3.5 h-3.5" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* タグ入力フィールド */}
+      <div className="relative">
+        <input
+          type="text"
+          value={inputValue}
+          onChange={(e) => setInputValue(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="タグを入力してEnterキーで追加（カンマ区切りで複数追加可能）"
+          className="w-full px-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500"
+        />
+        <Hash className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-500" />
+      </div>
+
+      {/* 候補タグ */}
+      {suggestions.length > 0 && (
+        <div className="space-y-2">
+          <div className="text-sm text-gray-400">候補タグ:</div>
+          <div className="flex flex-wrap gap-2">
+            {suggestions.map((suggestion) => {
+              const normalizedSuggestion = normalizeTag(suggestion);
+              const isSelected = selectedTags.includes(normalizedSuggestion);
+
+              return (
+                <button
+                  key={suggestion}
+                  onClick={() => handleSuggestionClick(suggestion)}
+                  disabled={isSelected}
+                  className={`px-3 py-1.5 rounded-lg text-sm font-medium flex items-center gap-1.5 transition-colors ${
+                    isSelected
+                      ? 'bg-blue-500/20 text-blue-400 border border-blue-400/30 cursor-default'
+                      : 'bg-gray-800/50 text-gray-300 hover:text-white hover:bg-gray-700 border border-gray-700'
+                  }`}
+                >
+                  <Hash className="w-3.5 h-3.5" />
+                  {suggestion}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* タグ数制限表示 */}
+      {selectedTags.length > 0 && (
+        <div className="text-xs text-gray-500">
+          {selectedTags.length} / {maxTags} タグ
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/TagSelector.test.tsx
+++ b/frontend/src/components/common/__tests__/TagSelector.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import TagSelector from '../TagSelector';
+
+const mockOnChange = vi.fn();
+
+describe('TagSelector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('選択済みタグが表示される', () => {
+    render(<TagSelector value="#React,#TypeScript" onChange={mockOnChange} />);
+
+    expect(screen.getByText('#React')).toBeInTheDocument();
+    expect(screen.getByText('#TypeScript')).toBeInTheDocument();
+  });
+
+  it('タグ入力フィールドが表示される', () => {
+    render(<TagSelector value="" onChange={mockOnChange} />);
+
+    expect(screen.getByPlaceholderText(/タグを入力/)).toBeInTheDocument();
+  });
+
+  it('タグをクリックすると削除される', () => {
+    render(<TagSelector value="#React,#TypeScript" onChange={mockOnChange} />);
+
+    const reactTag = screen.getByText('#React');
+    fireEvent.click(reactTag);
+
+    expect(mockOnChange).toHaveBeenCalledWith('#TypeScript');
+  });
+
+  it('新しいタグを入力してEnterキーで追加できる', () => {
+    render(<TagSelector value="#React" onChange={mockOnChange} />);
+
+    const input = screen.getByPlaceholderText(/タグを入力/);
+    fireEvent.change(input, { target: { value: 'TypeScript' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mockOnChange).toHaveBeenCalledWith('#React,#TypeScript');
+  });
+
+  it('候補タグが表示される', () => {
+    const suggestions = ['JavaScript', 'TypeScript', 'Python'];
+    render(<TagSelector value="" onChange={mockOnChange} suggestions={suggestions} />);
+
+    suggestions.forEach((tag) => {
+      expect(screen.getByText(`#${tag}`)).toBeInTheDocument();
+    });
+  });
+
+  it('候補タグをクリックすると追加される', () => {
+    const suggestions = ['JavaScript', 'TypeScript'];
+    render(<TagSelector value="" onChange={mockOnChange} suggestions={suggestions} />);
+
+    const jsTag = screen.getByText('#JavaScript');
+    fireEvent.click(jsTag);
+
+    expect(mockOnChange).toHaveBeenCalledWith('#JavaScript');
+  });
+
+  it('重複するタグは追加されない', () => {
+    render(<TagSelector value="#React" onChange={mockOnChange} />);
+
+    const input = screen.getByPlaceholderText(/タグを入力/);
+    fireEvent.change(input, { target: { value: 'React' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    // onChangeが呼ばれないことを確認
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it('タグは自動的に#が付与される', () => {
+    render(<TagSelector value="" onChange={mockOnChange} />);
+
+    const input = screen.getByPlaceholderText(/タグを入力/);
+    fireEvent.change(input, { target: { value: 'React' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mockOnChange).toHaveBeenCalledWith('#React');
+  });
+
+  it('カンマ区切りでタグが追加される', () => {
+    render(<TagSelector value="" onChange={mockOnChange} />);
+
+    const input = screen.getByPlaceholderText(/タグを入力/);
+    fireEvent.change(input, { target: { value: 'React,TypeScript' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mockOnChange).toHaveBeenCalledWith('#React,#TypeScript');
+  });
+
+  it('最大タグ数を超えると追加できない', () => {
+    render(<TagSelector value="#Tag1,#Tag2,#Tag3" onChange={mockOnChange} maxTags={3} />);
+
+    const input = screen.getByPlaceholderText(/タグを入力/);
+    fireEvent.change(input, { target: { value: 'Tag4' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it('選択済みタグにホバーエフェクトがある', () => {
+    render(<TagSelector value="#React" onChange={mockOnChange} />);
+
+    const reactTag = screen.getByText('#React');
+    expect(reactTag).toHaveClass('hover:bg-red-500/30');
+  });
+
+  it('候補タグと選択済みタグが区別される', () => {
+    const suggestions = ['React', 'TypeScript'];
+    render(<TagSelector value="#React" onChange={mockOnChange} suggestions={suggestions} />);
+
+    const selectedTag = screen.getAllByText('#React')[0]; // 選択済み
+    const suggestionTag = screen.getAllByText('#React')[1]; // 候補
+
+    // 選択済みタグは削除可能なスタイル
+    expect(selectedTag.parentElement).toHaveClass('bg-blue-500/20');
+
+    // 候補タグは追加可能なスタイル
+    expect(suggestionTag.parentElement).toHaveClass('bg-gray-800/50');
+  });
+});


### PR DESCRIPTION
## 概要
学習ログやノートなどで使用するカスタムタグ管理機能を追加しました。

## 変更内容
- **TagSelectorコンポーネントの実装**
  - 選択済みタグの表示（クリックで削除）
  - タグ入力フィールド
  - Enterキーでタグ追加
  - カンマ区切りで複数タグを一括追加
  - 候補タグの表示と選択
  - 自動的に#を付与
  - 重複タグの防止
  - 最大タグ数の制限（デフォルト10個）

- **包括的なテストスイートの追加**
  - 12個のテストケースでコンポーネントの動作を検証

## 主な機能
### タグ管理
- 選択済みタグは青色で表示、クリックで削除可能
- ホバー時に赤色に変化して削除を示唆

### タグ入力
- プレースホルダーでカンマ区切りの使い方を案内
- 入力値は自動的に#プレフィックスが付与される
- Enterキーで追加、カンマ区切りで複数追加に対応

### 候補タグ
- 提案されたタグをクリックで選択可能
- 選択済みタグは候補リストで無効化される

### バリデーション
- 重複タグは追加されない
- 最大タグ数に達すると追加を制限
- タグ数カウンター表示（例: 3 / 10 タグ）

## UIデザイン
- Tailwind CSSによるダークテーマ対応
- Lucide Reactアイコン（Hash, X）を使用
- 選択済みタグと候補タグで異なるスタイル
- スムーズなホバーアニメーション

## テストカバレッジ
- タグ表示と削除
- 入力フィールドの動作
- Enter/カンマ区切り入力
- 候補タグの選択
- 重複/最大数制限のバリデーション
- スタイリングとホバーエフェクト

## 今後の利用先
- 学習ログ作成時のタグ選択
- ノート作成時のタグ選択
- プロジェクト管理でのカテゴリ分類

## 関連Issue
Closes #1829