### PR TITLE
feat: Popoverコンポーネントの実装 (#1926)

### DIFF
--- a/frontend/src/components/common/Popover.tsx
+++ b/frontend/src/components/common/Popover.tsx
@@ -1,0 +1,41 @@
+import { useState, useRef, ReactNode, ReactElement } from 'react';
+
+interface PopoverProps {
+  trigger: ReactElement;
+  children: ReactNode;
+  position?: 'top' | 'bottom' | 'left' | 'right';
+  title?: string;
+  className?: string;
+}
+
+const positionClasses = {
+  top: 'bottom-full left-1/2 -translate-x-1/2 mb-2',
+  bottom: 'top-full left-1/2 -translate-x-1/2 mt-2',
+  left: 'right-full top-1/2 -translate-y-1/2 mr-2',
+  right: 'left-full top-1/2 -translate-y-1/2 ml-2',
+};
+
+export default function Popover({
+  trigger,
+  children,
+  position = 'bottom',
+  title,
+  className = '',
+}: PopoverProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <div onClick={() => setOpen(!open)}>{trigger}</div>
+      {open && (
+        <div
+          className={`absolute z-50 ${positionClasses[position]} bg-gray-800 border border-gray-700 rounded-lg shadow-xl p-3 min-w-[200px] ${className}`.trim()}
+        >
+          {title && <p className="text-sm font-semibold text-gray-200 mb-2">{title}</p>}
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Popover.test.tsx
+++ b/frontend/src/components/common/__tests__/Popover.test.tsx
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Popover from '../Popover';
+
+describe('Popover', () => {
+  it('トリガーが表示される', () => {
+    render(
+      <Popover trigger={<button>開く</button>}>
+        <p>ポップオーバー内容</p>
+      </Popover>
+    );
+    expect(screen.getByText('開く')).toBeInTheDocument();
+  });
+
+  it('初期状態でコンテンツが非表示', () => {
+    render(
+      <Popover trigger={<button>開く</button>}>
+        <p>ポップオーバー内容</p>
+      </Popover>
+    );
+    expect(screen.queryByText('ポップオーバー内容')).not.toBeInTheDocument();
+  });
+
+  it('クリックでコンテンツが表示される', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover trigger={<button>開く</button>}>
+        <p>ポップオーバー内容</p>
+      </Popover>
+    );
+    await user.click(screen.getByText('開く'));
+    expect(screen.getByText('ポップオーバー内容')).toBeInTheDocument();
+  });
+
+  it('再クリックで閉じる', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover trigger={<button>開く</button>}>
+        <p>ポップオーバー内容</p>
+      </Popover>
+    );
+    await user.click(screen.getByText('開く'));
+    await user.click(screen.getByText('開く'));
+    expect(screen.queryByText('ポップオーバー内容')).not.toBeInTheDocument();
+  });
+
+  it('上方向に配置される', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Popover trigger={<button>開く</button>} position="top">
+        <p>内容</p>
+      </Popover>
+    );
+    await user.click(screen.getByText('開く'));
+    expect(container.querySelector('.bottom-full')).toBeInTheDocument();
+  });
+
+  it('下方向に配置される（デフォルト）', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Popover trigger={<button>開く</button>}>
+        <p>内容</p>
+      </Popover>
+    );
+    await user.click(screen.getByText('開く'));
+    expect(container.querySelector('.top-full')).toBeInTheDocument();
+  });
+
+  it('左方向に配置される', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Popover trigger={<button>開く</button>} position="left">
+        <p>内容</p>
+      </Popover>
+    );
+    await user.click(screen.getByText('開く'));
+    expect(container.querySelector('.right-full')).toBeInTheDocument();
+  });
+
+  it('右方向に配置される', async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <Popover trigger={<button>開く</button>} position="right">
+        <p>内容</p>
+      </Popover>
+    );
+    await user.click(screen.getByText('開く'));
+    expect(container.querySelector('.left-full')).toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover trigger={<button>開く</button>} title="詳細情報">
+        <p>内容</p>
+      </Popover>
+    );
+    await user.click(screen.getByText('開く'));
+    expect(screen.getByText('詳細情報')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', async () => {
+    const user = userEvent.setup();
+    render(
+      <Popover trigger={<button>開く</button>} className="custom-class">
+        <p>内容</p>
+      </Popover>
+    );
+    await user.click(screen.getByText('開く'));
+    expect(document.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
ポップオーバーコンポーネントをTDDで実装

## 変更内容
- `Popover.tsx`: ポップオーバーコンポーネント
- `Popover.test.tsx`: 10件のテストケース

## テスト内容
- トリガー表示・初期非表示
- クリックで表示/閉じる
- 上下左右配置
- タイトル表示・カスタムクラス名