### PR TITLE
feat: QuoteBlockコンポーネントの実装 (#1966)

### DIFF
--- a/frontend/src/components/common/QuoteBlock.tsx
+++ b/frontend/src/components/common/QuoteBlock.tsx
@@ -1,0 +1,40 @@
+import { Quote } from 'lucide-react';
+
+interface QuoteBlockProps {
+  quote: string;
+  author?: string;
+  source?: string;
+  color?: 'gray' | 'blue' | 'green' | 'purple';
+  className?: string;
+}
+
+const colorClasses = {
+  gray: 'border-gray-500 text-gray-400',
+  blue: 'border-blue-500 text-blue-400',
+  green: 'border-green-500 text-green-400',
+  purple: 'border-purple-500 text-purple-400',
+};
+
+export default function QuoteBlock({
+  quote,
+  author,
+  source,
+  color = 'gray',
+  className = '',
+}: QuoteBlockProps) {
+  return (
+    <blockquote
+      className={`border-l-4 pl-4 py-2 ${colorClasses[color]} ${className}`.trim()}
+    >
+      <Quote className="w-5 h-5 mb-2 opacity-50" />
+      <p className="text-gray-200 text-sm italic leading-relaxed">{quote}</p>
+      {(author || source) && (
+        <footer className="mt-2 text-xs">
+          {author && <cite className="not-italic font-medium">{author}</cite>}
+          {author && source && <span className="mx-1">—</span>}
+          {source && <span className="opacity-70">{source}</span>}
+        </footer>
+      )}
+    </blockquote>
+  );
+}

--- a/frontend/src/components/common/__tests__/QuoteBlock.test.tsx
+++ b/frontend/src/components/common/__tests__/QuoteBlock.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import QuoteBlock from '../QuoteBlock';
+
+describe('QuoteBlock', () => {
+  it('引用テキストが表示される', () => {
+    render(<QuoteBlock quote="知識は力なり" />);
+    expect(screen.getByText('知識は力なり')).toBeInTheDocument();
+  });
+
+  it('著者名が表示される', () => {
+    render(<QuoteBlock quote="知識は力なり" author="フランシス・ベーコン" />);
+    expect(screen.getByText('フランシス・ベーコン')).toBeInTheDocument();
+  });
+
+  it('著者名がない場合は非表示', () => {
+    const { container } = render(<QuoteBlock quote="知識は力なり" />);
+    expect(container.querySelectorAll('cite').length).toBe(0);
+  });
+
+  it('出典が表示される', () => {
+    render(<QuoteBlock quote="テスト" source="書籍名" />);
+    expect(screen.getByText('書籍名')).toBeInTheDocument();
+  });
+
+  it('引用アイコンが表示される', () => {
+    const { container } = render(<QuoteBlock quote="テスト" />);
+    expect(container.querySelector('.lucide-quote')).toBeInTheDocument();
+  });
+
+  it('blueカラーバリアントが適用される', () => {
+    const { container } = render(<QuoteBlock quote="テスト" color="blue" />);
+    expect(container.querySelector('.border-blue-500')).toBeInTheDocument();
+  });
+
+  it('greenカラーバリアントが適用される', () => {
+    const { container } = render(<QuoteBlock quote="テスト" color="green" />);
+    expect(container.querySelector('.border-green-500')).toBeInTheDocument();
+  });
+
+  it('purpleカラーバリアントが適用される', () => {
+    const { container } = render(<QuoteBlock quote="テスト" color="purple" />);
+    expect(container.querySelector('.border-purple-500')).toBeInTheDocument();
+  });
+
+  it('デフォルトカラーはgray', () => {
+    const { container } = render(<QuoteBlock quote="テスト" />);
+    expect(container.querySelector('.border-gray-500')).toBeInTheDocument();
+  });
+
+  it('blockquote要素が使われる', () => {
+    const { container } = render(<QuoteBlock quote="テスト" />);
+    expect(container.querySelector('blockquote')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<QuoteBlock quote="テスト" className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
引用ブロックコンポーネントをTDDで実装

## 変更内容
- `QuoteBlock.tsx`: 引用ブロックコンポーネント
- `QuoteBlock.test.tsx`: 11件のテストケース

## テスト内容
- 引用テキスト・著者名・出典表示
- 著者名非表示・引用アイコン
- blue/green/purple/grayカラーバリアント
- blockquote要素・カスタムクラス名