### PR TITLE
feat: Alertコンポーネントを追加 (#1862)

### DIFF
--- a/frontend/src/components/common/Alert.tsx
+++ b/frontend/src/components/common/Alert.tsx
@@ -1,0 +1,70 @@
+import { Info, CheckCircle, AlertTriangle, XCircle, X } from 'lucide-react';
+
+const variantConfig = {
+  info: {
+    icon: Info,
+    borderColor: 'border-blue-500',
+    bgColor: 'bg-blue-500/10',
+    textColor: 'text-blue-400',
+  },
+  success: {
+    icon: CheckCircle,
+    borderColor: 'border-green-500',
+    bgColor: 'bg-green-500/10',
+    textColor: 'text-green-400',
+  },
+  warning: {
+    icon: AlertTriangle,
+    borderColor: 'border-yellow-500',
+    bgColor: 'bg-yellow-500/10',
+    textColor: 'text-yellow-400',
+  },
+  error: {
+    icon: XCircle,
+    borderColor: 'border-red-500',
+    bgColor: 'bg-red-500/10',
+    textColor: 'text-red-400',
+  },
+};
+
+interface AlertProps {
+  variant: 'info' | 'success' | 'warning' | 'error';
+  message: string;
+  title?: string;
+  onClose?: () => void;
+  className?: string;
+}
+
+export default function Alert({
+  variant,
+  message,
+  title,
+  onClose,
+  className = '',
+}: AlertProps) {
+  const config = variantConfig[variant];
+  const IconComponent = config.icon;
+
+  return (
+    <div
+      role="alert"
+      className={`flex items-start gap-3 p-4 border-l-4 rounded-r-lg ${config.borderColor} ${config.bgColor} ${className}`.trim()}
+    >
+      <IconComponent className={`w-5 h-5 ${config.textColor} mt-0.5 flex-shrink-0`} />
+      <div className="flex-1 min-w-0">
+        {title && (
+          <h4 className={`font-medium ${config.textColor} mb-1`}>{title}</h4>
+        )}
+        <p className="text-sm text-gray-300">{message}</p>
+      </div>
+      {onClose && (
+        <button
+          onClick={onClose}
+          className="text-gray-400 hover:text-gray-200 flex-shrink-0"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Alert.test.tsx
+++ b/frontend/src/components/common/__tests__/Alert.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Alert from '../Alert';
+
+describe('Alert', () => {
+  it('メッセージが表示される', () => {
+    render(<Alert variant="info" message="情報メッセージ" />);
+
+    expect(screen.getByText('情報メッセージ')).toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<Alert variant="info" title="タイトル" message="メッセージ" />);
+
+    expect(screen.getByText('タイトル')).toBeInTheDocument();
+  });
+
+  it('infoバリアントのスタイルが適用される', () => {
+    const { container } = render(<Alert variant="info" message="情報" />);
+
+    expect(container.querySelector('.border-blue-500')).toBeInTheDocument();
+  });
+
+  it('successバリアントのスタイルが適用される', () => {
+    const { container } = render(<Alert variant="success" message="成功" />);
+
+    expect(container.querySelector('.border-green-500')).toBeInTheDocument();
+  });
+
+  it('warningバリアントのスタイルが適用される', () => {
+    const { container } = render(<Alert variant="warning" message="警告" />);
+
+    expect(container.querySelector('.border-yellow-500')).toBeInTheDocument();
+  });
+
+  it('errorバリアントのスタイルが適用される', () => {
+    const { container } = render(<Alert variant="error" message="エラー" />);
+
+    expect(container.querySelector('.border-red-500')).toBeInTheDocument();
+  });
+
+  it('アイコンが表示される', () => {
+    const { container } = render(<Alert variant="info" message="情報" />);
+
+    expect(container.querySelector('.lucide-info')).toBeInTheDocument();
+  });
+
+  it('閉じるボタンが表示される', () => {
+    render(<Alert variant="info" message="情報" onClose={() => {}} />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('閉じるボタンクリックでコールバックが呼ばれる', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<Alert variant="info" message="情報" onClose={onClose} />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('閉じるボタンがない場合は表示されない', () => {
+    render(<Alert variant="info" message="情報" />);
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Alert variant="info" message="情報" className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('role=alertが設定されている', () => {
+    render(<Alert variant="error" message="エラー" />);
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- アラートメッセージを表示する汎用Alertコンポーネントを追加
- 4種類のバリアント（info/success/warning/error）
- バリアントに応じたアイコン自動選択、ボーダーカラー、背景色
- タイトル・説明文、閉じるボタン対応
- role="alert"によるアクセシビリティ
- TDDで開発（12テストケース）

## テスト計画
- [x] メッセージ表示
- [x] タイトル表示
- [x] 4種類のバリアントスタイル
- [x] アイコン表示
- [x] 閉じるボタンクリック
- [x] 閉じるボタン条件表示
- [x] カスタムクラス名
- [x] role=alert設定