### PR TITLE
feat: Ratingコンポーネントを追加 (#1856)

### DIFF
--- a/frontend/src/components/common/Rating.tsx
+++ b/frontend/src/components/common/Rating.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Star } from 'lucide-react';
+
+const sizeMap = {
+  sm: 'w-4 h-4',
+  md: 'w-6 h-6',
+  lg: 'w-8 h-8',
+};
+
+interface RatingProps {
+  value: number;
+  onChange?: (value: number) => void;
+  max?: number;
+  readOnly?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export default function Rating({
+  value,
+  onChange,
+  max = 5,
+  readOnly = false,
+  size = 'md',
+  className = '',
+}: RatingProps) {
+  const [hoverValue, setHoverValue] = useState<number | null>(null);
+
+  const displayValue = hoverValue ?? value;
+
+  const handleClick = (index: number) => {
+    if (readOnly || !onChange) return;
+    onChange(index === value ? 0 : index);
+  };
+
+  const stars = Array.from({ length: max }, (_, i) => i + 1);
+
+  return (
+    <div className={`flex items-center gap-1 ${className}`.trim()}>
+      {stars.map((starValue) => {
+        const isFilled = starValue <= displayValue;
+        const starClasses = `${sizeMap[size]} ${isFilled ? 'text-yellow-400 fill-yellow-400' : 'text-gray-600'}`;
+
+        if (readOnly) {
+          return (
+            <Star key={starValue} className={starClasses} />
+          );
+        }
+
+        return (
+          <button
+            key={starValue}
+            type="button"
+            onClick={() => handleClick(starValue)}
+            onMouseEnter={() => setHoverValue(starValue)}
+            onMouseLeave={() => setHoverValue(null)}
+            className="p-0 bg-transparent border-none cursor-pointer"
+          >
+            <Star className={starClasses} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Rating.test.tsx
+++ b/frontend/src/components/common/__tests__/Rating.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Rating from '../Rating';
+
+describe('Rating', () => {
+  it('デフォルトで5つの星が表示される', () => {
+    const { container } = render(<Rating value={0} onChange={() => {}} />);
+
+    const stars = container.querySelectorAll('.lucide-star');
+    expect(stars.length).toBe(5);
+  });
+
+  it('指定した数の星が表示される', () => {
+    const { container } = render(<Rating value={0} onChange={() => {}} max={3} />);
+
+    const stars = container.querySelectorAll('.lucide-star');
+    expect(stars.length).toBe(3);
+  });
+
+  it('値に応じて星が塗りつぶされる', () => {
+    const { container } = render(<Rating value={3} onChange={() => {}} />);
+
+    const filledStars = container.querySelectorAll('.text-yellow-400');
+    expect(filledStars.length).toBe(3);
+  });
+
+  it('クリックで値が変わる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Rating value={0} onChange={onChange} />);
+
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[2]);
+
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it('読み取り専用モードではクリックできない', () => {
+    render(<Rating value={3} readOnly />);
+
+    const buttons = screen.queryAllByRole('button');
+    expect(buttons.length).toBe(0);
+  });
+
+  it('ホバーでプレビューが表示される', async () => {
+    const { container } = render(<Rating value={1} onChange={() => {}} />);
+    const user = userEvent.setup();
+
+    const buttons = screen.getAllByRole('button');
+    await user.hover(buttons[3]);
+
+    const highlightedStars = container.querySelectorAll('.text-yellow-400');
+    expect(highlightedStars.length).toBe(4);
+  });
+
+  it('ホバー解除で元の値に戻る', async () => {
+    const { container } = render(<Rating value={2} onChange={() => {}} />);
+    const user = userEvent.setup();
+
+    const buttons = screen.getAllByRole('button');
+    await user.hover(buttons[4]);
+    await user.unhover(buttons[4]);
+
+    const filledStars = container.querySelectorAll('.text-yellow-400');
+    expect(filledStars.length).toBe(2);
+  });
+
+  it('smサイズが適用される', () => {
+    const { container } = render(<Rating value={0} onChange={() => {}} size="sm" />);
+
+    const star = container.querySelector('.w-4');
+    expect(star).toBeInTheDocument();
+  });
+
+  it('lgサイズが適用される', () => {
+    const { container } = render(<Rating value={0} onChange={() => {}} size="lg" />);
+
+    const star = container.querySelector('.w-8');
+    expect(star).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Rating value={0} onChange={() => {}} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('同じ値をクリックすると0にリセットされる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Rating value={3} onChange={onChange} />);
+
+    const buttons = screen.getAllByRole('button');
+    await user.click(buttons[2]);
+
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+});


### PR DESCRIPTION
## 概要
- 星評価を表示・入力できる汎用Ratingコンポーネントを追加
- ホバーでプレビュー表示、マウス離脱で元の値に復帰
- 読み取り専用モード、3段階サイズ（sm/md/lg）
- 同じ星をクリックで0にリセット（トグル）
- TDDで開発（11テストケース）

## テスト計画
- [x] デフォルト5つの星表示
- [x] 星の数カスタマイズ
- [x] 値に応じた塗りつぶし
- [x] クリックで値変更
- [x] 読み取り専用モード
- [x] ホバープレビュー
- [x] ホバー解除で復帰
- [x] サイズ変更
- [x] トグルリセット