### PR TITLE
feat: Carouselコンポーネントの実装 (#1930)

### DIFF
--- a/frontend/src/components/common/Carousel.tsx
+++ b/frontend/src/components/common/Carousel.tsx
@@ -1,0 +1,83 @@
+import { useState, ReactNode } from 'react';
+import { ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface CarouselProps<T> {
+  items: T[];
+  renderItem: (item: T, index: number) => ReactNode;
+  loop?: boolean;
+  showDots?: boolean;
+  onChange?: (index: number) => void;
+  className?: string;
+}
+
+export default function Carousel<T>({
+  items,
+  renderItem,
+  loop = false,
+  showDots = false,
+  onChange,
+  className = '',
+}: CarouselProps<T>) {
+  const [current, setCurrent] = useState(0);
+
+  const goTo = (index: number) => {
+    setCurrent(index);
+    onChange?.(index);
+  };
+
+  const prev = () => {
+    if (loop && current === 0) {
+      goTo(items.length - 1);
+    } else if (current > 0) {
+      goTo(current - 1);
+    }
+  };
+
+  const next = () => {
+    if (loop && current === items.length - 1) {
+      goTo(0);
+    } else if (current < items.length - 1) {
+      goTo(current + 1);
+    }
+  };
+
+  const canPrev = loop || current > 0;
+  const canNext = loop || current < items.length - 1;
+
+  return (
+    <div className={`relative ${className}`.trim()}>
+      <div className="overflow-hidden">{renderItem(items[current], current)}</div>
+      <button
+        type="button"
+        aria-label="前へ"
+        onClick={prev}
+        disabled={!canPrev}
+        className="absolute left-2 top-1/2 -translate-y-1/2 p-1 bg-gray-800/80 rounded-full text-gray-300 hover:text-white disabled:opacity-30"
+      >
+        <ChevronLeft className="w-5 h-5" />
+      </button>
+      <button
+        type="button"
+        aria-label="次へ"
+        onClick={next}
+        disabled={!canNext}
+        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 bg-gray-800/80 rounded-full text-gray-300 hover:text-white disabled:opacity-30"
+      >
+        <ChevronRight className="w-5 h-5" />
+      </button>
+      {showDots && (
+        <div className="flex justify-center gap-2 mt-3">
+          {items.map((_, i) => (
+            <button
+              key={i}
+              type="button"
+              data-testid="carousel-dot"
+              onClick={() => goTo(i)}
+              className={`w-2 h-2 rounded-full transition-colors ${i === current ? 'bg-blue-500' : 'bg-gray-600'}`}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Carousel.test.tsx
+++ b/frontend/src/components/common/__tests__/Carousel.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Carousel from '../Carousel';
+
+const items = ['スライド1', 'スライド2', 'スライド3'];
+
+describe('Carousel', () => {
+  it('最初のスライドが表示される', () => {
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} />);
+    expect(screen.getByText('スライド1')).toBeInTheDocument();
+  });
+
+  it('次へボタンで次のスライドが表示される', async () => {
+    const user = userEvent.setup();
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} />);
+    await user.click(screen.getByLabelText('次へ'));
+    expect(screen.getByText('スライド2')).toBeInTheDocument();
+  });
+
+  it('前へボタンで前のスライドが表示される', async () => {
+    const user = userEvent.setup();
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} />);
+    await user.click(screen.getByLabelText('次へ'));
+    await user.click(screen.getByLabelText('前へ'));
+    expect(screen.getByText('スライド1')).toBeInTheDocument();
+  });
+
+  it('最初のスライドで前へボタンが無効（ループなし）', () => {
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} />);
+    expect(screen.getByLabelText('前へ')).toBeDisabled();
+  });
+
+  it('最後のスライドで次へボタンが無効（ループなし）', async () => {
+    const user = userEvent.setup();
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} />);
+    await user.click(screen.getByLabelText('次へ'));
+    await user.click(screen.getByLabelText('次へ'));
+    expect(screen.getByLabelText('次へ')).toBeDisabled();
+  });
+
+  it('ループ有効時に最後から最初へ戻る', async () => {
+    const user = userEvent.setup();
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} loop />);
+    await user.click(screen.getByLabelText('次へ'));
+    await user.click(screen.getByLabelText('次へ'));
+    await user.click(screen.getByLabelText('次へ'));
+    expect(screen.getByText('スライド1')).toBeInTheDocument();
+  });
+
+  it('ドットインジケーターが表示される', () => {
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} showDots />);
+    const dots = screen.getAllByTestId('carousel-dot');
+    expect(dots.length).toBe(3);
+  });
+
+  it('ドットクリックでスライドが切り替わる', async () => {
+    const user = userEvent.setup();
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} showDots />);
+    await user.click(screen.getAllByTestId('carousel-dot')[2]);
+    expect(screen.getByText('スライド3')).toBeInTheDocument();
+  });
+
+  it('アクティブなドットにスタイルが適用される', () => {
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} showDots />);
+    const dots = screen.getAllByTestId('carousel-dot');
+    expect(dots[0].className).toContain('bg-blue-500');
+  });
+
+  it('onChangeコールバックが呼ばれる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} onChange={onChange} />);
+    await user.click(screen.getByLabelText('次へ'));
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Carousel items={items} renderItem={(item) => <div>{item}</div>} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
カルーセルコンポーネントをTDDで実装

## 変更内容
- `Carousel.tsx`: カルーセルコンポーネント
- `Carousel.test.tsx`: 11件のテストケース

## テスト内容
- 最初のスライド表示・前/次ナビゲーション
- ループなし時のボタン無効化
- ループ有効時の循環動作
- ドットインジケーター・ドットクリック
- onChangeコールバック・カスタムクラス名