### PR TITLE
feat: RadioGroupコンポーネントを追加 (#1902)

### DIFF
--- a/frontend/src/components/common/RadioGroup.tsx
+++ b/frontend/src/components/common/RadioGroup.tsx
@@ -1,0 +1,57 @@
+interface RadioOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+interface RadioGroupProps {
+  options: RadioOption[];
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  direction?: 'vertical' | 'horizontal';
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function RadioGroup({
+  options,
+  value,
+  onChange,
+  label,
+  direction = 'vertical',
+  disabled = false,
+  className = '',
+}: RadioGroupProps) {
+  const dirClass = direction === 'horizontal' ? 'flex-row' : 'flex-col';
+
+  return (
+    <div className={`${className}`.trim()}>
+      {label && <label className="block text-sm text-gray-400 mb-2">{label}</label>}
+      <div className={`flex gap-3 ${dirClass}`} role="radiogroup">
+        {options.map((option) => (
+          <label
+            key={option.value}
+            className={`flex items-start gap-3 cursor-pointer ${disabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+          >
+            <input
+              type="radio"
+              name="radio-group"
+              value={option.value}
+              checked={value === option.value}
+              onChange={() => onChange(option.value)}
+              disabled={disabled}
+              className="mt-1 accent-blue-600"
+            />
+            <div>
+              <span className="text-sm text-gray-200">{option.label}</span>
+              {option.description && (
+                <p className="text-xs text-gray-500 mt-0.5">{option.description}</p>
+              )}
+            </div>
+          </label>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/RadioGroup.test.tsx
+++ b/frontend/src/components/common/__tests__/RadioGroup.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RadioGroup from '../RadioGroup';
+
+const options = [
+  { value: 'a', label: 'オプションA' },
+  { value: 'b', label: 'オプションB' },
+  { value: 'c', label: 'オプションC' },
+];
+
+describe('RadioGroup', () => {
+  it('全てのオプションが表示される', () => {
+    render(<RadioGroup options={options} value="" onChange={() => {}} />);
+    expect(screen.getByText('オプションA')).toBeInTheDocument();
+    expect(screen.getByText('オプションB')).toBeInTheDocument();
+    expect(screen.getByText('オプションC')).toBeInTheDocument();
+  });
+
+  it('ラジオボタンが表示される', () => {
+    render(<RadioGroup options={options} value="" onChange={() => {}} />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios.length).toBe(3);
+  });
+
+  it('選択値が反映される', () => {
+    render(<RadioGroup options={options} value="b" onChange={() => {}} />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios[1]).toBeChecked();
+  });
+
+  it('クリックでコールバックが呼ばれる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<RadioGroup options={options} value="" onChange={onChange} />);
+    await user.click(screen.getByText('オプションB'));
+    expect(onChange).toHaveBeenCalledWith('b');
+  });
+
+  it('ラベルが表示される', () => {
+    render(<RadioGroup options={options} value="" onChange={() => {}} label="選択してください" />);
+    expect(screen.getByText('選択してください')).toBeInTheDocument();
+  });
+
+  it('説明付きオプションが表示される', () => {
+    const opts = [{ value: 'a', label: 'A', description: '説明文' }];
+    render(<RadioGroup options={opts} value="" onChange={() => {}} />);
+    expect(screen.getByText('説明文')).toBeInTheDocument();
+  });
+
+  it('水平レイアウトが適用される', () => {
+    const { container } = render(<RadioGroup options={options} value="" onChange={() => {}} direction="horizontal" />);
+    expect(container.querySelector('.flex-row')).toBeInTheDocument();
+  });
+
+  it('垂直レイアウトがデフォルト', () => {
+    const { container } = render(<RadioGroup options={options} value="" onChange={() => {}} />);
+    expect(container.querySelector('.flex-col')).toBeInTheDocument();
+  });
+
+  it('無効状態が適用される', () => {
+    render(<RadioGroup options={options} value="" onChange={() => {}} disabled />);
+    const radios = screen.getAllByRole('radio');
+    radios.forEach(r => expect(r).toBeDisabled());
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<RadioGroup options={options} value="" onChange={() => {}} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- ラジオボタングループRadioGroupコンポーネントを追加
- 水平/垂直レイアウト、説明付きオプション、無効状態対応
- TDDで開発（10テストケース）