### PR TITLE
feat: FeatureCardコンポーネントの実装 (#1968)

### DIFF
--- a/frontend/src/components/common/FeatureCard.tsx
+++ b/frontend/src/components/common/FeatureCard.tsx
@@ -1,0 +1,43 @@
+interface FeatureCardProps {
+  title: string;
+  description: string;
+  icon?: string;
+  badge?: string;
+  onClick?: () => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function FeatureCard({
+  title,
+  description,
+  icon,
+  badge,
+  onClick,
+  disabled = false,
+  className = '',
+}: FeatureCardProps) {
+  return (
+    <div
+      onClick={disabled ? undefined : onClick}
+      className={`p-4 bg-gray-800/50 border border-gray-700 rounded-xl hover:border-gray-600 transition-colors ${
+        onClick && !disabled ? 'cursor-pointer' : ''
+      } ${disabled ? 'opacity-50' : ''} ${className}`.trim()}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-3">
+          {icon && <span className="text-2xl">{icon}</span>}
+          <div>
+            <h3 className="text-sm font-semibold text-gray-200">{title}</h3>
+            <p className="mt-1 text-xs text-gray-400 leading-relaxed">{description}</p>
+          </div>
+        </div>
+        {badge && (
+          <span className="px-2 py-0.5 text-xs font-medium bg-blue-600/20 text-blue-400 rounded-full">
+            {badge}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/FeatureCard.test.tsx
+++ b/frontend/src/components/common/__tests__/FeatureCard.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import FeatureCard from '../FeatureCard';
+
+describe('FeatureCard', () => {
+  it('タイトルが表示される', () => {
+    render(<FeatureCard title="高速ビルド" description="Viteによる高速ビルド" />);
+    expect(screen.getByText('高速ビルド')).toBeInTheDocument();
+  });
+
+  it('説明が表示される', () => {
+    render(<FeatureCard title="高速ビルド" description="Viteによる高速ビルド" />);
+    expect(screen.getByText('Viteによる高速ビルド')).toBeInTheDocument();
+  });
+
+  it('アイコンが表示される', () => {
+    render(<FeatureCard title="テスト" description="説明" icon="🚀" />);
+    expect(screen.getByText('🚀')).toBeInTheDocument();
+  });
+
+  it('バッジが表示される', () => {
+    render(<FeatureCard title="テスト" description="説明" badge="NEW" />);
+    expect(screen.getByText('NEW')).toBeInTheDocument();
+  });
+
+  it('バッジがない場合は非表示', () => {
+    render(<FeatureCard title="テスト" description="説明" />);
+    expect(screen.queryByText('NEW')).not.toBeInTheDocument();
+  });
+
+  it('クリックでonClickが呼ばれる', async () => {
+    const onClick = vi.fn();
+    const user = userEvent.setup();
+    render(<FeatureCard title="テスト" description="説明" onClick={onClick} />);
+    await user.click(screen.getByText('テスト'));
+    expect(onClick).toHaveBeenCalled();
+  });
+
+  it('クリック可能時にcursorがpointer', () => {
+    const { container } = render(<FeatureCard title="テスト" description="説明" onClick={() => {}} />);
+    expect(container.querySelector('.cursor-pointer')).toBeInTheDocument();
+  });
+
+  it('disabled時にopacityが下がる', () => {
+    const { container } = render(<FeatureCard title="テスト" description="説明" disabled />);
+    expect(container.querySelector('.opacity-50')).toBeInTheDocument();
+  });
+
+  it('ホバーエフェクトが適用される', () => {
+    const { container } = render(<FeatureCard title="テスト" description="説明" />);
+    expect(container.querySelector('.hover\\:border-gray-600')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<FeatureCard title="テスト" description="説明" className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
フィーチャーカードコンポーネントをTDDで実装

## 変更内容
- `FeatureCard.tsx`: フィーチャーカードコンポーネント
- `FeatureCard.test.tsx`: 10件のテストケース

## テスト内容
- タイトル・説明・アイコン表示
- バッジ表示/非表示
- クリックコールバック・cursor変更
- disabled状態・ホバーエフェクト
- カスタムクラス名