### PR TITLE
feat: MasonryGridコンポーネントの実装 (#1950)

### DIFF
--- a/frontend/src/components/common/MasonryGrid.tsx
+++ b/frontend/src/components/common/MasonryGrid.tsx
@@ -1,0 +1,37 @@
+import { ReactNode, Children } from 'react';
+
+interface MasonryGridProps {
+  children: ReactNode;
+  columns?: number;
+  gap?: number;
+  className?: string;
+}
+
+export default function MasonryGrid({
+  children,
+  columns = 3,
+  gap = 8,
+  className = '',
+}: MasonryGridProps) {
+  const items = Children.toArray(children);
+
+  const columnItems: ReactNode[][] = Array.from({ length: columns }, () => []);
+  items.forEach((item, i) => {
+    columnItems[i % columns].push(item);
+  });
+
+  return (
+    <div className={`flex ${className}`.trim()} style={{ gap: `${gap}px` }}>
+      {columnItems.map((colItems, i) => (
+        <div
+          key={i}
+          data-testid="masonry-column"
+          className="flex-1 flex flex-col"
+          style={{ gap: `${gap}px` }}
+        >
+          {colItems}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/MasonryGrid.test.tsx
+++ b/frontend/src/components/common/__tests__/MasonryGrid.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import MasonryGrid from '../MasonryGrid';
+
+describe('MasonryGrid', () => {
+  it('子要素が表示される', () => {
+    render(
+      <MasonryGrid columns={3}>
+        <div>アイテム1</div>
+        <div>アイテム2</div>
+        <div>アイテム3</div>
+      </MasonryGrid>
+    );
+    expect(screen.getByText('アイテム1')).toBeInTheDocument();
+    expect(screen.getByText('アイテム2')).toBeInTheDocument();
+    expect(screen.getByText('アイテム3')).toBeInTheDocument();
+  });
+
+  it('指定カラム数のグリッドが生成される', () => {
+    const { container } = render(
+      <MasonryGrid columns={3}>
+        <div>1</div><div>2</div><div>3</div>
+      </MasonryGrid>
+    );
+    const cols = container.querySelectorAll('[data-testid="masonry-column"]');
+    expect(cols.length).toBe(3);
+  });
+
+  it('2カラムのグリッドが生成される', () => {
+    const { container } = render(
+      <MasonryGrid columns={2}>
+        <div>1</div><div>2</div>
+      </MasonryGrid>
+    );
+    const cols = container.querySelectorAll('[data-testid="masonry-column"]');
+    expect(cols.length).toBe(2);
+  });
+
+  it('アイテムがカラムに分配される', () => {
+    render(
+      <MasonryGrid columns={2}>
+        <div>A</div><div>B</div><div>C</div><div>D</div>
+      </MasonryGrid>
+    );
+    expect(screen.getByText('A')).toBeInTheDocument();
+    expect(screen.getByText('B')).toBeInTheDocument();
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.getByText('D')).toBeInTheDocument();
+  });
+
+  it('ギャップが適用される', () => {
+    const { container } = render(
+      <MasonryGrid columns={2} gap={16}>
+        <div>1</div><div>2</div>
+      </MasonryGrid>
+    );
+    const grid = container.firstChild;
+    expect(grid).toHaveStyle({ gap: '16px' });
+  });
+
+  it('デフォルトギャップは8px', () => {
+    const { container } = render(
+      <MasonryGrid columns={2}>
+        <div>1</div><div>2</div>
+      </MasonryGrid>
+    );
+    const grid = container.firstChild;
+    expect(grid).toHaveStyle({ gap: '8px' });
+  });
+
+  it('空の場合何も表示されない', () => {
+    const { container } = render(<MasonryGrid columns={3}>{[]}</MasonryGrid>);
+    const cols = container.querySelectorAll('[data-testid="masonry-column"]');
+    expect(cols.length).toBe(3);
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(
+      <MasonryGrid columns={2} className="custom-class">
+        <div>1</div>
+      </MasonryGrid>
+    );
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('デフォルトカラム数は3', () => {
+    const { container } = render(
+      <MasonryGrid>
+        <div>1</div><div>2</div><div>3</div>
+      </MasonryGrid>
+    );
+    const cols = container.querySelectorAll('[data-testid="masonry-column"]');
+    expect(cols.length).toBe(3);
+  });
+});


### PR DESCRIPTION
## 概要
メイソンリーグリッドコンポーネントをTDDで実装

## 変更内容
- `MasonryGrid.tsx`: メイソンリーグリッドコンポーネント
- `MasonryGrid.test.tsx`: 9件のテストケース

## テスト内容
- 子要素表示・カラム数設定
- アイテム分配・ギャップ設定
- デフォルトギャップ・デフォルトカラム数
- 空状態・カスタムクラス名