### PR TITLE
feat: ImageGalleryコンポーネントの実装 (#1936)

### DIFF
--- a/frontend/src/components/common/ImageGallery.tsx
+++ b/frontend/src/components/common/ImageGallery.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+import { X, ChevronLeft, ChevronRight } from 'lucide-react';
+
+interface ImageItem {
+  src: string;
+  alt: string;
+}
+
+interface ImageGalleryProps {
+  images: ImageItem[];
+  columns?: number;
+  emptyMessage?: string;
+  className?: string;
+}
+
+export default function ImageGallery({
+  images,
+  columns = 3,
+  emptyMessage = '画像がありません',
+  className = '',
+}: ImageGalleryProps) {
+  const [lightboxIndex, setLightboxIndex] = useState<number | null>(null);
+
+  if (images.length === 0) {
+    return (
+      <div className={`${className}`.trim()}>
+        <p className="text-center text-gray-500 py-8">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  const closeLightbox = () => setLightboxIndex(null);
+  const prev = () => setLightboxIndex((i) => (i != null && i > 0 ? i - 1 : i));
+  const next = () => setLightboxIndex((i) => (i != null && i < images.length - 1 ? i + 1 : i));
+
+  return (
+    <div className={`${className}`.trim()}>
+      <div
+        className="grid gap-2"
+        style={{ gridTemplateColumns: `repeat(${columns}, minmax(0, 1fr))` }}
+      >
+        {images.map((img, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => setLightboxIndex(i)}
+            className="overflow-hidden rounded-lg hover:opacity-80 transition-opacity"
+          >
+            <img src={img.src} alt={img.alt} className="w-full h-full object-cover" />
+          </button>
+        ))}
+      </div>
+
+      {lightboxIndex != null && (
+        <div
+          data-testid="lightbox"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80"
+        >
+          <button
+            type="button"
+            aria-label="閉じる"
+            onClick={closeLightbox}
+            className="absolute top-4 right-4 text-white hover:text-gray-300"
+          >
+            <X className="w-6 h-6" />
+          </button>
+          <button
+            type="button"
+            aria-label="前へ"
+            onClick={prev}
+            disabled={lightboxIndex === 0}
+            className="absolute left-4 text-white hover:text-gray-300 disabled:opacity-30"
+          >
+            <ChevronLeft className="w-8 h-8" />
+          </button>
+          <img
+            src={images[lightboxIndex].src}
+            alt={images[lightboxIndex].alt}
+            className="max-h-[80vh] max-w-[80vw] object-contain"
+          />
+          <button
+            type="button"
+            aria-label="次へ"
+            onClick={next}
+            disabled={lightboxIndex === images.length - 1}
+            className="absolute right-4 text-white hover:text-gray-300 disabled:opacity-30"
+          >
+            <ChevronRight className="w-8 h-8" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/ImageGallery.test.tsx
+++ b/frontend/src/components/common/__tests__/ImageGallery.test.tsx
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ImageGallery from '../ImageGallery';
+
+const images = [
+  { src: '/img1.jpg', alt: '画像1' },
+  { src: '/img2.jpg', alt: '画像2' },
+  { src: '/img3.jpg', alt: '画像3' },
+  { src: '/img4.jpg', alt: '画像4' },
+];
+
+describe('ImageGallery', () => {
+  it('すべての画像が表示される', () => {
+    render(<ImageGallery images={images} />);
+    const imgs = screen.getAllByRole('img');
+    expect(imgs.length).toBe(4);
+  });
+
+  it('alt属性が正しく設定される', () => {
+    render(<ImageGallery images={images} />);
+    expect(screen.getByAlt('画像1')).toBeInTheDocument();
+    expect(screen.getByAlt('画像2')).toBeInTheDocument();
+  });
+
+  it('画像クリックでライトボックスが表示される', async () => {
+    const user = userEvent.setup();
+    render(<ImageGallery images={images} />);
+    await user.click(screen.getByAlt('画像1'));
+    expect(screen.getByTestId('lightbox')).toBeInTheDocument();
+  });
+
+  it('ライトボックスで閉じるボタンが動作する', async () => {
+    const user = userEvent.setup();
+    render(<ImageGallery images={images} />);
+    await user.click(screen.getByAlt('画像1'));
+    await user.click(screen.getByLabelText('閉じる'));
+    expect(screen.queryByTestId('lightbox')).not.toBeInTheDocument();
+  });
+
+  it('ライトボックスで次へナビゲーション', async () => {
+    const user = userEvent.setup();
+    render(<ImageGallery images={images} />);
+    await user.click(screen.getByAlt('画像1'));
+    await user.click(screen.getByLabelText('次へ'));
+    const lightboxImg = screen.getByTestId('lightbox').querySelector('img');
+    expect(lightboxImg).toHaveAttribute('alt', '画像2');
+  });
+
+  it('ライトボックスで前へナビゲーション', async () => {
+    const user = userEvent.setup();
+    render(<ImageGallery images={images} />);
+    await user.click(screen.getByAlt('画像2'));
+    await user.click(screen.getByLabelText('前へ'));
+    const lightboxImg = screen.getByTestId('lightbox').querySelector('img');
+    expect(lightboxImg).toHaveAttribute('alt', '画像1');
+  });
+
+  it('カラム数が適用される', () => {
+    const { container } = render(<ImageGallery images={images} columns={3} />);
+    const grid = container.querySelector('[style]');
+    expect(grid).toHaveStyle({ gridTemplateColumns: 'repeat(3, minmax(0, 1fr))' });
+  });
+
+  it('デフォルトカラム数は3', () => {
+    const { container } = render(<ImageGallery images={images} />);
+    const grid = container.querySelector('[style]');
+    expect(grid).toHaveStyle({ gridTemplateColumns: 'repeat(3, minmax(0, 1fr))' });
+  });
+
+  it('空画像でメッセージが表示される', () => {
+    render(<ImageGallery images={[]} emptyMessage="画像がありません" />);
+    expect(screen.getByText('画像がありません')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<ImageGallery images={images} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
画像ギャラリーコンポーネントをTDDで実装

## 変更内容
- `ImageGallery.tsx`: 画像ギャラリーコンポーネント
- `ImageGallery.test.tsx`: 10件のテストケース

## テスト内容
- 全画像表示・alt属性
- ライトボックス表示/閉じる
- 前/次ナビゲーション
- カラム数設定・空画像メッセージ
- カスタムクラス名