### PR TITLE
feat: SpinnerButtonコンポーネントの実装 (#1948)

### DIFF
--- a/frontend/src/components/common/SpinnerButton.tsx
+++ b/frontend/src/components/common/SpinnerButton.tsx
@@ -1,0 +1,50 @@
+import { ReactNode } from 'react';
+import { Loader2 } from 'lucide-react';
+
+interface SpinnerButtonProps {
+  children: ReactNode;
+  onClick: () => void;
+  loading?: boolean;
+  loadingText?: string;
+  variant?: 'primary' | 'secondary' | 'danger';
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+  className?: string;
+}
+
+const variantClasses = {
+  primary: 'bg-blue-600 hover:bg-blue-500 text-white',
+  secondary: 'bg-gray-700 hover:bg-gray-600 text-gray-200',
+  danger: 'bg-red-600 hover:bg-red-500 text-white',
+};
+
+const sizeClasses = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-6 py-3 text-base',
+};
+
+export default function SpinnerButton({
+  children,
+  onClick,
+  loading = false,
+  loadingText,
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  className = '',
+}: SpinnerButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled || loading}
+      className={`inline-flex items-center justify-center gap-2 rounded-lg font-medium transition-colors disabled:opacity-50 ${variantClasses[variant]} ${sizeClasses[size]} ${className}`.trim()}
+    >
+      {loading && (
+        <Loader2 data-testid="spinner" className="w-4 h-4 animate-spin" />
+      )}
+      {loading && loadingText ? loadingText : children}
+    </button>
+  );
+}

--- a/frontend/src/components/common/__tests__/SpinnerButton.test.tsx
+++ b/frontend/src/components/common/__tests__/SpinnerButton.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import SpinnerButton from '../SpinnerButton';
+
+describe('SpinnerButton', () => {
+  it('ラベルが表示される', () => {
+    render(<SpinnerButton onClick={() => {}}>送信</SpinnerButton>);
+    expect(screen.getByText('送信')).toBeInTheDocument();
+  });
+
+  it('クリックでonClickが呼ばれる', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<SpinnerButton onClick={onClick}>送信</SpinnerButton>);
+    await user.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('ローディング中にスピナーが表示される', () => {
+    render(<SpinnerButton onClick={() => {}} loading>送信</SpinnerButton>);
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+  });
+
+  it('ローディング中はdisabled', () => {
+    render(<SpinnerButton onClick={() => {}} loading>送信</SpinnerButton>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('ローディング中にラベルテキストが表示される', () => {
+    render(<SpinnerButton onClick={() => {}} loading loadingText="送信中...">送信</SpinnerButton>);
+    expect(screen.getByText('送信中...')).toBeInTheDocument();
+  });
+
+  it('primaryバリアントのスタイルが適用される', () => {
+    const { container } = render(<SpinnerButton onClick={() => {}} variant="primary">送信</SpinnerButton>);
+    expect(container.querySelector('.bg-blue-600')).toBeInTheDocument();
+  });
+
+  it('secondaryバリアントのスタイルが適用される', () => {
+    const { container } = render(<SpinnerButton onClick={() => {}} variant="secondary">送信</SpinnerButton>);
+    expect(container.querySelector('.bg-gray-700')).toBeInTheDocument();
+  });
+
+  it('dangerバリアントのスタイルが適用される', () => {
+    const { container } = render(<SpinnerButton onClick={() => {}} variant="danger">送信</SpinnerButton>);
+    expect(container.querySelector('.bg-red-600')).toBeInTheDocument();
+  });
+
+  it('smサイズが適用される', () => {
+    const { container } = render(<SpinnerButton onClick={() => {}} size="sm">送信</SpinnerButton>);
+    expect(container.querySelector('.px-3')).toBeInTheDocument();
+  });
+
+  it('lgサイズが適用される', () => {
+    const { container } = render(<SpinnerButton onClick={() => {}} size="lg">送信</SpinnerButton>);
+    expect(container.querySelector('.px-6')).toBeInTheDocument();
+  });
+
+  it('disabled状態が適用される', () => {
+    render(<SpinnerButton onClick={() => {}} disabled>送信</SpinnerButton>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<SpinnerButton onClick={() => {}} className="custom-class">送信</SpinnerButton>);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
ローディング状態付きボタンコンポーネントをTDDで実装

## 変更内容
- `SpinnerButton.tsx`: スピナーボタンコンポーネント
- `SpinnerButton.test.tsx`: 12件のテストケース

## テスト内容
- ラベル表示・クリックコールバック
- ローディングスピナー・disabled
- ローディングテキスト
- primary/secondary/dangerバリアント
- sm/md/lgサイズ
- カスタムクラス名