### PR TITLE
feat: Dropdownコンポーネントを追加 (#1866)

### DIFF
--- a/frontend/src/components/common/Dropdown.tsx
+++ b/frontend/src/components/common/Dropdown.tsx
@@ -1,0 +1,85 @@
+import { useState, useRef, useEffect, ReactNode } from 'react';
+
+interface DropdownItem {
+  id: string;
+  label?: string;
+  disabled?: boolean;
+}
+
+interface DropdownDivider {
+  id: 'divider';
+}
+
+interface DropdownProps {
+  trigger: ReactNode;
+  items: (DropdownItem | DropdownDivider)[];
+  onSelect: (id: string) => void;
+  className?: string;
+}
+
+export default function Dropdown({
+  trigger,
+  items,
+  onSelect,
+  className = '',
+}: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (item: DropdownItem | DropdownDivider) => {
+    if (item.id === 'divider') return;
+    if ('disabled' in item && item.disabled) return;
+    onSelect(item.id);
+    setIsOpen(false);
+  };
+
+  return (
+    <div ref={ref} className={`relative inline-block ${className}`.trim()}>
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        className="inline-flex items-center"
+      >
+        {trigger}
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-48 bg-gray-800 border border-gray-700 rounded-lg shadow-lg z-50 py-1">
+          {items.map((item, index) => {
+            if (item.id === 'divider') {
+              return <div key={`divider-${index}`} className="border-t border-gray-700 my-1" />;
+            }
+
+            const menuItem = item as DropdownItem;
+            return (
+              <button
+                key={menuItem.id}
+                type="button"
+                onClick={() => handleSelect(menuItem)}
+                disabled={menuItem.disabled}
+                className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+                  menuItem.disabled
+                    ? 'text-gray-600 cursor-not-allowed'
+                    : 'text-gray-200 hover:bg-gray-700'
+                }`}
+              >
+                {menuItem.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Dropdown.test.tsx
+++ b/frontend/src/components/common/__tests__/Dropdown.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Dropdown from '../Dropdown';
+
+const items = [
+  { id: '1', label: '編集' },
+  { id: '2', label: '複製' },
+  { id: 'divider' as const },
+  { id: '3', label: '削除' },
+];
+
+describe('Dropdown', () => {
+  it('トリガーボタンが表示される', () => {
+    render(<Dropdown trigger="メニュー" items={items} onSelect={() => {}} />);
+
+    expect(screen.getByText('メニュー')).toBeInTheDocument();
+  });
+
+  it('初期状態でメニューが非表示', () => {
+    render(<Dropdown trigger="メニュー" items={items} onSelect={() => {}} />);
+
+    expect(screen.queryByText('編集')).not.toBeInTheDocument();
+  });
+
+  it('トリガークリックでメニューが表示される', async () => {
+    const user = userEvent.setup();
+    render(<Dropdown trigger="メニュー" items={items} onSelect={() => {}} />);
+
+    await user.click(screen.getByText('メニュー'));
+
+    expect(screen.getByText('編集')).toBeInTheDocument();
+    expect(screen.getByText('複製')).toBeInTheDocument();
+    expect(screen.getByText('削除')).toBeInTheDocument();
+  });
+
+  it('メニュー項目クリックでコールバックが呼ばれる', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<Dropdown trigger="メニュー" items={items} onSelect={onSelect} />);
+
+    await user.click(screen.getByText('メニュー'));
+    await user.click(screen.getByText('編集'));
+
+    expect(onSelect).toHaveBeenCalledWith('1');
+  });
+
+  it('メニュー項目クリック後にメニューが閉じる', async () => {
+    const user = userEvent.setup();
+    render(<Dropdown trigger="メニュー" items={items} onSelect={() => {}} />);
+
+    await user.click(screen.getByText('メニュー'));
+    await user.click(screen.getByText('編集'));
+
+    expect(screen.queryByText('編集')).not.toBeInTheDocument();
+  });
+
+  it('区切り線が表示される', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<Dropdown trigger="メニュー" items={items} onSelect={() => {}} />);
+
+    await user.click(screen.getByText('メニュー'));
+
+    const dividers = container.querySelectorAll('.border-t');
+    expect(dividers.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('無効な項目がクリックできない', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    const disabledItems = [
+      { id: '1', label: '無効', disabled: true },
+    ];
+    render(<Dropdown trigger="メニュー" items={disabledItems} onSelect={onSelect} />);
+
+    await user.click(screen.getByText('メニュー'));
+    await user.click(screen.getByText('無効'));
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('トリガーを再クリックでメニューが閉じる', async () => {
+    const user = userEvent.setup();
+    render(<Dropdown trigger="メニュー" items={items} onSelect={() => {}} />);
+
+    await user.click(screen.getByText('メニュー'));
+    expect(screen.getByText('編集')).toBeInTheDocument();
+
+    await user.click(screen.getByText('メニュー'));
+    expect(screen.queryByText('編集')).not.toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(
+      <Dropdown trigger="メニュー" items={items} onSelect={() => {}} className="custom-class" />
+    );
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('ReactNodeをトリガーに使用できる', () => {
+    render(
+      <Dropdown
+        trigger={<span data-testid="custom-trigger">カスタム</span>}
+        items={items}
+        onSelect={() => {}}
+      />
+    );
+
+    expect(screen.getByTestId('custom-trigger')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- ドロップダウンメニューを表示する汎用Dropdownコンポーネントを追加
- トリガーボタン + メニューリスト構成
- 区切り線、無効項目、外部クリック閉じ
- ReactNodeをトリガーに使用可能
- TDDで開発（10テストケース）

## テスト計画
- [x] トリガーボタン表示
- [x] 初期状態でメニュー非表示
- [x] クリックでメニュー表示
- [x] 項目クリックでコールバック
- [x] 項目クリック後閉じる
- [x] 区切り線表示
- [x] 無効項目
- [x] 再クリックで閉じる
- [x] カスタムクラス名
- [x] ReactNodeトリガー