### PR TITLE
feat: TextTruncateコンポーネントを追加 (#1884)

### DIFF
--- a/frontend/src/components/common/TextTruncate.tsx
+++ b/frontend/src/components/common/TextTruncate.tsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+
+interface TextTruncateProps {
+  text: string;
+  maxLength?: number;
+  expandLabel?: string;
+  collapseLabel?: string;
+  className?: string;
+}
+
+export default function TextTruncate({
+  text,
+  maxLength = 200,
+  expandLabel = 'もっと見る',
+  collapseLabel = '閉じる',
+  className = '',
+}: TextTruncateProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const shouldTruncate = text.length > maxLength;
+
+  return (
+    <div className={`${className}`.trim()}>
+      <span className="text-gray-300">
+        {isExpanded || !shouldTruncate ? text : text.slice(0, maxLength)}
+        {!isExpanded && shouldTruncate && <span>...</span>}
+      </span>
+      {shouldTruncate && (
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="ml-1 text-sm text-blue-400 hover:text-blue-300 transition-colors"
+        >
+          {isExpanded ? collapseLabel : expandLabel}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/TextTruncate.test.tsx
+++ b/frontend/src/components/common/__tests__/TextTruncate.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TextTruncate from '../TextTruncate';
+
+const longText = 'これは非常に長いテキストです。省略表示のテストに使用します。このテキストは十分に長い必要があります。さらに長くするために追加のテキストを入れます。まだまだ続きます。';
+
+describe('TextTruncate', () => {
+  it('テキストが表示される', () => {
+    render(<TextTruncate text="短いテキスト" />);
+
+    expect(screen.getByText('短いテキスト')).toBeInTheDocument();
+  });
+
+  it('文字数制限でテキストが省略される', () => {
+    render(<TextTruncate text={longText} maxLength={20} />);
+
+    expect(screen.getByText(/これは非常に長いテキストです。省略/)).toBeInTheDocument();
+    expect(screen.getByText('...')).toBeInTheDocument();
+  });
+
+  it('展開ボタンが表示される', () => {
+    render(<TextTruncate text={longText} maxLength={20} />);
+
+    expect(screen.getByText('もっと見る')).toBeInTheDocument();
+  });
+
+  it('展開ボタンクリックで全文表示', async () => {
+    const user = userEvent.setup();
+    render(<TextTruncate text={longText} maxLength={20} />);
+
+    await user.click(screen.getByText('もっと見る'));
+
+    expect(screen.getByText(longText)).toBeInTheDocument();
+  });
+
+  it('折りたたみボタンが表示される', async () => {
+    const user = userEvent.setup();
+    render(<TextTruncate text={longText} maxLength={20} />);
+
+    await user.click(screen.getByText('もっと見る'));
+
+    expect(screen.getByText('閉じる')).toBeInTheDocument();
+  });
+
+  it('折りたたみボタンクリックで省略表示に戻る', async () => {
+    const user = userEvent.setup();
+    render(<TextTruncate text={longText} maxLength={20} />);
+
+    await user.click(screen.getByText('もっと見る'));
+    await user.click(screen.getByText('閉じる'));
+
+    expect(screen.getByText('もっと見る')).toBeInTheDocument();
+  });
+
+  it('短いテキストでは展開ボタンが表示されない', () => {
+    render(<TextTruncate text="短い" maxLength={100} />);
+
+    expect(screen.queryByText('もっと見る')).not.toBeInTheDocument();
+  });
+
+  it('カスタム展開ラベルが使用される', () => {
+    render(<TextTruncate text={longText} maxLength={20} expandLabel="続きを読む" />);
+
+    expect(screen.getByText('続きを読む')).toBeInTheDocument();
+  });
+
+  it('カスタム折りたたみラベルが使用される', async () => {
+    const user = userEvent.setup();
+    render(<TextTruncate text={longText} maxLength={20} collapseLabel="少なく表示" />);
+
+    await user.click(screen.getByText('もっと見る'));
+
+    expect(screen.getByText('少なく表示')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<TextTruncate text="テスト" className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 長いテキストを省略表示するTextTruncateコンポーネントを追加
- 文字数制限での省略（...表示）
- 展開/折りたたみボタン
- カスタム展開/折りたたみラベル
- TDDで開発（10テストケース）

## テスト計画
- [x] テキスト表示
- [x] 文字数制限で省略
- [x] 展開ボタン表示
- [x] クリックで全文表示
- [x] 折りたたみボタン
- [x] 折りたたみで省略に戻る
- [x] 短いテキストでボタン非表示
- [x] カスタムラベル
- [x] カスタムクラス名