### PR TITLE
feat: Selectコンポーネントを追加 (#1906)

### DIFF
--- a/frontend/src/components/common/Select.tsx
+++ b/frontend/src/components/common/Select.tsx
@@ -1,0 +1,84 @@
+import { useState, useRef, useEffect } from 'react';
+import { ChevronDown } from 'lucide-react';
+
+interface SelectOption {
+  value: string;
+  label: string;
+}
+
+interface SelectProps {
+  options: SelectOption[];
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  label?: string;
+  error?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function Select({
+  options,
+  value,
+  onChange,
+  placeholder = '',
+  label,
+  error,
+  disabled = false,
+  className = '',
+}: SelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const selectedOption = options.find((o) => o.value === value);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const handleSelect = (optValue: string) => {
+    onChange(optValue);
+    setIsOpen(false);
+  };
+
+  return (
+    <div ref={ref} className={`${className}`.trim()}>
+      {label && <label className="block text-sm text-gray-400 mb-1">{label}</label>}
+      <button
+        type="button"
+        onClick={() => !disabled && setIsOpen(!isOpen)}
+        className={`w-full flex items-center justify-between px-4 py-2 bg-gray-800 border rounded-lg text-left transition-colors ${
+          error ? 'border-red-500' : 'border-gray-700 focus:border-blue-500'
+        } ${disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
+      >
+        <span className={selectedOption ? 'text-gray-200' : 'text-gray-500'}>
+          {selectedOption?.label || placeholder}
+        </span>
+        <ChevronDown className={`w-4 h-4 text-gray-400 transition-transform ${isOpen ? 'rotate-180' : ''}`} />
+      </button>
+      {isOpen && (
+        <div className="absolute z-50 mt-1 w-full bg-gray-800 border border-gray-700 rounded-lg shadow-lg max-h-60 overflow-y-auto">
+          {options.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => handleSelect(option.value)}
+              className={`w-full text-left px-4 py-2 text-sm transition-colors ${
+                option.value === value ? 'bg-blue-600/20 text-blue-400' : 'text-gray-200 hover:bg-gray-700'
+              }`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      )}
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Select.test.tsx
+++ b/frontend/src/components/common/__tests__/Select.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Select from '../Select';
+
+const options = [
+  { value: 'react', label: 'React' },
+  { value: 'vue', label: 'Vue' },
+  { value: 'angular', label: 'Angular' },
+];
+
+describe('Select', () => {
+  it('プレースホルダーが表示される', () => {
+    render(<Select options={options} value="" onChange={() => {}} placeholder="選択してください" />);
+    expect(screen.getByText('選択してください')).toBeInTheDocument();
+  });
+
+  it('選択値が表示される', () => {
+    render(<Select options={options} value="react" onChange={() => {}} />);
+    expect(screen.getByText('React')).toBeInTheDocument();
+  });
+
+  it('クリックでドロップダウンが開く', async () => {
+    const user = userEvent.setup();
+    render(<Select options={options} value="" onChange={() => {}} placeholder="選択" />);
+    await user.click(screen.getByText('選択'));
+    expect(screen.getByText('Vue')).toBeInTheDocument();
+    expect(screen.getByText('Angular')).toBeInTheDocument();
+  });
+
+  it('オプション選択でコールバックが呼ばれる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Select options={options} value="" onChange={onChange} placeholder="選択" />);
+    await user.click(screen.getByText('選択'));
+    await user.click(screen.getByText('Vue'));
+    expect(onChange).toHaveBeenCalledWith('vue');
+  });
+
+  it('選択後にドロップダウンが閉じる', async () => {
+    const user = userEvent.setup();
+    render(<Select options={options} value="" onChange={() => {}} placeholder="選択" />);
+    await user.click(screen.getByText('選択'));
+    await user.click(screen.getByText('Vue'));
+    expect(screen.queryByText('Angular')).not.toBeInTheDocument();
+  });
+
+  it('シェブロンアイコンが表示される', () => {
+    const { container } = render(<Select options={options} value="" onChange={() => {}} />);
+    expect(container.querySelector('.lucide-chevron-down')).toBeInTheDocument();
+  });
+
+  it('無効状態が適用される', () => {
+    const { container } = render(<Select options={options} value="" onChange={() => {}} disabled />);
+    expect(container.querySelector('.opacity-50')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<Select options={options} value="" onChange={() => {}} label="フレームワーク" />);
+    expect(screen.getByText('フレームワーク')).toBeInTheDocument();
+  });
+
+  it('エラーメッセージが表示される', () => {
+    render(<Select options={options} value="" onChange={() => {}} error="必須項目です" />);
+    expect(screen.getByText('必須項目です')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Select options={options} value="" onChange={() => {}} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- カスタムセレクトボックスSelectコンポーネントを追加
- プレースホルダー、エラーメッセージ、ラベル、無効状態対応
- 外部クリックで閉じる、選択ハイライト
- TDDで開発（10テストケース）