### PR TITLE
feat: タブコンポーネントを追加 (#1844)

### DIFF
--- a/frontend/src/components/common/Tabs.tsx
+++ b/frontend/src/components/common/Tabs.tsx
@@ -1,0 +1,52 @@
+import { useState, ReactNode } from 'react';
+
+interface Tab {
+  id: string;
+  label: string;
+  content: ReactNode;
+}
+
+interface TabsProps {
+  tabs: Tab[];
+  defaultActiveId?: string;
+  onChange?: (id: string) => void;
+}
+
+export default function Tabs({ tabs, defaultActiveId, onChange }: TabsProps) {
+  const [activeId, setActiveId] = useState(defaultActiveId || tabs[0]?.id);
+
+  const handleTabClick = (id: string) => {
+    setActiveId(id);
+    onChange?.(id);
+  };
+
+  const activeTab = tabs.find((tab) => tab.id === activeId);
+
+  return (
+    <div className="w-full">
+      {/* タブヘッダー */}
+      <div className="flex border-b border-gray-800">
+        {tabs.map((tab) => {
+          const isActive = tab.id === activeId;
+
+          return (
+            <button
+              key={tab.id}
+              onClick={() => handleTabClick(tab.id)}
+              className={`px-4 py-3 text-sm font-medium transition-colors border-b-2 ${
+                isActive
+                  ? 'text-blue-400 border-blue-400'
+                  : 'text-gray-400 hover:text-white border-transparent'
+              }`}
+            >
+              {tab.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* タブコンテンツ */}
+      <div className="py-4">{activeTab?.content}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Tabs.test.tsx
+++ b/frontend/src/components/common/__tests__/Tabs.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import Tabs from '../Tabs';
+
+describe('Tabs', () => {
+  const tabs = [
+    { id: '1', label: 'タブ1', content: 'コンテンツ1' },
+    { id: '2', label: 'タブ2', content: 'コンテンツ2' },
+    { id: '3', label: 'タブ3', content: 'コンテンツ3' },
+  ];
+
+  it('タブが表示される', () => {
+    render(<Tabs tabs={tabs} />);
+
+    expect(screen.getByText('タブ1')).toBeInTheDocument();
+    expect(screen.getByText('タブ2')).toBeInTheDocument();
+    expect(screen.getByText('タブ3')).toBeInTheDocument();
+  });
+
+  it('デフォルトで最初のタブのコンテンツが表示される', () => {
+    render(<Tabs tabs={tabs} />);
+
+    expect(screen.getByText('コンテンツ1')).toBeInTheDocument();
+    expect(screen.queryByText('コンテンツ2')).not.toBeInTheDocument();
+  });
+
+  it('タブをクリックするとコンテンツが切り替わる', () => {
+    render(<Tabs tabs={tabs} />);
+
+    const tab2 = screen.getByText('タブ2');
+    fireEvent.click(tab2);
+
+    expect(screen.getByText('コンテンツ2')).toBeInTheDocument();
+    expect(screen.queryByText('コンテンツ1')).not.toBeInTheDocument();
+  });
+
+  it('アクティブなタブがハイライトされる', () => {
+    render(<Tabs tabs={tabs} />);
+
+    const tab1 = screen.getByText('タブ1');
+    expect(tab1).toHaveClass('text-blue-400');
+  });
+
+  it('非アクティブなタブは灰色で表示される', () => {
+    render(<Tabs tabs={tabs} />);
+
+    const tab2 = screen.getByText('タブ2');
+    expect(tab2).toHaveClass('text-gray-400');
+  });
+
+  it('アクティブなタブにボーダーがある', () => {
+    render(<Tabs tabs={tabs} />);
+
+    const tab1 = screen.getByText('タブ1');
+    expect(tab1).toHaveClass('border-b-2', 'border-blue-400');
+  });
+
+  it('タブクリック時にonChangeが呼ばれる', () => {
+    const mockOnChange = vi.fn();
+    render(<Tabs tabs={tabs} onChange={mockOnChange} />);
+
+    const tab2 = screen.getByText('タブ2');
+    fireEvent.click(tab2);
+
+    expect(mockOnChange).toHaveBeenCalledWith('2');
+  });
+
+  it('defaultActiveIdで初期アクティブタブを指定できる', () => {
+    render(<Tabs tabs={tabs} defaultActiveId="2" />);
+
+    expect(screen.getByText('コンテンツ2')).toBeInTheDocument();
+    expect(screen.queryByText('コンテンツ1')).not.toBeInTheDocument();
+  });
+
+  it('ホバー時にタブの色が変わる', () => {
+    render(<Tabs tabs={tabs} />);
+
+    const tab2 = screen.getByText('タブ2');
+    expect(tab2).toHaveClass('hover:text-white');
+  });
+
+  it('トランジション効果がある', () => {
+    render(<Tabs tabs={tabs} />);
+
+    const tab1 = screen.getByText('タブ1');
+    expect(tab1).toHaveClass('transition-colors');
+  });
+
+  it('複数回クリックしても正しく動作する', () => {
+    render(<Tabs tabs={tabs} />);
+
+    const tab2 = screen.getByText('タブ2');
+    const tab3 = screen.getByText('タブ3');
+
+    fireEvent.click(tab2);
+    expect(screen.getByText('コンテンツ2')).toBeInTheDocument();
+
+    fireEvent.click(tab3);
+    expect(screen.getByText('コンテンツ3')).toBeInTheDocument();
+
+    fireEvent.click(tab2);
+    expect(screen.getByText('コンテンツ2')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
コンテンツを切り替えるタブコンポーネントを追加しました。

## 変更内容
- **Tabsコンポーネントの実装**
  - タブボタン表示
  - アクティブタブのハイライト
  - クリックでタブ切り替え
  - アンダーラインスタイル
  - デフォルトアクティブタブの指定
  - タブ切り替えコールバック

- **包括的なテストスイートの追加**
  - 11個のテストケースでコンポーネントの動作を検証

## 主な機能
### タブ切り替え
- タブボタンをクリックでコンテンツ切り替え
- アクティブタブを青色でハイライト
- 非アクティブタブは灰色
- ホバー時に白色に変化

### スタイル
- アクティブタブにアンダーライン（border-b-2）
- transition-colorsでスムーズなアニメーション

### 使用例
```tsx
// 基本的な使用
const tabs = [
  { id: '1', label: '概要', content: <div>概要コンテンツ</div> },
  { id: '2', label: '設定', content: <div>設定コンテンツ</div> },
  { id: '3', label: '詳細', content: <div>詳細コンテンツ</div> },
];

<Tabs tabs={tabs} />

// デフォルトアクティブタブ指定
<Tabs tabs={tabs} defaultActiveId="2" />

// タブ切り替え時のコールバック
<Tabs 
  tabs={tabs} 
  onChange={(id) => console.log('Active tab:', id)} 
/>
```

## UIデザイン
- Tailwind CSSによるダークテーマ対応
- アクティブタブは青色（text-blue-400、border-blue-400）
- 非アクティブタブは灰色（text-gray-400）
- ホバー時は白色（hover:text-white）
- ボーダー下部に灰色800のライン
- transition-colorsでスムーズなアニメーション

## テストカバレッジ
- タブ表示
- デフォルトコンテンツ表示
- タブクリックでコンテンツ切り替え
- アクティブタブのハイライト
- 非アクティブタブのスタイル
- アンダーライン表示
- onChange コールバック
- defaultActiveId 指定
- ホバーエフェクト
- トランジション効果
- 複数回クリックの動作

## 今後の利用先
- 設定ページ（一般/セキュリティ/通知など）
- プロフィールページ（投稿/いいね/フォロワーなど）
- ダッシュボード（統計/アクティビティ/目標など）
- 詳細ページ（概要/コメント/履歴など）
- リソースページ（記事/動画/書籍など）

## 関連Issue
Closes #1844