### PR TITLE
feat: Bannerコンポーネントの実装 (#1938)

### DIFF
--- a/frontend/src/components/common/Banner.tsx
+++ b/frontend/src/components/common/Banner.tsx
@@ -1,0 +1,60 @@
+import { Info, CheckCircle, AlertTriangle, XCircle, X } from 'lucide-react';
+
+interface BannerProps {
+  message: string;
+  variant?: 'info' | 'success' | 'warning' | 'error';
+  title?: string;
+  onClose?: () => void;
+  actionLabel?: string;
+  onAction?: () => void;
+  className?: string;
+}
+
+const variantStyles = {
+  info: { bg: 'bg-blue-900/30 border-blue-800', icon: Info, iconColor: 'text-blue-400' },
+  success: { bg: 'bg-green-900/30 border-green-800', icon: CheckCircle, iconColor: 'text-green-400' },
+  warning: { bg: 'bg-yellow-900/30 border-yellow-800', icon: AlertTriangle, iconColor: 'text-yellow-400' },
+  error: { bg: 'bg-red-900/30 border-red-800', icon: XCircle, iconColor: 'text-red-400' },
+};
+
+export default function Banner({
+  message,
+  variant = 'info',
+  title,
+  onClose,
+  actionLabel,
+  onAction,
+  className = '',
+}: BannerProps) {
+  const style = variantStyles[variant];
+  const Icon = style.icon;
+
+  return (
+    <div className={`flex items-start gap-3 px-4 py-3 border rounded-lg ${style.bg} ${className}`.trim()}>
+      <Icon className={`w-5 h-5 flex-shrink-0 mt-0.5 ${style.iconColor}`} />
+      <div className="flex-1 min-w-0">
+        {title && <p className="text-sm font-semibold text-gray-200">{title}</p>}
+        <p className="text-sm text-gray-300">{message}</p>
+        {actionLabel && onAction && (
+          <button
+            type="button"
+            onClick={onAction}
+            className="mt-1 text-sm font-medium text-blue-400 hover:text-blue-300"
+          >
+            {actionLabel}
+          </button>
+        )}
+      </div>
+      {onClose && (
+        <button
+          type="button"
+          aria-label="閉じる"
+          onClick={onClose}
+          className="text-gray-400 hover:text-white flex-shrink-0"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/Banner.test.tsx
+++ b/frontend/src/components/common/__tests__/Banner.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Banner from '../Banner';
+
+describe('Banner', () => {
+  it('メッセージが表示される', () => {
+    render(<Banner message="お知らせです" />);
+    expect(screen.getByText('お知らせです')).toBeInTheDocument();
+  });
+
+  it('infoバリアントのスタイルが適用される', () => {
+    const { container } = render(<Banner message="情報" variant="info" />);
+    expect(container.querySelector('.bg-blue-900\\/30')).toBeInTheDocument();
+  });
+
+  it('successバリアントのスタイルが適用される', () => {
+    const { container } = render(<Banner message="成功" variant="success" />);
+    expect(container.querySelector('.bg-green-900\\/30')).toBeInTheDocument();
+  });
+
+  it('warningバリアントのスタイルが適用される', () => {
+    const { container } = render(<Banner message="警告" variant="warning" />);
+    expect(container.querySelector('.bg-yellow-900\\/30')).toBeInTheDocument();
+  });
+
+  it('errorバリアントのスタイルが適用される', () => {
+    const { container } = render(<Banner message="エラー" variant="error" />);
+    expect(container.querySelector('.bg-red-900\\/30')).toBeInTheDocument();
+  });
+
+  it('閉じるボタンでonCloseが呼ばれる', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<Banner message="テスト" onClose={onClose} />);
+    await user.click(screen.getByLabelText('閉じる'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('onCloseがない場合閉じるボタンが非表示', () => {
+    render(<Banner message="テスト" />);
+    expect(screen.queryByLabelText('閉じる')).not.toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<Banner message="内容" title="重要なお知らせ" />);
+    expect(screen.getByText('重要なお知らせ')).toBeInTheDocument();
+  });
+
+  it('アクションボタンが表示される', async () => {
+    const onAction = vi.fn();
+    const user = userEvent.setup();
+    render(<Banner message="内容" actionLabel="詳細を見る" onAction={onAction} />);
+    await user.click(screen.getByText('詳細を見る'));
+    expect(onAction).toHaveBeenCalled();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<Banner message="テスト" className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('デフォルトバリアントはinfo', () => {
+    const { container } = render(<Banner message="テスト" />);
+    expect(container.querySelector('.bg-blue-900\\/30')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
バナーコンポーネントをTDDで実装

## 変更内容
- `Banner.tsx`: バナーコンポーネント
- `Banner.test.tsx`: 11件のテストケース

## テスト内容
- メッセージ表示・4バリアントスタイル
- 閉じるボタン・閉じるボタン非表示
- タイトル表示・アクションボタン
- カスタムクラス名・デフォルトバリアント