### PR TITLE
feat: CountdownTimerコンポーネントを追加 (#1872)

### DIFF
--- a/frontend/src/components/common/CountdownTimer.tsx
+++ b/frontend/src/components/common/CountdownTimer.tsx
@@ -1,0 +1,84 @@
+import { useState, useEffect, useRef } from 'react';
+
+interface CountdownTimerProps {
+  targetDate: string;
+  label?: string;
+  expiredMessage?: string;
+  compact?: boolean;
+  onExpire?: () => void;
+  className?: string;
+}
+
+function calculateTimeLeft(targetDate: string) {
+  const difference = new Date(targetDate).getTime() - Date.now();
+
+  if (difference <= 0) {
+    return { days: 0, hours: 0, minutes: 0, seconds: 0, expired: true };
+  }
+
+  return {
+    days: Math.floor(difference / (1000 * 60 * 60 * 24)),
+    hours: Math.floor((difference / (1000 * 60 * 60)) % 24),
+    minutes: Math.floor((difference / (1000 * 60)) % 60),
+    seconds: Math.floor((difference / 1000) % 60),
+    expired: false,
+  };
+}
+
+export default function CountdownTimer({
+  targetDate,
+  label,
+  expiredMessage = '期限終了',
+  compact = false,
+  onExpire,
+  className = '',
+}: CountdownTimerProps) {
+  const [timeLeft, setTimeLeft] = useState(() => calculateTimeLeft(targetDate));
+  const onExpireCalled = useRef(false);
+
+  useEffect(() => {
+    if (timeLeft.expired && !onExpireCalled.current) {
+      onExpireCalled.current = true;
+      onExpire?.();
+    }
+  }, [timeLeft.expired, onExpire]);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTimeLeft(calculateTimeLeft(targetDate));
+    }, 1000);
+
+    return () => clearInterval(timer);
+  }, [targetDate]);
+
+  if (timeLeft.expired) {
+    return (
+      <div className={`text-gray-400 ${className}`.trim()}>
+        {expiredMessage}
+      </div>
+    );
+  }
+
+  const units = [
+    { value: timeLeft.days, label: '日' },
+    { value: timeLeft.hours, label: '時間' },
+    { value: timeLeft.minutes, label: '分' },
+    { value: timeLeft.seconds, label: '秒' },
+  ];
+
+  return (
+    <div className={`${className}`.trim()}>
+      {label && <div className="text-gray-400 text-sm mb-2">{label}</div>}
+      <div className={`flex items-center gap-3 ${compact ? 'text-sm' : ''}`}>
+        {units.map((unit) => (
+          <div key={unit.label} className="flex items-baseline gap-1">
+            <span className={`font-bold text-white ${compact ? 'text-sm' : 'text-2xl'}`}>
+              {unit.value}
+            </span>
+            <span className="text-gray-400 text-xs">{unit.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/CountdownTimer.test.tsx
+++ b/frontend/src/components/common/__tests__/CountdownTimer.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CountdownTimer from '../CountdownTimer';
+
+describe('CountdownTimer', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-01T00:00:00Z'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('残り日数が表示される', () => {
+    render(<CountdownTimer targetDate="2026-01-11T00:00:00Z" />);
+
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('日')).toBeInTheDocument();
+  });
+
+  it('残り時間が表示される', () => {
+    render(<CountdownTimer targetDate="2026-01-01T05:00:00Z" />);
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('時間')).toBeInTheDocument();
+  });
+
+  it('残り分が表示される', () => {
+    render(<CountdownTimer targetDate="2026-01-01T00:30:00Z" />);
+
+    expect(screen.getByText('30')).toBeInTheDocument();
+    expect(screen.getByText('分')).toBeInTheDocument();
+  });
+
+  it('残り秒が表示される', () => {
+    render(<CountdownTimer targetDate="2026-01-01T00:00:45Z" />);
+
+    expect(screen.getByText('45')).toBeInTheDocument();
+    expect(screen.getByText('秒')).toBeInTheDocument();
+  });
+
+  it('期限切れ時にメッセージが表示される', () => {
+    render(<CountdownTimer targetDate="2025-12-31T00:00:00Z" expiredMessage="期限切れ" />);
+
+    expect(screen.getByText('期限切れ')).toBeInTheDocument();
+  });
+
+  it('デフォルトの期限切れメッセージ', () => {
+    render(<CountdownTimer targetDate="2025-12-31T00:00:00Z" />);
+
+    expect(screen.getByText('期限終了')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<CountdownTimer targetDate="2026-01-02T00:00:00Z" label="締め切りまで" />);
+
+    expect(screen.getByText('締め切りまで')).toBeInTheDocument();
+  });
+
+  it('コンパクトモードで表示される', () => {
+    const { container } = render(
+      <CountdownTimer targetDate="2026-01-02T00:00:00Z" compact />
+    );
+
+    expect(container.querySelector('.text-sm')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(
+      <CountdownTimer targetDate="2026-01-02T00:00:00Z" className="custom-class" />
+    );
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('onExpireコールバックが呼ばれる', () => {
+    const onExpire = vi.fn();
+    render(<CountdownTimer targetDate="2025-12-31T00:00:00Z" onExpire={onExpire} />);
+
+    expect(onExpire).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要
- カウントダウンタイマーを表示する汎用CountdownTimerコンポーネントを追加
- 目標日時までの残り時間を日/時/分/秒で表示
- 期限切れ時のカスタムメッセージ、onExpireコールバック
- コンパクト表示モード、ラベル付き
- TDDで開発（10テストケース）

## テスト計画
- [x] 残り日数表示
- [x] 残り時間表示
- [x] 残り分表示
- [x] 残り秒表示
- [x] 期限切れメッセージ
- [x] デフォルト期限切れメッセージ
- [x] ラベル表示
- [x] コンパクトモード
- [x] カスタムクラス名
- [x] onExpireコールバック