### PR TITLE
feat: ColorPickerコンポーネントを追加 (#1886)

### DIFF
--- a/frontend/src/components/common/ColorPicker.tsx
+++ b/frontend/src/components/common/ColorPicker.tsx
@@ -1,0 +1,58 @@
+const DEFAULT_COLORS = [
+  '#ef4444', '#f97316', '#eab308', '#22c55e', '#14b8a6',
+  '#3b82f6', '#6366f1', '#a855f7', '#ec4899', '#6b7280',
+];
+
+const sizeMap = {
+  sm: 'w-6 h-6',
+  md: 'w-8 h-8',
+  lg: 'w-10 h-10',
+};
+
+interface ColorPickerProps {
+  value: string;
+  onChange: (color: string) => void;
+  colors?: string[];
+  showInput?: boolean;
+  label?: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+export default function ColorPicker({
+  value,
+  onChange,
+  colors = DEFAULT_COLORS,
+  showInput = false,
+  label,
+  size = 'md',
+  className = '',
+}: ColorPickerProps) {
+  return (
+    <div className={`${className}`.trim()}>
+      {label && <label className="block text-sm text-gray-400 mb-2">{label}</label>}
+      <div className="flex flex-wrap gap-2">
+        {colors.map((color) => (
+          <button
+            key={color}
+            type="button"
+            data-testid="color-swatch"
+            onClick={() => onChange(color)}
+            className={`${sizeMap[size]} rounded-full cursor-pointer transition-all ${
+              value === color ? 'ring-2 ring-white ring-offset-2 ring-offset-gray-900' : ''
+            }`}
+            style={{ backgroundColor: color }}
+          />
+        ))}
+      </div>
+      {showInput && (
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="mt-3 w-full px-3 py-1.5 bg-gray-800 border border-gray-700 rounded text-sm text-gray-200 font-mono focus:outline-none focus:border-blue-500"
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/ColorPicker.test.tsx
+++ b/frontend/src/components/common/__tests__/ColorPicker.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ColorPicker from '../ColorPicker';
+
+describe('ColorPicker', () => {
+  it('プリセットカラーが表示される', () => {
+    const { container } = render(<ColorPicker value="#ef4444" onChange={() => {}} />);
+
+    const swatches = container.querySelectorAll('[data-testid="color-swatch"]');
+    expect(swatches.length).toBeGreaterThan(0);
+  });
+
+  it('選択中の色がハイライトされる', () => {
+    const { container } = render(<ColorPicker value="#ef4444" onChange={() => {}} />);
+
+    const selected = container.querySelector('.ring-2');
+    expect(selected).toBeInTheDocument();
+  });
+
+  it('色をクリックで選択できる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(<ColorPicker value="#ef4444" onChange={onChange} />);
+
+    const swatches = container.querySelectorAll('[data-testid="color-swatch"]');
+    await user.click(swatches[1]);
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('カスタムカラー入力が表示される', () => {
+    render(<ColorPicker value="#ef4444" onChange={() => {}} showInput />);
+
+    expect(screen.getByDisplayValue('#ef4444')).toBeInTheDocument();
+  });
+
+  it('カスタムカラーを入力できる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ColorPicker value="#ef4444" onChange={onChange} showInput />);
+
+    const input = screen.getByDisplayValue('#ef4444');
+    await user.clear(input);
+    await user.type(input, '#000000');
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<ColorPicker value="#ef4444" onChange={() => {}} label="テーマカラー" />);
+
+    expect(screen.getByText('テーマカラー')).toBeInTheDocument();
+  });
+
+  it('カスタムカラーパレットが使用される', () => {
+    const colors = ['#ff0000', '#00ff00', '#0000ff'];
+    const { container } = render(<ColorPicker value="#ff0000" onChange={() => {}} colors={colors} />);
+
+    const swatches = container.querySelectorAll('[data-testid="color-swatch"]');
+    expect(swatches.length).toBe(3);
+  });
+
+  it('smサイズが適用される', () => {
+    const { container } = render(<ColorPicker value="#ef4444" onChange={() => {}} size="sm" />);
+
+    expect(container.querySelector('.w-6')).toBeInTheDocument();
+  });
+
+  it('lgサイズが適用される', () => {
+    const { container } = render(<ColorPicker value="#ef4444" onChange={() => {}} size="lg" />);
+
+    expect(container.querySelector('.w-10')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<ColorPicker value="#ef4444" onChange={() => {}} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 色を選択するカラーピッカーコンポーネントを追加
- 10色のデフォルトパレット、カスタムパレット対応
- 選択中の色をリングでハイライト
- テキスト入力でのカスタムカラー指定
- 3段階サイズ（sm/md/lg）
- TDDで開発（10テストケース）

## テスト計画
- [x] プリセットカラー表示
- [x] 選択ハイライト
- [x] クリック選択
- [x] カスタム入力表示
- [x] カスタム入力
- [x] ラベル表示
- [x] カスタムパレット
- [x] サイズ変更
- [x] カスタムクラス名