### PR TITLE
feat: NotificationBadgeコンポーネントを追加 (#1890)

### DIFF
--- a/frontend/src/components/common/NotificationBadge.tsx
+++ b/frontend/src/components/common/NotificationBadge.tsx
@@ -1,0 +1,52 @@
+import { ReactNode } from 'react';
+
+const colorMap = {
+  red: 'bg-red-500',
+  blue: 'bg-blue-500',
+  green: 'bg-green-500',
+  yellow: 'bg-yellow-500',
+};
+
+interface NotificationBadgeProps {
+  children: ReactNode;
+  count: number;
+  max?: number;
+  dot?: boolean;
+  color?: keyof typeof colorMap;
+  pulse?: boolean;
+  showZero?: boolean;
+  className?: string;
+}
+
+export default function NotificationBadge({
+  children,
+  count,
+  max = 99,
+  dot = false,
+  color = 'red',
+  pulse = false,
+  showZero = false,
+  className = '',
+}: NotificationBadgeProps) {
+  const showBadge = count > 0 || showZero;
+  const displayCount = count > max ? `${max}+` : count;
+
+  return (
+    <div className={`relative inline-flex ${className}`.trim()}>
+      {children}
+      {showBadge && (
+        dot ? (
+          <span
+            className={`absolute -top-1 -right-1 w-2 h-2 rounded-full ${colorMap[color]} ${pulse ? 'animate-pulse' : ''}`}
+          />
+        ) : (
+          <span
+            className={`absolute -top-1 -right-1 min-w-[1.25rem] h-5 flex items-center justify-center px-1 text-xs font-bold text-white rounded-full ${colorMap[color]} ${pulse ? 'animate-pulse' : ''}`}
+          >
+            {displayCount}
+          </span>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/NotificationBadge.test.tsx
+++ b/frontend/src/components/common/__tests__/NotificationBadge.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import NotificationBadge from '../NotificationBadge';
+
+describe('NotificationBadge', () => {
+  it('子要素が表示される', () => {
+    render(
+      <NotificationBadge count={5}>
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(screen.getByText('アイコン')).toBeInTheDocument();
+  });
+
+  it('カウントが表示される', () => {
+    render(
+      <NotificationBadge count={5}>
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+
+  it('カウントが0の場合はバッジ非表示', () => {
+    render(
+      <NotificationBadge count={0}>
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('最大数を超えると+表示', () => {
+    render(
+      <NotificationBadge count={100} max={99}>
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(screen.getByText('99+')).toBeInTheDocument();
+  });
+
+  it('ドットモードでは数値が表示されない', () => {
+    const { container } = render(
+      <NotificationBadge count={5} dot>
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(screen.queryByText('5')).not.toBeInTheDocument();
+    const dot = container.querySelector('.w-2');
+    expect(dot).toBeInTheDocument();
+  });
+
+  it('バッジの色がカスタマイズできる', () => {
+    const { container } = render(
+      <NotificationBadge count={5} color="green">
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(container.querySelector('.bg-green-500')).toBeInTheDocument();
+  });
+
+  it('デフォルトのバッジ色は赤', () => {
+    const { container } = render(
+      <NotificationBadge count={5}>
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(container.querySelector('.bg-red-500')).toBeInTheDocument();
+  });
+
+  it('右上に配置される（デフォルト）', () => {
+    const { container } = render(
+      <NotificationBadge count={5}>
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(container.querySelector('.-top-1.-right-1')).toBeInTheDocument();
+  });
+
+  it('パルスアニメーションが適用される', () => {
+    const { container } = render(
+      <NotificationBadge count={5} pulse>
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(
+      <NotificationBadge count={5} className="custom-class">
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('showZeroでカウント0でもバッジ表示', () => {
+    render(
+      <NotificationBadge count={0} showZero>
+        <span>アイコン</span>
+      </NotificationBadge>
+    );
+
+    expect(screen.getByText('0')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 要素にオーバーレイする通知バッジNotificationBadgeコンポーネントを追加
- カウント数値表示、最大数超過時の99+表示
- ドットモード（数値なし）
- 4色（red/blue/green/yellow）、パルスアニメーション
- showZeroで0件表示対応
- TDDで開発（11テストケース）

## テスト計画
- [x] 子要素表示
- [x] カウント表示
- [x] 0件非表示
- [x] 最大数超過+表示
- [x] ドットモード
- [x] カスタムカラー
- [x] デフォルト赤色
- [x] 右上配置
- [x] パルスアニメーション
- [x] カスタムクラス名
- [x] showZero