### PR TITLE
feat: WatermarkTextコンポーネントの実装 (#1962)

### DIFF
--- a/frontend/src/components/common/WatermarkText.tsx
+++ b/frontend/src/components/common/WatermarkText.tsx
@@ -1,0 +1,35 @@
+import { ReactNode } from 'react';
+
+interface WatermarkTextProps {
+  text: string;
+  children: ReactNode;
+  opacity?: number;
+  rotate?: number;
+  fontSize?: string;
+  className?: string;
+}
+
+export default function WatermarkText({
+  text,
+  children,
+  opacity = 10,
+  rotate = -45,
+  fontSize = '3rem',
+  className = '',
+}: WatermarkTextProps) {
+  return (
+    <div className={`relative overflow-hidden ${className}`.trim()}>
+      <span
+        className="absolute inset-0 flex items-center justify-center pointer-events-none select-none text-gray-400 font-bold opacity-10"
+        style={{
+          opacity: opacity / 100,
+          transform: `rotate(${rotate}deg)`,
+          fontSize,
+        }}
+      >
+        {text}
+      </span>
+      <div className="relative z-10">{children}</div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/WatermarkText.test.tsx
+++ b/frontend/src/components/common/__tests__/WatermarkText.test.tsx
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import WatermarkText from '../WatermarkText';
+
+describe('WatermarkText', () => {
+  it('子要素が表示される', () => {
+    render(<WatermarkText text="DRAFT">コンテンツ</WatermarkText>);
+    expect(screen.getByText('コンテンツ')).toBeInTheDocument();
+  });
+
+  it('ウォーターマークテキストが表示される', () => {
+    render(<WatermarkText text="DRAFT">コンテンツ</WatermarkText>);
+    expect(screen.getByText('DRAFT')).toBeInTheDocument();
+  });
+
+  it('ウォーターマークが半透明', () => {
+    render(<WatermarkText text="DRAFT">コンテンツ</WatermarkText>);
+    const watermark = screen.getByText('DRAFT');
+    expect(watermark.className).toContain('opacity-');
+  });
+
+  it('カスタム透明度が適用される', () => {
+    render(<WatermarkText text="DRAFT" opacity={20}>コンテンツ</WatermarkText>);
+    const watermark = screen.getByText('DRAFT');
+    expect(watermark.style.opacity).toBe('0.2');
+  });
+
+  it('カスタム角度が適用される', () => {
+    render(<WatermarkText text="DRAFT" rotate={-30}>コンテンツ</WatermarkText>);
+    const watermark = screen.getByText('DRAFT');
+    expect(watermark.style.transform).toContain('rotate(-30deg)');
+  });
+
+  it('デフォルト角度は-45度', () => {
+    render(<WatermarkText text="DRAFT">コンテンツ</WatermarkText>);
+    const watermark = screen.getByText('DRAFT');
+    expect(watermark.style.transform).toContain('rotate(-45deg)');
+  });
+
+  it('フォントサイズが設定される', () => {
+    render(<WatermarkText text="DRAFT" fontSize="4rem">コンテンツ</WatermarkText>);
+    const watermark = screen.getByText('DRAFT');
+    expect(watermark.style.fontSize).toBe('4rem');
+  });
+
+  it('relative配置で子要素を包む', () => {
+    const { container } = render(<WatermarkText text="DRAFT">コンテンツ</WatermarkText>);
+    expect(container.querySelector('.relative')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<WatermarkText text="DRAFT" className="custom-class">コンテンツ</WatermarkText>);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('ウォーターマークがpointer-events-none', () => {
+    render(<WatermarkText text="DRAFT">コンテンツ</WatermarkText>);
+    const watermark = screen.getByText('DRAFT');
+    expect(watermark.className).toContain('pointer-events-none');
+  });
+});


### PR DESCRIPTION
## 概要
ウォーターマークテキストコンポーネントをTDDで実装

## 変更内容
- `WatermarkText.tsx`: ウォーターマークテキストコンポーネント
- `WatermarkText.test.tsx`: 10件のテストケース

## テスト内容
- 子要素表示・ウォーターマーク表示
- 半透明・カスタム透明度
- カスタム角度・デフォルト角度
- フォントサイズ・relative配置
- カスタムクラス名・pointer-events-none