### PR TITLE
feat: Timelineコンポーネントを追加 (#1882)

### DIFF
--- a/frontend/src/components/common/Timeline.tsx
+++ b/frontend/src/components/common/Timeline.tsx
@@ -1,0 +1,53 @@
+import { ReactNode } from 'react';
+
+interface TimelineEvent {
+  id: string;
+  title: string;
+  date: string;
+  description?: string;
+  content?: ReactNode;
+  active?: boolean;
+}
+
+interface TimelineProps {
+  events: TimelineEvent[];
+  className?: string;
+}
+
+export default function Timeline({
+  events,
+  className = '',
+}: TimelineProps) {
+  return (
+    <div className={`relative ${className}`.trim()}>
+      {events.map((event, index) => {
+        const isLast = index === events.length - 1;
+
+        return (
+          <div key={event.id} className="flex gap-4">
+            <div className="flex flex-col items-center">
+              <div
+                className={`w-3 h-3 rounded-full flex-shrink-0 ${
+                  event.active ? 'bg-blue-500' : 'bg-gray-600'
+                }`}
+              />
+              {!isLast && (
+                <div className="w-0.5 flex-1 bg-gray-700 min-h-[2rem]" />
+              )}
+            </div>
+            <div className="pb-6">
+              <span className="text-xs text-gray-500">{event.date}</span>
+              <h4 className={`text-sm font-medium ${event.active ? 'text-white' : 'text-gray-300'}`}>
+                {event.title}
+              </h4>
+              {event.description && (
+                <p className="text-xs text-gray-500 mt-1">{event.description}</p>
+              )}
+              {event.content}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Timeline.test.tsx
+++ b/frontend/src/components/common/__tests__/Timeline.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import Timeline from '../Timeline';
+
+const events = [
+  { id: '1', title: 'プロジェクト開始', date: '2026-01-01', description: '初回ミーティング' },
+  { id: '2', title: '設計完了', date: '2026-01-15' },
+  { id: '3', title: 'リリース', date: '2026-02-01', active: true },
+];
+
+describe('Timeline', () => {
+  it('全てのイベントタイトルが表示される', () => {
+    render(<Timeline events={events} />);
+
+    expect(screen.getByText('プロジェクト開始')).toBeInTheDocument();
+    expect(screen.getByText('設計完了')).toBeInTheDocument();
+    expect(screen.getByText('リリース')).toBeInTheDocument();
+  });
+
+  it('日付が表示される', () => {
+    render(<Timeline events={events} />);
+
+    expect(screen.getByText('2026-01-01')).toBeInTheDocument();
+    expect(screen.getByText('2026-01-15')).toBeInTheDocument();
+  });
+
+  it('説明文が表示される', () => {
+    render(<Timeline events={events} />);
+
+    expect(screen.getByText('初回ミーティング')).toBeInTheDocument();
+  });
+
+  it('アクティブなイベントがハイライトされる', () => {
+    const { container } = render(<Timeline events={events} />);
+
+    const activeDots = container.querySelectorAll('.bg-blue-500');
+    expect(activeDots.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('非アクティブなイベントはグレー', () => {
+    const { container } = render(<Timeline events={events} />);
+
+    const grayDots = container.querySelectorAll('.bg-gray-600');
+    expect(grayDots.length).toBe(2);
+  });
+
+  it('接続線が表示される', () => {
+    const { container } = render(<Timeline events={events} />);
+
+    const lines = container.querySelectorAll('.w-0\\.5');
+    expect(lines.length).toBe(2);
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Timeline events={events} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('単一イベントでも表示される', () => {
+    render(<Timeline events={[{ id: '1', title: '唯一', date: '2026-01-01' }]} />);
+
+    expect(screen.getByText('唯一')).toBeInTheDocument();
+  });
+
+  it('ReactNodeをコンテンツに使用できる', () => {
+    const richEvents = [
+      { id: '1', title: 'リッチ', date: '2026-01-01', content: <span data-testid="rich">カスタム</span> },
+    ];
+    render(<Timeline events={richEvents} />);
+
+    expect(screen.getByTestId('rich')).toBeInTheDocument();
+  });
+
+  it('ドットが全イベントに表示される', () => {
+    const { container } = render(<Timeline events={events} />);
+
+    const dots = container.querySelectorAll('.rounded-full');
+    expect(dots.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## 概要
- 時系列イベントを表示する汎用Timelineコンポーネントを追加
- 縦方向タイムライン、ドットと接続線
- アクティブ状態のハイライト（青/白）
- 日時、説明文、ReactNodeカスタムコンテンツ対応
- TDDで開発（10テストケース）

## テスト計画
- [x] 全イベントタイトル表示
- [x] 日付表示
- [x] 説明文表示
- [x] アクティブハイライト
- [x] 非アクティブグレー
- [x] 接続線
- [x] カスタムクラス名
- [x] 単一イベント
- [x] ReactNodeコンテンツ
- [x] ドット表示