### PR TITLE
feat: CommandPaletteコンポーネントの実装 (#1940)

### DIFF
--- a/frontend/src/components/common/CommandPalette.tsx
+++ b/frontend/src/components/common/CommandPalette.tsx
@@ -1,0 +1,94 @@
+import { useState, useEffect, useRef, useMemo } from 'react';
+import { Search } from 'lucide-react';
+
+interface Command {
+  id: string;
+  label: string;
+  category: string;
+  icon?: string;
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  commands: Command[];
+  onSelect: (command: Command) => void;
+  onClose: () => void;
+  className?: string;
+}
+
+export default function CommandPalette({
+  open,
+  commands,
+  onSelect,
+  onClose,
+  className = '',
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      setQuery('');
+      setTimeout(() => inputRef.current?.focus(), 0);
+    }
+  }, [open]);
+
+  const filtered = useMemo(
+    () => commands.filter((cmd) => cmd.label.toLowerCase().includes(query.toLowerCase())),
+    [commands, query]
+  );
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, Command[]>();
+    filtered.forEach((cmd) => {
+      const group = map.get(cmd.category) || [];
+      group.push(cmd);
+      map.set(cmd.category, group);
+    });
+    return map;
+  }, [filtered]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center pt-[20vh]">
+      <div data-testid="palette-overlay" className="absolute inset-0 bg-black/50" onClick={onClose} />
+      <div className={`relative w-full max-w-lg bg-gray-900 border border-gray-700 rounded-xl shadow-2xl overflow-hidden ${className}`.trim()}>
+        <div className="flex items-center gap-2 px-4 py-3 border-b border-gray-800">
+          <Search className="w-4 h-4 text-gray-500" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="コマンドを検索..."
+            className="flex-1 bg-transparent text-sm text-gray-200 placeholder-gray-500 focus:outline-none"
+            autoFocus
+          />
+        </div>
+        <div className="max-h-[300px] overflow-y-auto p-2">
+          {filtered.length === 0 ? (
+            <p className="text-center text-sm text-gray-500 py-4">コマンドが見つかりません</p>
+          ) : (
+            Array.from(grouped.entries()).map(([category, cmds]) => (
+              <div key={category}>
+                <p className="text-xs text-gray-500 px-2 py-1 font-medium">{category}</p>
+                {cmds.map((cmd) => (
+                  <button
+                    key={cmd.id}
+                    type="button"
+                    onClick={() => onSelect(cmd)}
+                    className="w-full flex items-center gap-2 px-3 py-2 text-sm text-gray-300 hover:bg-gray-800 rounded-lg transition-colors"
+                  >
+                    {cmd.icon && <span>{cmd.icon}</span>}
+                    <span>{cmd.label}</span>
+                  </button>
+                ))}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/CommandPalette.test.tsx
+++ b/frontend/src/components/common/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import CommandPalette from '../CommandPalette';
+
+const commands = [
+  { id: '1', label: 'ダッシュボード', category: 'ページ' },
+  { id: '2', label: 'プロフィール', category: 'ページ' },
+  { id: '3', label: 'ダークモード切替', category: '設定' },
+  { id: '4', label: 'ログアウト', category: 'アクション' },
+];
+
+describe('CommandPalette', () => {
+  it('開いた状態でコマンドが表示される', () => {
+    render(<CommandPalette open commands={commands} onSelect={() => {}} onClose={() => {}} />);
+    expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+    expect(screen.getByText('ログアウト')).toBeInTheDocument();
+  });
+
+  it('閉じた状態で非表示', () => {
+    render(<CommandPalette open={false} commands={commands} onSelect={() => {}} onClose={() => {}} />);
+    expect(screen.queryByText('ダッシュボード')).not.toBeInTheDocument();
+  });
+
+  it('検索でフィルタリングされる', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette open commands={commands} onSelect={() => {}} onClose={() => {}} />);
+    await user.type(screen.getByPlaceholderText('コマンドを検索...'), 'ダッシュ');
+    expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+    expect(screen.queryByText('ログアウト')).not.toBeInTheDocument();
+  });
+
+  it('コマンドクリックでonSelectが呼ばれる', async () => {
+    const onSelect = vi.fn();
+    const user = userEvent.setup();
+    render(<CommandPalette open commands={commands} onSelect={onSelect} onClose={() => {}} />);
+    await user.click(screen.getByText('ダッシュボード'));
+    expect(onSelect).toHaveBeenCalledWith(commands[0]);
+  });
+
+  it('オーバーレイクリックでonCloseが呼ばれる', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<CommandPalette open commands={commands} onSelect={() => {}} onClose={onClose} />);
+    await user.click(screen.getByTestId('palette-overlay'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('カテゴリが表示される', () => {
+    render(<CommandPalette open commands={commands} onSelect={() => {}} onClose={() => {}} />);
+    expect(screen.getByText('ページ')).toBeInTheDocument();
+    expect(screen.getByText('設定')).toBeInTheDocument();
+    expect(screen.getByText('アクション')).toBeInTheDocument();
+  });
+
+  it('検索結果が空の場合メッセージが表示される', async () => {
+    const user = userEvent.setup();
+    render(<CommandPalette open commands={commands} onSelect={() => {}} onClose={() => {}} />);
+    await user.type(screen.getByPlaceholderText('コマンドを検索...'), 'zzzzz');
+    expect(screen.getByText('コマンドが見つかりません')).toBeInTheDocument();
+  });
+
+  it('検索フィールドが自動フォーカスされる', () => {
+    render(<CommandPalette open commands={commands} onSelect={() => {}} onClose={() => {}} />);
+    expect(screen.getByPlaceholderText('コマンドを検索...')).toHaveFocus();
+  });
+
+  it('アイコン付きコマンドが表示される', () => {
+    const cmds = [{ id: '1', label: 'テスト', category: 'カテゴリ', icon: '🔍' }];
+    render(<CommandPalette open commands={cmds} onSelect={() => {}} onClose={() => {}} />);
+    expect(screen.getByText('🔍')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    render(<CommandPalette open commands={commands} onSelect={() => {}} onClose={() => {}} className="custom-class" />);
+    expect(document.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
コマンドパレットコンポーネントをTDDで実装

## 変更内容
- `CommandPalette.tsx`: コマンドパレットコンポーネント
- `CommandPalette.test.tsx`: 10件のテストケース

## テスト内容
- 開閉状態の表示制御
- 検索フィルタリング・空結果メッセージ
- コマンドクリック・オーバーレイクリック
- カテゴリ表示・自動フォーカス
- アイコン付きコマンド・カスタムクラス名