### PR TITLE
feat: OTPInputコンポーネントの実装 (#1934)

### DIFF
--- a/frontend/src/components/common/OTPInput.tsx
+++ b/frontend/src/components/common/OTPInput.tsx
@@ -1,0 +1,74 @@
+import { useRef, KeyboardEvent, ChangeEvent } from 'react';
+
+interface OTPInputProps {
+  length: number;
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  error?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function OTPInput({
+  length,
+  value,
+  onChange,
+  label,
+  error,
+  disabled = false,
+  className = '',
+}: OTPInputProps) {
+  const inputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  const digits = value.split('').concat(Array(length).fill('')).slice(0, length);
+
+  const handleChange = (index: number, e: ChangeEvent<HTMLInputElement>) => {
+    const val = e.target.value.replace(/\D/g, '');
+    if (!val) return;
+
+    const char = val.slice(-1);
+    const newDigits = [...digits];
+    newDigits[index] = char;
+    onChange(newDigits.join(''));
+
+    if (index < length - 1) {
+      inputRefs.current[index + 1]?.focus();
+    }
+  };
+
+  const handleKeyDown = (index: number, e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Backspace' && !digits[index] && index > 0) {
+      const newDigits = [...digits];
+      newDigits[index - 1] = '';
+      onChange(newDigits.join(''));
+      inputRefs.current[index - 1]?.focus();
+    }
+  };
+
+  return (
+    <div className={`${className}`.trim()}>
+      {label && <label className="block text-sm text-gray-400 mb-2">{label}</label>}
+      <div className="flex gap-2">
+        {Array.from({ length }).map((_, i) => (
+          <input
+            key={i}
+            ref={(el) => { inputRefs.current[i] = el; }}
+            type="text"
+            role="textbox"
+            inputMode="numeric"
+            maxLength={1}
+            value={digits[i]}
+            onChange={(e) => handleChange(i, e)}
+            onKeyDown={(e) => handleKeyDown(i, e)}
+            disabled={disabled}
+            className={`w-12 h-12 text-center text-lg font-mono bg-gray-800 border rounded-lg text-gray-200 focus:outline-none transition-colors disabled:opacity-50 ${
+              error ? 'border-red-500' : 'border-gray-700 focus:border-blue-500'
+            }`}
+          />
+        ))}
+      </div>
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/OTPInput.test.tsx
+++ b/frontend/src/components/common/__tests__/OTPInput.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import OTPInput from '../OTPInput';
+
+describe('OTPInput', () => {
+  it('指定桁数の入力フィールドが表示される', () => {
+    render(<OTPInput length={6} value="" onChange={() => {}} />);
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs.length).toBe(6);
+  });
+
+  it('4桁の入力フィールドが表示される', () => {
+    render(<OTPInput length={4} value="" onChange={() => {}} />);
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs.length).toBe(4);
+  });
+
+  it('値が各フィールドに表示される', () => {
+    render(<OTPInput length={4} value="1234" onChange={() => {}} />);
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs[0]).toHaveValue('1');
+    expect(inputs[1]).toHaveValue('2');
+    expect(inputs[2]).toHaveValue('3');
+    expect(inputs[3]).toHaveValue('4');
+  });
+
+  it('入力でonChangeが呼ばれる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<OTPInput length={4} value="" onChange={onChange} />);
+    const inputs = screen.getAllByRole('textbox');
+    await user.type(inputs[0], '5');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<OTPInput length={4} value="" onChange={() => {}} label="認証コード" />);
+    expect(screen.getByText('認証コード')).toBeInTheDocument();
+  });
+
+  it('エラーメッセージが表示される', () => {
+    render(<OTPInput length={4} value="" onChange={() => {}} error="無効なコードです" />);
+    expect(screen.getByText('無効なコードです')).toBeInTheDocument();
+  });
+
+  it('無効状態で入力が無効になる', () => {
+    render(<OTPInput length={4} value="" onChange={() => {}} disabled />);
+    const inputs = screen.getAllByRole('textbox');
+    inputs.forEach((input) => expect(input).toBeDisabled());
+  });
+
+  it('エラー時にボーダーが赤くなる', () => {
+    render(<OTPInput length={4} value="" onChange={() => {}} error="エラー" />);
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs[0].className).toContain('border-red-500');
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<OTPInput length={4} value="" onChange={() => {}} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('数字のみ入力可能', () => {
+    render(<OTPInput length={4} value="" onChange={() => {}} />);
+    const inputs = screen.getAllByRole('textbox');
+    expect(inputs[0]).toHaveAttribute('inputMode', 'numeric');
+  });
+});


### PR DESCRIPTION
## 概要
ワンタイムパスワード入力コンポーネントをTDDで実装

## 変更内容
- `OTPInput.tsx`: OTP入力コンポーネント
- `OTPInput.test.tsx`: 10件のテストケース

## テスト内容
- 指定桁数の入力フィールド表示
- 値の各フィールド表示・入力コールバック
- ラベル・エラー表示・disabled
- エラー時ボーダー色・数字のみ入力
- カスタムクラス名