### PR TITLE
feat: CheckboxGroupコンポーネントの実装 (#1924)

### DIFF
--- a/frontend/src/components/common/CheckboxGroup.tsx
+++ b/frontend/src/components/common/CheckboxGroup.tsx
@@ -1,0 +1,73 @@
+interface CheckboxOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+interface CheckboxGroupProps {
+  options: CheckboxOption[];
+  value: string[];
+  onChange: (value: string[]) => void;
+  label?: string;
+  error?: string;
+  disabled?: boolean;
+  showSelectAll?: boolean;
+  className?: string;
+}
+
+export default function CheckboxGroup({
+  options,
+  value,
+  onChange,
+  label,
+  error,
+  disabled = false,
+  showSelectAll = false,
+  className = '',
+}: CheckboxGroupProps) {
+  const handleToggle = (optionValue: string) => {
+    if (value.includes(optionValue)) {
+      onChange(value.filter((v) => v !== optionValue));
+    } else {
+      onChange([...value, optionValue]);
+    }
+  };
+
+  const allSelected = options.every((o) => value.includes(o.value));
+
+  return (
+    <div className={`${className}`.trim()}>
+      {label && <p className="text-sm text-gray-400 mb-2">{label}</p>}
+      {showSelectAll && (
+        <button
+          type="button"
+          onClick={() => onChange(allSelected ? [] : options.map((o) => o.value))}
+          disabled={disabled}
+          className="text-xs text-blue-400 hover:text-blue-300 mb-2 disabled:opacity-50"
+        >
+          {allSelected ? 'すべて解除' : 'すべて選択'}
+        </button>
+      )}
+      <div className="space-y-2">
+        {options.map((option) => (
+          <label key={option.value} className="flex items-start gap-3 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={value.includes(option.value)}
+              onChange={() => handleToggle(option.value)}
+              disabled={disabled}
+              className="mt-1 rounded border-gray-600 bg-gray-800 text-blue-500 focus:ring-blue-500"
+            />
+            <div>
+              <span className="text-sm text-gray-200">{option.label}</span>
+              {option.description && (
+                <p className="text-xs text-gray-500">{option.description}</p>
+              )}
+            </div>
+          </label>
+        ))}
+      </div>
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/CheckboxGroup.test.tsx
+++ b/frontend/src/components/common/__tests__/CheckboxGroup.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CheckboxGroup from '../CheckboxGroup';
+
+const options = [
+  { value: 'react', label: 'React' },
+  { value: 'vue', label: 'Vue' },
+  { value: 'angular', label: 'Angular', description: 'Google製フレームワーク' },
+];
+
+describe('CheckboxGroup', () => {
+  it('すべてのオプションが表示される', () => {
+    render(<CheckboxGroup options={options} value={[]} onChange={() => {}} />);
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('Vue')).toBeInTheDocument();
+    expect(screen.getByText('Angular')).toBeInTheDocument();
+  });
+
+  it('選択済みの値がチェックされる', () => {
+    render(<CheckboxGroup options={options} value={['react']} onChange={() => {}} />);
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
+  });
+
+  it('クリックで値が追加される', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<CheckboxGroup options={options} value={['react']} onChange={onChange} />);
+    await user.click(screen.getByText('Vue'));
+    expect(onChange).toHaveBeenCalledWith(['react', 'vue']);
+  });
+
+  it('クリックで値が削除される', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<CheckboxGroup options={options} value={['react', 'vue']} onChange={onChange} />);
+    await user.click(screen.getByText('React'));
+    expect(onChange).toHaveBeenCalledWith(['vue']);
+  });
+
+  it('説明テキストが表示される', () => {
+    render(<CheckboxGroup options={options} value={[]} onChange={() => {}} />);
+    expect(screen.getByText('Google製フレームワーク')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<CheckboxGroup options={options} value={[]} onChange={() => {}} label="フレームワーク" />);
+    expect(screen.getByText('フレームワーク')).toBeInTheDocument();
+  });
+
+  it('エラーメッセージが表示される', () => {
+    render(<CheckboxGroup options={options} value={[]} onChange={() => {}} error="選択してください" />);
+    expect(screen.getByText('選択してください')).toBeInTheDocument();
+  });
+
+  it('無効状態で全チェックボックスが無効になる', () => {
+    render(<CheckboxGroup options={options} value={[]} onChange={() => {}} disabled />);
+    const checkboxes = screen.getAllByRole('checkbox');
+    checkboxes.forEach((cb) => expect(cb).toBeDisabled());
+  });
+
+  it('全選択ボタンで全て選択される', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<CheckboxGroup options={options} value={[]} onChange={onChange} showSelectAll />);
+    await user.click(screen.getByText('すべて選択'));
+    expect(onChange).toHaveBeenCalledWith(['react', 'vue', 'angular']);
+  });
+
+  it('全解除ボタンで全て解除される', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<CheckboxGroup options={options} value={['react', 'vue', 'angular']} onChange={onChange} showSelectAll />);
+    await user.click(screen.getByText('すべて解除'));
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<CheckboxGroup options={options} value={[]} onChange={() => {}} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
チェックボックスグループコンポーネントをTDDで実装

## 変更内容
- `CheckboxGroup.tsx`: チェックボックスグループコンポーネント
- `CheckboxGroup.test.tsx`: 11件のテストケース

## テスト内容
- 全オプション表示・選択状態
- クリックで値追加/削除
- 説明テキスト・ラベル・エラー表示
- disabled対応・全選択/全解除
- カスタムクラス名