### PR TITLE
feat: ブレッドクラムコンポーネントを追加 (#1846)

### DIFF
--- a/frontend/src/components/common/Breadcrumb.tsx
+++ b/frontend/src/components/common/Breadcrumb.tsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom';
+import { ChevronRight } from 'lucide-react';
+
+interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+}
+
+export default function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav aria-label="パンくずリスト" className="flex items-center gap-2 text-sm">
+      {items.map((item, index) => {
+        const isLast = index === items.length - 1;
+
+        return (
+          <div key={index} className="flex items-center gap-2">
+            {item.href && !isLast ? (
+              <Link
+                to={item.href}
+                className="text-blue-400 hover:text-white transition-colors"
+              >
+                {item.label}
+              </Link>
+            ) : (
+              <span className="text-gray-400">{item.label}</span>
+            )}
+
+            {!isLast && <ChevronRight className="w-4 h-4 text-gray-600" />}
+          </div>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/common/__tests__/Breadcrumb.test.tsx
+++ b/frontend/src/components/common/__tests__/Breadcrumb.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import Breadcrumb from '../Breadcrumb';
+
+const renderWithRouter = (ui: React.ReactElement) => {
+  return render(<BrowserRouter>{ui}</BrowserRouter>);
+};
+
+describe('Breadcrumb', () => {
+  const items = [
+    { label: 'ホーム', href: '/' },
+    { label: 'プロジェクト', href: '/projects' },
+    { label: 'プロジェクト詳細' },
+  ];
+
+  it('ブレッドクラムが表示される', () => {
+    renderWithRouter(<Breadcrumb items={items} />);
+
+    expect(screen.getByText('ホーム')).toBeInTheDocument();
+    expect(screen.getByText('プロジェクト')).toBeInTheDocument();
+    expect(screen.getByText('プロジェクト詳細')).toBeInTheDocument();
+  });
+
+  it('リンク付きの項目が表示される', () => {
+    renderWithRouter(<Breadcrumb items={items} />);
+
+    const homeLink = screen.getByText('ホーム');
+    expect(homeLink.closest('a')).toHaveAttribute('href', '/');
+  });
+
+  it('最後の項目はリンクではない', () => {
+    renderWithRouter(<Breadcrumb items={items} />);
+
+    const lastItem = screen.getByText('プロジェクト詳細');
+    expect(lastItem.closest('a')).toBeNull();
+  });
+
+  it('セパレーターが表示される', () => {
+    const { container } = renderWithRouter(<Breadcrumb items={items} />);
+
+    const separators = container.querySelectorAll('svg');
+    // 3項目の場合、セパレーターは2つ
+    expect(separators.length).toBe(2);
+  });
+
+  it('リンク項目にホバーエフェクトがある', () => {
+    renderWithRouter(<Breadcrumb items={items} />);
+
+    const homeLink = screen.getByText('ホーム');
+    expect(homeLink).toHaveClass('hover:text-white');
+  });
+
+  it('最後の項目は灰色で表示される', () => {
+    renderWithRouter(<Breadcrumb items={items} />);
+
+    const lastItem = screen.getByText('プロジェクト詳細');
+    expect(lastItem).toHaveClass('text-gray-400');
+  });
+
+  it('リンク項目は青色で表示される', () => {
+    renderWithRouter(<Breadcrumb items={items} />);
+
+    const homeLink = screen.getByText('ホーム');
+    expect(homeLink).toHaveClass('text-blue-400');
+  });
+
+  it('1つだけの項目でも表示される', () => {
+    renderWithRouter(<Breadcrumb items={[{ label: 'ホーム' }]} />);
+
+    expect(screen.getByText('ホーム')).toBeInTheDocument();
+  });
+
+  it('navタグで囲まれている', () => {
+    const { container } = renderWithRouter(<Breadcrumb items={items} />);
+
+    const nav = container.querySelector('nav');
+    expect(nav).toBeInTheDocument();
+  });
+
+  it('aria-labelが設定されている', () => {
+    const { container } = renderWithRouter(<Breadcrumb items={items} />);
+
+    const nav = container.querySelector('nav');
+    expect(nav).toHaveAttribute('aria-label', 'パンくずリスト');
+  });
+});


### PR DESCRIPTION
## 概要
現在地を示すパンくずリストコンポーネントを追加しました。

## 変更内容
- **Breadcrumbコンポーネントの実装**
  - パンくずリスト表示
  - 各項目にリンク（最後の項目を除く）
  - セパレーター（ChevronRight）
  - 現在ページ（最後の項目）は非アクティブ
  - アクセシビリティ対応（aria-label）

- **包括的なテストスイートの追加**
  - 10個のテストケースでコンポーネントの動作を検証

## 主な機能
### パンくずリスト
- 階層構造を視覚的に表示
- 各項目をクリックして前のページに戻る
- ChevronRightアイコンでセパレーター表示

### スタイル
- リンク項目は青色（text-blue-400）
- 現在ページは灰色（text-gray-400）
- ホバー時は白色（hover:text-white）

### 使用例
```tsx
// 基本的な使用
<Breadcrumb 
  items={[
    { label: 'ホーム', href: '/' },
    { label: 'プロジェクト', href: '/projects' },
    { label: 'プロジェクト詳細' },
  ]} 
/>

// 単一項目
<Breadcrumb items={[{ label: 'ホーム' }]} />
```

## UIデザイン
- Tailwind CSSによるダークテーマ対応
- リンク項目は青色（text-blue-400）
- 現在ページは灰色（text-gray-400）
- ホバー時は白色（hover:text-white）
- ChevronRightアイコンでセパレーター
- transition-colorsでスムーズなアニメーション

## テストカバレッジ
- ブレッドクラム表示
- リンク付き項目
- 最後の項目は非リンク
- セパレーター表示
- ホバーエフェクト
- スタイル適用
- 単一項目のケース
- navタグ
- aria-label属性

## 今後の利用先
- 詳細ページ（プロジェクト、ノート、学習ログなど）
- 設定ページ（階層構造がある場合）
- ネストされたページ
- リソースページ

## 関連Issue
Closes #1846