### PR TITLE
feat: FileUploadコンポーネントを追加 (#1880)

### DIFF
--- a/frontend/src/components/common/FileUpload.tsx
+++ b/frontend/src/components/common/FileUpload.tsx
@@ -1,0 +1,70 @@
+import { useState, useRef } from 'react';
+import { UploadCloud } from 'lucide-react';
+
+interface FileUploadProps {
+  onUpload: (files: File[]) => void;
+  accept?: string;
+  multiple?: boolean;
+  maxSizeMB?: number;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function FileUpload({
+  onUpload,
+  accept,
+  multiple = false,
+  maxSizeMB,
+  disabled = false,
+  className = '',
+}: FileUploadProps) {
+  const [isDragOver, setIsDragOver] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleFiles = (files: FileList | null) => {
+    if (!files || disabled) return;
+    onUpload(Array.from(files));
+  };
+
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    if (!disabled) {
+      handleFiles(e.dataTransfer.files);
+    }
+  };
+
+  return (
+    <div className={`${className}`.trim()}>
+      <div
+        data-testid="drop-zone"
+        onClick={() => !disabled && inputRef.current?.click()}
+        onDragOver={(e) => { e.preventDefault(); setIsDragOver(true); }}
+        onDragLeave={() => setIsDragOver(false)}
+        onDrop={handleDrop}
+        className={`flex flex-col items-center justify-center p-8 border-2 border-dashed rounded-lg cursor-pointer transition-colors ${
+          isDragOver ? 'border-blue-500 bg-blue-500/10' : 'border-gray-700 hover:border-gray-600'
+        } ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+      >
+        <UploadCloud className="w-10 h-10 text-gray-500 mb-3" />
+        <p className="text-sm text-gray-300 mb-1">ファイルをドラッグ&ドロップ</p>
+        <p className="text-xs text-gray-500">またはクリックして選択</p>
+        {accept && (
+          <p className="text-xs text-gray-500 mt-2">{accept}</p>
+        )}
+        {maxSizeMB && (
+          <p className="text-xs text-gray-500 mt-1">最大 {maxSizeMB}MB</p>
+        )}
+      </div>
+      <input
+        ref={inputRef}
+        type="file"
+        accept={accept}
+        multiple={multiple}
+        disabled={disabled}
+        onChange={(e) => handleFiles(e.target.files)}
+        className="hidden"
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/FileUpload.test.tsx
+++ b/frontend/src/components/common/__tests__/FileUpload.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FileUpload from '../FileUpload';
+
+describe('FileUpload', () => {
+  it('アップロードエリアが表示される', () => {
+    render(<FileUpload onUpload={() => {}} />);
+
+    expect(screen.getByText('ファイルをドラッグ&ドロップ')).toBeInTheDocument();
+  });
+
+  it('アップロードアイコンが表示される', () => {
+    const { container } = render(<FileUpload onUpload={() => {}} />);
+
+    expect(container.querySelector('.lucide-upload-cloud')).toBeInTheDocument();
+  });
+
+  it('クリックでファイル選択ができる', () => {
+    const { container } = render(<FileUpload onUpload={() => {}} />);
+
+    const input = container.querySelector('input[type="file"]');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('ファイル選択時にコールバックが呼ばれる', async () => {
+    const onUpload = vi.fn();
+    const { container } = render(<FileUpload onUpload={onUpload} />);
+
+    const input = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['test'], 'test.txt', { type: 'text/plain' });
+
+    fireEvent.change(input, { target: { files: [file] } });
+
+    expect(onUpload).toHaveBeenCalledWith([file]);
+  });
+
+  it('複数ファイルが選択できる', () => {
+    const { container } = render(<FileUpload onUpload={() => {}} multiple />);
+
+    const input = container.querySelector('input[type="file"]');
+    expect(input).toHaveAttribute('multiple');
+  });
+
+  it('ファイルタイプが制限される', () => {
+    const { container } = render(<FileUpload onUpload={() => {}} accept=".jpg,.png" />);
+
+    const input = container.querySelector('input[type="file"]');
+    expect(input).toHaveAttribute('accept', '.jpg,.png');
+  });
+
+  it('許可されたファイル形式が表示される', () => {
+    render(<FileUpload onUpload={() => {}} accept=".jpg,.png" />);
+
+    expect(screen.getByText('.jpg,.png')).toBeInTheDocument();
+  });
+
+  it('最大ファイルサイズが表示される', () => {
+    render(<FileUpload onUpload={() => {}} maxSizeMB={5} />);
+
+    expect(screen.getByText('最大 5MB')).toBeInTheDocument();
+  });
+
+  it('ドラッグオーバーでハイライトされる', () => {
+    const { container } = render(<FileUpload onUpload={() => {}} />);
+
+    const dropZone = container.querySelector('[data-testid="drop-zone"]')!;
+    fireEvent.dragOver(dropZone);
+
+    expect(dropZone).toHaveClass('border-blue-500');
+  });
+
+  it('ドラッグリーブでハイライトが解除される', () => {
+    const { container } = render(<FileUpload onUpload={() => {}} />);
+
+    const dropZone = container.querySelector('[data-testid="drop-zone"]')!;
+    fireEvent.dragOver(dropZone);
+    fireEvent.dragLeave(dropZone);
+
+    expect(dropZone).not.toHaveClass('border-blue-500');
+  });
+
+  it('無効状態が適用される', () => {
+    const { container } = render(<FileUpload onUpload={() => {}} disabled />);
+
+    expect(container.querySelector('.opacity-50')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<FileUpload onUpload={() => {}} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- ドラッグ&ドロップ対応のFileUploadコンポーネントを追加
- クリックでファイル選択ダイアログ表示
- ファイルタイプ制限、最大サイズ表示、複数ファイル対応
- ドラッグオーバー時のハイライトフィードバック
- TDDで開発（12テストケース）

## テスト計画
- [x] アップロードエリア表示
- [x] アイコン表示
- [x] ファイル選択input
- [x] ファイル選択コールバック
- [x] 複数ファイル
- [x] ファイルタイプ制限
- [x] 許可形式表示
- [x] 最大サイズ表示
- [x] ドラッグオーバーハイライト
- [x] ドラッグリーブ解除
- [x] 無効状態
- [x] カスタムクラス名