### PR TITLE
feat: 学習ログクイックエントリー機能の実装

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -24,6 +24,7 @@ type LearningLogServiceInterface interface {
 	GetWeeklyDuration(userID uint) (int, error)
 	FavoriteLog(id, userID uint) error
 	UnfavoriteLog(id, userID uint) error
+	GetRecentCategories(userID uint) ([]string, error)
 }
 
 // LearningLogHandler は学習ログ関連のHTTPハンドラ。
@@ -293,6 +294,19 @@ func (h *LearningLogHandler) Favorite(c *gin.Context) {
 	}
 
 	respondOK(c, gin.H{"message": "学習ログをお気に入りに追加しました"})
+}
+
+// GetRecentCategories はユーザーの最近よく使うカテゴリを返す。
+func (h *LearningLogHandler) GetRecentCategories(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	categories, err := h.service.GetRecentCategories(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, ensureSlice(categories))
 }
 
 // Unfavorite は学習ログのお気に入りを解除する。

--- a/backend/internal/handler/quick_entry_test.go
+++ b/backend/internal/handler/quick_entry_test.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/assert"
+)
+
+// ============================================================
+// クイックエントリー: 最近のカテゴリ取得ハンドラーテスト
+// ============================================================
+
+func TestGetRecentCategories_Handler_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+
+	categories := []string{"coding", "reading"}
+	svc.On("GetRecentCategories", uint(1)).Return(categories, nil)
+
+	r := gin.New()
+	r.GET("/learning-logs/recent-categories", authMiddleware(1), h.GetRecentCategories)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/learning-logs/recent-categories", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	svc.AssertExpectations(t)
+}
+
+func TestGetRecentCategories_Handler_Empty(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+
+	svc.On("GetRecentCategories", uint(1)).Return([]string{}, nil)
+
+	r := gin.New()
+	r.GET("/learning-logs/recent-categories", authMiddleware(1), h.GetRecentCategories)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/learning-logs/recent-categories", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1340,6 +1340,11 @@ func (m *MockLearningLogService) UnfavoriteLog(id, userID uint) error {
 	return args.Error(0)
 }
 
+func (m *MockLearningLogService) GetRecentCategories(userID uint) ([]string, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]string), args.Error(1)
+}
+
 // setupLearningLogHandler はLearningLogHandlerテスト用のセットアップを行う。
 func setupLearningLogHandler() (*LearningLogHandler, *MockLearningLogService) {
 	svc := new(MockLearningLogService)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -160,6 +160,7 @@ type LearningLogRepositoryInterface interface {
 	SumDurationByPeriod(userID uint, days int) (int, error)
 	GetStreakInfo(userID uint) (*model.StreakInfo, error)
 	GetCalendarData(userID uint) ([]model.CalendarEntry, error)
+	GetRecentCategories(userID uint, limit int) ([]string, error)
 }
 
 // LearningGoalRepositoryInterface は学習目標データ操作の契約を定義する。

--- a/backend/internal/repository/learning_log.go
+++ b/backend/internal/repository/learning_log.go
@@ -164,6 +164,19 @@ func (r *LearningLogRepository) GetStreakInfo(userID uint) (*model.StreakInfo, e
 	return info, nil
 }
 
+// GetRecentCategories はユーザーの最近よく使うカテゴリを頻度順で返す。
+func (r *LearningLogRepository) GetRecentCategories(userID uint, limit int) ([]string, error) {
+	var categories []string
+	err := r.db.Model(&model.LearningLog{}).
+		Select("category").
+		Where("user_id = ?", userID).
+		Group("category").
+		Order("COUNT(*) DESC").
+		Limit(limit).
+		Pluck("category", &categories).Error
+	return categories, err
+}
+
 // GetCalendarData はカレンダー表示用の日別ログ件数を取得する。
 func (r *LearningLogRepository) GetCalendarData(userID uint) ([]model.CalendarEntry, error) {
 	var entries []model.CalendarEntry

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -407,6 +407,7 @@ func registerLearningLogRoutes(g *gin.RouterGroup, c *di.Container) {
 		learningLogs.POST("", c.LearningLogHandler.Create)
 		learningLogs.GET("", c.LearningLogHandler.GetMyLogs)
 		learningLogs.GET("/export", c.LearningLogHandler.ExportLogs)
+		learningLogs.GET("/recent-categories", c.LearningLogHandler.GetRecentCategories)
 		learningLogs.GET("/category/:category", c.LearningLogHandler.GetByCategory)
 		learningLogs.GET("/source/:source", c.LearningLogHandler.GetBySource)
 		learningLogs.GET("/user/:userId", c.LearningLogHandler.GetByUserID)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -158,6 +158,11 @@ func (s *LearningLogService) GetCalendarData(userID uint) ([]model.CalendarEntry
 	return s.repo.GetCalendarData(userID)
 }
 
+// GetRecentCategories はユーザーの最近よく使うカテゴリを頻度順で返す。
+func (s *LearningLogService) GetRecentCategories(userID uint) ([]string, error) {
+	return s.repo.GetRecentCategories(userID, 5)
+}
+
 // ExportCSV は指定ユーザーの学習ログをCSV形式でエクスポートする。
 // days: 取得する過去の日数（0は全期間）。負の値はバリデーションエラー。
 func (s *LearningLogService) ExportCSV(userID uint, days int) ([]byte, error) {

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -540,6 +540,11 @@ func (m *MockLearningLogRepository) GetCalendarData(userID uint) ([]model.Calend
 	return args.Get(0).([]model.CalendarEntry), args.Error(1)
 }
 
+func (m *MockLearningLogRepository) GetRecentCategories(userID uint, limit int) ([]string, error) {
+	args := m.Called(userID, limit)
+	return args.Get(0).([]string), args.Error(1)
+}
+
 // ============================================================
 // MockLearningGoalRepository は repository.LearningGoalRepositoryInterface のテスト用モック実装。
 // ============================================================

--- a/backend/internal/service/quick_entry_test.go
+++ b/backend/internal/service/quick_entry_test.go
@@ -1,0 +1,44 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// ============================================================
+// クイックエントリー: 最近のカテゴリ取得テスト
+// ============================================================
+
+func TestGetRecentCategories_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	categories := []string{"coding", "reading", "course"}
+	repo.On("GetRecentCategories", uint(1), 5).Return(categories, nil)
+
+	result, err := svc.GetRecentCategories(uint(1))
+	assert.NoError(t, err)
+	assert.Equal(t, categories, result)
+	repo.AssertExpectations(t)
+}
+
+func TestGetRecentCategories_Empty(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetRecentCategories", uint(1), 5).Return([]string{}, nil)
+
+	result, err := svc.GetRecentCategories(uint(1))
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestGetRecentCategories_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetRecentCategories", uint(1), 5).Return([]string{}, ErrNotFound)
+
+	_, err := svc.GetRecentCategories(uint(1))
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}

--- a/frontend/src/api/learningLogs.ts
+++ b/frontend/src/api/learningLogs.ts
@@ -40,6 +40,9 @@ export const favoriteLog = (id: number) =>
 export const unfavoriteLog = (id: number) =>
   client.put<LearningLog>(`/learning-logs/${id}/unfavorite`);
 
+export const getRecentCategories = () =>
+  client.get<string[]>('/learning-logs/recent-categories');
+
 export type ExportPeriod = '7' | '30' | '90' | 'all';
 
 export const exportLogsCSV = (period: ExportPeriod = '30') =>

--- a/frontend/src/components/dashboard/QuickEntryWidget.tsx
+++ b/frontend/src/components/dashboard/QuickEntryWidget.tsx
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { BookOpen, Code, GraduationCap, Users, Layers, Clock, Check } from 'lucide-react';
+import { useQuickEntry } from '../../hooks/useQuickEntry';
+import type { LogCategory } from '../../types/learningLog';
+import { panelClass } from '../../constants/styles';
+
+const CATEGORIES: { id: LogCategory; icon: React.ElementType; color: string }[] = [
+  { id: 'coding', icon: Code, color: 'text-blue-400 border-blue-500/50 bg-blue-500/10' },
+  { id: 'reading', icon: BookOpen, color: 'text-green-400 border-green-500/50 bg-green-500/10' },
+  { id: 'course', icon: GraduationCap, color: 'text-purple-400 border-purple-500/50 bg-purple-500/10' },
+  { id: 'meetup', icon: Users, color: 'text-orange-400 border-orange-500/50 bg-orange-500/10' },
+  { id: 'other', icon: Layers, color: 'text-gray-400 border-gray-500/50 bg-gray-500/10' },
+];
+
+const DURATION_PRESETS = [15, 30, 60, 90, 120];
+
+export default function QuickEntryWidget() {
+  const { t } = useTranslation();
+  const { recentCategories, submitting, submit } = useQuickEntry();
+  const [selectedCategory, setSelectedCategory] = useState<LogCategory | null>(null);
+  const [duration, setDuration] = useState<number>(30);
+  const [note, setNote] = useState('');
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const sortedCategories = [...CATEGORIES].sort((a, b) => {
+    const aIdx = recentCategories.indexOf(a.id);
+    const bIdx = recentCategories.indexOf(b.id);
+    if (aIdx === -1 && bIdx === -1) return 0;
+    if (aIdx === -1) return 1;
+    if (bIdx === -1) return -1;
+    return aIdx - bIdx;
+  });
+
+  const handleSubmit = async () => {
+    if (!selectedCategory) return;
+    const ok = await submit(selectedCategory, duration, note);
+    if (ok) {
+      setShowSuccess(true);
+      setSelectedCategory(null);
+      setDuration(30);
+      setNote('');
+      setTimeout(() => setShowSuccess(false), 2000);
+    }
+  };
+
+  return (
+    <div className={panelClass}>
+      <div className="flex items-center gap-2 mb-4">
+        <Clock className="w-4 h-4 text-blue-400" />
+        <h3 className="text-sm font-medium text-white">{t('quickEntry.title')}</h3>
+      </div>
+
+      {showSuccess ? (
+        <div className="flex flex-col items-center justify-center py-6 animate-pulse">
+          <div className="w-12 h-12 rounded-full bg-green-500/20 flex items-center justify-center mb-2">
+            <Check className="w-6 h-6 text-green-400" />
+          </div>
+          <p className="text-sm text-green-400">{t('quickEntry.success')}</p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {/* Category Selection */}
+          <div>
+            <p className="text-xs text-gray-500 mb-2">{t('quickEntry.selectCategory')}</p>
+            <div className="flex flex-wrap gap-1.5">
+              {sortedCategories.map(({ id, icon: Icon, color }) => (
+                <button
+                  key={id}
+                  onClick={() => setSelectedCategory(id)}
+                  className={`flex items-center gap-1 px-2.5 py-1.5 text-xs rounded-lg border transition-all ${
+                    selectedCategory === id
+                      ? color
+                      : 'border-gray-700 text-gray-400 hover:border-gray-600'
+                  }`}
+                >
+                  <Icon className="w-3.5 h-3.5" />
+                  {t(`quickEntry.categories.${id}`)}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Duration */}
+          {selectedCategory && (
+            <>
+              <div>
+                <p className="text-xs text-gray-500 mb-2">{t('quickEntry.duration')}</p>
+                <div className="flex flex-wrap gap-1.5">
+                  {DURATION_PRESETS.map((d) => (
+                    <button
+                      key={d}
+                      onClick={() => setDuration(d)}
+                      className={`px-2.5 py-1.5 text-xs rounded-lg border transition-all ${
+                        duration === d
+                          ? 'border-blue-500/50 bg-blue-500/10 text-blue-400'
+                          : 'border-gray-700 text-gray-400 hover:border-gray-600'
+                      }`}
+                    >
+                      {d}{t('quickEntry.minutes')}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* Note */}
+              <div>
+                <input
+                  type="text"
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  placeholder={t('quickEntry.notePlaceholder')}
+                  className="w-full bg-gray-800 border border-gray-700 rounded-lg px-3 py-2 text-sm text-gray-200 placeholder-gray-500 focus:border-blue-500 focus:outline-none"
+                />
+              </div>
+
+              {/* Submit */}
+              <button
+                onClick={handleSubmit}
+                disabled={submitting}
+                className="w-full py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 disabled:bg-gray-700 disabled:text-gray-500 rounded-lg transition-colors"
+              >
+                {submitting ? t('quickEntry.submitting') : t('quickEntry.submit')}
+              </button>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -57,3 +57,4 @@ export { useSubmitShortcut } from './useSubmitShortcut';
 export { useStreakFreeze } from './useStreakFreeze';
 export { useBookmarkCollections, useCollectionPosts as useBookmarkCollectionPosts } from './useBookmarkCollections';
 export { useScheduledPosts } from './useScheduledPosts';
+export { useQuickEntry } from './useQuickEntry';

--- a/frontend/src/hooks/useQuickEntry.ts
+++ b/frontend/src/hooks/useQuickEntry.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback } from 'react';
+import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
+import { createLog, getRecentCategories } from '../api/learningLogs';
+import type { LogCategory } from '../types/learningLog';
+import { useAsyncData } from './useAsyncData';
+
+export function useQuickEntry() {
+  const { t } = useTranslation();
+  const [submitting, setSubmitting] = useState(false);
+
+  const { data: recentCategories, refetch: refetchCategories } = useAsyncData(
+    async () => {
+      const { data } = await getRecentCategories();
+      return data || [];
+    },
+    { initialData: [] as string[] }
+  );
+
+  const submit = useCallback(async (
+    category: LogCategory,
+    duration: number,
+    note: string
+  ) => {
+    setSubmitting(true);
+    try {
+      await createLog({
+        title: `${t(`quickEntry.categories.${category}`)} - ${duration}${t('quickEntry.minutes')}`,
+        content: note || t('quickEntry.defaultNote'),
+        category,
+        duration,
+        source: 'manual',
+      });
+      toast.success(t('quickEntry.success'));
+      refetchCategories();
+      return true;
+    } catch {
+      toast.error(t('quickEntry.failed'));
+      return false;
+    } finally {
+      setSubmitting(false);
+    }
+  }, [t, refetchCategories]);
+
+  return {
+    recentCategories,
+    submitting,
+    submit,
+  };
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1556,6 +1556,25 @@
     "newVideo": "Neu",
     "unavailable": "Die YouTube-Video-Funktion ist derzeit nicht verfügbar"
   },
+  "quickEntry": {
+    "title": "Schnelle Lernaufzeichnung",
+    "selectCategory": "Kategorie wählen",
+    "duration": "Dauer",
+    "minutes": "Min",
+    "notePlaceholder": "Notiz (optional)",
+    "defaultNote": "Per Schnelleintrag erfasst",
+    "submit": "Aufzeichnen",
+    "submitting": "Wird aufgezeichnet...",
+    "success": "Lernen aufgezeichnet",
+    "failed": "Aufzeichnung fehlgeschlagen",
+    "categories": {
+      "coding": "Programmieren",
+      "reading": "Lesen",
+      "course": "Kurs",
+      "meetup": "Treffen",
+      "other": "Sonstiges"
+    }
+  },
   "scheduledPublish": {
     "schedule": "Veröffentlichung planen",
     "scheduled": "Geplant",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1557,6 +1557,25 @@
     "newVideo": "New",
     "unavailable": "YouTube video feature is currently unavailable"
   },
+  "quickEntry": {
+    "title": "Quick Learning Log",
+    "selectCategory": "Select category",
+    "duration": "Duration",
+    "minutes": "min",
+    "notePlaceholder": "Note (optional)",
+    "defaultNote": "Logged via quick entry",
+    "submit": "Log it",
+    "submitting": "Logging...",
+    "success": "Learning logged successfully",
+    "failed": "Failed to log learning",
+    "categories": {
+      "coding": "Coding",
+      "reading": "Reading",
+      "course": "Course",
+      "meetup": "Meetup",
+      "other": "Other"
+    }
+  },
   "scheduledPublish": {
     "schedule": "Schedule Publish",
     "scheduled": "Scheduled",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1557,6 +1557,25 @@
     "newVideo": "Nuevo",
     "unavailable": "La función de videos de YouTube no está disponible actualmente"
   },
+  "quickEntry": {
+    "title": "Registro rápido de aprendizaje",
+    "selectCategory": "Seleccionar categoría",
+    "duration": "Duración",
+    "minutes": "min",
+    "notePlaceholder": "Nota (opcional)",
+    "defaultNote": "Registrado mediante entrada rápida",
+    "submit": "Registrar",
+    "submitting": "Registrando...",
+    "success": "Aprendizaje registrado",
+    "failed": "Error al registrar",
+    "categories": {
+      "coding": "Programación",
+      "reading": "Lectura",
+      "course": "Curso",
+      "meetup": "Encuentro",
+      "other": "Otro"
+    }
+  },
   "scheduledPublish": {
     "schedule": "Programar publicación",
     "scheduled": "Programado",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1557,6 +1557,25 @@
     "newVideo": "Nouveau",
     "unavailable": "La fonctionnalité vidéos YouTube est actuellement indisponible"
   },
+  "quickEntry": {
+    "title": "Enregistrement rapide",
+    "selectCategory": "Choisir une catégorie",
+    "duration": "Durée",
+    "minutes": "min",
+    "notePlaceholder": "Note (facultatif)",
+    "defaultNote": "Enregistré via saisie rapide",
+    "submit": "Enregistrer",
+    "submitting": "Enregistrement...",
+    "success": "Apprentissage enregistré",
+    "failed": "Échec de l'enregistrement",
+    "categories": {
+      "coding": "Programmation",
+      "reading": "Lecture",
+      "course": "Cours",
+      "meetup": "Rencontre",
+      "other": "Autre"
+    }
+  },
   "scheduledPublish": {
     "schedule": "Programmer la publication",
     "scheduled": "Programmé",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1458,6 +1458,25 @@
     "newVideo": "新着",
     "unavailable": "YouTube動画機能は現在利用できません"
   },
+  "quickEntry": {
+    "title": "クイック学習記録",
+    "selectCategory": "カテゴリを選択",
+    "duration": "学習時間",
+    "minutes": "分",
+    "notePlaceholder": "メモ（任意）",
+    "defaultNote": "クイックエントリーで記録",
+    "submit": "記録する",
+    "submitting": "記録中...",
+    "success": "学習を記録しました",
+    "failed": "記録に失敗しました",
+    "categories": {
+      "coding": "コーディング",
+      "reading": "読書",
+      "course": "講座",
+      "meetup": "勉強会",
+      "other": "その他"
+    }
+  },
   "scheduledPublish": {
     "schedule": "スケジュール公開",
     "scheduled": "スケジュール済み",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1559,6 +1559,25 @@
     "newVideo": "신규",
     "unavailable": "YouTube 동영상 기능을 현재 사용할 수 없습니다"
   },
+  "quickEntry": {
+    "title": "빠른 학습 기록",
+    "selectCategory": "카테고리 선택",
+    "duration": "학습 시간",
+    "minutes": "분",
+    "notePlaceholder": "메모 (선택사항)",
+    "defaultNote": "빠른 기록으로 등록",
+    "submit": "기록하기",
+    "submitting": "기록 중...",
+    "success": "학습이 기록되었습니다",
+    "failed": "기록에 실패했습니다",
+    "categories": {
+      "coding": "코딩",
+      "reading": "독서",
+      "course": "강좌",
+      "meetup": "모임",
+      "other": "기타"
+    }
+  },
   "scheduledPublish": {
     "schedule": "예약 게시",
     "scheduled": "예약됨",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1557,6 +1557,25 @@
     "newVideo": "Novo",
     "unavailable": "O recurso de vídeos do YouTube não está disponível no momento"
   },
+  "quickEntry": {
+    "title": "Registro rápido de aprendizado",
+    "selectCategory": "Selecionar categoria",
+    "duration": "Duração",
+    "minutes": "min",
+    "notePlaceholder": "Nota (opcional)",
+    "defaultNote": "Registrado via entrada rápida",
+    "submit": "Registrar",
+    "submitting": "Registrando...",
+    "success": "Aprendizado registrado",
+    "failed": "Falha ao registrar",
+    "categories": {
+      "coding": "Programação",
+      "reading": "Leitura",
+      "course": "Curso",
+      "meetup": "Encontro",
+      "other": "Outro"
+    }
+  },
   "scheduledPublish": {
     "schedule": "Agendar publicação",
     "scheduled": "Agendado",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1556,6 +1556,25 @@
     "newVideo": "Новое",
     "unavailable": "Функция видео YouTube в настоящее время недоступна"
   },
+  "quickEntry": {
+    "title": "Быстрая запись обучения",
+    "selectCategory": "Выберите категорию",
+    "duration": "Продолжительность",
+    "minutes": "мин",
+    "notePlaceholder": "Заметка (необязательно)",
+    "defaultNote": "Записано через быструю запись",
+    "submit": "Записать",
+    "submitting": "Запись...",
+    "success": "Обучение записано",
+    "failed": "Ошибка записи",
+    "categories": {
+      "coding": "Программирование",
+      "reading": "Чтение",
+      "course": "Курс",
+      "meetup": "Встреча",
+      "other": "Другое"
+    }
+  },
   "scheduledPublish": {
     "schedule": "Запланировать публикацию",
     "scheduled": "Запланировано",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1557,6 +1557,25 @@
     "newVideo": "最新",
     "unavailable": "YouTube视频功能当前不可用"
   },
+  "quickEntry": {
+    "title": "快速学习记录",
+    "selectCategory": "选择类别",
+    "duration": "学习时长",
+    "minutes": "分钟",
+    "notePlaceholder": "备注（可选）",
+    "defaultNote": "通过快速记录添加",
+    "submit": "记录",
+    "submitting": "记录中...",
+    "success": "学习已记录",
+    "failed": "记录失败",
+    "categories": {
+      "coding": "编程",
+      "reading": "阅读",
+      "course": "课程",
+      "meetup": "聚会",
+      "other": "其他"
+    }
+  },
   "scheduledPublish": {
     "schedule": "定时发布",
     "scheduled": "已定时",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1559,6 +1559,25 @@
     "newVideo": "最新",
     "unavailable": "YouTube影片功能目前無法使用"
   },
+  "quickEntry": {
+    "title": "快速學習記錄",
+    "selectCategory": "選擇類別",
+    "duration": "學習時長",
+    "minutes": "分鐘",
+    "notePlaceholder": "備註（選填）",
+    "defaultNote": "透過快速記錄新增",
+    "submit": "記錄",
+    "submitting": "記錄中...",
+    "success": "學習已記錄",
+    "failed": "記錄失敗",
+    "categories": {
+      "coding": "程式設計",
+      "reading": "閱讀",
+      "course": "課程",
+      "meetup": "聚會",
+      "other": "其他"
+    }
+  },
   "scheduledPublish": {
     "schedule": "排程發佈",
     "scheduled": "已排程",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -27,6 +27,7 @@ import RecommendedUsersWidget from '../components/dashboard/RecommendedUsersWidg
 import TrendingWidget from '../components/dashboard/TrendingWidget';
 import StudyCircleWidget from '../components/dashboard/StudyCircleWidget';
 import GoalsProgressWidget from '../components/dashboard/GoalsProgressWidget';
+import QuickEntryWidget from '../components/dashboard/QuickEntryWidget';
 
 export default function DashboardPage() {
   const { t } = useTranslation();
@@ -200,6 +201,9 @@ export default function DashboardPage() {
             <StudyCircleWidget />
           </div>
         </div>
+
+        {/* Quick Entry */}
+        <QuickEntryWidget />
 
         {/* Quick Actions */}
         <QuickActionsWidget />


### PR DESCRIPTION
## 概要
ダッシュボードから素早く学習ログを記録できるクイックエントリーウィジェットを実装。

Closes #1984

## 変更内容

### バックエンド
- LearningLogRepositoryに`GetRecentCategories`メソッドを追加（頻度順でカテゴリ取得）
- LearningLogServiceに`GetRecentCategories`メソッドを追加
- LearningLogHandlerに`GetRecentCategories`エンドポイントを追加
- ルーターに`GET /learning-logs/recent-categories`を追加
- TDDで実装: サービステスト3件、ハンドラーテスト2件（全パス）

### フロントエンド
- `getRecentCategories` API関数を追加
- `useQuickEntry`フックを作成（最近のカテゴリ取得・ログ送信）
- `QuickEntryWidget`コンポーネントを作成
  - カテゴリ選択（頻度順ソート）
  - 時間プリセット（15/30/60/90/120分）
  - メモ入力
  - 成功時アニメーションフィードバック
- ダッシュボードサイドバーに統合

### i18n
- 全10言語に`quickEntry`セクション（11キー + categories 5キー）を追加

## テスト計画
- [x] サービス層テスト3件パス
- [x] ハンドラー層テスト2件パス
- [x] TypeScriptビルドチェック通過