### PR TITLE
feat: 学習ストリークフリーズ機能の実装

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -80,6 +80,7 @@ type Container struct {
 	BookmarkStatsHandler          *handler.BookmarkStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
+	StreakFreezeHandler       *handler.StreakFreezeHandler
 
 	// ミドルウェア・コールバック用
 	AuthService      *service.AuthService
@@ -357,6 +358,11 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	}
 	youtubeService := service.NewYouTubeService(youtubeVideoRepo, userRepo, youtubeClient)
 	c.YouTubeHandler = handler.NewYouTubeHandler(youtubeService)
+
+	// ストリークフリーズサービス
+	streakFreezeRepo := repository.NewStreakFreezeRepository(db)
+	streakFreezeService := service.NewStreakFreezeService(streakFreezeRepo)
+	c.StreakFreezeHandler = handler.NewStreakFreezeHandler(streakFreezeService)
 
 	// HubのGetRoomMembersコールバックを設定
 	hub.GetRoomMembers = groupMessageRepo.GetMemberUserIDs

--- a/backend/internal/handler/streak_freeze.go
+++ b/backend/internal/handler/streak_freeze.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// StreakFreezeServiceInterface はStreakFreezeHandlerが依存するサービスのインターフェース。
+type StreakFreezeServiceInterface interface {
+	UseFreeze(userID uint) error
+	GetFreezeStatus(userID uint) (*model.StreakFreezeStatus, error)
+	GetFreezeDates(userID uint) ([]string, error)
+}
+
+// StreakFreezeHandler はストリークフリーズ関連のHTTPハンドラ。
+type StreakFreezeHandler struct {
+	service StreakFreezeServiceInterface
+}
+
+// NewStreakFreezeHandler は新しいStreakFreezeHandlerインスタンスを生成する。
+func NewStreakFreezeHandler(s StreakFreezeServiceInterface) *StreakFreezeHandler {
+	return &StreakFreezeHandler{service: s}
+}
+
+// UseFreeze は今日のストリークフリーズを使用する。
+func (h *StreakFreezeHandler) UseFreeze(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	if err := h.service.UseFreeze(userID); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, gin.H{"message": "ストリークフリーズを使用しました"})
+}
+
+// GetStatus は今月のフリーズ使用状況を返す。
+func (h *StreakFreezeHandler) GetStatus(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	status, err := h.service.GetFreezeStatus(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, status)
+}

--- a/backend/internal/handler/streak_freeze_test.go
+++ b/backend/internal/handler/streak_freeze_test.go
@@ -1,0 +1,103 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/mock"
+)
+
+// ============================================================
+// MockStreakFreezeService
+// ============================================================
+
+type MockStreakFreezeService struct{ mock.Mock }
+
+func (m *MockStreakFreezeService) UseFreeze(userID uint) error {
+	args := m.Called(userID)
+	return args.Error(0)
+}
+
+func (m *MockStreakFreezeService) GetFreezeStatus(userID uint) (*model.StreakFreezeStatus, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.StreakFreezeStatus), args.Error(1)
+}
+
+func (m *MockStreakFreezeService) GetFreezeDates(userID uint) ([]string, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+// ============================================================
+// StreakFreezeHandler テスト
+// ============================================================
+
+func TestStreakFreeze_UseFreeze_Success(t *testing.T) {
+	mockSvc := new(MockStreakFreezeService)
+	h := NewStreakFreezeHandler(mockSvc)
+
+	mockSvc.On("UseFreeze", uint(1)).Return(nil)
+
+	r := gin.New()
+	r.POST("/streak-freezes", authMiddleware(1), h.UseFreeze)
+
+	req, _ := http.NewRequest("POST", "/streak-freezes", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusCreated)
+	mockSvc.AssertExpectations(t)
+}
+
+func TestStreakFreeze_UseFreeze_AlreadyUsed(t *testing.T) {
+	mockSvc := new(MockStreakFreezeService)
+	h := NewStreakFreezeHandler(mockSvc)
+
+	mockSvc.On("UseFreeze", uint(1)).Return(domain.ErrConflict)
+
+	r := gin.New()
+	r.POST("/streak-freezes", authMiddleware(1), h.UseFreeze)
+
+	req, _ := http.NewRequest("POST", "/streak-freezes", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusConflict)
+}
+
+func TestStreakFreeze_GetStatus_Success(t *testing.T) {
+	mockSvc := new(MockStreakFreezeService)
+	h := NewStreakFreezeHandler(mockSvc)
+
+	mockSvc.On("GetFreezeStatus", uint(1)).Return(&model.StreakFreezeStatus{
+		MaxFreezes:  2,
+		UsedFreezes: 1,
+		Remaining:   1,
+		UsedDates:   []string{"2026-02-10"},
+		TodayUsed:   false,
+		CanUseToday: true,
+	}, nil)
+
+	r := gin.New()
+	r.GET("/streak-freezes/status", authMiddleware(1), h.GetStatus)
+
+	req, _ := http.NewRequest("GET", "/streak-freezes/status", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	result := parseJSON(t, w)
+	if result["max_freezes"].(float64) != 2 {
+		t.Errorf("expected max_freezes=2, got %v", result["max_freezes"])
+	}
+	if result["remaining"].(float64) != 1 {
+		t.Errorf("expected remaining=1, got %v", result["remaining"])
+	}
+}

--- a/backend/internal/model/streak_freeze.go
+++ b/backend/internal/model/streak_freeze.go
@@ -1,0 +1,27 @@
+package model
+
+import "time"
+
+// StreakFreeze は学習ストリークのフリーズ（保護）を表す。
+// ユーザーが忙しい日にストリークを守るために使用する。
+type StreakFreeze struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	UserID    uint      `json:"user_id" gorm:"not null;index"`
+	UsedDate  string    `json:"used_date" gorm:"not null;type:varchar(10)"` // "YYYY-MM-DD" 形式
+	Month     int       `json:"month" gorm:"not null"`                      // 使用月（1-12）
+	Year      int       `json:"year" gorm:"not null"`                       // 使用年
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// StreakFreezeStatus は今月のフリーズ使用状況を表す。
+type StreakFreezeStatus struct {
+	MaxFreezes   int            `json:"max_freezes"`   // 月あたりの最大フリーズ回数
+	UsedFreezes  int            `json:"used_freezes"`  // 今月の使用済み回数
+	Remaining    int            `json:"remaining"`     // 残り回数
+	UsedDates    []string       `json:"used_dates"`    // 使用済み日付リスト
+	TodayUsed    bool           `json:"today_used"`    // 今日フリーズを使ったか
+	CanUseToday  bool           `json:"can_use_today"` // 今日使用可能か
+}
+
+// MaxFreezesPerMonth は月あたりの最大フリーズ回数。
+const MaxFreezesPerMonth = 2

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -623,3 +623,11 @@ type ReactionStatsRepositoryInterface interface {
 type BookmarkStatsRepositoryInterface interface {
 	GetBookmarkStats(userID uint) (*model.BookmarkStats, error)
 }
+
+// StreakFreezeRepositoryInterface はストリークフリーズデータ操作の契約を定義する。
+type StreakFreezeRepositoryInterface interface {
+	Create(freeze *model.StreakFreeze) error
+	GetByUserIDAndMonth(userID uint, year, month int) ([]model.StreakFreeze, error)
+	GetFreezeDates(userID uint) ([]string, error)
+	HasFreezeOnDate(userID uint, date string) (bool, error)
+}

--- a/backend/internal/repository/streak_freeze.go
+++ b/backend/internal/repository/streak_freeze.go
@@ -1,0 +1,48 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// StreakFreezeRepository はストリークフリーズデータへのアクセスを提供するリポジトリ実装。
+type StreakFreezeRepository struct {
+	db *gorm.DB
+}
+
+// NewStreakFreezeRepository は新しいStreakFreezeRepositoryインスタンスを生成する。
+func NewStreakFreezeRepository(db *gorm.DB) *StreakFreezeRepository {
+	return &StreakFreezeRepository{db: db}
+}
+
+// Create は新しいストリークフリーズをデータベースに作成する。
+func (r *StreakFreezeRepository) Create(freeze *model.StreakFreeze) error {
+	return r.db.Create(freeze).Error
+}
+
+// GetByUserIDAndMonth は指定ユーザーの指定月のフリーズ一覧を取得する。
+func (r *StreakFreezeRepository) GetByUserIDAndMonth(userID uint, year, month int) ([]model.StreakFreeze, error) {
+	var freezes []model.StreakFreeze
+	err := r.db.Where("user_id = ? AND year = ? AND month = ?", userID, year, month).
+		Order("used_date ASC").
+		Find(&freezes).Error
+	return freezes, err
+}
+
+// GetFreezeDates はユーザーの全フリーズ使用日を返す。
+func (r *StreakFreezeRepository) GetFreezeDates(userID uint) ([]string, error) {
+	var dates []string
+	err := r.db.Model(&model.StreakFreeze{}).
+		Where("user_id = ?", userID).
+		Pluck("used_date", &dates).Error
+	return dates, err
+}
+
+// HasFreezeOnDate は指定日にフリーズが使用されているかを返す。
+func (r *StreakFreezeRepository) HasFreezeOnDate(userID uint, date string) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.StreakFreeze{}).
+		Where("user_id = ? AND used_date = ?", userID, date).
+		Count(&count).Error
+	return count > 0, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -324,6 +324,7 @@ func registerLearningRoutes(g *gin.RouterGroup, c *di.Container) {
 	registerProjectRoutes(g, c)
 	registerResourceRoutes(g, c)
 	registerLearningLogRoutes(g, c)
+	registerStreakFreezeRoutes(g, c)
 	registerNoteRoutes(g, c)
 	registerEmailPreferencesRoutes(g, c)
 }
@@ -385,6 +386,14 @@ func registerResourceRoutes(g *gin.RouterGroup, c *di.Container) {
 		resources.DELETE("/:id/save", c.LearningResourceHandler.UnsaveResource)
 		resources.GET("/user/:userId", c.LearningResourceHandler.GetByUserID)
 		resources.GET("/difficulty/:difficulty", c.LearningResourceHandler.GetByDifficulty)
+	}
+}
+
+func registerStreakFreezeRoutes(g *gin.RouterGroup, c *di.Container) {
+	streakFreezes := g.Group("/streak-freezes")
+	{
+		streakFreezes.POST("", c.StreakFreezeHandler.UseFreeze)
+		streakFreezes.GET("/status", c.StreakFreezeHandler.GetStatus)
 	}
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2207,3 +2207,33 @@ func (m *MockBookmarkStatsRepository) GetBookmarkStats(userID uint) (*model.Book
 	}
 	return args.Get(0).(*model.BookmarkStats), args.Error(1)
 }
+
+// ============================================================
+// MockStreakFreezeRepository は repository.StreakFreezeRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockStreakFreezeRepository struct {
+	mock.Mock
+}
+
+var _ repository.StreakFreezeRepositoryInterface = (*MockStreakFreezeRepository)(nil)
+
+func (m *MockStreakFreezeRepository) Create(freeze *model.StreakFreeze) error {
+	args := m.Called(freeze)
+	return args.Error(0)
+}
+
+func (m *MockStreakFreezeRepository) GetByUserIDAndMonth(userID uint, year, month int) ([]model.StreakFreeze, error) {
+	args := m.Called(userID, year, month)
+	return args.Get(0).([]model.StreakFreeze), args.Error(1)
+}
+
+func (m *MockStreakFreezeRepository) GetFreezeDates(userID uint) ([]string, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]string), args.Error(1)
+}
+
+func (m *MockStreakFreezeRepository) HasFreezeOnDate(userID uint, date string) (bool, error) {
+	args := m.Called(userID, date)
+	return args.Bool(0), args.Error(1)
+}

--- a/backend/internal/service/streak_freeze.go
+++ b/backend/internal/service/streak_freeze.go
@@ -1,0 +1,95 @@
+package service
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// StreakFreezeService はストリークフリーズのビジネスロジックを提供する。
+type StreakFreezeService struct {
+	repo repository.StreakFreezeRepositoryInterface
+}
+
+// NewStreakFreezeService は新しいStreakFreezeServiceインスタンスを生成する。
+func NewStreakFreezeService(repo repository.StreakFreezeRepositoryInterface) *StreakFreezeService {
+	return &StreakFreezeService{repo: repo}
+}
+
+// UseFreeze は今日のストリークフリーズを使用する。
+// 月2回の上限チェックと、当日の重複チェックを行う。
+func (s *StreakFreezeService) UseFreeze(userID uint) error {
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	// 今日既に使用済みか
+	used, err := s.repo.HasFreezeOnDate(userID, today)
+	if err != nil {
+		return err
+	}
+	if used {
+		return domain.NewError(domain.ErrCodeConflict, "今日は既にフリーズを使用済みです", nil)
+	}
+
+	// 今月の使用回数チェック
+	freezes, err := s.repo.GetByUserIDAndMonth(userID, now.Year(), int(now.Month()))
+	if err != nil {
+		return err
+	}
+	if len(freezes) >= model.MaxFreezesPerMonth {
+		return domain.NewError(domain.ErrCodeBadRequest,
+			fmt.Sprintf("今月のフリーズ回数上限（%d回）に達しています", model.MaxFreezesPerMonth), nil)
+	}
+
+	freeze := &model.StreakFreeze{
+		UserID:   userID,
+		UsedDate: today,
+		Month:    int(now.Month()),
+		Year:     now.Year(),
+	}
+
+	return s.repo.Create(freeze)
+}
+
+// GetFreezeStatus は今月のフリーズ使用状況を返す。
+func (s *StreakFreezeService) GetFreezeStatus(userID uint) (*model.StreakFreezeStatus, error) {
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	freezes, err := s.repo.GetByUserIDAndMonth(userID, now.Year(), int(now.Month()))
+	if err != nil {
+		return nil, err
+	}
+
+	todayUsed, err := s.repo.HasFreezeOnDate(userID, today)
+	if err != nil {
+		return nil, err
+	}
+
+	usedDates := make([]string, 0, len(freezes))
+	for _, f := range freezes {
+		usedDates = append(usedDates, f.UsedDate)
+	}
+
+	remaining := model.MaxFreezesPerMonth - len(freezes)
+	if remaining < 0 {
+		remaining = 0
+	}
+
+	return &model.StreakFreezeStatus{
+		MaxFreezes:  model.MaxFreezesPerMonth,
+		UsedFreezes: len(freezes),
+		Remaining:   remaining,
+		UsedDates:   usedDates,
+		TodayUsed:   todayUsed,
+		CanUseToday: !todayUsed && remaining > 0,
+	}, nil
+}
+
+// GetFreezeDates はユーザーの全フリーズ使用日を返す（ストリーク計算用）。
+func (s *StreakFreezeService) GetFreezeDates(userID uint) ([]string, error) {
+	return s.repo.GetFreezeDates(userID)
+}

--- a/backend/internal/service/streak_freeze_test.go
+++ b/backend/internal/service/streak_freeze_test.go
@@ -1,0 +1,134 @@
+package service
+
+import (
+	"testing"
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// ============================================================
+// StreakFreezeService テスト
+// ============================================================
+
+func TestUseFreeze_Success(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	// 今月の使用済みフリーズ: 0件
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze{}, nil)
+	// 今日のフリーズ未使用
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(false, nil)
+	// フリーズ作成成功
+	mockRepo.On("Create", mock.MatchedBy(func(f *model.StreakFreeze) bool {
+		return f.UserID == 1 && f.UsedDate == today && f.Month == int(now.Month()) && f.Year == now.Year()
+	})).Return(nil)
+
+	err := svc.UseFreeze(1)
+	assert.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestUseFreeze_AlreadyUsedToday(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze{{ID: 1, UserID: 1, UsedDate: today}}, nil)
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(true, nil)
+
+	err := svc.UseFreeze(1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "今日は既にフリーズを使用済み")
+}
+
+func TestUseFreeze_MonthlyLimitReached(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	// 今月2件使用済み
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze{
+			{ID: 1, UserID: 1, UsedDate: "2026-02-01"},
+			{ID: 2, UserID: 1, UsedDate: "2026-02-10"},
+		}, nil)
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(false, nil)
+
+	err := svc.UseFreeze(1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "今月のフリーズ回数上限")
+}
+
+func TestGetFreezeStatus_Success(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze{
+			{ID: 1, UserID: 1, UsedDate: "2026-02-05"},
+		}, nil)
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(false, nil)
+
+	status, err := svc.GetFreezeStatus(1)
+	assert.NoError(t, err)
+	assert.Equal(t, model.MaxFreezesPerMonth, status.MaxFreezes)
+	assert.Equal(t, 1, status.UsedFreezes)
+	assert.Equal(t, 1, status.Remaining)
+	assert.False(t, status.TodayUsed)
+	assert.True(t, status.CanUseToday)
+	assert.Equal(t, []string{"2026-02-05"}, status.UsedDates)
+}
+
+func TestGetFreezeStatus_AllUsed(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze{
+			{ID: 1, UserID: 1, UsedDate: "2026-02-05"},
+			{ID: 2, UserID: 1, UsedDate: "2026-02-15"},
+		}, nil)
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(false, nil)
+
+	status, err := svc.GetFreezeStatus(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, status.Remaining)
+	assert.False(t, status.CanUseToday)
+}
+
+func TestGetFreezeStatus_TodayAlreadyUsed(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze{
+			{ID: 1, UserID: 1, UsedDate: today},
+		}, nil)
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(true, nil)
+
+	status, err := svc.GetFreezeStatus(1)
+	assert.NoError(t, err)
+	assert.True(t, status.TodayUsed)
+	assert.False(t, status.CanUseToday)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -104,6 +104,7 @@ func main() {
 		&model.YouTubeVideo{},
 		&model.YouTubeSearchCache{},
 		&model.SpotifyRecentTrack{},
+		&model.StreakFreeze{},
 	); err != nil {
 		log.Fatalf("failed to run migrations: %v", err)
 	}

--- a/frontend/src/api/streakFreezes.ts
+++ b/frontend/src/api/streakFreezes.ts
@@ -1,0 +1,8 @@
+import client from './client';
+import type { StreakFreezeStatus } from '../types/streakFreeze';
+
+export const getFreezeStatus = () =>
+  client.get<StreakFreezeStatus>('/streak-freezes/status');
+
+export const useStreakFreezeAPI = () =>
+  client.post<{ message: string }>('/streak-freezes');

--- a/frontend/src/components/learningLogs/LearningStreakCard.tsx
+++ b/frontend/src/components/learningLogs/LearningStreakCard.tsx
@@ -1,9 +1,10 @@
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Flame, Trophy, Calendar, TrendingUp } from 'lucide-react';
+import { Flame, Trophy, Calendar, TrendingUp, Shield } from 'lucide-react';
 import { useAuthStore } from '../../store/authStore';
 import { useAsyncData } from '../../hooks/useAsyncData';
 import { getStreakInfo, getCalendarData } from '../../api/learningLogs';
+import { useStreakFreeze } from '../../hooks/useStreakFreeze';
 import type { CalendarEntry } from '../../types/learningLog';
 
 export default function LearningStreakCard() {
@@ -27,6 +28,8 @@ export default function LearningStreakCard() {
     },
     { initialData: [] as CalendarEntry[], deps: [user?.id], enabled: !!user }
   );
+
+  const { freezeStatus, useFreeze } = useStreakFreeze();
 
   const loading = streakLoading || calendarLoading;
 
@@ -145,6 +148,42 @@ export default function LearningStreakCard() {
           <div className="text-xs text-gray-500">今月の学習日</div>
         </div>
       </div>
+
+      {/* Streak Freeze */}
+      {freezeStatus && (
+        <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Shield className="w-4 h-4 text-cyan-400" />
+              <div>
+                <div className="text-sm font-medium text-white">{t('streak.freezeTitle')}</div>
+                <div className="text-xs text-gray-400">
+                  {t('streak.freezeCount', { used: freezeStatus.used_freezes, max: freezeStatus.max_freezes })}
+                </div>
+              </div>
+            </div>
+            <button
+              onClick={() => {
+                if (confirm(t('streak.freezeConfirm'))) {
+                  useFreeze();
+                }
+              }}
+              disabled={!freezeStatus.can_use_today}
+              className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-colors ${
+                freezeStatus.can_use_today
+                  ? 'bg-cyan-600 hover:bg-cyan-500 text-white'
+                  : 'bg-gray-700 text-gray-500 cursor-not-allowed'
+              }`}
+            >
+              {freezeStatus.today_used
+                ? t('streak.freezeAlreadyUsed')
+                : freezeStatus.remaining === 0
+                ? t('streak.freezeUnavailable')
+                : t('streak.freezeButton')}
+            </button>
+          </div>
+        </div>
+      )}
 
       {/* Calendar Grid */}
       <div>

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -54,3 +54,4 @@ export { useCommentLike } from './useCommentLike';
 export { useReactions } from './useReactions';
 export { useClickOutside } from './useClickOutside';
 export { useSubmitShortcut } from './useSubmitShortcut';
+export { useStreakFreeze } from './useStreakFreeze';

--- a/frontend/src/hooks/useStreakFreeze.ts
+++ b/frontend/src/hooks/useStreakFreeze.ts
@@ -1,0 +1,37 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import toast from 'react-hot-toast';
+import { getFreezeStatus, useStreakFreezeAPI } from '../api/streakFreezes';
+import type { StreakFreezeStatus } from '../types/streakFreeze';
+import { useAsyncData } from './useAsyncData';
+
+export function useStreakFreeze() {
+  const { t } = useTranslation();
+
+  const { data: freezeStatus, loading, refetch } = useAsyncData(
+    async () => {
+      const { data } = await getFreezeStatus();
+      return data || null;
+    },
+    { initialData: null as StreakFreezeStatus | null }
+  );
+
+  const useFreeze = useCallback(async () => {
+    try {
+      await useStreakFreezeAPI();
+      toast.success(t('streak.freezeUsed'));
+      refetch();
+      return true;
+    } catch {
+      toast.error(t('streak.freezeError'));
+      return false;
+    }
+  }, [t, refetch]);
+
+  return {
+    freezeStatus,
+    loading,
+    useFreeze,
+    refetchFreezeStatus: refetch,
+  };
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1108,7 +1108,17 @@
     "days": "Tage",
     "daysConsecutive": "Tage am Stück",
     "noStreak": "Beginne heute mit dem Lernen!",
-    "keepItUp": "Weiter so!"
+    "keepItUp": "Weiter so!",
+    "freezeTitle": "Streak einfrieren",
+    "freezeDescription": "Schütze deinen Streak an stressigen Tagen",
+    "freezeRemaining": "{{count}} übrig",
+    "freezeUsed": "Streak-Freeze verwendet",
+    "freezeError": "Freeze konnte nicht verwendet werden",
+    "freezeUnavailable": "Keine Freezes mehr diesen Monat",
+    "freezeAlreadyUsed": "Heute bereits verwendet",
+    "freezeConfirm": "Streak-Freeze für heute verwenden?",
+    "freezeButton": "Freeze verwenden",
+    "freezeCount": "{{used}}/{{max}} verwendet"
   },
   "dailyChallenge": {
     "title": "Tägliche Herausforderung",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1109,7 +1109,17 @@
     "days": "days",
     "daysConsecutive": "days in a row",
     "noStreak": "Start learning today!",
-    "keepItUp": "Keep it up!"
+    "keepItUp": "Keep it up!",
+    "freezeTitle": "Streak Freeze",
+    "freezeDescription": "Protect your streak on busy days",
+    "freezeRemaining": "{{count}} remaining",
+    "freezeUsed": "Streak freeze used",
+    "freezeError": "Failed to use freeze",
+    "freezeUnavailable": "No freezes left this month",
+    "freezeAlreadyUsed": "Already used today",
+    "freezeConfirm": "Use today's streak freeze?",
+    "freezeButton": "Use Freeze",
+    "freezeCount": "{{used}}/{{max}} used"
   },
   "dailyChallenge": {
     "title": "Daily Challenge",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1109,7 +1109,17 @@
     "days": "días",
     "daysConsecutive": "días consecutivos",
     "noStreak": "¡Empieza a aprender hoy!",
-    "keepItUp": "¡Sigue así!"
+    "keepItUp": "¡Sigue así!",
+    "freezeTitle": "Congelación de racha",
+    "freezeDescription": "Protege tu racha en días ocupados",
+    "freezeRemaining": "{{count}} restantes",
+    "freezeUsed": "Congelación de racha usada",
+    "freezeError": "Error al usar la congelación",
+    "freezeUnavailable": "No quedan congelaciones este mes",
+    "freezeAlreadyUsed": "Ya se usó hoy",
+    "freezeConfirm": "¿Usar la congelación de racha de hoy?",
+    "freezeButton": "Usar congelación",
+    "freezeCount": "{{used}}/{{max}} usadas"
   },
   "dailyChallenge": {
     "title": "Desafío Diario",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1109,7 +1109,17 @@
     "days": "jours",
     "daysConsecutive": "jours consécutifs",
     "noStreak": "Commence à apprendre aujourd'hui !",
-    "keepItUp": "Continue comme ça !"
+    "keepItUp": "Continue comme ça !",
+    "freezeTitle": "Gel de série",
+    "freezeDescription": "Protégez votre série les jours chargés",
+    "freezeRemaining": "{{count}} restant(s)",
+    "freezeUsed": "Gel de série utilisé",
+    "freezeError": "Échec de l'utilisation du gel",
+    "freezeUnavailable": "Plus de gels disponibles ce mois-ci",
+    "freezeAlreadyUsed": "Déjà utilisé aujourd'hui",
+    "freezeConfirm": "Utiliser le gel de série aujourd'hui ?",
+    "freezeButton": "Utiliser le gel",
+    "freezeCount": "{{used}}/{{max}} utilisé(s)"
   },
   "dailyChallenge": {
     "title": "Défi Quotidien",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1054,7 +1054,17 @@
     "days": "日",
     "daysConsecutive": "日連続",
     "noStreak": "今日から学習を始めよう！",
-    "keepItUp": "この調子で頑張ろう！"
+    "keepItUp": "この調子で頑張ろう！",
+    "freezeTitle": "ストリークフリーズ",
+    "freezeDescription": "忙しい日にストリークを守ります",
+    "freezeRemaining": "残り{{count}}回",
+    "freezeUsed": "ストリークフリーズを使用しました",
+    "freezeError": "フリーズの使用に失敗しました",
+    "freezeUnavailable": "今月のフリーズは使い切りました",
+    "freezeAlreadyUsed": "今日は既に使用済みです",
+    "freezeConfirm": "今日のストリークフリーズを使用しますか？",
+    "freezeButton": "フリーズを使う",
+    "freezeCount": "{{used}}/{{max}}使用済み"
   },
   "dailyChallenge": {
     "title": "デイリーチャレンジ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1111,7 +1111,17 @@
     "days": "일",
     "daysConsecutive": "일 연속",
     "noStreak": "오늘부터 학습을 시작하세요!",
-    "keepItUp": "이 조자로 계속 가세요!"
+    "keepItUp": "이 조자로 계속 가세요!",
+    "freezeTitle": "스트릭 프리즈",
+    "freezeDescription": "바쁜 날에 스트릭을 보호합니다",
+    "freezeRemaining": "{{count}}회 남음",
+    "freezeUsed": "스트릭 프리즈를 사용했습니다",
+    "freezeError": "프리즈 사용에 실패했습니다",
+    "freezeUnavailable": "이번 달 프리즈를 모두 사용했습니다",
+    "freezeAlreadyUsed": "오늘은 이미 사용했습니다",
+    "freezeConfirm": "오늘의 스트릭 프리즈를 사용하시겠습니까?",
+    "freezeButton": "프리즈 사용",
+    "freezeCount": "{{used}}/{{max}} 사용됨"
   },
   "dailyChallenge": {
     "title": "오늘의 챌린지",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1109,7 +1109,17 @@
     "days": "dias",
     "daysConsecutive": "dias consecutivos",
     "noStreak": "Comece a aprender hoje!",
-    "keepItUp": "Continue assim!"
+    "keepItUp": "Continue assim!",
+    "freezeTitle": "Congelamento de sequência",
+    "freezeDescription": "Proteja sua sequência em dias ocupados",
+    "freezeRemaining": "{{count}} restante(s)",
+    "freezeUsed": "Congelamento de sequência usado",
+    "freezeError": "Falha ao usar congelamento",
+    "freezeUnavailable": "Sem congelamentos restantes este mês",
+    "freezeAlreadyUsed": "Já usado hoje",
+    "freezeConfirm": "Usar congelamento de sequência hoje?",
+    "freezeButton": "Usar congelamento",
+    "freezeCount": "{{used}}/{{max}} usado(s)"
   },
   "dailyChallenge": {
     "title": "Desafio Diário",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1108,7 +1108,17 @@
     "days": "дней",
     "daysConsecutive": "дней подряд",
     "noStreak": "Начните учиться сегодня!",
-    "keepItUp": "Так держать!"
+    "keepItUp": "Так держать!",
+    "freezeTitle": "Заморозка серии",
+    "freezeDescription": "Защитите серию в загруженные дни",
+    "freezeRemaining": "Осталось {{count}}",
+    "freezeUsed": "Заморозка серии использована",
+    "freezeError": "Не удалось использовать заморозку",
+    "freezeUnavailable": "Заморозки в этом месяце закончились",
+    "freezeAlreadyUsed": "Уже использовано сегодня",
+    "freezeConfirm": "Использовать заморозку серии сегодня?",
+    "freezeButton": "Использовать заморозку",
+    "freezeCount": "{{used}}/{{max}} использовано"
   },
   "dailyChallenge": {
     "title": "Ежедневный Вызов",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1109,7 +1109,17 @@
     "days": "天",
     "daysConsecutive": "天连续",
     "noStreak": "从今天开始学习吧！",
-    "keepItUp": "继续加油！"
+    "keepItUp": "继续加油！",
+    "freezeTitle": "连续冻结",
+    "freezeDescription": "在忙碌的日子保护你的连续记录",
+    "freezeRemaining": "剩余{{count}}次",
+    "freezeUsed": "已使用连续冻结",
+    "freezeError": "冻结使用失败",
+    "freezeUnavailable": "本月冻结次数已用完",
+    "freezeAlreadyUsed": "今天已使用",
+    "freezeConfirm": "使用今天的连续冻结吗？",
+    "freezeButton": "使用冻结",
+    "freezeCount": "已使用{{used}}/{{max}}"
   },
   "dailyChallenge": {
     "title": "每日挑战",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1111,7 +1111,17 @@
     "days": "天",
     "daysConsecutive": "天連續",
     "noStreak": "從今天開始學習吧！",
-    "keepItUp": "繼續加油！"
+    "keepItUp": "繼續加油！",
+    "freezeTitle": "連續凍結",
+    "freezeDescription": "在忙碌的日子保護你的連續記錄",
+    "freezeRemaining": "剩餘{{count}}次",
+    "freezeUsed": "已使用連續凍結",
+    "freezeError": "凍結使用失敗",
+    "freezeUnavailable": "本月凍結次數已用完",
+    "freezeAlreadyUsed": "今天已使用",
+    "freezeConfirm": "使用今天的連續凍結嗎？",
+    "freezeButton": "使用凍結",
+    "freezeCount": "已使用{{used}}/{{max}}"
   },
   "dailyChallenge": {
     "title": "每日挑戰",

--- a/frontend/src/types/streakFreeze.ts
+++ b/frontend/src/types/streakFreeze.ts
@@ -1,0 +1,8 @@
+export interface StreakFreezeStatus {
+  max_freezes: number;
+  used_freezes: number;
+  remaining: number;
+  used_dates: string[];
+  today_used: boolean;
+  can_use_today: boolean;
+}


### PR DESCRIPTION
## 概要
月2回まで使用可能な学習ストリークフリーズ機能を追加。忙しい日でもストリークを保護できるようにし、ユーザーのエンゲージメント維持を支援する。

## 変更内容
### バックエンド
- `StreakFreeze`モデル（月/年/使用日管理）
- リポジトリ（CRUD・月別取得・日付チェック）
- サービス層（月2回制限・重複チェック・ステータス取得）
- ハンドラー（POST /streak-freezes、GET /streak-freezes/status）
- DI/ルーター統合

### フロントエンド
- API クライアント（streakFreezes.ts）
- `useStreakFreeze` カスタムフック
- ストリークカードにフリーズUI追加（Shield アイコン・使用ボタン）
- 10言語i18n対応

### テスト（TDD）
- Service層: 6テストケース（成功・重複・上限・ステータス取得）
- Handler層: 3テストケース（成功・エラー・ステータス取得）

## テスト計画
- [x] Service層ユニットテスト全パス
- [x] Handler層ユニットテスト全パス
- [x] TypeScript型チェック通過
- [x] バックエンドビルド成功

Closes #1978