### PR TITLE
feat: Toggleコンポーネントを追加 (#1864)

### DIFF
--- a/frontend/src/components/common/Toggle.tsx
+++ b/frontend/src/components/common/Toggle.tsx
@@ -1,0 +1,49 @@
+const sizeConfig = {
+  sm: { track: 'w-8 h-4', thumb: 'w-3 h-3', translate: 'translate-x-4' },
+  md: { track: 'w-11 h-6', thumb: 'w-5 h-5', translate: 'translate-x-5' },
+  lg: { track: 'w-14 h-7', thumb: 'w-6 h-6', translate: 'translate-x-7' },
+};
+
+interface ToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  label?: string;
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function Toggle({
+  checked,
+  onChange,
+  label,
+  size = 'md',
+  disabled = false,
+  className = '',
+}: ToggleProps) {
+  const config = sizeConfig[size];
+
+  return (
+    <div className={`flex items-center gap-3 ${className}`.trim()}>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex flex-shrink-0 ${config.track} rounded-full transition-colors ${
+          checked ? 'bg-blue-600' : 'bg-gray-600'
+        } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+      >
+        <span
+          className={`inline-block ${config.thumb} rounded-full bg-white shadow transform transition-transform ${
+            checked ? config.translate : 'translate-x-0.5'
+          } mt-0.5`}
+        />
+      </button>
+      {label && (
+        <span className="text-sm text-gray-300">{label}</span>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Toggle.test.tsx
+++ b/frontend/src/components/common/__tests__/Toggle.test.tsx
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Toggle from '../Toggle';
+
+describe('Toggle', () => {
+  it('トグルが表示される', () => {
+    render(<Toggle checked={false} onChange={() => {}} />);
+
+    expect(screen.getByRole('switch')).toBeInTheDocument();
+  });
+
+  it('ONの状態が表示される', () => {
+    const { container } = render(<Toggle checked={true} onChange={() => {}} />);
+
+    expect(container.querySelector('.bg-blue-600')).toBeInTheDocument();
+  });
+
+  it('OFFの状態が表示される', () => {
+    const { container } = render(<Toggle checked={false} onChange={() => {}} />);
+
+    expect(container.querySelector('.bg-gray-600')).toBeInTheDocument();
+  });
+
+  it('クリックで状態が切り替わる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Toggle checked={false} onChange={onChange} />);
+
+    await user.click(screen.getByRole('switch'));
+
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('ON状態でクリックするとOFFになる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Toggle checked={true} onChange={onChange} />);
+
+    await user.click(screen.getByRole('switch'));
+
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  it('ラベルが表示される', () => {
+    render(<Toggle checked={false} onChange={() => {}} label="通知" />);
+
+    expect(screen.getByText('通知')).toBeInTheDocument();
+  });
+
+  it('smサイズが適用される', () => {
+    const { container } = render(<Toggle checked={false} onChange={() => {}} size="sm" />);
+
+    expect(container.querySelector('.w-8')).toBeInTheDocument();
+  });
+
+  it('lgサイズが適用される', () => {
+    const { container } = render(<Toggle checked={false} onChange={() => {}} size="lg" />);
+
+    expect(container.querySelector('.w-14')).toBeInTheDocument();
+  });
+
+  it('無効状態が適用される', () => {
+    render(<Toggle checked={false} onChange={() => {}} disabled />);
+
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+
+  it('無効状態ではクリックしても変化しない', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Toggle checked={false} onChange={onChange} disabled />);
+
+    await user.click(screen.getByRole('switch'));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('aria-checkedが正しく設定される', () => {
+    render(<Toggle checked={true} onChange={() => {}} />);
+
+    expect(screen.getByRole('switch')).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Toggle checked={false} onChange={() => {}} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- ON/OFF切り替え用の汎用Toggleスイッチコンポーネントを追加
- 3段階サイズ（sm/md/lg）、ラベル表示
- 無効状態対応（クリック無効化、opacity変更）
- role="switch"、aria-checkedによるアクセシビリティ
- TDDで開発（12テストケース）

## テスト計画
- [x] トグル表示
- [x] ON/OFF状態スタイル
- [x] クリックで切り替え
- [x] ラベル表示
- [x] 3段階サイズ
- [x] 無効状態
- [x] aria-checked
- [x] カスタムクラス名