### PR TITLE
feat: 区切り線コンポーネントを追加 (#1850)

### DIFF
--- a/frontend/src/components/common/Divider.tsx
+++ b/frontend/src/components/common/Divider.tsx
@@ -1,0 +1,59 @@
+import { ReactNode } from 'react';
+
+interface DividerProps {
+  children?: ReactNode;
+  orientation?: 'horizontal' | 'vertical';
+  textAlign?: 'left' | 'center' | 'right';
+  className?: string;
+}
+
+export default function Divider({
+  children,
+  orientation = 'horizontal',
+  textAlign = 'center',
+  className = '',
+}: DividerProps) {
+  // テキストがない場合はシンプルな線
+  if (!children) {
+    if (orientation === 'vertical') {
+      return (
+        <div
+          className={`border-l border-gray-800 h-full ${className}`.trim()}
+          role="separator"
+          aria-orientation="vertical"
+        />
+      );
+    }
+
+    return (
+      <div
+        className={`border-t border-gray-800 w-full ${className}`.trim()}
+        role="separator"
+        aria-orientation="horizontal"
+      />
+    );
+  }
+
+  // テキスト付き区切り線（水平のみ）
+  const alignClasses = {
+    left: 'justify-start',
+    center: 'justify-center',
+    right: 'justify-end',
+  };
+
+  return (
+    <div
+      className={`flex items-center gap-4 ${alignClasses[textAlign]} w-full ${className}`.trim()}
+      role="separator"
+      aria-orientation="horizontal"
+    >
+      {(textAlign === 'center' || textAlign === 'right') && (
+        <div className="flex-1 border-t border-gray-800" />
+      )}
+      <span className="text-sm text-gray-400">{children}</span>
+      {(textAlign === 'center' || textAlign === 'left') && (
+        <div className="flex-1 border-t border-gray-800" />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Divider.test.tsx
+++ b/frontend/src/components/common/__tests__/Divider.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Divider from '../Divider';
+
+describe('Divider', () => {
+  it('区切り線が表示される', () => {
+    const { container } = render(<Divider />);
+
+    const divider = container.querySelector('.border-gray-800');
+    expect(divider).toBeInTheDocument();
+  });
+
+  it('水平方向の区切り線が表示される', () => {
+    const { container } = render(<Divider />);
+
+    const divider = container.querySelector('.border-t');
+    expect(divider).toBeInTheDocument();
+  });
+
+  it('垂直方向の区切り線が表示される', () => {
+    const { container } = render(<Divider orientation="vertical" />);
+
+    const divider = container.querySelector('.border-l');
+    expect(divider).toBeInTheDocument();
+  });
+
+  it('テキスト付き区切り線が表示される', () => {
+    render(<Divider>テキスト</Divider>);
+
+    expect(screen.getByText('テキスト')).toBeInTheDocument();
+  });
+
+  it('テキストが中央に表示される', () => {
+    render(<Divider textAlign="center">中央</Divider>);
+
+    const text = screen.getByText('中央');
+    expect(text.parentElement).toHaveClass('justify-center');
+  });
+
+  it('テキストが左に表示される', () => {
+    render(<Divider textAlign="left">左</Divider>);
+
+    const text = screen.getByText('左');
+    expect(text.parentElement).toHaveClass('justify-start');
+  });
+
+  it('テキストが右に表示される', () => {
+    render(<Divider textAlign="right">右</Divider>);
+
+    const text = screen.getByText('右');
+    expect(text.parentElement).toHaveClass('justify-end');
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Divider className="custom-class" />);
+
+    const divider = container.querySelector('.custom-class');
+    expect(divider).toBeInTheDocument();
+  });
+
+  it('デフォルトは水平方向', () => {
+    const { container } = render(<Divider />);
+
+    const divider = container.querySelector('.border-t');
+    expect(divider).toBeInTheDocument();
+  });
+
+  it('テキストがない場合はシンプルな線のみ', () => {
+    const { container } = render(<Divider />);
+
+    const divider = container.querySelector('.border-t');
+    expect(divider).toBeInTheDocument();
+    expect(container.querySelector('.flex')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
セクション間の区切りを示す区切り線コンポーネントを追加しました。

## 変更内容
- **Dividerコンポーネントの実装**
  - 水平/垂直方向の区切り線
  - テキスト付き区切り線（中央/左/右）
  - アクセシビリティ対応（role="separator"）
  - カスタマイズ可能なスタイル

- **包括的なテストスイートの追加**
  - 10個のテストケースでコンポーネントの動作を検証

## 主な機能
### 方向指定
- **horizontal**: 水平方向（デフォルト）
- **vertical**: 垂直方向

### テキスト付き区切り線
- テキストの位置を指定可能（left/center/right）
- テキストの両側に線を表示

### 使用例
```tsx
// シンプルな区切り線
<Divider />

// 垂直方向
<Divider orientation="vertical" />

// テキスト付き（中央）
<Divider>または</Divider>

// テキスト付き（左）
<Divider textAlign="left">セクション1</Divider>

// テキスト付き（右）
<Divider textAlign="right">続きを読む</Divider>

// カスタムクラス
<Divider className="my-8">セクション区切り</Divider>
```

## UIデザイン
- Tailwind CSSによるダークテーマ対応
- ボーダー色はグレー800
- テキストは灰色400（text-gray-400）
- role="separator"でアクセシビリティ対応
- aria-orientation属性で方向を明示

## テストカバレッジ
- 区切り線表示
- 水平/垂直方向
- テキスト付き区切り線
- テキスト位置（left/center/right）
- カスタムクラス
- デフォルト方向（horizontal）
- シンプルな線とテキスト付きの切り替え

## 今後の利用先
- セクション区切り
- フォームフィールド間
- カード内の区切り
- リスト項目間
- モーダルのヘッダー/ボディ/フッター間
- ログイン/サインアップフォーム

## 関連Issue
Closes #1850