### PR TITLE
feat: PriceTagコンポーネントを追加 (#1904)

### DIFF
--- a/frontend/src/components/common/PriceTag.tsx
+++ b/frontend/src/components/common/PriceTag.tsx
@@ -1,0 +1,53 @@
+const sizeClasses = {
+  sm: 'text-sm',
+  md: 'text-lg',
+  lg: 'text-2xl',
+};
+
+interface PriceTagProps {
+  price: number;
+  originalPrice?: number;
+  currency?: string;
+  showDiscount?: boolean;
+  size?: 'sm' | 'md' | 'lg';
+  label?: string;
+  className?: string;
+}
+
+function formatPrice(price: number, currency: string) {
+  if (currency === '¥') return `¥${price.toLocaleString()}`;
+  return `${currency}${price.toLocaleString()}`;
+}
+
+export default function PriceTag({
+  price,
+  originalPrice,
+  currency = '¥',
+  showDiscount = false,
+  size = 'md',
+  label,
+  className = '',
+}: PriceTagProps) {
+  const discountPercent = originalPrice
+    ? Math.round(((originalPrice - price) / originalPrice) * 100)
+    : 0;
+
+  return (
+    <div className={`flex items-baseline gap-2 ${className}`.trim()}>
+      <span className={`font-bold text-white ${sizeClasses[size]}`}>
+        {price === 0 ? '無料' : formatPrice(price, currency)}
+      </span>
+      {originalPrice && originalPrice > price && (
+        <span className="text-sm text-gray-500 line-through">
+          {formatPrice(originalPrice, currency)}
+        </span>
+      )}
+      {showDiscount && discountPercent > 0 && (
+        <span className="text-sm text-green-400 font-medium">
+          -{discountPercent}%
+        </span>
+      )}
+      {label && <span className="text-xs text-gray-500">{label}</span>}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/PriceTag.test.tsx
+++ b/frontend/src/components/common/__tests__/PriceTag.test.tsx
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PriceTag from '../PriceTag';
+
+describe('PriceTag', () => {
+  it('価格が表示される', () => {
+    render(<PriceTag price={1000} />);
+    expect(screen.getByText('¥1,000')).toBeInTheDocument();
+  });
+
+  it('通貨記号がカスタマイズできる', () => {
+    render(<PriceTag price={100} currency="$" />);
+    expect(screen.getByText('$100')).toBeInTheDocument();
+  });
+
+  it('元の価格が表示される', () => {
+    render(<PriceTag price={800} originalPrice={1000} />);
+    expect(screen.getByText('¥1,000')).toBeInTheDocument();
+  });
+
+  it('元の価格に取り消し線が付く', () => {
+    const { container } = render(<PriceTag price={800} originalPrice={1000} />);
+    expect(container.querySelector('.line-through')).toBeInTheDocument();
+  });
+
+  it('割引率が表示される', () => {
+    render(<PriceTag price={800} originalPrice={1000} showDiscount />);
+    expect(screen.getByText('-20%')).toBeInTheDocument();
+  });
+
+  it('無料の場合は無料と表示される', () => {
+    render(<PriceTag price={0} />);
+    expect(screen.getByText('無料')).toBeInTheDocument();
+  });
+
+  it('smサイズが適用される', () => {
+    const { container } = render(<PriceTag price={1000} size="sm" />);
+    expect(container.querySelector('.text-sm')).toBeInTheDocument();
+  });
+
+  it('lgサイズが適用される', () => {
+    const { container } = render(<PriceTag price={1000} size="lg" />);
+    expect(container.querySelector('.text-2xl')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<PriceTag price={1000} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<PriceTag price={1000} label="月額" />);
+    expect(screen.getByText('月額')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- 価格表示PriceTagコンポーネントを追加
- 割引価格（取り消し線）、割引率表示、通貨記号カスタマイズ、無料表示対応
- TDDで開発（10テストケース）