### PR TITLE
feat: TagInputコンポーネントの実装 (#1932)

### DIFF
--- a/frontend/src/components/common/TagInput.tsx
+++ b/frontend/src/components/common/TagInput.tsx
@@ -1,79 +1,75 @@
-import { useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { useState, KeyboardEvent } from 'react';
 import { X } from 'lucide-react';
-import { inputClass } from '../../constants/styles';
 
 interface TagInputProps {
-  tags: string[];
-  onChange: (tags: string[]) => void;
-  placeholder?: string;
-  maxLength?: number;
-  prefix?: string;
+  value: string[];
+  onChange: (value: string[]) => void;
   label?: string;
-  id?: string;
+  placeholder?: string;
+  maxTags?: number;
+  disabled?: boolean;
+  className?: string;
 }
 
-export default function TagInput({ tags, onChange, placeholder, maxLength = 50, prefix, label, id }: TagInputProps) {
-  const { t } = useTranslation();
+export default function TagInput({
+  value,
+  onChange,
+  label,
+  placeholder = 'タグを入力...',
+  maxTags,
+  disabled = false,
+  className = '',
+}: TagInputProps) {
   const [input, setInput] = useState('');
 
-  const addTag = () => {
-    const trimmed = input.trim();
-    if (trimmed && !tags.includes(trimmed)) {
-      onChange([...tags, trimmed]);
+  const isMaxReached = maxTags != null && value.length >= maxTags;
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      const tag = input.trim();
+      if (!tag || value.includes(tag)) return;
+      onChange([...value, tag]);
       setInput('');
     }
   };
 
-  const removeTag = (tag: string) => {
-    onChange(tags.filter(t => t !== tag));
+  const removeTag = (index: number) => {
+    onChange(value.filter((_, i) => i !== index));
   };
 
   return (
-    <div>
-      {label && (
-        <label htmlFor={id} className="block text-sm font-medium text-gray-300 mb-1">
-          {label}
-        </label>
-      )}
-      <div className="flex gap-2">
+    <div className={`${className}`.trim()}>
+      {label && <label className="block text-sm text-gray-400 mb-1">{label}</label>}
+      <div className="flex flex-wrap gap-2 p-2 bg-gray-800 border border-gray-700 rounded-lg min-h-[42px]">
+        {value.map((tag, i) => (
+          <span
+            key={tag}
+            className="flex items-center gap-1 px-2 py-1 bg-gray-700 rounded text-sm text-gray-200"
+          >
+            {tag}
+            {!disabled && (
+              <button
+                type="button"
+                aria-label="削除"
+                onClick={() => removeTag(i)}
+                className="text-gray-400 hover:text-white"
+              >
+                <X className="w-3 h-3" />
+              </button>
+            )}
+          </span>
+        ))}
         <input
-          id={id}
           type="text"
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => e.key === 'Enter' && (e.preventDefault(), addTag())}
-          maxLength={maxLength}
-          className={`${inputClass} flex-1`}
-          placeholder={placeholder}
+          onKeyDown={handleKeyDown}
+          placeholder={value.length === 0 ? placeholder : ''}
+          disabled={disabled || isMaxReached}
+          className="flex-1 min-w-[80px] bg-transparent text-sm text-gray-200 placeholder-gray-500 focus:outline-none disabled:opacity-50"
         />
-        <button
-          type="button"
-          onClick={addTag}
-          className="px-4 py-2 bg-gray-600 hover:bg-gray-500 text-white rounded-lg transition-colors"
-        >
-          {t('common.add')}
-        </button>
       </div>
-      {tags.length > 0 && (
-        <div className="flex flex-wrap gap-2 mt-2">
-          {tags.map((tag, idx) => (
-            <span
-              key={idx}
-              className="inline-flex items-center gap-1 px-2 py-1 bg-gray-700 text-gray-300 text-sm rounded"
-            >
-              {prefix}{tag}
-              <button
-                type="button"
-                onClick={() => removeTag(tag)}
-                className="text-gray-400 hover:text-white"
-              >
-                <X className="w-3 h-3" aria-hidden="true" />
-              </button>
-            </span>
-          ))}
-        </div>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/common/__tests__/TagInput.test.tsx
+++ b/frontend/src/components/common/__tests__/TagInput.test.tsx
@@ -1,73 +1,75 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import TagInput from '../TagInput';
 
-const defaultProps = {
-  tags: [] as string[],
-  onChange: vi.fn(),
-};
-
 describe('TagInput', () => {
-  it('入力フィールドと追加ボタンが表示される', () => {
-    render(<TagInput {...defaultProps} />);
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
-    expect(screen.getByText('追加')).toBeInTheDocument();
-  });
-
-  it('追加ボタンクリックでonChangeが呼ばれる', () => {
-    const onChange = vi.fn();
-    render(<TagInput tags={[]} onChange={onChange} />);
-    const input = screen.getByRole('textbox');
-    fireEvent.change(input, { target: { value: 'React' } });
-    fireEvent.click(screen.getByText('追加'));
-    expect(onChange).toHaveBeenCalledWith(['React']);
-  });
-
   it('既存タグが表示される', () => {
-    render(<TagInput tags={['React', 'TypeScript']} onChange={vi.fn()} />);
+    render(<TagInput value={['React', 'TypeScript']} onChange={() => {}} />);
     expect(screen.getByText('React')).toBeInTheDocument();
     expect(screen.getByText('TypeScript')).toBeInTheDocument();
   });
 
-  it('prefix付きでタグが表示される', () => {
-    render(<TagInput tags={['frontend']} onChange={vi.fn()} prefix="#" />);
-    expect(screen.getByText('#frontend')).toBeInTheDocument();
+  it('入力フィールドが表示される', () => {
+    render(<TagInput value={[]} onChange={() => {}} />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
   });
 
-  it('タグ削除ボタンクリックでonChangeが呼ばれる', () => {
+  it('Enterキーでタグが追加される', async () => {
     const onChange = vi.fn();
-    render(<TagInput tags={['React', 'Go']} onChange={onChange} />);
-    const removeButtons = screen.getAllByRole('button').filter(
-      btn => btn.querySelector('svg.w-3')
-    );
-    fireEvent.click(removeButtons[0]);
-    expect(onChange).toHaveBeenCalledWith(['Go']);
+    const user = userEvent.setup();
+    render(<TagInput value={['React']} onChange={onChange} />);
+    await user.type(screen.getByRole('textbox'), 'Vue{Enter}');
+    expect(onChange).toHaveBeenCalledWith(['React', 'Vue']);
   });
 
-  it('空入力では追加されない', () => {
+  it('空入力でタグが追加されない', async () => {
     const onChange = vi.fn();
-    render(<TagInput tags={[]} onChange={onChange} />);
-    fireEvent.click(screen.getByText('追加'));
+    const user = userEvent.setup();
+    render(<TagInput value={['React']} onChange={onChange} />);
+    await user.type(screen.getByRole('textbox'), '{Enter}');
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('labelが表示される', () => {
-    render(<TagInput {...defaultProps} label="技術スタック" />);
-    expect(screen.getByText('技術スタック')).toBeInTheDocument();
+  it('重複タグが追加されない', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<TagInput value={['React']} onChange={onChange} />);
+    await user.type(screen.getByRole('textbox'), 'React{Enter}');
+    expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('id属性が設定される', () => {
-    render(<TagInput {...defaultProps} id="test-tags" />);
-    expect(screen.getByRole('textbox')).toHaveAttribute('id', 'test-tags');
+  it('削除ボタンでタグが削除される', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<TagInput value={['React', 'Vue']} onChange={onChange} />);
+    const removeButtons = screen.getAllByLabelText('削除');
+    await user.click(removeButtons[0]);
+    expect(onChange).toHaveBeenCalledWith(['Vue']);
   });
 
-  it('placeholderが表示される', () => {
-    render(<TagInput {...defaultProps} placeholder="タグを入力" />);
-    expect(screen.getByPlaceholderText('タグを入力')).toBeInTheDocument();
+  it('最大タグ数に達すると入力が無効になる', () => {
+    render(<TagInput value={['React', 'Vue', 'Angular']} onChange={() => {}} maxTags={3} />);
+    expect(screen.getByRole('textbox')).toBeDisabled();
   });
 
-  it('maxLength属性が設定される', () => {
-    render(<TagInput {...defaultProps} maxLength={100} />);
-    expect(screen.getByRole('textbox')).toHaveAttribute('maxLength', '100');
+  it('プレースホルダーが表示される', () => {
+    render(<TagInput value={[]} onChange={() => {}} placeholder="タグを追加" />);
+    expect(screen.getByPlaceholderText('タグを追加')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<TagInput value={[]} onChange={() => {}} label="スキル" />);
+    expect(screen.getByText('スキル')).toBeInTheDocument();
+  });
+
+  it('無効状態で入力が無効になる', () => {
+    render(<TagInput value={[]} onChange={() => {}} disabled />);
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<TagInput value={[]} onChange={() => {}} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## 概要
タグ入力コンポーネントをTDDで実装

## 変更内容
- `TagInput.tsx`: タグ入力コンポーネント
- `TagInput.test.tsx`: 11件のテストケース

## テスト内容
- 既存タグ表示・入力フィールド表示
- Enterでタグ追加・空入力防止・重複防止
- 削除ボタン・最大タグ数制限
- プレースホルダー・ラベル・disabled
- カスタムクラス名