### PR TITLE
feat: CodeBlockコンポーネントを追加 (#1914)

### DIFF
--- a/frontend/src/components/common/CodeBlock.tsx
+++ b/frontend/src/components/common/CodeBlock.tsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+
+interface CodeBlockProps {
+  code: string;
+  language?: string;
+  title?: string;
+  showLineNumbers?: boolean;
+  showCopy?: boolean;
+  className?: string;
+}
+
+export default function CodeBlock({
+  code,
+  language,
+  title,
+  showLineNumbers = false,
+  showCopy = false,
+  className = '',
+}: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+  const lines = code.split('\n');
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className={`bg-gray-900 border border-gray-800 rounded-lg overflow-hidden ${className}`.trim()}>
+      {(title || language || showCopy) && (
+        <div className="flex items-center justify-between px-4 py-2 bg-gray-800/50 border-b border-gray-800">
+          <div className="flex items-center gap-2">
+            {title && <span className="text-xs text-gray-400">{title}</span>}
+            {language && <span className="text-xs text-gray-500">{language}</span>}
+          </div>
+          {showCopy && (
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="p-1 text-gray-400 hover:text-white transition-colors"
+            >
+              {copied ? <Check className="w-4 h-4 text-green-400" /> : <Copy className="w-4 h-4" />}
+            </button>
+          )}
+        </div>
+      )}
+      <pre className="p-4 overflow-x-auto">
+        <code className="text-sm font-mono text-gray-300">
+          {showLineNumbers ? (
+            lines.map((line, i) => (
+              <div key={i} className="flex">
+                <span className="select-none text-gray-600 w-8 text-right mr-4 flex-shrink-0">{i + 1}</span>
+                <span>{line}</span>
+              </div>
+            ))
+          ) : (
+            code
+          )}
+        </code>
+      </pre>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/CodeBlock.test.tsx
+++ b/frontend/src/components/common/__tests__/CodeBlock.test.tsx
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CodeBlock from '../CodeBlock';
+
+describe('CodeBlock', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('コードが表示される', () => {
+    render(<CodeBlock code="const x = 1;" />);
+    expect(screen.getByText('const x = 1;')).toBeInTheDocument();
+  });
+
+  it('言語名が表示される', () => {
+    render(<CodeBlock code="const x = 1;" language="typescript" />);
+    expect(screen.getByText('typescript')).toBeInTheDocument();
+  });
+
+  it('行番号が表示される', () => {
+    render(<CodeBlock code={'line1\nline2\nline3'} showLineNumbers />);
+    expect(screen.getByText('1')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('コピーボタンが表示される', () => {
+    const { container } = render(<CodeBlock code="test" showCopy />);
+    expect(container.querySelector('.lucide-copy')).toBeInTheDocument();
+  });
+
+  it('コピーボタンクリックでクリップボードにコピー', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    render(<CodeBlock code="copied text" showCopy />);
+    await user.click(screen.getByRole('button'));
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('copied text');
+  });
+
+  it('コピー後にチェックアイコン表示', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const { container } = render(<CodeBlock code="test" showCopy />);
+    await user.click(screen.getByRole('button'));
+    expect(container.querySelector('.lucide-check')).toBeInTheDocument();
+  });
+
+  it('pre要素が使用される', () => {
+    const { container } = render(<CodeBlock code="test" />);
+    expect(container.querySelector('pre')).toBeInTheDocument();
+  });
+
+  it('code要素が使用される', () => {
+    const { container } = render(<CodeBlock code="test" />);
+    expect(container.querySelector('code')).toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<CodeBlock code="test" title="example.ts" />);
+    expect(screen.getByText('example.ts')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<CodeBlock code="test" className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
- コードブロック表示CodeBlockコンポーネントを追加
- 行番号表示、コピーボタン（成功フィードバック）、言語名、タイトル対応
- TDDで開発（10テストケース）