### PR TITLE
feat: CharacterCountコンポーネントを追加 (#1878)

### DIFF
--- a/frontend/src/components/common/CharacterCount.tsx
+++ b/frontend/src/components/common/CharacterCount.tsx
@@ -1,0 +1,48 @@
+interface CharacterCountProps {
+  current: number;
+  max: number;
+  showBar?: boolean;
+  showRemaining?: boolean;
+  className?: string;
+}
+
+export default function CharacterCount({
+  current,
+  max,
+  showBar = false,
+  showRemaining = false,
+  className = '',
+}: CharacterCountProps) {
+  const percentage = (current / max) * 100;
+  const isOver = current > max;
+  const isWarning = percentage >= 80 && !isOver;
+
+  const textColor = isOver ? 'text-red-400' : isWarning ? 'text-yellow-400' : 'text-gray-400';
+  const barColor = isOver ? 'bg-red-400' : isWarning ? 'bg-yellow-400' : 'bg-blue-400';
+
+  return (
+    <div className={`${className}`.trim()}>
+      <div className={`flex items-center gap-1 text-xs ${textColor}`}>
+        {showRemaining ? (
+          <>
+            <span>{max - current}</span>
+            <span>残り</span>
+          </>
+        ) : (
+          <>
+            <span>{current}</span>
+            <span>/ {max}</span>
+          </>
+        )}
+      </div>
+      {showBar && (
+        <div className="h-1 bg-gray-700 rounded-full mt-1 overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${barColor}`}
+            style={{ width: `${Math.min(percentage, 100)}%` }}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/CharacterCount.test.tsx
+++ b/frontend/src/components/common/__tests__/CharacterCount.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CharacterCount from '../CharacterCount';
+
+describe('CharacterCount', () => {
+  it('現在の文字数が表示される', () => {
+    render(<CharacterCount current={50} max={200} />);
+
+    expect(screen.getByText('50')).toBeInTheDocument();
+  });
+
+  it('最大文字数が表示される', () => {
+    render(<CharacterCount current={50} max={200} />);
+
+    expect(screen.getByText('/ 200')).toBeInTheDocument();
+  });
+
+  it('文字数超過時に警告色が適用される', () => {
+    const { container } = render(<CharacterCount current={250} max={200} />);
+
+    expect(container.querySelector('.text-red-400')).toBeInTheDocument();
+  });
+
+  it('80%以上で注意色が適用される', () => {
+    const { container } = render(<CharacterCount current={170} max={200} />);
+
+    expect(container.querySelector('.text-yellow-400')).toBeInTheDocument();
+  });
+
+  it('80%未満で通常色が適用される', () => {
+    const { container } = render(<CharacterCount current={50} max={200} />);
+
+    expect(container.querySelector('.text-gray-400')).toBeInTheDocument();
+  });
+
+  it('プログレスバーが表示される', () => {
+    const { container } = render(<CharacterCount current={100} max={200} showBar />);
+
+    const bar = container.querySelector('.h-1');
+    expect(bar).toBeInTheDocument();
+  });
+
+  it('プログレスバーの幅が正しい', () => {
+    const { container } = render(<CharacterCount current={100} max={200} showBar />);
+
+    const progress = container.querySelector('[style*="width: 50%"]');
+    expect(progress).toBeInTheDocument();
+  });
+
+  it('残り文字数モードが表示される', () => {
+    render(<CharacterCount current={50} max={200} showRemaining />);
+
+    expect(screen.getByText('150')).toBeInTheDocument();
+    expect(screen.getByText('残り')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<CharacterCount current={50} max={200} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('文字数が0の場合も表示される', () => {
+    render(<CharacterCount current={0} max={200} />);
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- テキスト入力の文字数を表示するCharacterCountコンポーネントを追加
- 80%以上で黄色、超過で赤色の段階的警告カラー
- オプショナルなプログレスバー表示
- 残り文字数モード対応
- TDDで開発（10テストケース）

## テスト計画
- [x] 現在の文字数表示
- [x] 最大文字数表示
- [x] 超過時警告色
- [x] 80%以上注意色
- [x] 通常色
- [x] プログレスバー
- [x] バー幅の正確性
- [x] 残り文字数モード
- [x] カスタムクラス名
- [x] 文字数0の処理