### PR TITLE
feat: Drawerコンポーネントの実装 (#1922)

### DIFF
--- a/frontend/src/components/common/Drawer.tsx
+++ b/frontend/src/components/common/Drawer.tsx
@@ -1,0 +1,64 @@
+import { ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+interface DrawerProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  title?: string;
+  position?: 'left' | 'right' | 'bottom';
+  width?: string;
+  className?: string;
+}
+
+const positionClasses = {
+  right: 'right-0 top-0 h-full',
+  left: 'left-0 top-0 h-full',
+  bottom: 'bottom-0 left-0 w-full',
+};
+
+export default function Drawer({
+  open,
+  onClose,
+  children,
+  title,
+  position = 'right',
+  width = '320px',
+  className = '',
+}: DrawerProps) {
+  if (!open) return null;
+
+  const isHorizontal = position !== 'bottom';
+  const style = isHorizontal ? { width } : undefined;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div
+        data-testid="drawer-overlay"
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+      />
+      <div
+        className={`absolute ${positionClasses[position]} bg-gray-900 border-gray-800 shadow-xl flex flex-col ${className}`.trim()}
+        style={style}
+      >
+        {title && (
+          <div className="flex items-center justify-between px-4 py-3 border-b border-gray-800">
+            <h3 className="text-lg font-semibold text-gray-200">{title}</h3>
+            <button type="button" onClick={onClose} className="text-gray-400 hover:text-white">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        )}
+        {!title && (
+          <div className="flex justify-end px-4 py-2">
+            <button type="button" onClick={onClose} className="text-gray-400 hover:text-white">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        )}
+        <div className="flex-1 overflow-y-auto p-4">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Drawer.test.tsx
+++ b/frontend/src/components/common/__tests__/Drawer.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Drawer from '../Drawer';
+
+describe('Drawer', () => {
+  it('開いた状態でコンテンツが表示される', () => {
+    render(<Drawer open onClose={() => {}}>内容</Drawer>);
+    expect(screen.getByText('内容')).toBeInTheDocument();
+  });
+
+  it('閉じた状態で非表示', () => {
+    render(<Drawer open={false} onClose={() => {}}>内容</Drawer>);
+    expect(screen.queryByText('内容')).not.toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<Drawer open onClose={() => {}} title="設定">内容</Drawer>);
+    expect(screen.getByText('設定')).toBeInTheDocument();
+  });
+
+  it('閉じるボタンで onClose が呼ばれる', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<Drawer open onClose={onClose} title="設定">内容</Drawer>);
+    await user.click(screen.getByRole('button'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('オーバーレイクリックで閉じる', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<Drawer open onClose={onClose}>内容</Drawer>);
+    await user.click(screen.getByTestId('drawer-overlay'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('右からスライドイン（デフォルト）', () => {
+    const { container } = render(<Drawer open onClose={() => {}}>内容</Drawer>);
+    expect(container.querySelector('.right-0')).toBeInTheDocument();
+  });
+
+  it('左からスライドイン', () => {
+    const { container } = render(<Drawer open onClose={() => {}} position="left">内容</Drawer>);
+    expect(container.querySelector('.left-0')).toBeInTheDocument();
+  });
+
+  it('下からスライドイン', () => {
+    const { container } = render(<Drawer open onClose={() => {}} position="bottom">内容</Drawer>);
+    expect(container.querySelector('.bottom-0')).toBeInTheDocument();
+  });
+
+  it('カスタム幅が適用される', () => {
+    render(<Drawer open onClose={() => {}} width="400px">内容</Drawer>);
+    const panel = screen.getByText('内容').closest('[style]');
+    expect(panel).toHaveStyle({ width: '400px' });
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    render(<Drawer open onClose={() => {}} className="custom-class">内容</Drawer>);
+    expect(screen.getByText('内容').closest('.custom-class')).toBeInTheDocument();
+  });
+
+  it('子要素が正しく描画される', () => {
+    render(
+      <Drawer open onClose={() => {}}>
+        <p>パラグラフ1</p>
+        <p>パラグラフ2</p>
+      </Drawer>
+    );
+    expect(screen.getByText('パラグラフ1')).toBeInTheDocument();
+    expect(screen.getByText('パラグラフ2')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
スライドインパネルコンポーネントをTDDで実装

## 変更内容
- `Drawer.tsx`: スライドインパネルコンポーネント
- `Drawer.test.tsx`: 11件のテストケース

## テスト内容
- 開閉状態の表示制御
- タイトル表示・閉じるボタン
- オーバーレイクリック
- 左/右/下からスライドイン
- カスタム幅・カスタムクラス名
- 子要素の描画