### PR TITLE
feat: StatCardコンポーネントを追加 (#1876)

### DIFF
--- a/frontend/src/components/common/StatCard.tsx
+++ b/frontend/src/components/common/StatCard.tsx
@@ -1,0 +1,63 @@
+import { TrendingUp, TrendingDown, BarChart3, Clock, Users, FileText } from 'lucide-react';
+
+const iconMap = {
+  'trending-up': TrendingUp,
+  'trending-down': TrendingDown,
+  'bar-chart': BarChart3,
+  clock: Clock,
+  users: Users,
+  file: FileText,
+};
+
+interface StatCardProps {
+  value: number;
+  label: string;
+  icon?: keyof typeof iconMap;
+  change?: number;
+  formatted?: string;
+  suffix?: string;
+  className?: string;
+}
+
+export default function StatCard({
+  value,
+  label,
+  icon,
+  change,
+  formatted,
+  suffix,
+  className = '',
+}: StatCardProps) {
+  const IconComponent = icon ? iconMap[icon] : null;
+
+  const changeColor =
+    change === undefined
+      ? ''
+      : change > 0
+        ? 'text-green-400'
+        : change < 0
+          ? 'text-red-400'
+          : 'text-gray-400';
+
+  return (
+    <div className={`bg-gray-900 border border-gray-800 rounded-lg p-6 ${className}`.trim()}>
+      <div className="flex items-center justify-between mb-4">
+        <span className="text-sm text-gray-400">{label}</span>
+        {IconComponent && (
+          <IconComponent className="w-5 h-5 text-gray-500" />
+        )}
+      </div>
+      <div className="flex items-baseline gap-2">
+        <span className="text-3xl font-bold text-white">
+          {formatted ?? value}
+        </span>
+        {suffix && <span className="text-sm text-gray-400">{suffix}</span>}
+      </div>
+      {change !== undefined && (
+        <div className={`mt-2 text-sm ${changeColor}`}>
+          {change > 0 ? '+' : ''}{change}%
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/StatCard.test.tsx
+++ b/frontend/src/components/common/__tests__/StatCard.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import StatCard from '../StatCard';
+
+describe('StatCard', () => {
+  it('数値が表示される', () => {
+    render(<StatCard value={1234} label="合計学習時間" />);
+
+    expect(screen.getByText('1234')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<StatCard value={100} label="投稿数" />);
+
+    expect(screen.getByText('投稿数')).toBeInTheDocument();
+  });
+
+  it('アイコンが表示される', () => {
+    const { container } = render(<StatCard value={100} label="投稿数" icon="trending-up" />);
+
+    expect(container.querySelector('.lucide-trending-up')).toBeInTheDocument();
+  });
+
+  it('増加の変化率が表示される', () => {
+    render(<StatCard value={100} label="投稿数" change={12.5} />);
+
+    expect(screen.getByText('+12.5%')).toBeInTheDocument();
+  });
+
+  it('減少の変化率が表示される', () => {
+    render(<StatCard value={100} label="投稿数" change={-5.3} />);
+
+    expect(screen.getByText('-5.3%')).toBeInTheDocument();
+  });
+
+  it('増加はグリーンカラー', () => {
+    const { container } = render(<StatCard value={100} label="投稿数" change={10} />);
+
+    expect(container.querySelector('.text-green-400')).toBeInTheDocument();
+  });
+
+  it('減少はレッドカラー', () => {
+    const { container } = render(<StatCard value={100} label="投稿数" change={-10} />);
+
+    expect(container.querySelector('.text-red-400')).toBeInTheDocument();
+  });
+
+  it('変化率0はグレーカラー', () => {
+    const { container } = render(<StatCard value={100} label="投稿数" change={0} />);
+
+    expect(container.querySelector('.text-gray-400')).toBeInTheDocument();
+  });
+
+  it('フォーマットされた数値が表示される', () => {
+    render(<StatCard value={1234567} label="合計" formatted="1,234,567" />);
+
+    expect(screen.getByText('1,234,567')).toBeInTheDocument();
+  });
+
+  it('サフィックスが表示される', () => {
+    render(<StatCard value={120} label="学習時間" suffix="時間" />);
+
+    expect(screen.getByText('時間')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<StatCard value={100} label="投稿数" className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 統計情報をカード形式で表示する汎用StatCardコンポーネントを追加
- 数値、ラベル、アイコン、変化率の表示
- 増加=緑、減少=赤、変化なし=グレーのトレンドカラー
- フォーマット済み数値、サフィックス対応
- TDDで開発（11テストケース）

## テスト計画
- [x] 数値表示
- [x] ラベル表示
- [x] アイコン表示
- [x] 増加/減少の変化率
- [x] トレンドカラー
- [x] フォーマット済み数値
- [x] サフィックス
- [x] カスタムクラス名