### PR TITLE
feat: SortableListコンポーネントを追加 (#1888)

### DIFF
--- a/frontend/src/components/common/SortableList.tsx
+++ b/frontend/src/components/common/SortableList.tsx
@@ -1,0 +1,71 @@
+import { ChevronUp, ChevronDown, GripVertical, X } from 'lucide-react';
+
+interface SortableItem {
+  id: string;
+  label: string;
+}
+
+interface SortableListProps {
+  items: SortableItem[];
+  onReorder: (items: SortableItem[]) => void;
+  onRemove?: (id: string) => void;
+  className?: string;
+}
+
+export default function SortableList({
+  items,
+  onReorder,
+  onRemove,
+  className = '',
+}: SortableListProps) {
+  const moveItem = (index: number, direction: 'up' | 'down') => {
+    const newItems = [...items];
+    const targetIndex = direction === 'up' ? index - 1 : index + 1;
+    [newItems[index], newItems[targetIndex]] = [newItems[targetIndex], newItems[index]];
+    onReorder(newItems);
+  };
+
+  return (
+    <div className={`space-y-1 ${className}`.trim()}>
+      {items.map((item, index) => (
+        <div
+          key={item.id}
+          className="flex items-center gap-2 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg"
+        >
+          <GripVertical className="w-4 h-4 text-gray-500 flex-shrink-0" />
+          <span className="flex-1 text-sm text-gray-200">{item.label}</span>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              data-testid="move-up"
+              disabled={index === 0}
+              onClick={() => moveItem(index, 'up')}
+              className="p-1 text-gray-400 hover:text-white disabled:text-gray-700 disabled:cursor-not-allowed"
+            >
+              <ChevronUp className="w-4 h-4" />
+            </button>
+            <button
+              type="button"
+              data-testid="move-down"
+              disabled={index === items.length - 1}
+              onClick={() => moveItem(index, 'down')}
+              className="p-1 text-gray-400 hover:text-white disabled:text-gray-700 disabled:cursor-not-allowed"
+            >
+              <ChevronDown className="w-4 h-4" />
+            </button>
+            {onRemove && (
+              <button
+                type="button"
+                data-testid="remove-item"
+                onClick={() => onRemove(item.id)}
+                className="p-1 text-gray-400 hover:text-red-400"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/SortableList.test.tsx
+++ b/frontend/src/components/common/__tests__/SortableList.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SortableList from '../SortableList';
+
+const items = [
+  { id: '1', label: 'アイテム1' },
+  { id: '2', label: 'アイテム2' },
+  { id: '3', label: 'アイテム3' },
+];
+
+describe('SortableList', () => {
+  it('全てのアイテムが表示される', () => {
+    render(<SortableList items={items} onReorder={() => {}} />);
+
+    expect(screen.getByText('アイテム1')).toBeInTheDocument();
+    expect(screen.getByText('アイテム2')).toBeInTheDocument();
+    expect(screen.getByText('アイテム3')).toBeInTheDocument();
+  });
+
+  it('上移動ボタンが表示される', () => {
+    const { container } = render(<SortableList items={items} onReorder={() => {}} />);
+
+    const upButtons = container.querySelectorAll('.lucide-chevron-up');
+    expect(upButtons.length).toBeGreaterThan(0);
+  });
+
+  it('下移動ボタンが表示される', () => {
+    const { container } = render(<SortableList items={items} onReorder={() => {}} />);
+
+    const downButtons = container.querySelectorAll('.lucide-chevron-down');
+    expect(downButtons.length).toBeGreaterThan(0);
+  });
+
+  it('上移動でアイテムが上に移動する', async () => {
+    const onReorder = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(<SortableList items={items} onReorder={onReorder} />);
+
+    const upButtons = container.querySelectorAll('[data-testid="move-up"]');
+    await user.click(upButtons[1]);
+
+    expect(onReorder).toHaveBeenCalledWith([
+      { id: '2', label: 'アイテム2' },
+      { id: '1', label: 'アイテム1' },
+      { id: '3', label: 'アイテム3' },
+    ]);
+  });
+
+  it('下移動でアイテムが下に移動する', async () => {
+    const onReorder = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(<SortableList items={items} onReorder={onReorder} />);
+
+    const downButtons = container.querySelectorAll('[data-testid="move-down"]');
+    await user.click(downButtons[0]);
+
+    expect(onReorder).toHaveBeenCalledWith([
+      { id: '2', label: 'アイテム2' },
+      { id: '1', label: 'アイテム1' },
+      { id: '3', label: 'アイテム3' },
+    ]);
+  });
+
+  it('先頭アイテムの上移動ボタンが無効', () => {
+    const { container } = render(<SortableList items={items} onReorder={() => {}} />);
+
+    const upButtons = container.querySelectorAll('[data-testid="move-up"]');
+    expect(upButtons[0]).toBeDisabled();
+  });
+
+  it('末尾アイテムの下移動ボタンが無効', () => {
+    const { container } = render(<SortableList items={items} onReorder={() => {}} />);
+
+    const downButtons = container.querySelectorAll('[data-testid="move-down"]');
+    expect(downButtons[downButtons.length - 1]).toBeDisabled();
+  });
+
+  it('削除ボタンが表示される', () => {
+    const { container } = render(<SortableList items={items} onReorder={() => {}} onRemove={() => {}} />);
+
+    const removeButtons = container.querySelectorAll('[data-testid="remove-item"]');
+    expect(removeButtons.length).toBe(3);
+  });
+
+  it('削除ボタンクリックでコールバックが呼ばれる', async () => {
+    const onRemove = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(<SortableList items={items} onReorder={() => {}} onRemove={onRemove} />);
+
+    const removeButtons = container.querySelectorAll('[data-testid="remove-item"]');
+    await user.click(removeButtons[0]);
+
+    expect(onRemove).toHaveBeenCalledWith('1');
+  });
+
+  it('グリップアイコンが表示される', () => {
+    const { container } = render(<SortableList items={items} onReorder={() => {}} />);
+
+    const grips = container.querySelectorAll('.lucide-grip-vertical');
+    expect(grips.length).toBe(3);
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<SortableList items={items} onReorder={() => {}} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- リスト項目の並べ替え機能を提供するSortableListコンポーネントを追加
- 上下ボタンでの移動（先頭/末尾は無効化）
- グリップアイコンで視覚的にドラッグ可能を示唆
- 削除ボタン（オプション）
- TDDで開発（11テストケース）

## テスト計画
- [x] 全アイテム表示
- [x] 上下移動ボタン
- [x] 上移動で並べ替え
- [x] 下移動で並べ替え
- [x] 先頭の上移動無効
- [x] 末尾の下移動無効
- [x] 削除ボタン
- [x] 削除コールバック
- [x] グリップアイコン
- [x] カスタムクラス名