### PR TITLE
feat: BottomSheetコンポーネントの実装 (#1954)

### DIFF
--- a/frontend/src/components/common/BottomSheet.tsx
+++ b/frontend/src/components/common/BottomSheet.tsx
@@ -1,0 +1,57 @@
+import { ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+interface BottomSheetProps {
+  open: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  title?: string;
+  maxHeight?: string;
+  className?: string;
+}
+
+export default function BottomSheet({
+  open,
+  onClose,
+  children,
+  title,
+  maxHeight = '50vh',
+  className = '',
+}: BottomSheetProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50">
+      <div
+        data-testid="bottomsheet-overlay"
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+      />
+      <div
+        className={`absolute bottom-0 left-0 right-0 bg-gray-900 rounded-t-2xl shadow-xl flex flex-col ${className}`.trim()}
+        style={{ maxHeight }}
+      >
+        <div className="flex justify-center pt-3 pb-1">
+          <div
+            data-testid="drag-handle"
+            className="w-10 h-1 bg-gray-600 rounded-full"
+          />
+        </div>
+        {title && (
+          <div className="flex items-center justify-between px-4 py-2 border-b border-gray-800">
+            <h3 className="text-lg font-semibold text-gray-200">{title}</h3>
+            <button
+              type="button"
+              aria-label="閉じる"
+              onClick={onClose}
+              className="text-gray-400 hover:text-white"
+            >
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+        )}
+        <div className="flex-1 overflow-y-auto p-4">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/BottomSheet.test.tsx
+++ b/frontend/src/components/common/__tests__/BottomSheet.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BottomSheet from '../BottomSheet';
+
+describe('BottomSheet', () => {
+  it('開いた状態でコンテンツが表示される', () => {
+    render(<BottomSheet open onClose={() => {}}>内容</BottomSheet>);
+    expect(screen.getByText('内容')).toBeInTheDocument();
+  });
+
+  it('閉じた状態で非表示', () => {
+    render(<BottomSheet open={false} onClose={() => {}}>内容</BottomSheet>);
+    expect(screen.queryByText('内容')).not.toBeInTheDocument();
+  });
+
+  it('タイトルが表示される', () => {
+    render(<BottomSheet open onClose={() => {}} title="メニュー">内容</BottomSheet>);
+    expect(screen.getByText('メニュー')).toBeInTheDocument();
+  });
+
+  it('ドラッグハンドルが表示される', () => {
+    render(<BottomSheet open onClose={() => {}}>内容</BottomSheet>);
+    expect(screen.getByTestId('drag-handle')).toBeInTheDocument();
+  });
+
+  it('オーバーレイクリックでonCloseが呼ばれる', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<BottomSheet open onClose={onClose}>内容</BottomSheet>);
+    await user.click(screen.getByTestId('bottomsheet-overlay'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('カスタム高さが適用される', () => {
+    render(<BottomSheet open onClose={() => {}} maxHeight="80vh">内容</BottomSheet>);
+    const sheet = screen.getByText('内容').closest('[style]');
+    expect(sheet).toHaveStyle({ maxHeight: '80vh' });
+  });
+
+  it('デフォルト高さは50vh', () => {
+    render(<BottomSheet open onClose={() => {}}>内容</BottomSheet>);
+    const sheet = screen.getByText('内容').closest('[style]');
+    expect(sheet).toHaveStyle({ maxHeight: '50vh' });
+  });
+
+  it('子要素が正しく描画される', () => {
+    render(
+      <BottomSheet open onClose={() => {}}>
+        <p>要素1</p>
+        <p>要素2</p>
+      </BottomSheet>
+    );
+    expect(screen.getByText('要素1')).toBeInTheDocument();
+    expect(screen.getByText('要素2')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    render(<BottomSheet open onClose={() => {}} className="custom-class">内容</BottomSheet>);
+    expect(screen.getByText('内容').closest('.custom-class')).toBeInTheDocument();
+  });
+
+  it('閉じるボタンが表示される', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<BottomSheet open onClose={onClose} title="タイトル">内容</BottomSheet>);
+    await user.click(screen.getByLabelText('閉じる'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要
ボトムシートコンポーネントをTDDで実装

## 変更内容
- `BottomSheet.tsx`: ボトムシートコンポーネント
- `BottomSheet.test.tsx`: 10件のテストケース

## テスト内容
- 開閉状態の表示制御
- タイトル・ドラッグハンドル表示
- オーバーレイクリック・閉じるボタン
- カスタム/デフォルト高さ
- 子要素描画・カスタムクラス名