### PR TITLE
feat: ScrollToTopコンポーネントの実装 (#1946)

### DIFF
--- a/frontend/src/components/common/ScrollToTop.tsx
+++ b/frontend/src/components/common/ScrollToTop.tsx
@@ -1,26 +1,41 @@
 import { useState, useEffect } from 'react';
-import { ChevronUp } from 'lucide-react';
-import { useTranslation } from 'react-i18next';
+import { ArrowUp } from 'lucide-react';
 
-export default function ScrollToTop() {
-  const { t } = useTranslation();
+interface ScrollToTopProps {
+  threshold?: number;
+  className?: string;
+}
+
+export default function ScrollToTop({
+  threshold = 300,
+  className = '',
+}: ScrollToTopProps) {
   const [visible, setVisible] = useState(false);
 
   useEffect(() => {
-    const onScroll = () => setVisible(window.scrollY > 200);
-    window.addEventListener('scroll', onScroll, { passive: true });
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
+    const handleScroll = () => {
+      setVisible(window.scrollY > threshold);
+    };
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [threshold]);
+
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
 
   if (!visible) return null;
 
   return (
-    <button
-      onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
-      className="fixed bottom-6 right-6 z-40 p-3 bg-gray-800 hover:bg-gray-700 text-gray-300 hover:text-white border border-gray-700 rounded-full shadow-sm transition-all duration-200"
-      aria-label={t('common.scrollToTop')}
-    >
-      <ChevronUp className="w-5 h-5" />
-    </button>
+    <div className={`fixed bottom-6 right-6 z-40 ${className}`.trim()}>
+      <button
+        type="button"
+        aria-label="トップへ戻る"
+        onClick={scrollToTop}
+        className="p-3 bg-blue-600 hover:bg-blue-500 text-white rounded-full shadow-lg transition-colors"
+      >
+        <ArrowUp className="w-5 h-5" />
+      </button>
+    </div>
   );
 }

--- a/frontend/src/components/common/__tests__/ScrollToTop.test.tsx
+++ b/frontend/src/components/common/__tests__/ScrollToTop.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ScrollToTop from '../ScrollToTop';
+
+describe('ScrollToTop', () => {
+  it('初期状態で非表示', () => {
+    render(<ScrollToTop />);
+    expect(screen.queryByLabelText('トップへ戻る')).not.toBeInTheDocument();
+  });
+
+  it('スクロール後に表示される', () => {
+    render(<ScrollToTop threshold={100} />);
+    Object.defineProperty(window, 'scrollY', { value: 200, writable: true });
+    fireEvent.scroll(window);
+    expect(screen.getByLabelText('トップへ戻る')).toBeInTheDocument();
+  });
+
+  it('スクロール戻りで非表示に戻る', () => {
+    render(<ScrollToTop threshold={100} />);
+    Object.defineProperty(window, 'scrollY', { value: 200, writable: true });
+    fireEvent.scroll(window);
+    Object.defineProperty(window, 'scrollY', { value: 50, writable: true });
+    fireEvent.scroll(window);
+    expect(screen.queryByLabelText('トップへ戻る')).not.toBeInTheDocument();
+  });
+
+  it('クリックでwindow.scrollToが呼ばれる', async () => {
+    const scrollToMock = vi.fn();
+    window.scrollTo = scrollToMock;
+    const user = userEvent.setup();
+    render(<ScrollToTop threshold={100} />);
+    Object.defineProperty(window, 'scrollY', { value: 200, writable: true });
+    fireEvent.scroll(window);
+    await user.click(screen.getByLabelText('トップへ戻る'));
+    expect(scrollToMock).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+  });
+
+  it('デフォルトしきい値は300', () => {
+    render(<ScrollToTop />);
+    Object.defineProperty(window, 'scrollY', { value: 200, writable: true });
+    fireEvent.scroll(window);
+    expect(screen.queryByLabelText('トップへ戻る')).not.toBeInTheDocument();
+  });
+
+  it('カスタムしきい値が適用される', () => {
+    render(<ScrollToTop threshold={50} />);
+    Object.defineProperty(window, 'scrollY', { value: 60, writable: true });
+    fireEvent.scroll(window);
+    expect(screen.getByLabelText('トップへ戻る')).toBeInTheDocument();
+  });
+
+  it('ボタンにアイコンが表示される', () => {
+    render(<ScrollToTop threshold={0} />);
+    Object.defineProperty(window, 'scrollY', { value: 10, writable: true });
+    fireEvent.scroll(window);
+    const btn = screen.getByLabelText('トップへ戻る');
+    expect(btn.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    render(<ScrollToTop threshold={0} className="custom-class" />);
+    Object.defineProperty(window, 'scrollY', { value: 10, writable: true });
+    fireEvent.scroll(window);
+    expect(screen.getByLabelText('トップへ戻る').closest('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
トップへ戻るボタンコンポーネントをTDDで実装

## 変更内容
- `ScrollToTop.tsx`: トップへ戻るボタンコンポーネント
- `ScrollToTop.test.tsx`: 8件のテストケース

## テスト内容
- 初期非表示・スクロール後表示
- スクロール戻りで非表示
- クリックでスムーススクロール
- デフォルト/カスタムしきい値
- アイコン表示・カスタムクラス名