### PR TITLE
feat: ブックマークコレクション機能の実装

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -80,7 +80,8 @@ type Container struct {
 	BookmarkStatsHandler          *handler.BookmarkStatsHandler
 	YouTubeHandler                *handler.YouTubeHandler
 	SpotifyHandler           *handler.SpotifyHandler
-	StreakFreezeHandler       *handler.StreakFreezeHandler
+	StreakFreezeHandler            *handler.StreakFreezeHandler
+	BookmarkCollectionHandler     *handler.BookmarkCollectionHandler
 
 	// ミドルウェア・コールバック用
 	AuthService      *service.AuthService
@@ -363,6 +364,11 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	streakFreezeRepo := repository.NewStreakFreezeRepository(db)
 	streakFreezeService := service.NewStreakFreezeService(streakFreezeRepo)
 	c.StreakFreezeHandler = handler.NewStreakFreezeHandler(streakFreezeService)
+
+	// ブックマークコレクションサービス
+	bookmarkCollectionRepo := repository.NewBookmarkCollectionRepository(db)
+	bookmarkCollectionService := service.NewBookmarkCollectionService(bookmarkCollectionRepo)
+	c.BookmarkCollectionHandler = handler.NewBookmarkCollectionHandler(bookmarkCollectionService)
 
 	// HubのGetRoomMembersコールバックを設定
 	hub.GetRoomMembers = groupMessageRepo.GetMemberUserIDs

--- a/backend/internal/handler/bookmark_collection.go
+++ b/backend/internal/handler/bookmark_collection.go
@@ -1,0 +1,174 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// BookmarkCollectionServiceInterface はBookmarkCollectionHandlerが依存するサービスのインターフェース。
+type BookmarkCollectionServiceInterface interface {
+	Create(collection *model.BookmarkCollection) error
+	GetByUserID(userID uint) ([]model.BookmarkCollection, error)
+	Update(id, userID uint, updates *model.BookmarkCollection) (*model.BookmarkCollection, error)
+	Delete(id, userID uint) error
+	AddPost(collectionID, postID, userID uint) error
+	RemovePost(collectionID, postID, userID uint) error
+	GetPosts(collectionID uint, limit, offset int) ([]model.Post, int64, error)
+}
+
+// BookmarkCollectionHandler はブックマークコレクション関連のHTTPハンドラ。
+type BookmarkCollectionHandler struct {
+	service BookmarkCollectionServiceInterface
+}
+
+// NewBookmarkCollectionHandler は新しいBookmarkCollectionHandlerインスタンスを生成する。
+func NewBookmarkCollectionHandler(s BookmarkCollectionServiceInterface) *BookmarkCollectionHandler {
+	return &BookmarkCollectionHandler{service: s}
+}
+
+// Create は新しいブックマークコレクションを作成する。
+func (h *BookmarkCollectionHandler) Create(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	input := bindJSON[struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Color       string `json:"color"`
+	}](c)
+	if input == nil {
+		return
+	}
+
+	collection := &model.BookmarkCollection{
+		UserID:      userID,
+		Name:        input.Name,
+		Description: input.Description,
+		Color:       input.Color,
+	}
+
+	if err := h.service.Create(collection); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, collection)
+}
+
+// GetMyCollections はユーザー自身のコレクション一覧を返す。
+func (h *BookmarkCollectionHandler) GetMyCollections(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	collections, err := h.service.GetByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, ensureSlice(collections))
+}
+
+// Update はコレクションを更新する。
+func (h *BookmarkCollectionHandler) Update(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	input := bindJSON[struct {
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Color       string `json:"color"`
+	}](c)
+	if input == nil {
+		return
+	}
+
+	updated, err := h.service.Update(id, userID, &model.BookmarkCollection{
+		Name:        input.Name,
+		Description: input.Description,
+		Color:       input.Color,
+	})
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, updated)
+}
+
+// Delete はコレクションを削除する。
+func (h *BookmarkCollectionHandler) Delete(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.Delete(id, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondDeleted(c)
+}
+
+// AddPost はコレクションにブックマークを追加する。
+func (h *BookmarkCollectionHandler) AddPost(c *gin.Context) {
+	userID := c.GetUint("userID")
+	collectionID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	postID, ok := parseID(c, "postId")
+	if !ok {
+		return
+	}
+
+	if err := h.service.AddPost(collectionID, postID, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, gin.H{"message": "コレクションに追加しました"})
+}
+
+// RemovePost はコレクションからブックマークを削除する。
+func (h *BookmarkCollectionHandler) RemovePost(c *gin.Context) {
+	userID := c.GetUint("userID")
+	collectionID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	postID, ok := parseID(c, "postId")
+	if !ok {
+		return
+	}
+
+	if err := h.service.RemovePost(collectionID, postID, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondDeleted(c)
+}
+
+// GetPosts はコレクション内の投稿一覧を返す。
+func (h *BookmarkCollectionHandler) GetPosts(c *gin.Context) {
+	collectionID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	limit, offset := parseLimitOffset(c)
+
+	posts, total, err := h.service.GetPosts(collectionID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{
+		"posts": ensureSlice(posts),
+		"total": total,
+	})
+}

--- a/backend/internal/handler/bookmark_collection_test.go
+++ b/backend/internal/handler/bookmark_collection_test.go
@@ -1,0 +1,212 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/mock"
+)
+
+// ============================================================
+// MockBookmarkCollectionService
+// ============================================================
+
+type MockBookmarkCollectionService struct{ mock.Mock }
+
+func (m *MockBookmarkCollectionService) Create(collection *model.BookmarkCollection) error {
+	return m.Called(collection).Error(0)
+}
+
+func (m *MockBookmarkCollectionService) GetByUserID(userID uint) ([]model.BookmarkCollection, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.BookmarkCollection), args.Error(1)
+}
+
+func (m *MockBookmarkCollectionService) Update(id, userID uint, updates *model.BookmarkCollection) (*model.BookmarkCollection, error) {
+	args := m.Called(id, userID, updates)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.BookmarkCollection), args.Error(1)
+}
+
+func (m *MockBookmarkCollectionService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+
+func (m *MockBookmarkCollectionService) AddPost(collectionID, postID, userID uint) error {
+	return m.Called(collectionID, postID, userID).Error(0)
+}
+
+func (m *MockBookmarkCollectionService) RemovePost(collectionID, postID, userID uint) error {
+	return m.Called(collectionID, postID, userID).Error(0)
+}
+
+func (m *MockBookmarkCollectionService) GetPosts(collectionID uint, limit, offset int) ([]model.Post, int64, error) {
+	args := m.Called(collectionID, limit, offset)
+	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
+}
+
+// ============================================================
+// BookmarkCollectionHandler テスト
+// ============================================================
+
+func TestBookmarkCollection_Create_Success(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("Create", mock.MatchedBy(func(c *model.BookmarkCollection) bool {
+		return c.UserID == 1 && c.Name == "Go学習"
+	})).Return(nil)
+
+	r := gin.New()
+	r.POST("/bookmark-collections", authMiddleware(1), h.Create)
+
+	body := jsonBody(map[string]string{"name": "Go学習", "color": "blue"})
+	req, _ := http.NewRequest("POST", "/bookmark-collections", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusCreated)
+	mockSvc.AssertExpectations(t)
+}
+
+func TestBookmarkCollection_GetMyCollections_Success(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	collections := []model.BookmarkCollection{
+		{ID: 1, UserID: 1, Name: "Go"},
+		{ID: 2, UserID: 1, Name: "React"},
+	}
+	mockSvc.On("GetByUserID", uint(1)).Return(collections, nil)
+
+	r := gin.New()
+	r.GET("/bookmark-collections", authMiddleware(1), h.GetMyCollections)
+
+	req, _ := http.NewRequest("GET", "/bookmark-collections", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	mockSvc.AssertExpectations(t)
+}
+
+func TestBookmarkCollection_Update_Success(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	updated := &model.BookmarkCollection{ID: 1, UserID: 1, Name: "新名"}
+	mockSvc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.BookmarkCollection")).Return(updated, nil)
+
+	r := gin.New()
+	r.PUT("/bookmark-collections/:id", authMiddleware(1), h.Update)
+
+	body := jsonBody(map[string]string{"name": "新名"})
+	req, _ := http.NewRequest("PUT", "/bookmark-collections/1", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	result := parseJSON(t, w)
+	if result["name"] != "新名" {
+		t.Errorf("expected name=新名, got %v", result["name"])
+	}
+}
+
+func TestBookmarkCollection_Update_Forbidden(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.BookmarkCollection")).
+		Return(nil, domain.ErrForbidden)
+
+	r := gin.New()
+	r.PUT("/bookmark-collections/:id", authMiddleware(1), h.Update)
+
+	body := jsonBody(map[string]string{"name": "新名"})
+	req, _ := http.NewRequest("PUT", "/bookmark-collections/1", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+func TestBookmarkCollection_Delete_Success(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("Delete", uint(1), uint(1)).Return(nil)
+
+	r := gin.New()
+	r.DELETE("/bookmark-collections/:id", authMiddleware(1), h.Delete)
+
+	req, _ := http.NewRequest("DELETE", "/bookmark-collections/1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+}
+
+func TestBookmarkCollection_AddPost_Success(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("AddPost", uint(1), uint(10), uint(1)).Return(nil)
+
+	r := gin.New()
+	r.POST("/bookmark-collections/:id/posts/:postId", authMiddleware(1), h.AddPost)
+
+	req, _ := http.NewRequest("POST", "/bookmark-collections/1/posts/10", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusCreated)
+}
+
+func TestBookmarkCollection_AddPost_Conflict(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("AddPost", uint(1), uint(10), uint(1)).Return(domain.ErrConflict)
+
+	r := gin.New()
+	r.POST("/bookmark-collections/:id/posts/:postId", authMiddleware(1), h.AddPost)
+
+	req, _ := http.NewRequest("POST", "/bookmark-collections/1/posts/10", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusConflict)
+}
+
+func TestBookmarkCollection_GetPosts_Success(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	posts := []model.Post{
+		{ID: 1, Title: "投稿1"},
+		{ID: 2, Title: "投稿2"},
+	}
+	mockSvc.On("GetPosts", uint(1), 20, 0).Return(posts, int64(2), nil)
+
+	r := gin.New()
+	r.GET("/bookmark-collections/:id/posts", h.GetPosts)
+
+	req, _ := http.NewRequest("GET", "/bookmark-collections/1/posts", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	result := parseJSON(t, w)
+	if result["total"].(float64) != 2 {
+		t.Errorf("expected total=2, got %v", result["total"])
+	}
+}

--- a/backend/internal/model/bookmark_collection.go
+++ b/backend/internal/model/bookmark_collection.go
@@ -1,0 +1,23 @@
+package model
+
+import "time"
+
+// BookmarkCollection はブックマークを整理するコレクション（フォルダ）を表す。
+type BookmarkCollection struct {
+	ID          uint      `json:"id" gorm:"primaryKey"`
+	UserID      uint      `json:"user_id" gorm:"not null;index"`
+	Name        string    `json:"name" gorm:"not null"`
+	Description string    `json:"description" gorm:"type:text"`
+	Color       string    `json:"color" gorm:"default:'blue'"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
+}
+
+// BookmarkCollectionItem はコレクション内のブックマークアイテムを表す。
+type BookmarkCollectionItem struct {
+	ID           uint      `json:"id" gorm:"primaryKey"`
+	CollectionID uint      `json:"collection_id" gorm:"not null;uniqueIndex:idx_collection_post"`
+	PostID       uint      `json:"post_id" gorm:"not null;uniqueIndex:idx_collection_post;index"`
+	Post         Post      `json:"post,omitempty" gorm:"foreignKey:PostID"`
+	CreatedAt    time.Time `json:"created_at"`
+}

--- a/backend/internal/repository/bookmark_collection.go
+++ b/backend/internal/repository/bookmark_collection.go
@@ -1,0 +1,99 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// BookmarkCollectionRepository はブックマークコレクションデータへのアクセスを提供するリポジトリ実装。
+type BookmarkCollectionRepository struct {
+	db *gorm.DB
+}
+
+// NewBookmarkCollectionRepository は新しいBookmarkCollectionRepositoryインスタンスを生成する。
+func NewBookmarkCollectionRepository(db *gorm.DB) *BookmarkCollectionRepository {
+	return &BookmarkCollectionRepository{db: db}
+}
+
+// Create は新しいブックマークコレクションを作成する。
+func (r *BookmarkCollectionRepository) Create(collection *model.BookmarkCollection) error {
+	return r.db.Create(collection).Error
+}
+
+// FindByID は指定IDのコレクションを取得する。
+func (r *BookmarkCollectionRepository) FindByID(id uint) (*model.BookmarkCollection, error) {
+	var collection model.BookmarkCollection
+	err := r.db.First(&collection, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return &collection, nil
+}
+
+// FindByUserID は指定ユーザーのコレクション一覧を取得する。
+func (r *BookmarkCollectionRepository) FindByUserID(userID uint) ([]model.BookmarkCollection, error) {
+	var collections []model.BookmarkCollection
+	err := r.db.Where("user_id = ?", userID).Order("created_at DESC").Find(&collections).Error
+	return collections, err
+}
+
+// Update はコレクションを更新する。
+func (r *BookmarkCollectionRepository) Update(collection *model.BookmarkCollection) error {
+	return r.db.Save(collection).Error
+}
+
+// Delete はコレクションとそのアイテムを削除する。
+func (r *BookmarkCollectionRepository) Delete(id uint) error {
+	tx := r.db.Begin()
+	if err := tx.Where("collection_id = ?", id).Delete(&model.BookmarkCollectionItem{}).Error; err != nil {
+		tx.Rollback()
+		return err
+	}
+	if err := tx.Delete(&model.BookmarkCollection{}, id).Error; err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit().Error
+}
+
+// AddPost はコレクションに投稿を追加する。
+func (r *BookmarkCollectionRepository) AddPost(item *model.BookmarkCollectionItem) error {
+	return r.db.Create(item).Error
+}
+
+// RemovePost はコレクションから投稿を削除する。
+func (r *BookmarkCollectionRepository) RemovePost(collectionID, postID uint) error {
+	return r.db.Where("collection_id = ? AND post_id = ?", collectionID, postID).
+		Delete(&model.BookmarkCollectionItem{}).Error
+}
+
+// GetPosts はコレクション内の投稿一覧を取得する。
+func (r *BookmarkCollectionRepository) GetPosts(collectionID uint, limit, offset int) ([]model.Post, int64, error) {
+	var total int64
+	r.db.Model(&model.BookmarkCollectionItem{}).Where("collection_id = ?", collectionID).Count(&total)
+
+	var items []model.BookmarkCollectionItem
+	err := r.db.Where("collection_id = ?", collectionID).
+		Preload("Post").
+		Order("created_at DESC").
+		Limit(limit).Offset(offset).
+		Find(&items).Error
+	if err != nil {
+		return nil, 0, err
+	}
+
+	posts := make([]model.Post, 0, len(items))
+	for _, item := range items {
+		posts = append(posts, item.Post)
+	}
+	return posts, total, nil
+}
+
+// HasPost はコレクションに指定投稿が含まれているかを返す。
+func (r *BookmarkCollectionRepository) HasPost(collectionID, postID uint) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.BookmarkCollectionItem{}).
+		Where("collection_id = ? AND post_id = ?", collectionID, postID).
+		Count(&count).Error
+	return count > 0, err
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -624,6 +624,19 @@ type BookmarkStatsRepositoryInterface interface {
 	GetBookmarkStats(userID uint) (*model.BookmarkStats, error)
 }
 
+// BookmarkCollectionRepositoryInterface はブックマークコレクションデータ操作の契約を定義する。
+type BookmarkCollectionRepositoryInterface interface {
+	Create(collection *model.BookmarkCollection) error
+	FindByID(id uint) (*model.BookmarkCollection, error)
+	FindByUserID(userID uint) ([]model.BookmarkCollection, error)
+	Update(collection *model.BookmarkCollection) error
+	Delete(id uint) error
+	AddPost(item *model.BookmarkCollectionItem) error
+	RemovePost(collectionID, postID uint) error
+	GetPosts(collectionID uint, limit, offset int) ([]model.Post, int64, error)
+	HasPost(collectionID, postID uint) (bool, error)
+}
+
 // StreakFreezeRepositoryInterface はストリークフリーズデータ操作の契約を定義する。
 type StreakFreezeRepositoryInterface interface {
 	Create(freeze *model.StreakFreeze) error

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -104,6 +104,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerNotificationRoutes(protected, c)
 		registerIntegrationRoutes(protected, c)
 		registerLearningRoutes(protected, c)
+		registerBookmarkCollectionRoutes(protected, c)
 		registerCommunityRoutes(protected, c)
 		registerAnalyticsRoutes(protected, c)
 		registerRecommendationRoutes(protected, c)
@@ -682,6 +683,19 @@ func registerUserStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 		users.GET("/:id/mention-stats", c.MentionStatsHandler.GetStats)
 		users.GET("/:id/reaction-stats", c.ReactionStatsHandler.GetStats)
 		users.GET("/:id/bookmark-stats", c.BookmarkStatsHandler.GetStats)
+	}
+}
+
+func registerBookmarkCollectionRoutes(g *gin.RouterGroup, c *di.Container) {
+	collections := g.Group("/bookmark-collections")
+	{
+		collections.POST("", c.BookmarkCollectionHandler.Create)
+		collections.GET("", c.BookmarkCollectionHandler.GetMyCollections)
+		collections.PUT("/:id", c.BookmarkCollectionHandler.Update)
+		collections.DELETE("/:id", c.BookmarkCollectionHandler.Delete)
+		collections.POST("/:id/posts/:postId", c.BookmarkCollectionHandler.AddPost)
+		collections.DELETE("/:id/posts/:postId", c.BookmarkCollectionHandler.RemovePost)
+		collections.GET("/:id/posts", c.BookmarkCollectionHandler.GetPosts)
 	}
 }
 

--- a/backend/internal/service/bookmark_collection.go
+++ b/backend/internal/service/bookmark_collection.go
@@ -1,0 +1,108 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// BookmarkCollectionService はブックマークコレクションのビジネスロジックを提供する。
+type BookmarkCollectionService struct {
+	repo repository.BookmarkCollectionRepositoryInterface
+}
+
+// NewBookmarkCollectionService は新しいBookmarkCollectionServiceインスタンスを生成する。
+func NewBookmarkCollectionService(repo repository.BookmarkCollectionRepositoryInterface) *BookmarkCollectionService {
+	return &BookmarkCollectionService{repo: repo}
+}
+
+// Create は新しいブックマークコレクションを作成する。
+func (s *BookmarkCollectionService) Create(collection *model.BookmarkCollection) error {
+	if strings.TrimSpace(collection.Name) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "コレクション名は必須です", nil)
+	}
+	return s.repo.Create(collection)
+}
+
+// GetByUserID はユーザーのコレクション一覧を取得する。
+func (s *BookmarkCollectionService) GetByUserID(userID uint) ([]model.BookmarkCollection, error) {
+	return s.repo.FindByUserID(userID)
+}
+
+// Update はコレクションを更新する。所有権を検証する。
+func (s *BookmarkCollectionService) Update(id, userID uint, updates *model.BookmarkCollection) (*model.BookmarkCollection, error) {
+	collection, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(updates.Name) != "" {
+		collection.Name = updates.Name
+	}
+	if updates.Description != "" {
+		collection.Description = updates.Description
+	}
+	if updates.Color != "" {
+		collection.Color = updates.Color
+	}
+
+	if err := s.repo.Update(collection); err != nil {
+		return nil, err
+	}
+	return collection, nil
+}
+
+// Delete はコレクションを削除する。所有権を検証する。
+func (s *BookmarkCollectionService) Delete(id, userID uint) error {
+	if _, err := s.findAndCheckOwnership(id, userID); err != nil {
+		return err
+	}
+	return s.repo.Delete(id)
+}
+
+// AddPost はコレクションにブックマークを追加する。
+func (s *BookmarkCollectionService) AddPost(collectionID, postID, userID uint) error {
+	if _, err := s.findAndCheckOwnership(collectionID, userID); err != nil {
+		return err
+	}
+
+	exists, err := s.repo.HasPost(collectionID, postID)
+	if err != nil {
+		return err
+	}
+	if exists {
+		return domain.NewError(domain.ErrCodeConflict, "この投稿は既にコレクションに追加されています", nil)
+	}
+
+	return s.repo.AddPost(&model.BookmarkCollectionItem{
+		CollectionID: collectionID,
+		PostID:       postID,
+	})
+}
+
+// RemovePost はコレクションからブックマークを削除する。
+func (s *BookmarkCollectionService) RemovePost(collectionID, postID, userID uint) error {
+	if _, err := s.findAndCheckOwnership(collectionID, userID); err != nil {
+		return err
+	}
+	return s.repo.RemovePost(collectionID, postID)
+}
+
+// GetPosts はコレクション内の投稿一覧を取得する。
+func (s *BookmarkCollectionService) GetPosts(collectionID uint, limit, offset int) ([]model.Post, int64, error) {
+	return s.repo.GetPosts(collectionID, limit, offset)
+}
+
+// findAndCheckOwnership はコレクションを取得し、所有権を検証する。
+func (s *BookmarkCollectionService) findAndCheckOwnership(id, userID uint) (*model.BookmarkCollection, error) {
+	collection, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, err
+	}
+	if collection.UserID != userID {
+		return nil, ErrForbidden
+	}
+	return collection, nil
+}

--- a/backend/internal/service/bookmark_collection_test.go
+++ b/backend/internal/service/bookmark_collection_test.go
@@ -1,0 +1,123 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestBookmarkCollection_Create_Success(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	mockRepo.On("Create", mock.MatchedBy(func(c *model.BookmarkCollection) bool {
+		return c.UserID == 1 && c.Name == "Go学習"
+	})).Return(nil)
+
+	collection := &model.BookmarkCollection{UserID: 1, Name: "Go学習", Color: "blue"}
+	err := svc.Create(collection)
+	assert.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestBookmarkCollection_Create_EmptyName(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	collection := &model.BookmarkCollection{UserID: 1, Name: ""}
+	err := svc.Create(collection)
+	assert.Error(t, err)
+}
+
+func TestBookmarkCollection_Update_Success(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	existing := &model.BookmarkCollection{ID: 1, UserID: 1, Name: "旧名"}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+	mockRepo.On("Update", mock.MatchedBy(func(c *model.BookmarkCollection) bool {
+		return c.Name == "新名"
+	})).Return(nil)
+
+	updated, err := svc.Update(1, 1, &model.BookmarkCollection{Name: "新名"})
+	assert.NoError(t, err)
+	assert.Equal(t, "新名", updated.Name)
+}
+
+func TestBookmarkCollection_Update_Forbidden(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	existing := &model.BookmarkCollection{ID: 1, UserID: 2, Name: "他人のコレクション"}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.Update(1, 1, &model.BookmarkCollection{Name: "新名"})
+	assert.Error(t, err)
+}
+
+func TestBookmarkCollection_Delete_Success(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	existing := &model.BookmarkCollection{ID: 1, UserID: 1}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+	mockRepo.On("Delete", uint(1)).Return(nil)
+
+	err := svc.Delete(1, 1)
+	assert.NoError(t, err)
+}
+
+func TestBookmarkCollection_Delete_Forbidden(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	existing := &model.BookmarkCollection{ID: 1, UserID: 2}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	err := svc.Delete(1, 1)
+	assert.Error(t, err)
+}
+
+func TestBookmarkCollection_AddPost_Success(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	existing := &model.BookmarkCollection{ID: 1, UserID: 1}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+	mockRepo.On("HasPost", uint(1), uint(10)).Return(false, nil)
+	mockRepo.On("AddPost", mock.MatchedBy(func(item *model.BookmarkCollectionItem) bool {
+		return item.CollectionID == 1 && item.PostID == 10
+	})).Return(nil)
+
+	err := svc.AddPost(1, 10, 1)
+	assert.NoError(t, err)
+}
+
+func TestBookmarkCollection_AddPost_AlreadyExists(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	existing := &model.BookmarkCollection{ID: 1, UserID: 1}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+	mockRepo.On("HasPost", uint(1), uint(10)).Return(true, nil)
+
+	err := svc.AddPost(1, 10, 1)
+	assert.Error(t, err)
+}
+
+func TestBookmarkCollection_GetByUserID(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	collections := []model.BookmarkCollection{
+		{ID: 1, UserID: 1, Name: "Go"},
+		{ID: 2, UserID: 1, Name: "React"},
+	}
+	mockRepo.On("FindByUserID", uint(1)).Return(collections, nil)
+
+	result, err := svc.GetByUserID(1)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2237,3 +2237,61 @@ func (m *MockStreakFreezeRepository) HasFreezeOnDate(userID uint, date string) (
 	args := m.Called(userID, date)
 	return args.Bool(0), args.Error(1)
 }
+
+// ============================================================
+// MockBookmarkCollectionRepository は repository.BookmarkCollectionRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockBookmarkCollectionRepository struct {
+	mock.Mock
+}
+
+var _ repository.BookmarkCollectionRepositoryInterface = (*MockBookmarkCollectionRepository)(nil)
+
+func (m *MockBookmarkCollectionRepository) Create(collection *model.BookmarkCollection) error {
+	args := m.Called(collection)
+	return args.Error(0)
+}
+
+func (m *MockBookmarkCollectionRepository) FindByID(id uint) (*model.BookmarkCollection, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.BookmarkCollection), args.Error(1)
+}
+
+func (m *MockBookmarkCollectionRepository) FindByUserID(userID uint) ([]model.BookmarkCollection, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.BookmarkCollection), args.Error(1)
+}
+
+func (m *MockBookmarkCollectionRepository) Update(collection *model.BookmarkCollection) error {
+	args := m.Called(collection)
+	return args.Error(0)
+}
+
+func (m *MockBookmarkCollectionRepository) Delete(id uint) error {
+	args := m.Called(id)
+	return args.Error(0)
+}
+
+func (m *MockBookmarkCollectionRepository) AddPost(item *model.BookmarkCollectionItem) error {
+	args := m.Called(item)
+	return args.Error(0)
+}
+
+func (m *MockBookmarkCollectionRepository) RemovePost(collectionID, postID uint) error {
+	args := m.Called(collectionID, postID)
+	return args.Error(0)
+}
+
+func (m *MockBookmarkCollectionRepository) GetPosts(collectionID uint, limit, offset int) ([]model.Post, int64, error) {
+	args := m.Called(collectionID, limit, offset)
+	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockBookmarkCollectionRepository) HasPost(collectionID, postID uint) (bool, error) {
+	args := m.Called(collectionID, postID)
+	return args.Bool(0), args.Error(1)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -105,6 +105,8 @@ func main() {
 		&model.YouTubeSearchCache{},
 		&model.SpotifyRecentTrack{},
 		&model.StreakFreeze{},
+		&model.BookmarkCollection{},
+		&model.BookmarkCollectionItem{},
 	); err != nil {
 		log.Fatalf("failed to run migrations: %v", err)
 	}

--- a/frontend/src/api/bookmarkCollections.ts
+++ b/frontend/src/api/bookmarkCollections.ts
@@ -1,0 +1,26 @@
+import client from './client';
+import type { BookmarkCollection } from '../types/bookmarkCollection';
+import type { Post } from '../types/post';
+
+export const getMyCollections = () =>
+  client.get<BookmarkCollection[]>('/bookmark-collections');
+
+export const createCollection = (data: { name: string; description?: string; color?: string }) =>
+  client.post<BookmarkCollection>('/bookmark-collections', data);
+
+export const updateCollection = (id: number, data: { name?: string; description?: string; color?: string }) =>
+  client.put<BookmarkCollection>(`/bookmark-collections/${id}`, data);
+
+export const deleteCollection = (id: number) =>
+  client.delete(`/bookmark-collections/${id}`);
+
+export const addPostToCollection = (collectionId: number, postId: number) =>
+  client.post(`/bookmark-collections/${collectionId}/posts/${postId}`);
+
+export const removePostFromCollection = (collectionId: number, postId: number) =>
+  client.delete(`/bookmark-collections/${collectionId}/posts/${postId}`);
+
+export const getCollectionPosts = (collectionId: number, limit = 20, offset = 0) =>
+  client.get<{ posts: Post[]; total: number }>(`/bookmark-collections/${collectionId}/posts`, {
+    params: { limit, offset },
+  });

--- a/frontend/src/components/posts/BookmarkCollectionPicker.tsx
+++ b/frontend/src/components/posts/BookmarkCollectionPicker.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FolderPlus, Plus, Check, X } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { useBookmarkCollections } from '../../hooks/useBookmarkCollections';
+import { addPostToCollection, removePostFromCollection } from '../../api/bookmarkCollections';
+
+interface BookmarkCollectionPickerProps {
+  postId: number;
+  onClose: () => void;
+}
+
+export default function BookmarkCollectionPicker({ postId, onClose }: BookmarkCollectionPickerProps) {
+  const { t } = useTranslation();
+  const { collections, loading, create, refetch } = useBookmarkCollections();
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [addingTo, setAddingTo] = useState<number | null>(null);
+
+  const handleAddToCollection = async (collectionId: number) => {
+    setAddingTo(collectionId);
+    try {
+      await addPostToCollection(collectionId, postId);
+      toast.success(t('bookmarkCollections.addedToCollection'));
+      await refetch();
+    } catch {
+      toast.error(t('bookmarkCollections.alreadyInCollection'));
+    } finally {
+      setAddingTo(null);
+    }
+  };
+
+  const handleRemoveFromCollection = async (collectionId: number) => {
+    try {
+      await removePostFromCollection(collectionId, postId);
+      toast.success(t('bookmarkCollections.removedFromCollection'));
+      await refetch();
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  };
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return;
+    try {
+      const col = await create(newName.trim());
+      await addPostToCollection(col.id, postId);
+      toast.success(t('bookmarkCollections.createdAndAdded'));
+      setNewName('');
+      setShowCreateForm(false);
+    } catch {
+      toast.error(t('errors.somethingWrong'));
+    }
+  };
+
+  return (
+    <div className="absolute bottom-10 right-0 z-20 w-64 bg-gray-800 border border-gray-700 rounded-lg shadow-xl p-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-medium text-gray-200">
+          {t('bookmarkCollections.saveToCollection')}
+        </span>
+        <button onClick={onClose} className="text-gray-500 hover:text-gray-300">
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="text-xs text-gray-500 py-2">{t('common.loading')}</div>
+      ) : (
+        <div className="max-h-40 overflow-y-auto space-y-1">
+          {collections.map((col) => (
+            <div
+              key={col.id}
+              className="flex items-center justify-between px-2 py-1.5 rounded hover:bg-gray-700/50 group"
+            >
+              <button
+                onClick={() => handleAddToCollection(col.id)}
+                disabled={addingTo === col.id}
+                className="flex items-center gap-2 text-sm text-gray-300 flex-1 text-left"
+              >
+                <span
+                  className="w-2.5 h-2.5 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: col.color || '#3b82f6' }}
+                />
+                <span className="truncate">{col.name}</span>
+              </button>
+              <button
+                onClick={() => handleRemoveFromCollection(col.id)}
+                className="text-gray-600 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
+                aria-label={t('bookmarkCollections.removeFromCollection')}
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            </div>
+          ))}
+          {collections.length === 0 && (
+            <p className="text-xs text-gray-500 py-1">{t('bookmarkCollections.noCollections')}</p>
+          )}
+        </div>
+      )}
+
+      {showCreateForm ? (
+        <div className="mt-2 flex gap-1.5">
+          <input
+            type="text"
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
+            placeholder={t('bookmarkCollections.collectionName')}
+            className="flex-1 bg-gray-900 border border-gray-700 rounded px-2 py-1 text-sm text-gray-200 placeholder-gray-500 focus:outline-none focus:border-blue-500"
+            autoFocus
+          />
+          <button
+            onClick={handleCreate}
+            className="p-1 text-green-400 hover:text-green-300"
+          >
+            <Check className="w-4 h-4" />
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setShowCreateForm(true)}
+          className="mt-2 flex items-center gap-1.5 text-sm text-blue-400 hover:text-blue-300 w-full"
+        >
+          <Plus className="w-4 h-4" />
+          {t('bookmarkCollections.createNew')}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/posts/PostCardActions.tsx
+++ b/frontend/src/components/posts/PostCardActions.tsx
@@ -1,11 +1,12 @@
 import { useState, useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { Heart, MessageCircle, Smile, Eye, Link2, Bookmark } from 'lucide-react';
+import { Heart, MessageCircle, Smile, Eye, Link2, Bookmark, FolderPlus } from 'lucide-react';
 import toast from 'react-hot-toast';
 import { likePost, unlikePost, bookmarkPost, unbookmarkPost } from '../../api/posts';
 import { useReactions } from '../../hooks/useReactions';
 import { AVAILABLE_REACTION_EMOJIS } from '../../constants/reactions';
+import BookmarkCollectionPicker from './BookmarkCollectionPicker';
 
 interface PostCardActionsProps {
   postId: number;
@@ -35,6 +36,7 @@ export default function PostCardActions({
   const { reactions, userReactions, toggleReaction } = useReactions(postId);
   const [showReactionPicker, setShowReactionPicker] = useState(false);
   const [linkCopied, setLinkCopied] = useState(false);
+  const [showCollectionPicker, setShowCollectionPicker] = useState(false);
 
   const handleCopyLink = useCallback(async () => {
     try {
@@ -182,6 +184,22 @@ export default function PostCardActions({
           <Bookmark className="w-4 h-4" fill={bookmarked ? 'currentColor' : 'none'} aria-hidden="true" />
           {bookmarkCount > 0 && <span>{bookmarkCount}</span>}
         </button>
+        <div className="relative">
+          <button
+            onClick={() => setShowCollectionPicker(!showCollectionPicker)}
+            aria-label={t('bookmarkCollections.saveToCollection')}
+            aria-expanded={showCollectionPicker}
+            className="text-gray-500 hover:text-blue-400 transition-colors"
+          >
+            <FolderPlus className="w-4 h-4" aria-hidden="true" />
+          </button>
+          {showCollectionPicker && (
+            <BookmarkCollectionPicker
+              postId={postId}
+              onClose={() => setShowCollectionPicker(false)}
+            />
+          )}
+        </div>
       </div>
     </>
   );

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -55,3 +55,4 @@ export { useReactions } from './useReactions';
 export { useClickOutside } from './useClickOutside';
 export { useSubmitShortcut } from './useSubmitShortcut';
 export { useStreakFreeze } from './useStreakFreeze';
+export { useBookmarkCollections, useCollectionPosts as useBookmarkCollectionPosts } from './useBookmarkCollections';

--- a/frontend/src/hooks/useBookmarkCollections.ts
+++ b/frontend/src/hooks/useBookmarkCollections.ts
@@ -1,0 +1,84 @@
+import { useState, useCallback } from 'react';
+import {
+  getMyCollections,
+  createCollection,
+  updateCollection,
+  deleteCollection,
+  addPostToCollection,
+  removePostFromCollection,
+  getCollectionPosts,
+} from '../api/bookmarkCollections';
+import type { BookmarkCollection } from '../types/bookmarkCollection';
+import type { Post } from '../types/post';
+import { useAsyncData } from './useAsyncData';
+
+export function useBookmarkCollections() {
+  const { data: collections, loading, error, refetch } = useAsyncData(
+    async () => {
+      const { data } = await getMyCollections();
+      return data;
+    },
+    { initialData: [] as BookmarkCollection[] }
+  );
+
+  const create = useCallback(async (name: string, description = '', color = 'blue') => {
+    const { data } = await createCollection({ name, description, color });
+    await refetch();
+    return data;
+  }, [refetch]);
+
+  const update = useCallback(async (id: number, updates: { name?: string; description?: string; color?: string }) => {
+    const { data } = await updateCollection(id, updates);
+    await refetch();
+    return data;
+  }, [refetch]);
+
+  const remove = useCallback(async (id: number) => {
+    await deleteCollection(id);
+    await refetch();
+  }, [refetch]);
+
+  return {
+    collections,
+    loading,
+    error,
+    refetch,
+    create,
+    update,
+    remove,
+  };
+}
+
+export function useCollectionPosts(collectionId: number, limit = 20) {
+  const [offset, setOffset] = useState(0);
+
+  const { data, loading, error, refetch } = useAsyncData(
+    async () => {
+      const { data } = await getCollectionPosts(collectionId, limit, offset);
+      return data;
+    },
+    { initialData: { posts: [] as Post[], total: 0 }, deps: [collectionId, limit, offset] }
+  );
+
+  const addPost = useCallback(async (postId: number) => {
+    await addPostToCollection(collectionId, postId);
+    await refetch();
+  }, [collectionId, refetch]);
+
+  const removePost = useCallback(async (postId: number) => {
+    await removePostFromCollection(collectionId, postId);
+    await refetch();
+  }, [collectionId, refetch]);
+
+  return {
+    posts: data.posts,
+    total: data.total,
+    loading,
+    error,
+    offset,
+    setOffset,
+    refetch,
+    addPost,
+    removePost,
+  };
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1555,5 +1555,18 @@
     "watchOnYoutube": "Auf YouTube ansehen",
     "newVideo": "Neu",
     "unavailable": "Die YouTube-Video-Funktion ist derzeit nicht verfügbar"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "In Sammlung speichern",
+    "addedToCollection": "Zur Sammlung hinzugefügt",
+    "removedFromCollection": "Aus Sammlung entfernt",
+    "alreadyInCollection": "Dieser Beitrag ist bereits in der Sammlung",
+    "createdAndAdded": "Sammlung erstellt und Beitrag hinzugefügt",
+    "createNew": "Neue Sammlung erstellen",
+    "collectionName": "Sammlungsname",
+    "noCollections": "Noch keine Sammlungen",
+    "removeFromCollection": "Aus Sammlung entfernen",
+    "deleteCollection": "Sammlung löschen",
+    "editCollection": "Sammlung bearbeiten"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1556,5 +1556,18 @@
     "watchOnYoutube": "Watch on YouTube",
     "newVideo": "New",
     "unavailable": "YouTube video feature is currently unavailable"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "Save to Collection",
+    "addedToCollection": "Added to collection",
+    "removedFromCollection": "Removed from collection",
+    "alreadyInCollection": "This post is already in the collection",
+    "createdAndAdded": "Collection created and post added",
+    "createNew": "Create new collection",
+    "collectionName": "Collection name",
+    "noCollections": "No collections yet",
+    "removeFromCollection": "Remove from collection",
+    "deleteCollection": "Delete collection",
+    "editCollection": "Edit collection"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1556,5 +1556,18 @@
     "watchOnYoutube": "Ver en YouTube",
     "newVideo": "Nuevo",
     "unavailable": "La función de videos de YouTube no está disponible actualmente"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "Guardar en colección",
+    "addedToCollection": "Añadido a la colección",
+    "removedFromCollection": "Eliminado de la colección",
+    "alreadyInCollection": "Esta publicación ya está en la colección",
+    "createdAndAdded": "Colección creada y publicación añadida",
+    "createNew": "Crear nueva colección",
+    "collectionName": "Nombre de la colección",
+    "noCollections": "No hay colecciones aún",
+    "removeFromCollection": "Eliminar de la colección",
+    "deleteCollection": "Eliminar colección",
+    "editCollection": "Editar colección"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1556,5 +1556,18 @@
     "watchOnYoutube": "Regarder sur YouTube",
     "newVideo": "Nouveau",
     "unavailable": "La fonctionnalité vidéos YouTube est actuellement indisponible"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "Enregistrer dans une collection",
+    "addedToCollection": "Ajouté à la collection",
+    "removedFromCollection": "Supprimé de la collection",
+    "alreadyInCollection": "Cette publication est déjà dans la collection",
+    "createdAndAdded": "Collection créée et publication ajoutée",
+    "createNew": "Créer une nouvelle collection",
+    "collectionName": "Nom de la collection",
+    "noCollections": "Aucune collection pour le moment",
+    "removeFromCollection": "Retirer de la collection",
+    "deleteCollection": "Supprimer la collection",
+    "editCollection": "Modifier la collection"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1457,5 +1457,18 @@
     "watchOnYoutube": "YouTubeで視聴",
     "newVideo": "新着",
     "unavailable": "YouTube動画機能は現在利用できません"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "コレクションに保存",
+    "addedToCollection": "コレクションに追加しました",
+    "removedFromCollection": "コレクションから削除しました",
+    "alreadyInCollection": "この投稿は既にコレクションに追加されています",
+    "createdAndAdded": "コレクションを作成し、投稿を追加しました",
+    "createNew": "新しいコレクションを作成",
+    "collectionName": "コレクション名",
+    "noCollections": "コレクションがありません",
+    "removeFromCollection": "コレクションから削除",
+    "deleteCollection": "コレクションを削除",
+    "editCollection": "コレクションを編集"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1558,5 +1558,18 @@
     "watchOnYoutube": "YouTube에서 시청",
     "newVideo": "신규",
     "unavailable": "YouTube 동영상 기능을 현재 사용할 수 없습니다"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "컬렉션에 저장",
+    "addedToCollection": "컬렉션에 추가되었습니다",
+    "removedFromCollection": "컬렉션에서 삭제되었습니다",
+    "alreadyInCollection": "이 게시물은 이미 컬렉션에 있습니다",
+    "createdAndAdded": "컬렉션이 생성되고 게시물이 추가되었습니다",
+    "createNew": "새 컬렉션 만들기",
+    "collectionName": "컬렉션 이름",
+    "noCollections": "컬렉션이 없습니다",
+    "removeFromCollection": "컬렉션에서 삭제",
+    "deleteCollection": "컬렉션 삭제",
+    "editCollection": "컬렉션 편집"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1556,5 +1556,18 @@
     "watchOnYoutube": "Assistir no YouTube",
     "newVideo": "Novo",
     "unavailable": "O recurso de vídeos do YouTube não está disponível no momento"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "Salvar na coleção",
+    "addedToCollection": "Adicionado à coleção",
+    "removedFromCollection": "Removido da coleção",
+    "alreadyInCollection": "Esta publicação já está na coleção",
+    "createdAndAdded": "Coleção criada e publicação adicionada",
+    "createNew": "Criar nova coleção",
+    "collectionName": "Nome da coleção",
+    "noCollections": "Nenhuma coleção ainda",
+    "removeFromCollection": "Remover da coleção",
+    "deleteCollection": "Excluir coleção",
+    "editCollection": "Editar coleção"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1555,5 +1555,18 @@
     "watchOnYoutube": "Смотреть на YouTube",
     "newVideo": "Новое",
     "unavailable": "Функция видео YouTube в настоящее время недоступна"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "Сохранить в коллекцию",
+    "addedToCollection": "Добавлено в коллекцию",
+    "removedFromCollection": "Удалено из коллекции",
+    "alreadyInCollection": "Эта публикация уже в коллекции",
+    "createdAndAdded": "Коллекция создана и публикация добавлена",
+    "createNew": "Создать новую коллекцию",
+    "collectionName": "Название коллекции",
+    "noCollections": "Коллекций пока нет",
+    "removeFromCollection": "Удалить из коллекции",
+    "deleteCollection": "Удалить коллекцию",
+    "editCollection": "Редактировать коллекцию"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1556,5 +1556,18 @@
     "watchOnYoutube": "在YouTube上观看",
     "newVideo": "最新",
     "unavailable": "YouTube视频功能当前不可用"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "保存到收藏夹",
+    "addedToCollection": "已添加到收藏夹",
+    "removedFromCollection": "已从收藏夹移除",
+    "alreadyInCollection": "该帖子已在收藏夹中",
+    "createdAndAdded": "收藏夹已创建并添加了帖子",
+    "createNew": "创建新收藏夹",
+    "collectionName": "收藏夹名称",
+    "noCollections": "还没有收藏夹",
+    "removeFromCollection": "从收藏夹移除",
+    "deleteCollection": "删除收藏夹",
+    "editCollection": "编辑收藏夹"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1558,5 +1558,18 @@
     "watchOnYoutube": "在YouTube上觀看",
     "newVideo": "最新",
     "unavailable": "YouTube影片功能目前無法使用"
+  },
+  "bookmarkCollections": {
+    "saveToCollection": "儲存至收藏夾",
+    "addedToCollection": "已新增至收藏夾",
+    "removedFromCollection": "已從收藏夾移除",
+    "alreadyInCollection": "此貼文已在收藏夾中",
+    "createdAndAdded": "收藏夾已建立並新增了貼文",
+    "createNew": "建立新收藏夾",
+    "collectionName": "收藏夾名稱",
+    "noCollections": "尚無收藏夾",
+    "removeFromCollection": "從收藏夾移除",
+    "deleteCollection": "刪除收藏夾",
+    "editCollection": "編輯收藏夾"
   }
 }

--- a/frontend/src/types/bookmarkCollection.ts
+++ b/frontend/src/types/bookmarkCollection.ts
@@ -1,0 +1,16 @@
+import type { Post } from './post';
+
+export interface BookmarkCollection {
+  id: number;
+  user_id: number;
+  name: string;
+  description: string;
+  color: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface BookmarkCollectionWithPosts {
+  posts: Post[];
+  total: number;
+}


### PR DESCRIPTION
## 概要
ブックマークを整理するコレクション機能を追加。ユーザーは投稿をカテゴリ別にグループ化して管理できます。

## 変更内容
### バックエンド
- BookmarkCollection / BookmarkCollectionItem モデル追加
- リポジトリ実装（CRUD、投稿追加/削除、トランザクション対応削除）
- サービス実装（バリデーション、所有権検証、重複チェック）
- 7つのAPIエンドポイント（作成/一覧/更新/削除/投稿追加/投稿削除/投稿一覧）
- DI / ルーター / AutoMigrate 登録

### フロントエンド
- 型定義（BookmarkCollection, BookmarkCollectionWithPosts）
- APIクライアント（7メソッド）
- カスタムフック（useBookmarkCollections, useCollectionPosts）
- BookmarkCollectionPicker コンポーネント
- PostCardActions にコレクション追加ボタン統合

### i18n
- 10言語（ja/en/ko/zh-CN/zh-TW/es/fr/de/pt/ru）に bookmarkCollections セクション追加

## テスト
- Service層: 9テスト（作成/空名/更新/権限/削除/権限/追加/重複/一覧）
- Handler層: 8テスト（作成/一覧/更新/権限/削除/追加/コンフリクト/投稿一覧）

## テスト計画
- [x] `go test ./internal/service/... -run TestBookmarkCollection` 全パス
- [x] `go test ./internal/handler/... -run TestBookmarkCollection` 全パス
- [x] `go build ./...` ビルド成功
- [x] `npx tsc --noEmit` 型チェック成功

Closes #1980