### PR TITLE
feat: ThemeSwitcherコンポーネントの実装 (#1974)

### DIFF
--- a/frontend/src/components/common/ThemeSwitcher.tsx
+++ b/frontend/src/components/common/ThemeSwitcher.tsx
@@ -1,0 +1,49 @@
+import { Sun, Moon, Monitor } from 'lucide-react';
+
+type Theme = 'light' | 'dark' | 'system';
+
+interface ThemeSwitcherProps {
+  value: Theme;
+  onChange: (theme: Theme) => void;
+  label?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+const themes: { value: Theme; label: string; icon: typeof Sun }[] = [
+  { value: 'light', label: 'ライト', icon: Sun },
+  { value: 'dark', label: 'ダーク', icon: Moon },
+  { value: 'system', label: 'システム', icon: Monitor },
+];
+
+export default function ThemeSwitcher({
+  value,
+  onChange,
+  label,
+  disabled = false,
+  className = '',
+}: ThemeSwitcherProps) {
+  return (
+    <div className={`${className}`.trim()}>
+      {label && <p className="text-sm text-gray-400 mb-1">{label}</p>}
+      <div className="inline-flex bg-gray-800 rounded-lg p-1">
+        {themes.map(({ value: themeValue, label: themeLabel, icon: Icon }) => (
+          <button
+            key={themeValue}
+            type="button"
+            aria-label={themeLabel}
+            onClick={() => onChange(themeValue)}
+            disabled={disabled}
+            className={`p-2 rounded-md transition-colors disabled:opacity-50 ${
+              value === themeValue
+                ? 'bg-blue-600 text-white'
+                : 'text-gray-400 hover:text-gray-200'
+            }`}
+          >
+            <Icon className="w-4 h-4" />
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/ThemeSwitcher.test.tsx
+++ b/frontend/src/components/common/__tests__/ThemeSwitcher.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ThemeSwitcher from '../ThemeSwitcher';
+
+describe('ThemeSwitcher', () => {
+  it('3つのテーマオプションが表示される', () => {
+    render(<ThemeSwitcher value="dark" onChange={() => {}} />);
+    expect(screen.getByLabelText('ライト')).toBeInTheDocument();
+    expect(screen.getByLabelText('ダーク')).toBeInTheDocument();
+    expect(screen.getByLabelText('システム')).toBeInTheDocument();
+  });
+
+  it('現在のテーマがハイライトされる', () => {
+    render(<ThemeSwitcher value="dark" onChange={() => {}} />);
+    const darkBtn = screen.getByLabelText('ダーク');
+    expect(darkBtn.className).toContain('bg-blue-600');
+  });
+
+  it('クリックでonChangeが呼ばれる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ThemeSwitcher value="dark" onChange={onChange} />);
+    await user.click(screen.getByLabelText('ライト'));
+    expect(onChange).toHaveBeenCalledWith('light');
+  });
+
+  it('システムモードを選択できる', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<ThemeSwitcher value="dark" onChange={onChange} />);
+    await user.click(screen.getByLabelText('システム'));
+    expect(onChange).toHaveBeenCalledWith('system');
+  });
+
+  it('ラベルが表示される', () => {
+    render(<ThemeSwitcher value="dark" onChange={() => {}} label="テーマ" />);
+    expect(screen.getByText('テーマ')).toBeInTheDocument();
+  });
+
+  it('disabled状態で全ボタンが無効', () => {
+    render(<ThemeSwitcher value="dark" onChange={() => {}} disabled />);
+    const buttons = screen.getAllByRole('button');
+    buttons.forEach((btn) => expect(btn).toBeDisabled());
+  });
+
+  it('各ボタンにアイコンが表示される', () => {
+    const { container } = render(<ThemeSwitcher value="dark" onChange={() => {}} />);
+    const svgs = container.querySelectorAll('svg');
+    expect(svgs.length).toBe(3);
+  });
+
+  it('非アクティブボタンはハイライトされない', () => {
+    render(<ThemeSwitcher value="dark" onChange={() => {}} />);
+    const lightBtn = screen.getByLabelText('ライト');
+    expect(lightBtn.className).not.toContain('bg-blue-600');
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<ThemeSwitcher value="dark" onChange={() => {}} className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
テーマ切替コンポーネントをTDDで実装

## 変更内容
- `ThemeSwitcher.tsx`: テーマ切替コンポーネント
- `ThemeSwitcher.test.tsx`: 9件のテストケース

## テスト内容
- 3テーマオプション表示・ハイライト
- クリックでテーマ変更
- ラベル表示・disabled
- アイコン表示・非アクティブ状態
- カスタムクラス名