### PR TITLE
feat: DatePickerコンポーネントを追加 (#1896)

### DIFF
--- a/frontend/src/components/common/DatePicker.tsx
+++ b/frontend/src/components/common/DatePicker.tsx
@@ -1,0 +1,141 @@
+import { useState, useRef, useEffect } from 'react';
+import { Calendar, ChevronLeft, ChevronRight } from 'lucide-react';
+
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'];
+const MONTH_NAMES = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
+
+interface DatePickerProps {
+  value: string;
+  onChange: (date: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+function getDaysInMonth(year: number, month: number) {
+  return new Date(year, month + 1, 0).getDate();
+}
+
+function getFirstDayOfMonth(year: number, month: number) {
+  return new Date(year, month, 1).getDay();
+}
+
+export default function DatePicker({
+  value,
+  onChange,
+  placeholder = '',
+  disabled = false,
+  className = '',
+}: DatePickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const currentDate = value ? new Date(value) : new Date();
+  const [viewYear, setViewYear] = useState(currentDate.getFullYear());
+  const [viewMonth, setViewMonth] = useState(currentDate.getMonth());
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const daysInMonth = getDaysInMonth(viewYear, viewMonth);
+  const firstDay = getFirstDayOfMonth(viewYear, viewMonth);
+
+  const handlePrev = () => {
+    if (viewMonth === 0) {
+      setViewMonth(11);
+      setViewYear(viewYear - 1);
+    } else {
+      setViewMonth(viewMonth - 1);
+    }
+  };
+
+  const handleNext = () => {
+    if (viewMonth === 11) {
+      setViewMonth(0);
+      setViewYear(viewYear + 1);
+    } else {
+      setViewMonth(viewMonth + 1);
+    }
+  };
+
+  const handleSelectDay = (day: number) => {
+    const dateStr = `${viewYear}-${String(viewMonth + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+    onChange(dateStr);
+    setIsOpen(false);
+  };
+
+  const selectedDay = value ? new Date(value).getDate() : null;
+  const selectedMonth = value ? new Date(value).getMonth() : null;
+  const selectedYear = value ? new Date(value).getFullYear() : null;
+
+  return (
+    <div ref={ref} className={`relative ${className}`.trim()}>
+      <div className="relative">
+        <input
+          type="text"
+          value={value}
+          readOnly
+          placeholder={placeholder}
+          disabled={disabled}
+          onClick={() => !disabled && setIsOpen(!isOpen)}
+          className="w-full pl-10 pr-4 py-2 bg-gray-800 border border-gray-700 rounded-lg text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        />
+        <Calendar className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+      </div>
+
+      {isOpen && (
+        <div className="absolute z-50 mt-2 w-72 bg-gray-800 border border-gray-700 rounded-lg shadow-lg p-4">
+          <div className="flex items-center justify-between mb-4">
+            <button type="button" aria-label="前月" onClick={handlePrev} className="p-1 text-gray-400 hover:text-white">
+              <ChevronLeft className="w-4 h-4" />
+            </button>
+            <span className="text-sm text-gray-200 font-medium">
+              {viewYear}年 {MONTH_NAMES[viewMonth]}
+            </span>
+            <button type="button" aria-label="次月" onClick={handleNext} className="p-1 text-gray-400 hover:text-white">
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+
+          <div className="grid grid-cols-7 gap-1 mb-2">
+            {WEEKDAYS.map((day) => (
+              <div key={day} className="text-center text-xs text-gray-500 py-1">
+                {day}
+              </div>
+            ))}
+          </div>
+
+          <div className="grid grid-cols-7 gap-1">
+            {Array.from({ length: firstDay }).map((_, i) => (
+              <div key={`empty-${i}`} />
+            ))}
+            {Array.from({ length: daysInMonth }, (_, i) => i + 1).map((day) => {
+              const isSelected = day === selectedDay && viewMonth === selectedMonth && viewYear === selectedYear;
+              return (
+                <button
+                  key={day}
+                  type="button"
+                  onClick={() => handleSelectDay(day)}
+                  className={`text-center text-sm py-1.5 rounded transition-colors ${
+                    isSelected
+                      ? 'bg-blue-600 text-white'
+                      : 'text-gray-300 hover:bg-gray-700'
+                  }`}
+                >
+                  {day}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/DatePicker.test.tsx
+++ b/frontend/src/components/common/__tests__/DatePicker.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DatePicker from '../DatePicker';
+
+describe('DatePicker', () => {
+  it('入力フィールドが表示される', () => {
+    render(<DatePicker value="" onChange={() => {}} />);
+
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('プレースホルダーが表示される', () => {
+    render(<DatePicker value="" onChange={() => {}} placeholder="日付を選択" />);
+
+    expect(screen.getByPlaceholderText('日付を選択')).toBeInTheDocument();
+  });
+
+  it('値が表示される', () => {
+    render(<DatePicker value="2026-01-15" onChange={() => {}} />);
+
+    expect(screen.getByDisplayValue('2026-01-15')).toBeInTheDocument();
+  });
+
+  it('カレンダーアイコンが表示される', () => {
+    const { container } = render(<DatePicker value="" onChange={() => {}} />);
+
+    expect(container.querySelector('.lucide-calendar')).toBeInTheDocument();
+  });
+
+  it('クリックでカレンダーが開く', async () => {
+    const user = userEvent.setup();
+    render(<DatePicker value="" onChange={() => {}} />);
+
+    await user.click(screen.getByRole('textbox'));
+
+    expect(screen.getByText('日')).toBeInTheDocument();
+    expect(screen.getByText('月')).toBeInTheDocument();
+  });
+
+  it('日付クリックで値が変わる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<DatePicker value="2026-01-15" onChange={onChange} />);
+
+    await user.click(screen.getByRole('textbox'));
+
+    const day10 = screen.getByText('10');
+    await user.click(day10);
+
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('前月ボタンで月が切り替わる', async () => {
+    const user = userEvent.setup();
+    render(<DatePicker value="2026-02-15" onChange={() => {}} />);
+
+    await user.click(screen.getByRole('textbox'));
+
+    const prevButton = screen.getByLabelText('前月');
+    await user.click(prevButton);
+
+    expect(screen.getByText('1月')).toBeInTheDocument();
+  });
+
+  it('次月ボタンで月が切り替わる', async () => {
+    const user = userEvent.setup();
+    render(<DatePicker value="2026-01-15" onChange={() => {}} />);
+
+    await user.click(screen.getByRole('textbox'));
+
+    const nextButton = screen.getByLabelText('次月');
+    await user.click(nextButton);
+
+    expect(screen.getByText('2月')).toBeInTheDocument();
+  });
+
+  it('無効状態が適用される', () => {
+    render(<DatePicker value="" onChange={() => {}} disabled />);
+
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<DatePicker value="" onChange={() => {}} className="custom-class" />);
+
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 日付を選択するDatePickerカレンダーコンポーネントを追加
- カレンダーUIでの日付選択（曜日ヘッダー付き）
- 前月/次月の切り替え
- 選択中の日付のハイライト
- 外部クリックで閉じる
- TDDで開発（10テストケース）

## テスト計画
- [x] 入力フィールド表示
- [x] プレースホルダー
- [x] 値表示
- [x] カレンダーアイコン
- [x] クリックで開く
- [x] 日付クリック
- [x] 前月切り替え
- [x] 次月切り替え
- [x] 無効状態
- [x] カスタムクラス名