### PR TITLE
feat: DataTableコンポーネントの実装 (#1928)

### DIFF
--- a/frontend/src/components/common/DataTable.tsx
+++ b/frontend/src/components/common/DataTable.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { ChevronUp, ChevronDown } from 'lucide-react';
+
+interface Column {
+  key: string;
+  label: string;
+  sortable?: boolean;
+}
+
+interface DataTableProps {
+  columns: Column[];
+  data: Record<string, unknown>[];
+  onRowClick?: (row: Record<string, unknown>, index: number) => void;
+  emptyMessage?: string;
+  striped?: boolean;
+  className?: string;
+}
+
+export default function DataTable({
+  columns,
+  data,
+  onRowClick,
+  emptyMessage = 'データがありません',
+  striped = false,
+  className = '',
+}: DataTableProps) {
+  const [sortKey, setSortKey] = useState<string | null>(null);
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc');
+
+  const handleSort = (col: Column) => {
+    if (!col.sortable) return;
+    if (sortKey === col.key) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortKey(col.key);
+      setSortDir('asc');
+    }
+  };
+
+  const sortedData = sortKey
+    ? [...data].sort((a, b) => {
+        const aVal = a[sortKey];
+        const bVal = b[sortKey];
+        if (aVal == null || bVal == null) return 0;
+        const cmp = aVal < bVal ? -1 : aVal > bVal ? 1 : 0;
+        return sortDir === 'asc' ? cmp : -cmp;
+      })
+    : data;
+
+  return (
+    <div className={`overflow-x-auto ${className}`.trim()}>
+      <table className="w-full text-sm text-left">
+        <thead>
+          <tr className="border-b border-gray-700">
+            {columns.map((col) => (
+              <th
+                key={col.key}
+                className={`px-4 py-3 text-gray-400 font-medium ${col.sortable ? 'cursor-pointer hover:text-gray-200 select-none' : ''}`}
+                onClick={() => handleSort(col)}
+              >
+                <span className="flex items-center gap-1">
+                  {col.label}
+                  {col.sortable && sortKey === col.key && (
+                    sortDir === 'asc' ? <ChevronUp className="w-3 h-3" /> : <ChevronDown className="w-3 h-3" />
+                  )}
+                </span>
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {sortedData.length === 0 ? (
+            <tr>
+              <td colSpan={columns.length} className="px-4 py-8 text-center text-gray-500">
+                {emptyMessage}
+              </td>
+            </tr>
+          ) : (
+            sortedData.map((row, i) => (
+              <tr
+                key={i}
+                className={`border-b border-gray-800 ${striped && i % 2 === 1 ? 'bg-gray-800/30' : ''} ${onRowClick ? 'cursor-pointer hover:bg-gray-800/50' : ''}`}
+                onClick={() => onRowClick?.(row, i)}
+              >
+                {columns.map((col) => (
+                  <td key={col.key} className="px-4 py-3 text-gray-300">
+                    {String(row[col.key] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/DataTable.test.tsx
+++ b/frontend/src/components/common/__tests__/DataTable.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DataTable from '../DataTable';
+
+const columns = [
+  { key: 'name', label: '名前', sortable: true },
+  { key: 'age', label: '年齢', sortable: true },
+  { key: 'role', label: '役割' },
+];
+
+const data = [
+  { name: '田中', age: 30, role: 'エンジニア' },
+  { name: '佐藤', age: 25, role: 'デザイナー' },
+  { name: '鈴木', age: 35, role: 'マネージャー' },
+];
+
+describe('DataTable', () => {
+  it('ヘッダーが表示される', () => {
+    render(<DataTable columns={columns} data={data} />);
+    expect(screen.getByText('名前')).toBeInTheDocument();
+    expect(screen.getByText('年齢')).toBeInTheDocument();
+    expect(screen.getByText('役割')).toBeInTheDocument();
+  });
+
+  it('データ行が表示される', () => {
+    render(<DataTable columns={columns} data={data} />);
+    expect(screen.getByText('田中')).toBeInTheDocument();
+    expect(screen.getByText('佐藤')).toBeInTheDocument();
+    expect(screen.getByText('鈴木')).toBeInTheDocument();
+  });
+
+  it('全セルが表示される', () => {
+    render(<DataTable columns={columns} data={data} />);
+    expect(screen.getByText('エンジニア')).toBeInTheDocument();
+    expect(screen.getByText('デザイナー')).toBeInTheDocument();
+    expect(screen.getByText('マネージャー')).toBeInTheDocument();
+  });
+
+  it('ソート可能カラムをクリックでソートされる', async () => {
+    const user = userEvent.setup();
+    render(<DataTable columns={columns} data={data} />);
+    await user.click(screen.getByText('年齢'));
+    const cells = screen.getAllByRole('cell');
+    const ageCells = cells.filter((_, i) => i % 3 === 1);
+    expect(ageCells[0].textContent).toBe('25');
+  });
+
+  it('2回クリックで降順ソート', async () => {
+    const user = userEvent.setup();
+    render(<DataTable columns={columns} data={data} />);
+    await user.click(screen.getByText('年齢'));
+    await user.click(screen.getByText('年齢'));
+    const cells = screen.getAllByRole('cell');
+    const ageCells = cells.filter((_, i) => i % 3 === 1);
+    expect(ageCells[0].textContent).toBe('35');
+  });
+
+  it('空データで空メッセージが表示される', () => {
+    render(<DataTable columns={columns} data={[]} emptyMessage="データがありません" />);
+    expect(screen.getByText('データがありません')).toBeInTheDocument();
+  });
+
+  it('行クリックでコールバックが呼ばれる', async () => {
+    const onRowClick = vi.fn();
+    const user = userEvent.setup();
+    render(<DataTable columns={columns} data={data} onRowClick={onRowClick} />);
+    await user.click(screen.getByText('田中'));
+    expect(onRowClick).toHaveBeenCalledWith(data[0], 0);
+  });
+
+  it('ストライプ行が適用される', () => {
+    const { container } = render(<DataTable columns={columns} data={data} striped />);
+    expect(container.querySelector('.bg-gray-800\\/30')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<DataTable columns={columns} data={data} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('ソート不可カラムはクリックしてもソートされない', async () => {
+    const user = userEvent.setup();
+    render(<DataTable columns={columns} data={data} />);
+    await user.click(screen.getByText('役割'));
+    const cells = screen.getAllByRole('cell');
+    expect(cells[0].textContent).toBe('田中');
+  });
+
+  it('テーブル要素が正しく描画される', () => {
+    render(<DataTable columns={columns} data={data} />);
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
データテーブルコンポーネントをTDDで実装

## 変更内容
- `DataTable.tsx`: データテーブルコンポーネント
- `DataTable.test.tsx`: 11件のテストケース

## テスト内容
- ヘッダー・データ行・全セル表示
- 昇順/降順ソート
- 空データメッセージ・行クリック
- ストライプ行・カスタムクラス名
- ソート不可カラムの動作