### PR TITLE
feat: HeatMapコンポーネントを追加 (#1910)

### DIFF
--- a/frontend/src/components/common/HeatMap.tsx
+++ b/frontend/src/components/common/HeatMap.tsx
@@ -1,0 +1,58 @@
+interface HeatMapData {
+  date: string;
+  count: number;
+}
+
+const cellSizeMap = {
+  sm: 'w-3 h-3',
+  md: 'w-4 h-4',
+  lg: 'w-5 h-5',
+};
+
+function getIntensityClass(count: number): string {
+  if (count === 0) return 'bg-gray-800';
+  if (count <= 3) return 'bg-green-900';
+  if (count <= 6) return 'bg-green-700';
+  return 'bg-green-500';
+}
+
+interface HeatMapProps {
+  data: HeatMapData[];
+  cellSize?: 'sm' | 'md' | 'lg';
+  showLegend?: boolean;
+  className?: string;
+}
+
+export default function HeatMap({
+  data,
+  cellSize = 'md',
+  showLegend = false,
+  className = '',
+}: HeatMapProps) {
+  return (
+    <div className={`${className}`.trim()}>
+      <div className="flex flex-wrap gap-1">
+        {data.map((item) => (
+          <div
+            key={item.date}
+            data-testid="heatmap-cell"
+            data-date={item.date}
+            data-count={String(item.count)}
+            className={`${cellSizeMap[cellSize]} rounded-sm ${getIntensityClass(item.count)}`}
+            title={`${item.date}: ${item.count}`}
+          />
+        ))}
+      </div>
+      {showLegend && (
+        <div className="flex items-center gap-1 mt-2 text-xs text-gray-500">
+          <span>少</span>
+          <div className="w-3 h-3 rounded-sm bg-gray-800" />
+          <div className="w-3 h-3 rounded-sm bg-green-900" />
+          <div className="w-3 h-3 rounded-sm bg-green-700" />
+          <div className="w-3 h-3 rounded-sm bg-green-500" />
+          <span>多</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/HeatMap.test.tsx
+++ b/frontend/src/components/common/__tests__/HeatMap.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import HeatMap from '../HeatMap';
+
+const data = [
+  { date: '2026-01-01', count: 0 },
+  { date: '2026-01-02', count: 3 },
+  { date: '2026-01-03', count: 7 },
+  { date: '2026-01-04', count: 12 },
+];
+
+describe('HeatMap', () => {
+  it('ヒートマップが表示される', () => {
+    const { container } = render(<HeatMap data={data} />);
+    const cells = container.querySelectorAll('[data-testid="heatmap-cell"]');
+    expect(cells.length).toBe(4);
+  });
+
+  it('活動量0はグレー', () => {
+    const { container } = render(<HeatMap data={data} />);
+    const cells = container.querySelectorAll('[data-testid="heatmap-cell"]');
+    expect(cells[0]).toHaveClass('bg-gray-800');
+  });
+
+  it('低活動量は薄い緑', () => {
+    const { container } = render(<HeatMap data={data} />);
+    const cells = container.querySelectorAll('[data-testid="heatmap-cell"]');
+    expect(cells[1]).toHaveClass('bg-green-900');
+  });
+
+  it('中活動量は中程度の緑', () => {
+    const { container } = render(<HeatMap data={data} />);
+    const cells = container.querySelectorAll('[data-testid="heatmap-cell"]');
+    expect(cells[2]).toHaveClass('bg-green-700');
+  });
+
+  it('高活動量は濃い緑', () => {
+    const { container } = render(<HeatMap data={data} />);
+    const cells = container.querySelectorAll('[data-testid="heatmap-cell"]');
+    expect(cells[3]).toHaveClass('bg-green-500');
+  });
+
+  it('凡例が表示される', () => {
+    render(<HeatMap data={data} showLegend />);
+    expect(screen.getByText('少')).toBeInTheDocument();
+    expect(screen.getByText('多')).toBeInTheDocument();
+  });
+
+  it('セルサイズがカスタマイズできる', () => {
+    const { container } = render(<HeatMap data={data} cellSize="lg" />);
+    expect(container.querySelector('.w-5')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<HeatMap data={data} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('空のデータでも表示される', () => {
+    const { container } = render(<HeatMap data={[]} />);
+    expect(container.querySelector('.custom-class')).not.toBeInTheDocument();
+  });
+
+  it('ツールチップ用のdata属性が設定される', () => {
+    const { container } = render(<HeatMap data={data} />);
+    const cells = container.querySelectorAll('[data-testid="heatmap-cell"]');
+    expect(cells[1]).toHaveAttribute('data-date', '2026-01-02');
+    expect(cells[1]).toHaveAttribute('data-count', '3');
+  });
+});


### PR DESCRIPTION
## 概要
- GitHubスタイルの活動ヒートマップHeatMapコンポーネントを追加
- 4段階の強度（gray/green-900/green-700/green-500）
- 凡例表示、セルサイズカスタマイズ、ツールチップ用data属性
- TDDで開発（10テストケース）