### PR TITLE
feat: LanguageSwitcherコンポーネントの実装 (#1972)

### DIFF
--- a/frontend/src/components/common/LanguageSwitcher.tsx
+++ b/frontend/src/components/common/LanguageSwitcher.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import { Globe, ChevronDown } from 'lucide-react';
+
+interface Language {
+  code: string;
+  label: string;
+  flag?: string;
+}
+
+interface LanguageSwitcherProps {
+  languages: Language[];
+  current: string;
+  onChange: (code: string) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function LanguageSwitcher({
+  languages,
+  current,
+  onChange,
+  disabled = false,
+  className = '',
+}: LanguageSwitcherProps) {
+  const [open, setOpen] = useState(false);
+  const currentLang = languages.find((l) => l.code === current);
+
+  const handleSelect = (code: string) => {
+    onChange(code);
+    setOpen(false);
+  };
+
+  return (
+    <div className={`relative inline-block ${className}`.trim()}>
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        disabled={disabled}
+        className="flex items-center gap-2 px-3 py-2 bg-gray-800 border border-gray-700 rounded-lg text-sm text-gray-200 hover:border-gray-600 disabled:opacity-50"
+      >
+        <Globe className="w-4 h-4 text-gray-400" />
+        {currentLang?.flag && <span>{currentLang.flag}</span>}
+        <span>{currentLang?.label}</span>
+        <ChevronDown className="w-3 h-3 text-gray-400" />
+      </button>
+      {open && (
+        <div className="absolute top-full left-0 mt-1 w-full bg-gray-800 border border-gray-700 rounded-lg shadow-xl overflow-hidden z-50">
+          {languages.map((lang) => (
+            <div
+              key={lang.code}
+              role="option"
+              aria-selected={lang.code === current}
+              onClick={() => handleSelect(lang.code)}
+              className={`flex items-center gap-2 px-3 py-2 text-sm cursor-pointer hover:bg-gray-700/50 ${
+                lang.code === current ? 'bg-gray-700 text-white' : 'text-gray-300'
+              }`}
+            >
+              {lang.flag && <span>{lang.flag}</span>}
+              <span>{lang.label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/LanguageSwitcher.test.tsx
+++ b/frontend/src/components/common/__tests__/LanguageSwitcher.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LanguageSwitcher from '../LanguageSwitcher';
+
+const languages = [
+  { code: 'ja', label: '日本語', flag: '🇯🇵' },
+  { code: 'en', label: 'English', flag: '🇺🇸' },
+  { code: 'ko', label: '한국어', flag: '🇰🇷' },
+];
+
+describe('LanguageSwitcher', () => {
+  it('現在の言語が表示される', () => {
+    render(<LanguageSwitcher languages={languages} current="ja" onChange={() => {}} />);
+    expect(screen.getByText('日本語')).toBeInTheDocument();
+  });
+
+  it('クリックでドロップダウンが開く', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSwitcher languages={languages} current="ja" onChange={() => {}} />);
+    await user.click(screen.getByText('日本語'));
+    expect(screen.getByText('English')).toBeInTheDocument();
+    expect(screen.getByText('한국어')).toBeInTheDocument();
+  });
+
+  it('言語選択でonChangeが呼ばれる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LanguageSwitcher languages={languages} current="ja" onChange={onChange} />);
+    await user.click(screen.getByText('日本語'));
+    await user.click(screen.getByText('English'));
+    expect(onChange).toHaveBeenCalledWith('en');
+  });
+
+  it('選択後にドロップダウンが閉じる', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSwitcher languages={languages} current="ja" onChange={() => {}} />);
+    await user.click(screen.getByText('日本語'));
+    await user.click(screen.getByText('English'));
+    expect(screen.queryByText('한국어')).not.toBeInTheDocument();
+  });
+
+  it('フラグが表示される', () => {
+    render(<LanguageSwitcher languages={languages} current="ja" onChange={() => {}} />);
+    expect(screen.getByText('🇯🇵')).toBeInTheDocument();
+  });
+
+  it('ドロップダウンでフラグが表示される', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSwitcher languages={languages} current="ja" onChange={() => {}} />);
+    await user.click(screen.getByText('日本語'));
+    expect(screen.getByText('🇺🇸')).toBeInTheDocument();
+  });
+
+  it('現在の言語がハイライトされる', async () => {
+    const user = userEvent.setup();
+    render(<LanguageSwitcher languages={languages} current="ja" onChange={() => {}} />);
+    await user.click(screen.getByText('日本語'));
+    const items = screen.getAllByRole('option');
+    expect(items[0].className).toContain('bg-gray-700');
+  });
+
+  it('disabled状態でクリックが無効', () => {
+    render(<LanguageSwitcher languages={languages} current="ja" onChange={() => {}} disabled />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<LanguageSwitcher languages={languages} current="ja" onChange={() => {}} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+
+  it('アイコンが表示される', () => {
+    const { container } = render(<LanguageSwitcher languages={languages} current="ja" onChange={() => {}} />);
+    expect(container.querySelector('.lucide-globe')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
言語切替コンポーネントをTDDで実装

## 変更内容
- `LanguageSwitcher.tsx`: 言語切替コンポーネント
- `LanguageSwitcher.test.tsx`: 10件のテストケース

## テスト内容
- 現在の言語表示・ドロップダウン開閉
- 言語選択コールバック・選択後閉じる
- フラグ表示・現在の言語ハイライト
- disabled・カスタムクラス名・アイコン