### PR TITLE
feat: PasswordInputコンポーネントを追加 (#1918)

### DIFF
--- a/frontend/src/components/common/PasswordInput.tsx
+++ b/frontend/src/components/common/PasswordInput.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { Eye, EyeOff } from 'lucide-react';
+
+function getStrength(password: string): number {
+  if (!password) return 0;
+  let score = 0;
+  if (password.length >= 8) score++;
+  if (/[a-z]/.test(password) && /[A-Z]/.test(password)) score++;
+  if (/\d/.test(password)) score++;
+  if (/[^a-zA-Z0-9]/.test(password)) score++;
+  return score;
+}
+
+const strengthColors = ['bg-red-500', 'bg-orange-500', 'bg-yellow-500', 'bg-green-500'];
+
+interface PasswordInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  error?: string;
+  placeholder?: string;
+  showStrength?: boolean;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function PasswordInput({
+  value,
+  onChange,
+  label,
+  error,
+  placeholder = 'パスワード',
+  showStrength = false,
+  disabled = false,
+  className = '',
+}: PasswordInputProps) {
+  const [visible, setVisible] = useState(false);
+  const strength = getStrength(value);
+
+  return (
+    <div className={`${className}`.trim()}>
+      {label && <label className="block text-sm text-gray-400 mb-1">{label}</label>}
+      <div className="relative">
+        <input
+          type={visible ? 'text' : 'password'}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          disabled={disabled}
+          className={`w-full pr-10 pl-4 py-2 bg-gray-800 border rounded-lg text-gray-200 placeholder-gray-500 focus:outline-none transition-colors disabled:opacity-50 ${
+            error ? 'border-red-500' : 'border-gray-700 focus:border-blue-500'
+          }`}
+        />
+        <button
+          type="button"
+          onClick={() => setVisible(!visible)}
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-white"
+        >
+          {visible ? <Eye className="w-4 h-4" /> : <EyeOff className="w-4 h-4" />}
+        </button>
+      </div>
+      {showStrength && value && (
+        <div className="flex gap-1 mt-2">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div
+              key={i}
+              data-testid="strength-bar"
+              className={`h-1 flex-1 rounded-full ${i < strength ? strengthColors[strength - 1] : 'bg-gray-700'}`}
+            />
+          ))}
+        </div>
+      )}
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/PasswordInput.test.tsx
+++ b/frontend/src/components/common/__tests__/PasswordInput.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import PasswordInput from '../PasswordInput';
+
+describe('PasswordInput', () => {
+  it('パスワード入力が表示される', () => {
+    render(<PasswordInput value="" onChange={() => {}} />);
+    const input = screen.getByPlaceholderText('パスワード');
+    expect(input).toHaveAttribute('type', 'password');
+  });
+
+  it('表示切り替えボタンが表示される', () => {
+    const { container } = render(<PasswordInput value="" onChange={() => {}} />);
+    expect(container.querySelector('.lucide-eye-off')).toBeInTheDocument();
+  });
+
+  it('クリックでパスワードが表示される', async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput value="secret" onChange={() => {}} />);
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByPlaceholderText('パスワード')).toHaveAttribute('type', 'text');
+  });
+
+  it('再クリックで非表示に戻る', async () => {
+    const user = userEvent.setup();
+    render(<PasswordInput value="secret" onChange={() => {}} />);
+    await user.click(screen.getByRole('button'));
+    await user.click(screen.getByRole('button'));
+    expect(screen.getByPlaceholderText('パスワード')).toHaveAttribute('type', 'password');
+  });
+
+  it('値の変更でコールバックが呼ばれる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<PasswordInput value="" onChange={onChange} />);
+    await user.type(screen.getByPlaceholderText('パスワード'), 'a');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('強度メーターが表示される', () => {
+    const { container } = render(<PasswordInput value="Test1234!" onChange={() => {}} showStrength />);
+    const bars = container.querySelectorAll('[data-testid="strength-bar"]');
+    expect(bars.length).toBe(4);
+  });
+
+  it('弱いパスワードは赤', () => {
+    const { container } = render(<PasswordInput value="ab" onChange={() => {}} showStrength />);
+    expect(container.querySelector('.bg-red-500')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<PasswordInput value="" onChange={() => {}} label="新しいパスワード" />);
+    expect(screen.getByText('新しいパスワード')).toBeInTheDocument();
+  });
+
+  it('エラーメッセージが表示される', () => {
+    render(<PasswordInput value="" onChange={() => {}} error="必須項目です" />);
+    expect(screen.getByText('必須項目です')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<PasswordInput value="" onChange={() => {}} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('無効状態が適用される', () => {
+    render(<PasswordInput value="" onChange={() => {}} disabled />);
+    expect(screen.getByPlaceholderText('パスワード')).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## 概要
- パスワード入力PasswordInputコンポーネントを追加
- 表示/非表示切り替え、4段階強度メーター、ラベル、エラー表示対応
- TDDで開発（11テストケース）