### PR TITLE
feat: Kbdコンポーネントを追加 (#1870)

### DIFF
--- a/frontend/src/components/common/Kbd.tsx
+++ b/frontend/src/components/common/Kbd.tsx
@@ -1,0 +1,32 @@
+const sizeClasses = {
+  sm: 'text-xs px-1 py-0.5',
+  md: 'text-sm px-1.5 py-0.5',
+  lg: 'text-base px-2 py-1',
+};
+
+interface KbdProps {
+  keys: string[];
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export default function Kbd({
+  keys,
+  size = 'md',
+  className = '',
+}: KbdProps) {
+  return (
+    <span className={`inline-flex items-center gap-1 ${className}`.trim()}>
+      {keys.map((key, index) => (
+        <span key={index} className="inline-flex items-center gap-1">
+          {index > 0 && <span className="text-gray-500">+</span>}
+          <kbd
+            className={`${sizeClasses[size]} rounded border border-gray-600 bg-gray-800 text-gray-300 font-mono shadow-sm`}
+          >
+            {key}
+          </kbd>
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/frontend/src/components/common/__tests__/Kbd.test.tsx
+++ b/frontend/src/components/common/__tests__/Kbd.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Kbd from '../Kbd';
+
+describe('Kbd', () => {
+  it('単一キーが表示される', () => {
+    render(<Kbd keys={['Enter']} />);
+
+    expect(screen.getByText('Enter')).toBeInTheDocument();
+  });
+
+  it('複数キーが+で区切られる', () => {
+    render(<Kbd keys={['Ctrl', 'S']} />);
+
+    expect(screen.getByText('Ctrl')).toBeInTheDocument();
+    expect(screen.getByText('S')).toBeInTheDocument();
+    expect(screen.getByText('+')).toBeInTheDocument();
+  });
+
+  it('kbd要素が使用される', () => {
+    const { container } = render(<Kbd keys={['A']} />);
+
+    expect(container.querySelector('kbd')).toBeInTheDocument();
+  });
+
+  it('smサイズが適用される', () => {
+    const { container } = render(<Kbd keys={['A']} size="sm" />);
+
+    expect(container.querySelector('.text-xs')).toBeInTheDocument();
+  });
+
+  it('lgサイズが適用される', () => {
+    const { container } = render(<Kbd keys={['A']} size="lg" />);
+
+    expect(container.querySelector('.text-base')).toBeInTheDocument();
+  });
+
+  it('キーキャップ風のスタイルが適用される', () => {
+    const { container } = render(<Kbd keys={['A']} />);
+
+    const kbd = container.querySelector('kbd');
+    expect(kbd).toHaveClass('rounded');
+  });
+
+  it('3つのキーの組み合わせが表示される', () => {
+    render(<Kbd keys={['Ctrl', 'Shift', 'P']} />);
+
+    expect(screen.getByText('Ctrl')).toBeInTheDocument();
+    expect(screen.getByText('Shift')).toBeInTheDocument();
+    expect(screen.getByText('P')).toBeInTheDocument();
+    expect(screen.getAllByText('+')).toHaveLength(2);
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Kbd keys={['A']} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('特殊キーが正しく表示される', () => {
+    render(<Kbd keys={['⌘', '⇧', 'K']} />);
+
+    expect(screen.getByText('⌘')).toBeInTheDocument();
+    expect(screen.getByText('⇧')).toBeInTheDocument();
+    expect(screen.getByText('K')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- キーボードショートカットを表示する汎用Kbdコンポーネントを追加
- キーキャップ風のビジュアルスタイル（border、shadow、monospace）
- 複数キーの組み合わせ表示（+区切り）
- 3段階サイズ（sm/md/lg）
- TDDで開発（9テストケース）

## テスト計画
- [x] 単一キー表示
- [x] 複数キー+区切り
- [x] kbd要素使用
- [x] サイズ変更
- [x] キーキャップスタイル
- [x] 3キー組み合わせ
- [x] カスタムクラス名
- [x] 特殊キー表示