### PR TITLE
feat: スキルレベルバッジコンポーネントを追加 (#1840)

### DIFF
--- a/frontend/src/components/common/Badge.tsx
+++ b/frontend/src/components/common/Badge.tsx
@@ -1,0 +1,40 @@
+import { ReactNode } from 'react';
+
+interface BadgeProps {
+  children: ReactNode;
+  variant?: 'default' | 'beginner' | 'intermediate' | 'advanced' | 'expert';
+  size?: 'sm' | 'md' | 'lg';
+  icon?: ReactNode;
+  className?: string;
+}
+
+export default function Badge({
+  children,
+  variant = 'default',
+  size = 'md',
+  icon,
+  className = '',
+}: BadgeProps) {
+  const variantClasses = {
+    default: 'bg-gray-500/20 text-gray-400 border-gray-500/30',
+    beginner: 'bg-green-500/20 text-green-400 border-green-500/30',
+    intermediate: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
+    advanced: 'bg-purple-500/20 text-purple-400 border-purple-500/30',
+    expert: 'bg-orange-500/20 text-orange-400 border-orange-500/30',
+  };
+
+  const sizeClasses = {
+    sm: 'text-xs px-2 py-0.5',
+    md: 'text-sm px-2.5 py-1',
+    lg: 'text-base px-3 py-1.5',
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full font-medium border ${variantClasses[variant]} ${sizeClasses[size]} ${className}`.trim()}
+    >
+      {icon && <span className="flex-shrink-0">{icon}</span>}
+      {children}
+    </span>
+  );
+}

--- a/frontend/src/components/common/__tests__/Badge.test.tsx
+++ b/frontend/src/components/common/__tests__/Badge.test.tsx
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Badge from '../Badge';
+
+describe('Badge', () => {
+  it('バッジが表示される', () => {
+    render(<Badge>テスト</Badge>);
+    expect(screen.getByText('テスト')).toBeInTheDocument();
+  });
+
+  it('初級バッジが緑色で表示される', () => {
+    render(<Badge variant="beginner">初級</Badge>);
+
+    const badge = screen.getByText('初級');
+    expect(badge).toHaveClass('bg-green-500/20', 'text-green-400');
+  });
+
+  it('中級バッジが青色で表示される', () => {
+    render(<Badge variant="intermediate">中級</Badge>);
+
+    const badge = screen.getByText('中級');
+    expect(badge).toHaveClass('bg-blue-500/20', 'text-blue-400');
+  });
+
+  it('上級バッジが紫色で表示される', () => {
+    render(<Badge variant="advanced">上級</Badge>);
+
+    const badge = screen.getByText('上級');
+    expect(badge).toHaveClass('bg-purple-500/20', 'text-purple-400');
+  });
+
+  it('エキスパートバッジがオレンジ色で表示される', () => {
+    render(<Badge variant="expert">エキスパート</Badge>);
+
+    const badge = screen.getByText('エキスパート');
+    expect(badge).toHaveClass('bg-orange-500/20', 'text-orange-400');
+  });
+
+  it('デフォルトバッジが灰色で表示される', () => {
+    render(<Badge variant="default">デフォルト</Badge>);
+
+    const badge = screen.getByText('デフォルト');
+    expect(badge).toHaveClass('bg-gray-500/20', 'text-gray-400');
+  });
+
+  it('小サイズのバッジが表示される', () => {
+    render(<Badge size="sm">小</Badge>);
+
+    const badge = screen.getByText('小');
+    expect(badge).toHaveClass('text-xs', 'px-2', 'py-0.5');
+  });
+
+  it('中サイズのバッジが表示される', () => {
+    render(<Badge size="md">中</Badge>);
+
+    const badge = screen.getByText('中');
+    expect(badge).toHaveClass('text-sm', 'px-2.5', 'py-1');
+  });
+
+  it('大サイズのバッジが表示される', () => {
+    render(<Badge size="lg">大</Badge>);
+
+    const badge = screen.getByText('大');
+    expect(badge).toHaveClass('text-base', 'px-3', 'py-1.5');
+  });
+
+  it('アイコン付きバッジが表示される', () => {
+    const { container } = render(
+      <Badge icon={<span data-testid="icon">★</span>}>アイコン</Badge>
+    );
+
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+    expect(screen.getByText('アイコン')).toBeInTheDocument();
+  });
+
+  it('角が丸くなっている', () => {
+    render(<Badge>丸角</Badge>);
+
+    const badge = screen.getByText('丸角');
+    expect(badge).toHaveClass('rounded-full');
+  });
+
+  it('フォントが太字になっている', () => {
+    render(<Badge>太字</Badge>);
+
+    const badge = screen.getByText('太字');
+    expect(badge).toHaveClass('font-medium');
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    render(<Badge className="custom-class">カスタム</Badge>);
+
+    const badge = screen.getByText('カスタム');
+    expect(badge).toHaveClass('custom-class');
+  });
+
+  it('デフォルトサイズは中サイズ', () => {
+    render(<Badge>デフォルト</Badge>);
+
+    const badge = screen.getByText('デフォルト');
+    expect(badge).toHaveClass('text-sm', 'px-2.5', 'py-1');
+  });
+
+  it('デフォルトバリアントはdefault', () => {
+    render(<Badge>バリアント</Badge>);
+
+    const badge = screen.getByText('バリアント');
+    expect(badge).toHaveClass('bg-gray-500/20', 'text-gray-400');
+  });
+
+  it('複数のバッジが独立して表示される', () => {
+    render(
+      <>
+        <Badge variant="beginner">初級</Badge>
+        <Badge variant="intermediate">中級</Badge>
+        <Badge variant="advanced">上級</Badge>
+      </>
+    );
+
+    expect(screen.getByText('初級')).toBeInTheDocument();
+    expect(screen.getByText('中級')).toBeInTheDocument();
+    expect(screen.getByText('上級')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
スキルレベルを視覚的に表示するバッジコンポーネントを追加しました。

## 変更内容
- **Badgeコンポーネントの実装**
  - レベル別の色分け（初級/中級/上級/エキスパート/デフォルト）
  - サイズバリエーション（sm/md/lg）
  - アイコン付きバッジ対応
  - カスタマイズ可能なスタイル

- **包括的なテストスイートの追加**
  - 15個のテストケースでコンポーネントの動作を検証

## 主な機能
### レベル別スタイル
- **beginner**: 緑色（初級）
- **intermediate**: 青色（中級）
- **advanced**: 紫色（上級）
- **expert**: オレンジ色（エキスパート）
- **default**: 灰色（デフォルト）

### サイズ
- **sm**: 小サイズ（text-xs）
- **md**: 中サイズ（text-sm、デフォルト）
- **lg**: 大サイズ（text-base）

### 使用例
```tsx
// 基本的な使用
<Badge variant="beginner">初級</Badge>

// アイコン付き
<Badge variant="expert" icon={<Star />}>
  エキスパート
</Badge>

// サイズ指定
<Badge variant="advanced" size="lg">
  上級
</Badge>

// カスタムスタイル
<Badge className="ml-2">
  カスタム
</Badge>
```

## UIデザイン
- Tailwind CSSによるダークテーマ対応
- 背景は各レベルに応じた色（20%透明度）
- テキストとボーダーは対応する色（400系統）
- rounded-fullで完全な丸角
- font-mediumで太字
- inline-flexでアイコンとテキストを整列

## テストカバレッジ
- バッジ表示
- 5つのバリアント（beginner/intermediate/advanced/expert/default）
- 3つのサイズ（sm/md/lg）
- アイコン付きバッジ
- スタイル適用
- デフォルト値
- 複数バッジの独立性

## 今後の利用先
- プロフィールページ（スキル表示）
- 学習進捗（レベル表示）
- ユーザーカード（レベル表示）
- ランキングページ（ランク表示）
- タグ表示
- ステータス表示

## 関連Issue
Closes #1840