### PR TITLE
feat: ResizablePanelコンポーネントの実装 (#1944)

### DIFF
--- a/frontend/src/components/common/ResizablePanel.tsx
+++ b/frontend/src/components/common/ResizablePanel.tsx
@@ -1,0 +1,69 @@
+import { useState, useCallback, ReactNode, useRef } from 'react';
+
+interface ResizablePanelProps {
+  children: ReactNode;
+  defaultSize?: number;
+  minSize?: number;
+  maxSize?: number;
+  direction?: 'horizontal' | 'vertical';
+  className?: string;
+}
+
+export default function ResizablePanel({
+  children,
+  defaultSize = 250,
+  minSize = 100,
+  maxSize = 800,
+  direction = 'horizontal',
+  className = '',
+}: ResizablePanelProps) {
+  const [size, setSize] = useState(defaultSize);
+  const isResizing = useRef(false);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      e.preventDefault();
+      isResizing.current = true;
+      const startPos = direction === 'horizontal' ? e.clientX : e.clientY;
+      const startSize = size;
+
+      const handleMouseMove = (moveEvent: MouseEvent) => {
+        if (!isResizing.current) return;
+        const currentPos = direction === 'horizontal' ? moveEvent.clientX : moveEvent.clientY;
+        const delta = currentPos - startPos;
+        const newSize = Math.min(maxSize, Math.max(minSize, startSize + delta));
+        setSize(newSize);
+      };
+
+      const handleMouseUp = () => {
+        isResizing.current = false;
+        document.removeEventListener('mousemove', handleMouseMove);
+        document.removeEventListener('mouseup', handleMouseUp);
+      };
+
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    },
+    [size, minSize, maxSize, direction]
+  );
+
+  const isHorizontal = direction === 'horizontal';
+  const style = isHorizontal ? { width: `${size}px` } : { height: `${size}px` };
+
+  return (
+    <div className={`relative flex ${isHorizontal ? 'flex-row' : 'flex-col'} ${className}`.trim()}>
+      <div className="overflow-auto" style={style}>
+        {children}
+      </div>
+      <div
+        data-testid="resize-handle"
+        onMouseDown={handleMouseDown}
+        className={`flex-shrink-0 ${
+          isHorizontal
+            ? 'w-1 cursor-col-resize hover:bg-blue-500'
+            : 'h-1 cursor-row-resize hover:bg-blue-500'
+        } bg-gray-700 transition-colors`}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/ResizablePanel.test.tsx
+++ b/frontend/src/components/common/__tests__/ResizablePanel.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ResizablePanel from '../ResizablePanel';
+
+describe('ResizablePanel', () => {
+  it('コンテンツが表示される', () => {
+    render(<ResizablePanel>パネル内容</ResizablePanel>);
+    expect(screen.getByText('パネル内容')).toBeInTheDocument();
+  });
+
+  it('初期幅が適用される', () => {
+    render(<ResizablePanel defaultSize={300}>内容</ResizablePanel>);
+    const panel = screen.getByText('内容').closest('[style]');
+    expect(panel).toHaveStyle({ width: '300px' });
+  });
+
+  it('リサイズハンドルが表示される', () => {
+    render(<ResizablePanel>内容</ResizablePanel>);
+    expect(screen.getByTestId('resize-handle')).toBeInTheDocument();
+  });
+
+  it('最小幅が設定される', () => {
+    render(<ResizablePanel minSize={100} defaultSize={100}>内容</ResizablePanel>);
+    const panel = screen.getByText('内容').closest('[style]');
+    expect(panel).toHaveStyle({ width: '100px' });
+  });
+
+  it('水平方向がデフォルト', () => {
+    render(<ResizablePanel>内容</ResizablePanel>);
+    const handle = screen.getByTestId('resize-handle');
+    expect(handle.className).toContain('cursor-col-resize');
+  });
+
+  it('垂直方向に設定可能', () => {
+    render(<ResizablePanel direction="vertical" defaultSize={200}>内容</ResizablePanel>);
+    const handle = screen.getByTestId('resize-handle');
+    expect(handle.className).toContain('cursor-row-resize');
+  });
+
+  it('垂直方向で高さが適用される', () => {
+    render(<ResizablePanel direction="vertical" defaultSize={200}>内容</ResizablePanel>);
+    const panel = screen.getByText('内容').closest('[style]');
+    expect(panel).toHaveStyle({ height: '200px' });
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<ResizablePanel className="custom-class">内容</ResizablePanel>);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('子要素が正しく描画される', () => {
+    render(
+      <ResizablePanel>
+        <div>子要素1</div>
+        <div>子要素2</div>
+      </ResizablePanel>
+    );
+    expect(screen.getByText('子要素1')).toBeInTheDocument();
+    expect(screen.getByText('子要素2')).toBeInTheDocument();
+  });
+
+  it('デフォルトサイズが250px', () => {
+    render(<ResizablePanel>内容</ResizablePanel>);
+    const panel = screen.getByText('内容').closest('[style]');
+    expect(panel).toHaveStyle({ width: '250px' });
+  });
+});


### PR DESCRIPTION
## 概要
リサイズ可能パネルコンポーネントをTDDで実装

## 変更内容
- `ResizablePanel.tsx`: リサイズ可能パネルコンポーネント
- `ResizablePanel.test.tsx`: 10件のテストケース

## テスト内容
- コンテンツ表示・初期幅
- リサイズハンドル表示・最小幅
- 水平/垂直方向切替
- デフォルトサイズ・カスタムクラス名
- 子要素の描画