### PR TITLE
feat: Chipコンポーネントを追加 (#1898)

### DIFF
--- a/frontend/src/components/common/Chip.tsx
+++ b/frontend/src/components/common/Chip.tsx
@@ -1,0 +1,51 @@
+import { ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+const sizeClasses = {
+  sm: 'text-xs px-2 py-0.5',
+  md: 'text-sm px-3 py-1',
+  lg: 'text-base px-4 py-1.5',
+};
+
+interface ChipProps {
+  label: string;
+  selected?: boolean;
+  onClick?: () => void;
+  onDelete?: () => void;
+  icon?: ReactNode;
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function Chip({
+  label,
+  selected = false,
+  onClick,
+  onDelete,
+  icon,
+  size = 'md',
+  disabled = false,
+  className = '',
+}: ChipProps) {
+  return (
+    <span
+      onClick={disabled ? undefined : onClick}
+      className={`inline-flex items-center gap-1.5 rounded-full border transition-colors ${sizeClasses[size]} ${
+        selected ? 'bg-blue-600 border-blue-500 text-white' : 'bg-gray-800 border-gray-700 text-gray-300'
+      } ${onClick && !disabled ? 'cursor-pointer hover:border-gray-600' : ''} ${disabled ? 'opacity-50 cursor-not-allowed' : ''} ${className}`.trim()}
+    >
+      {icon}
+      {label}
+      {onDelete && (
+        <button
+          type="button"
+          onClick={(e) => { e.stopPropagation(); onDelete(); }}
+          className="ml-0.5 text-gray-400 hover:text-white"
+        >
+          <X className="w-3 h-3" />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/frontend/src/components/common/__tests__/Chip.test.tsx
+++ b/frontend/src/components/common/__tests__/Chip.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Chip from '../Chip';
+
+describe('Chip', () => {
+  it('ラベルが表示される', () => {
+    render(<Chip label="React" />);
+    expect(screen.getByText('React')).toBeInTheDocument();
+  });
+
+  it('選択状態のスタイルが適用される', () => {
+    const { container } = render(<Chip label="React" selected />);
+    expect(container.querySelector('.bg-blue-600')).toBeInTheDocument();
+  });
+
+  it('非選択状態のスタイルが適用される', () => {
+    const { container } = render(<Chip label="React" />);
+    expect(container.querySelector('.bg-gray-800')).toBeInTheDocument();
+  });
+
+  it('クリックでコールバックが呼ばれる', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<Chip label="React" onClick={onClick} />);
+    await user.click(screen.getByText('React'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('削除ボタンが表示される', () => {
+    const { container } = render(<Chip label="React" onDelete={() => {}} />);
+    expect(container.querySelector('.lucide-x')).toBeInTheDocument();
+  });
+
+  it('削除ボタンクリックでコールバックが呼ばれる', async () => {
+    const onDelete = vi.fn();
+    const user = userEvent.setup();
+    const { container } = render(<Chip label="React" onDelete={onDelete} />);
+    const deleteBtn = container.querySelector('.lucide-x')!.parentElement!;
+    await user.click(deleteBtn);
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it('アイコンが表示される', () => {
+    const { container } = render(<Chip label="React" icon={<span data-testid="icon">★</span>} />);
+    expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('smサイズが適用される', () => {
+    const { container } = render(<Chip label="React" size="sm" />);
+    expect(container.querySelector('.text-xs')).toBeInTheDocument();
+  });
+
+  it('lgサイズが適用される', () => {
+    const { container } = render(<Chip label="React" size="lg" />);
+    expect(container.querySelector('.text-base')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Chip label="React" className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('無効状態が適用される', () => {
+    const { container } = render(<Chip label="React" disabled />);
+    expect(container.querySelector('.opacity-50')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 選択可能なチップ/タグコンポーネントを追加
- 選択/非選択状態のスタイル切り替え、削除ボタン、アイコン対応
- 3段階サイズ、無効状態
- TDDで開発（11テストケース）