### PR TITLE
feat: Accordionコンポーネントを追加 (#1852)

### DIFF
--- a/frontend/src/components/common/Accordion.tsx
+++ b/frontend/src/components/common/Accordion.tsx
@@ -1,0 +1,65 @@
+import { useState, ReactNode } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+interface AccordionItem {
+  id: string;
+  title: string;
+  content: ReactNode;
+}
+
+interface AccordionProps {
+  items: AccordionItem[];
+  single?: boolean;
+  defaultOpenIds?: string[];
+  onChange?: (openIds: string[]) => void;
+  className?: string;
+}
+
+export default function Accordion({
+  items,
+  single = false,
+  defaultOpenIds = [],
+  onChange,
+  className = '',
+}: AccordionProps) {
+  const [openIds, setOpenIds] = useState<string[]>(defaultOpenIds);
+
+  const toggle = (id: string) => {
+    const newOpenIds = openIds.includes(id)
+      ? openIds.filter((openId) => openId !== id)
+      : single
+        ? [id]
+        : [...openIds, id];
+
+    setOpenIds(newOpenIds);
+    onChange?.(newOpenIds);
+  };
+
+  return (
+    <div className={`divide-y divide-gray-800 border border-gray-800 rounded-lg ${className}`.trim()}>
+      {items.map((item) => {
+        const isOpen = openIds.includes(item.id);
+
+        return (
+          <div key={item.id}>
+            <button
+              onClick={() => toggle(item.id)}
+              className="flex items-center justify-between w-full px-4 py-3 text-left text-gray-200 hover:bg-gray-800/50 transition-colors"
+              aria-expanded={isOpen}
+            >
+              <span>{item.title}</span>
+              <ChevronDown
+                className={`w-4 h-4 text-gray-400 transition-transform ${isOpen ? 'rotate-180' : ''}`}
+              />
+            </button>
+            {isOpen && (
+              <div className="px-4 py-3 text-gray-300">
+                {item.content}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Accordion.test.tsx
+++ b/frontend/src/components/common/__tests__/Accordion.test.tsx
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Accordion from '../Accordion';
+
+const items = [
+  { id: '1', title: 'セクション1', content: 'コンテンツ1' },
+  { id: '2', title: 'セクション2', content: 'コンテンツ2' },
+  { id: '3', title: 'セクション3', content: 'コンテンツ3' },
+];
+
+describe('Accordion', () => {
+  it('全てのセクションタイトルが表示される', () => {
+    render(<Accordion items={items} />);
+
+    expect(screen.getByText('セクション1')).toBeInTheDocument();
+    expect(screen.getByText('セクション2')).toBeInTheDocument();
+    expect(screen.getByText('セクション3')).toBeInTheDocument();
+  });
+
+  it('初期状態でコンテンツが非表示', () => {
+    render(<Accordion items={items} />);
+
+    expect(screen.queryByText('コンテンツ1')).not.toBeInTheDocument();
+    expect(screen.queryByText('コンテンツ2')).not.toBeInTheDocument();
+  });
+
+  it('クリックでセクションが展開される', async () => {
+    const user = userEvent.setup();
+    render(<Accordion items={items} />);
+
+    await user.click(screen.getByText('セクション1'));
+
+    expect(screen.getByText('コンテンツ1')).toBeInTheDocument();
+  });
+
+  it('展開中のセクションをクリックで閉じる', async () => {
+    const user = userEvent.setup();
+    render(<Accordion items={items} />);
+
+    await user.click(screen.getByText('セクション1'));
+    expect(screen.getByText('コンテンツ1')).toBeInTheDocument();
+
+    await user.click(screen.getByText('セクション1'));
+    expect(screen.queryByText('コンテンツ1')).not.toBeInTheDocument();
+  });
+
+  it('単一展開モードで他のセクションが閉じる', async () => {
+    const user = userEvent.setup();
+    render(<Accordion items={items} single />);
+
+    await user.click(screen.getByText('セクション1'));
+    expect(screen.getByText('コンテンツ1')).toBeInTheDocument();
+
+    await user.click(screen.getByText('セクション2'));
+    expect(screen.queryByText('コンテンツ1')).not.toBeInTheDocument();
+    expect(screen.getByText('コンテンツ2')).toBeInTheDocument();
+  });
+
+  it('複数展開モードで複数セクションが開く', async () => {
+    const user = userEvent.setup();
+    render(<Accordion items={items} />);
+
+    await user.click(screen.getByText('セクション1'));
+    await user.click(screen.getByText('セクション2'));
+
+    expect(screen.getByText('コンテンツ1')).toBeInTheDocument();
+    expect(screen.getByText('コンテンツ2')).toBeInTheDocument();
+  });
+
+  it('デフォルト展開状態が設定できる', () => {
+    render(<Accordion items={items} defaultOpenIds={['1', '3']} />);
+
+    expect(screen.getByText('コンテンツ1')).toBeInTheDocument();
+    expect(screen.queryByText('コンテンツ2')).not.toBeInTheDocument();
+    expect(screen.getByText('コンテンツ3')).toBeInTheDocument();
+  });
+
+  it('onChangeコールバックが呼ばれる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Accordion items={items} onChange={onChange} />);
+
+    await user.click(screen.getByText('セクション1'));
+
+    expect(onChange).toHaveBeenCalledWith(['1']);
+  });
+
+  it('展開アイコンが表示される', () => {
+    const { container } = render(<Accordion items={items} />);
+
+    const icons = container.querySelectorAll('.lucide-chevron-down');
+    expect(icons.length).toBe(3);
+  });
+
+  it('展開時にアイコンが回転する', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Accordion items={items} />);
+
+    await user.click(screen.getByText('セクション1'));
+
+    const rotatedIcon = container.querySelector('.rotate-180');
+    expect(rotatedIcon).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Accordion items={items} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('ReactNodeをコンテンツに使用できる', async () => {
+    const user = userEvent.setup();
+    const richItems = [
+      { id: '1', title: 'リッチ', content: <span data-testid="rich">リッチコンテンツ</span> },
+    ];
+    render(<Accordion items={richItems} />);
+
+    await user.click(screen.getByText('リッチ'));
+
+    expect(screen.getByTestId('rich')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 折りたたみ可能なセクションを表示する汎用Accordionコンポーネントを追加
- 単一展開モード（一度に1つだけ開く）と複数展開モードに対応
- デフォルト展開状態、onChangeコールバック、アイコン回転アニメーション
- TDDで開発（12テストケース）

## テスト計画
- [x] 全セクションタイトル表示
- [x] 初期状態でコンテンツ非表示
- [x] クリックで展開/閉じる
- [x] 単一展開モード
- [x] 複数展開モード
- [x] デフォルト展開状態
- [x] onChangeコールバック
- [x] アイコン回転
- [x] カスタムクラス名
- [x] ReactNodeコンテンツ