### PR TITLE
feat: ProfileCardコンポーネントの実装 (#1970)

### DIFF
--- a/frontend/src/components/common/ProfileCard.tsx
+++ b/frontend/src/components/common/ProfileCard.tsx
@@ -1,0 +1,64 @@
+interface Stat {
+  label: string;
+  value: number;
+}
+
+interface ProfileCardProps {
+  name: string;
+  title?: string;
+  avatarUrl?: string;
+  bio?: string;
+  stats?: Stat[];
+  onFollow?: () => void;
+  isFollowing?: boolean;
+  className?: string;
+}
+
+export default function ProfileCard({
+  name,
+  title,
+  avatarUrl,
+  bio,
+  stats,
+  onFollow,
+  isFollowing = false,
+  className = '',
+}: ProfileCardProps) {
+  return (
+    <div className={`p-6 bg-gray-800/50 border border-gray-700 rounded-xl text-center ${className}`.trim()}>
+      <div className="w-16 h-16 mx-auto rounded-full bg-gray-700 overflow-hidden flex items-center justify-center">
+        {avatarUrl ? (
+          <img src={avatarUrl} alt={name} className="w-full h-full object-cover" />
+        ) : (
+          <span className="text-xl font-bold text-gray-200">{name.charAt(0)}</span>
+        )}
+      </div>
+      <h3 className="mt-3 text-lg font-semibold text-gray-200">{name}</h3>
+      {title && <p className="text-sm text-gray-400">{title}</p>}
+      {bio && <p className="mt-2 text-xs text-gray-500 leading-relaxed">{bio}</p>}
+      {stats && stats.length > 0 && (
+        <div className="flex justify-center gap-6 mt-4">
+          {stats.map((stat) => (
+            <div key={stat.label}>
+              <p className="text-lg font-bold text-gray-200">{stat.value}</p>
+              <p className="text-xs text-gray-500">{stat.label}</p>
+            </div>
+          ))}
+        </div>
+      )}
+      {onFollow && (
+        <button
+          type="button"
+          onClick={onFollow}
+          className={`mt-4 px-6 py-2 text-sm font-medium rounded-lg transition-colors ${
+            isFollowing
+              ? 'bg-gray-700 text-gray-300 hover:bg-gray-600'
+              : 'bg-blue-600 text-white hover:bg-blue-500'
+          }`}
+        >
+          {isFollowing ? 'フォロー中' : 'フォロー'}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/ProfileCard.test.tsx
+++ b/frontend/src/components/common/__tests__/ProfileCard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ProfileCard from '../ProfileCard';
+
+describe('ProfileCard', () => {
+  it('名前が表示される', () => {
+    render(<ProfileCard name="田中太郎" />);
+    expect(screen.getByText('田中太郎')).toBeInTheDocument();
+  });
+
+  it('肩書きが表示される', () => {
+    render(<ProfileCard name="田中太郎" title="フロントエンドエンジニア" />);
+    expect(screen.getByText('フロントエンドエンジニア')).toBeInTheDocument();
+  });
+
+  it('アバター画像が表示される', () => {
+    render(<ProfileCard name="田中太郎" avatarUrl="/avatar.jpg" />);
+    const img = screen.getByRole('img');
+    expect(img).toHaveAttribute('src', '/avatar.jpg');
+  });
+
+  it('アバターがない場合イニシャルが表示される', () => {
+    render(<ProfileCard name="田中太郎" />);
+    expect(screen.getByText('田')).toBeInTheDocument();
+  });
+
+  it('スタッツが表示される', () => {
+    const stats = [
+      { label: '投稿', value: 42 },
+      { label: 'フォロワー', value: 128 },
+    ];
+    render(<ProfileCard name="田中" stats={stats} />);
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText('128')).toBeInTheDocument();
+    expect(screen.getByText('投稿')).toBeInTheDocument();
+  });
+
+  it('フォローボタンが表示される', async () => {
+    const onFollow = vi.fn();
+    const user = userEvent.setup();
+    render(<ProfileCard name="田中" onFollow={onFollow} />);
+    await user.click(screen.getByText('フォロー'));
+    expect(onFollow).toHaveBeenCalled();
+  });
+
+  it('フォロー済みの場合ボタンテキストが変わる', () => {
+    render(<ProfileCard name="田中" onFollow={() => {}} isFollowing />);
+    expect(screen.getByText('フォロー中')).toBeInTheDocument();
+  });
+
+  it('自己紹介が表示される', () => {
+    render(<ProfileCard name="田中" bio="React大好きエンジニアです" />);
+    expect(screen.getByText('React大好きエンジニアです')).toBeInTheDocument();
+  });
+
+  it('フォローボタンがない場合非表示', () => {
+    render(<ProfileCard name="田中" />);
+    expect(screen.queryByText('フォロー')).not.toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<ProfileCard name="田中" className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
プロフィールカードコンポーネントをTDDで実装

## 変更内容
- `ProfileCard.tsx`: プロフィールカードコンポーネント
- `ProfileCard.test.tsx`: 10件のテストケース

## テスト内容
- 名前・肩書き・アバター画像/イニシャル
- スタッツ表示
- フォロー/フォロー中ボタン
- 自己紹介・フォローボタン非表示
- カスタムクラス名