### PR TITLE
feat: CopyButtonコンポーネントを追加 (#1874)

### DIFF
--- a/frontend/src/components/common/CopyButton.tsx
+++ b/frontend/src/components/common/CopyButton.tsx
@@ -1,0 +1,45 @@
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CopyButtonProps {
+  text: string;
+  label?: string;
+  successLabel?: string;
+  onCopy?: () => void;
+  className?: string;
+}
+
+export default function CopyButton({
+  text,
+  label,
+  successLabel,
+  onCopy,
+  className = '',
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    onCopy?.();
+
+    setTimeout(() => {
+      setCopied(false);
+    }, 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className={`inline-flex items-center gap-2 px-3 py-1.5 text-sm text-gray-300 hover:text-white bg-gray-800 hover:bg-gray-700 border border-gray-700 rounded-lg transition-colors ${className}`.trim()}
+    >
+      {copied ? (
+        <Check className="w-4 h-4 text-green-400" />
+      ) : (
+        <Copy className="w-4 h-4" />
+      )}
+      {label && !copied && <span>{label}</span>}
+      {successLabel && copied && <span>{successLabel}</span>}
+    </button>
+  );
+}

--- a/frontend/src/components/common/__tests__/CopyButton.test.tsx
+++ b/frontend/src/components/common/__tests__/CopyButton.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CopyButton from '../CopyButton';
+
+describe('CopyButton', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('コピーボタンが表示される', () => {
+    render(<CopyButton text="コピーするテキスト" />);
+
+    expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('コピーアイコンが表示される', () => {
+    const { container } = render(<CopyButton text="テスト" />);
+
+    expect(container.querySelector('.lucide-copy')).toBeInTheDocument();
+  });
+
+  it('クリックでクリップボードにコピーされる', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CopyButton text="コピーテキスト" />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('コピーテキスト');
+  });
+
+  it('コピー成功後にチェックアイコンが表示される', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const { container } = render(<CopyButton text="テスト" />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(container.querySelector('.lucide-check')).toBeInTheDocument();
+  });
+
+  it('一定時間後に元のアイコンに戻る', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const { container } = render(<CopyButton text="テスト" />);
+
+    await user.click(screen.getByRole('button'));
+    expect(container.querySelector('.lucide-check')).toBeInTheDocument();
+
+    vi.advanceTimersByTime(2000);
+
+    expect(container.querySelector('.lucide-copy')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<CopyButton text="テスト" label="コピー" />);
+
+    expect(screen.getByText('コピー')).toBeInTheDocument();
+  });
+
+  it('コピー成功後にラベルが変わる', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CopyButton text="テスト" label="コピー" successLabel="コピー済み" />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(screen.getByText('コピー済み')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<CopyButton text="テスト" className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('onCopyコールバックが呼ばれる', async () => {
+    const onCopy = vi.fn();
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CopyButton text="テスト" onCopy={onCopy} />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onCopy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 概要
- テキストをクリップボードにコピーするCopyButtonコンポーネントを追加
- コピー成功時にチェックアイコンへ切り替え、2秒後に自動復帰
- カスタムラベル、成功時ラベル切り替え
- onCopyコールバック対応
- TDDで開発（9テストケース）

## テスト計画
- [x] ボタン表示
- [x] コピーアイコン表示
- [x] クリップボードコピー
- [x] 成功チェックアイコン
- [x] 自動復帰
- [x] ラベル表示
- [x] 成功ラベル切り替え
- [x] カスタムクラス名
- [x] onCopyコールバック