### PR TITLE
feat: RichTextEditorコンポーネントの実装 (#1964)

### DIFF
--- a/frontend/src/components/common/RichTextEditor.tsx
+++ b/frontend/src/components/common/RichTextEditor.tsx
@@ -1,0 +1,95 @@
+import { useRef, useCallback } from 'react';
+import { Bold, Italic, Underline, List } from 'lucide-react';
+
+interface RichTextEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  error?: string;
+  placeholder?: string;
+  className?: string;
+}
+
+export default function RichTextEditor({
+  value,
+  onChange,
+  label,
+  error,
+  placeholder,
+  className = '',
+}: RichTextEditorProps) {
+  const editorRef = useRef<HTMLDivElement>(null);
+
+  const execCommand = useCallback((command: string) => {
+    document.execCommand(command, false);
+    if (editorRef.current) {
+      onChange(editorRef.current.innerHTML);
+    }
+  }, [onChange]);
+
+  const handleInput = useCallback(() => {
+    if (editorRef.current) {
+      onChange(editorRef.current.innerHTML);
+    }
+  }, [onChange]);
+
+  const showPlaceholder = !value && placeholder;
+
+  return (
+    <div className={`${className}`.trim()}>
+      {label && <label className="block text-sm text-gray-400 mb-1">{label}</label>}
+      <div className="border border-gray-700 rounded-lg overflow-hidden">
+        <div data-testid="toolbar" className="flex gap-1 px-2 py-1.5 border-b border-gray-700 bg-gray-800/50">
+          <button
+            type="button"
+            aria-label="太字"
+            onClick={() => execCommand('bold')}
+            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded"
+          >
+            <Bold className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="斜体"
+            onClick={() => execCommand('italic')}
+            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded"
+          >
+            <Italic className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="下線"
+            onClick={() => execCommand('underline')}
+            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded"
+          >
+            <Underline className="w-4 h-4" />
+          </button>
+          <button
+            type="button"
+            aria-label="リスト"
+            onClick={() => execCommand('insertUnorderedList')}
+            className="p-1.5 text-gray-400 hover:text-white hover:bg-gray-700 rounded"
+          >
+            <List className="w-4 h-4" />
+          </button>
+        </div>
+        <div className="relative">
+          {showPlaceholder && (
+            <span className="absolute top-3 left-4 text-sm text-gray-500 pointer-events-none">
+              {placeholder}
+            </span>
+          )}
+          <div
+            ref={editorRef}
+            role="textbox"
+            contentEditable
+            onInput={handleInput}
+            dangerouslySetInnerHTML={{ __html: value }}
+            className="min-h-[120px] px-4 py-3 bg-gray-800 text-sm text-gray-200 focus:outline-none"
+          />
+        </div>
+      </div>
+      {error && <p className="mt-1 text-xs text-red-400">{error}</p>}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/RichTextEditor.test.tsx
+++ b/frontend/src/components/common/__tests__/RichTextEditor.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RichTextEditor from '../RichTextEditor';
+
+describe('RichTextEditor', () => {
+  it('エディター領域が表示される', () => {
+    render(<RichTextEditor value="" onChange={() => {}} />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('ツールバーが表示される', () => {
+    render(<RichTextEditor value="" onChange={() => {}} />);
+    expect(screen.getByTestId('toolbar')).toBeInTheDocument();
+  });
+
+  it('太字ボタンが表示される', () => {
+    render(<RichTextEditor value="" onChange={() => {}} />);
+    expect(screen.getByLabelText('太字')).toBeInTheDocument();
+  });
+
+  it('斜体ボタンが表示される', () => {
+    render(<RichTextEditor value="" onChange={() => {}} />);
+    expect(screen.getByLabelText('斜体')).toBeInTheDocument();
+  });
+
+  it('下線ボタンが表示される', () => {
+    render(<RichTextEditor value="" onChange={() => {}} />);
+    expect(screen.getByLabelText('下線')).toBeInTheDocument();
+  });
+
+  it('プレースホルダーが表示される', () => {
+    render(<RichTextEditor value="" onChange={() => {}} placeholder="ここに入力..." />);
+    expect(screen.getByText('ここに入力...')).toBeInTheDocument();
+  });
+
+  it('値が表示される', () => {
+    render(<RichTextEditor value="テスト内容" onChange={() => {}} />);
+    expect(screen.getByText('テスト内容')).toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<RichTextEditor value="" onChange={() => {}} label="本文" />);
+    expect(screen.getByText('本文')).toBeInTheDocument();
+  });
+
+  it('エラーメッセージが表示される', () => {
+    render(<RichTextEditor value="" onChange={() => {}} error="入力してください" />);
+    expect(screen.getByText('入力してください')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<RichTextEditor value="" onChange={() => {}} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
リッチテキストエディターコンポーネントをTDDで実装

## 変更内容
- `RichTextEditor.tsx`: リッチテキストエディターコンポーネント
- `RichTextEditor.test.tsx`: 10件のテストケース

## テスト内容
- エディター領域・ツールバー表示
- 太字/斜体/下線ボタン
- プレースホルダー・値表示
- ラベル・エラーメッセージ
- カスタムクラス名