### PR TITLE
feat: FloatingLabelInputコンポーネントの実装 (#1956)

### DIFF
--- a/frontend/src/components/common/FloatingLabelInput.tsx
+++ b/frontend/src/components/common/FloatingLabelInput.tsx
@@ -1,0 +1,52 @@
+import { useState } from 'react';
+
+interface FloatingLabelInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  label: string;
+  type?: string;
+  error?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function FloatingLabelInput({
+  value,
+  onChange,
+  label,
+  type = 'text',
+  error,
+  disabled = false,
+  className = '',
+}: FloatingLabelInputProps) {
+  const [focused, setFocused] = useState(false);
+  const isFloating = focused || value.length > 0;
+
+  return (
+    <div className={`${className}`.trim()}>
+      <div className="relative">
+        <input
+          type={type}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setFocused(false)}
+          disabled={disabled}
+          className={`w-full px-4 pt-5 pb-2 bg-gray-800 border rounded-lg text-gray-200 focus:outline-none transition-colors disabled:opacity-50 peer ${
+            error ? 'border-red-500' : 'border-gray-700 focus:border-blue-500'
+          }`}
+        />
+        <span
+          className={`absolute left-4 transition-all pointer-events-none ${
+            isFloating
+              ? 'top-1 text-xs text-blue-400'
+              : 'top-3.5 text-sm text-gray-500'
+          }`}
+        >
+          {label}
+        </span>
+      </div>
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/FloatingLabelInput.test.tsx
+++ b/frontend/src/components/common/__tests__/FloatingLabelInput.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FloatingLabelInput from '../FloatingLabelInput';
+
+describe('FloatingLabelInput', () => {
+  it('入力フィールドが表示される', () => {
+    render(<FloatingLabelInput value="" onChange={() => {}} label="メール" />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<FloatingLabelInput value="" onChange={() => {}} label="メール" />);
+    expect(screen.getByText('メール')).toBeInTheDocument();
+  });
+
+  it('値がある時ラベルが浮く', () => {
+    render(<FloatingLabelInput value="test@example.com" onChange={() => {}} label="メール" />);
+    const label = screen.getByText('メール');
+    expect(label.className).toContain('text-xs');
+  });
+
+  it('値がない時ラベルが通常位置', () => {
+    render(<FloatingLabelInput value="" onChange={() => {}} label="メール" />);
+    const label = screen.getByText('メール');
+    expect(label.className).toContain('text-sm');
+  });
+
+  it('値の変更でコールバックが呼ばれる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<FloatingLabelInput value="" onChange={onChange} label="メール" />);
+    await user.type(screen.getByRole('textbox'), 'a');
+    expect(onChange).toHaveBeenCalled();
+  });
+
+  it('エラーメッセージが表示される', () => {
+    render(<FloatingLabelInput value="" onChange={() => {}} label="メール" error="必須です" />);
+    expect(screen.getByText('必須です')).toBeInTheDocument();
+  });
+
+  it('エラー時にボーダーが赤くなる', () => {
+    render(<FloatingLabelInput value="" onChange={() => {}} label="メール" error="エラー" />);
+    expect(screen.getByRole('textbox').className).toContain('border-red-500');
+  });
+
+  it('無効状態が適用される', () => {
+    render(<FloatingLabelInput value="" onChange={() => {}} label="メール" disabled />);
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('type属性が設定される', () => {
+    render(<FloatingLabelInput value="" onChange={() => {}} label="メール" type="email" />);
+    expect(screen.getByRole('textbox')).toHaveAttribute('type', 'email');
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<FloatingLabelInput value="" onChange={() => {}} label="メール" className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
フローティングラベル入力コンポーネントをTDDで実装

## 変更内容
- `FloatingLabelInput.tsx`: フローティングラベル入力コンポーネント
- `FloatingLabelInput.test.tsx`: 10件のテストケース

## テスト内容
- 入力フィールド・ラベル表示
- 値あり/なし時のラベル位置
- 値変更コールバック
- エラー表示・エラー時ボーダー
- disabled・type属性・カスタムクラス名