### PR TITLE
feat: CurrencyDisplayコンポーネントの実装 (#1976)

### DIFF
--- a/frontend/src/components/common/CurrencyDisplay.tsx
+++ b/frontend/src/components/common/CurrencyDisplay.tsx
@@ -1,0 +1,46 @@
+import { TrendingUp, TrendingDown } from 'lucide-react';
+
+interface CurrencyDisplayProps {
+  amount: number;
+  currency: 'JPY' | 'USD' | 'EUR';
+  change?: number;
+  label?: string;
+  size?: 'sm' | 'md' | 'lg';
+  className?: string;
+}
+
+const currencySymbols = { JPY: '¥', USD: '$', EUR: '€' };
+const sizeClasses = { sm: 'text-lg', md: 'text-2xl', lg: 'text-3xl' };
+
+function formatAmount(amount: number, currency: string): string {
+  const formatted = amount.toLocaleString('ja-JP');
+  return `${currencySymbols[currency as keyof typeof currencySymbols]}${formatted}`;
+}
+
+export default function CurrencyDisplay({
+  amount,
+  currency,
+  change,
+  label,
+  size = 'md',
+  className = '',
+}: CurrencyDisplayProps) {
+  return (
+    <div className={`${className}`.trim()}>
+      {label && <p className="text-xs text-gray-500 mb-1">{label}</p>}
+      <p className={`${sizeClasses[size]} font-bold text-gray-200`}>
+        {formatAmount(amount, currency)}
+      </p>
+      {change != null && (
+        <div className={`flex items-center gap-1 mt-1 text-sm ${change >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+          {change >= 0 ? (
+            <TrendingUp className="w-4 h-4" />
+          ) : (
+            <TrendingDown className="w-4 h-4" />
+          )}
+          <span>{change >= 0 ? '+' : ''}{change}%</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/common/__tests__/CurrencyDisplay.test.tsx
+++ b/frontend/src/components/common/__tests__/CurrencyDisplay.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CurrencyDisplay from '../CurrencyDisplay';
+
+describe('CurrencyDisplay', () => {
+  it('金額が表示される', () => {
+    render(<CurrencyDisplay amount={1000} currency="JPY" />);
+    expect(screen.getByText(/1,000/)).toBeInTheDocument();
+  });
+
+  it('JPYの通貨記号が表示される', () => {
+    render(<CurrencyDisplay amount={1000} currency="JPY" />);
+    expect(screen.getByText(/¥/)).toBeInTheDocument();
+  });
+
+  it('USDの通貨記号が表示される', () => {
+    render(<CurrencyDisplay amount={100} currency="USD" />);
+    expect(screen.getByText(/\$/)).toBeInTheDocument();
+  });
+
+  it('EURの通貨記号が表示される', () => {
+    render(<CurrencyDisplay amount={100} currency="EUR" />);
+    expect(screen.getByText(/€/)).toBeInTheDocument();
+  });
+
+  it('正の変動が緑色で表示される', () => {
+    const { container } = render(<CurrencyDisplay amount={1000} currency="JPY" change={5.2} />);
+    expect(container.querySelector('.text-green-400')).toBeInTheDocument();
+  });
+
+  it('負の変動が赤色で表示される', () => {
+    const { container } = render(<CurrencyDisplay amount={1000} currency="JPY" change={-3.1} />);
+    expect(container.querySelector('.text-red-400')).toBeInTheDocument();
+  });
+
+  it('変動パーセンテージが表示される', () => {
+    render(<CurrencyDisplay amount={1000} currency="JPY" change={5.2} />);
+    expect(screen.getByText(/5.2%/)).toBeInTheDocument();
+  });
+
+  it('変動がない場合はパーセンテージ非表示', () => {
+    render(<CurrencyDisplay amount={1000} currency="JPY" />);
+    expect(screen.queryByText(/%/)).not.toBeInTheDocument();
+  });
+
+  it('ラベルが表示される', () => {
+    render(<CurrencyDisplay amount={1000} currency="JPY" label="売上" />);
+    expect(screen.getByText('売上')).toBeInTheDocument();
+  });
+
+  it('smサイズが適用される', () => {
+    const { container } = render(<CurrencyDisplay amount={1000} currency="JPY" size="sm" />);
+    expect(container.querySelector('.text-lg')).toBeInTheDocument();
+  });
+
+  it('lgサイズが適用される', () => {
+    const { container } = render(<CurrencyDisplay amount={1000} currency="JPY" size="lg" />);
+    expect(container.querySelector('.text-3xl')).toBeInTheDocument();
+  });
+
+  it('カスタムクラス名が適用される', () => {
+    const { container } = render(<CurrencyDisplay amount={1000} currency="JPY" className="custom-class" />);
+    expect(container.querySelector('.custom-class')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要
通貨表示コンポーネントをTDDで実装

## 変更内容
- `CurrencyDisplay.tsx`: 通貨表示コンポーネント
- `CurrencyDisplay.test.tsx`: 12件のテストケース

## テスト内容
- 金額表示・JPY/USD/EUR通貨記号
- 正/負の変動カラー・パーセンテージ表示
- 変動なし時非表示・ラベル表示
- sm/lgサイズ・カスタムクラス名