### PR TITLE
refactor: 18サービスの所有権検証ロジックをジェネリックヘルパーに集約

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -40,14 +40,7 @@ func (s *AnswerService) Create(answer *model.Answer) error {
 
 // findAndCheckOwnership は回答を取得し、指定ユーザーが所有者かを検証する。
 func (s *AnswerService) findAndCheckOwnership(answerID, userID uint) (*model.Answer, error) {
-	answer, err := s.answerRepo.FindByID(answerID)
-	if err != nil {
-		return nil, err
-	}
-	if answer.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return answer, nil
+	return checkOwnership(s.answerRepo.FindByID, answerID, userID, func(a *model.Answer) uint { return a.UserID })
 }
 
 // Update は所有権を検証した後、回答を更新する。

--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -75,14 +75,7 @@ func (s *BookReviewService) Search(query string, limit, offset int) ([]model.Boo
 
 // findAndCheckOwnership は書籍レビューを取得し、指定ユーザーが所有者かを検証する。
 func (s *BookReviewService) findAndCheckOwnership(id, userID uint) (*model.BookReview, error) {
-	review, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if review.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return review, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(r *model.BookReview) uint { return r.UserID })
 }
 
 // Update は所有権を検証した後、書籍レビューを更新する。

--- a/backend/internal/service/bookmark_collection.go
+++ b/backend/internal/service/bookmark_collection.go
@@ -97,12 +97,5 @@ func (s *BookmarkCollectionService) GetPosts(collectionID uint, limit, offset in
 
 // findAndCheckOwnership はコレクションを取得し、所有権を検証する。
 func (s *BookmarkCollectionService) findAndCheckOwnership(id, userID uint) (*model.BookmarkCollection, error) {
-	collection, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if collection.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return collection, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(c *model.BookmarkCollection) uint { return c.UserID })
 }

--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -76,14 +76,7 @@ func (s *ChatRoomService) GetByID(roomID, userID uint) (*model.ChatRoom, error) 
 
 // findAndCheckOwnership はチャットルームを取得し、指定ユーザーがオーナーかを検証する。
 func (s *ChatRoomService) findAndCheckOwnership(roomID, userID uint) (*model.ChatRoom, error) {
-	room, err := s.roomRepo.FindByID(roomID)
-	if err != nil {
-		return nil, err
-	}
-	if room.OwnerID != userID {
-		return nil, ErrForbidden
-	}
-	return room, nil
+	return checkOwnership(s.roomRepo.FindByID, roomID, userID, func(r *model.ChatRoom) uint { return r.OwnerID })
 }
 
 // Update はオーナー権限を検証した後、チャットルーム情報を更新する。

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -65,14 +65,7 @@ func (s *CodeSnippetService) GetByUserLanguage(userID uint, language string) ([]
 
 // findAndCheckOwnership はスニペットを取得し、指定ユーザーが所有者かを検証する。
 func (s *CodeSnippetService) findAndCheckOwnership(id, userID uint) (*model.CodeSnippet, error) {
-	snippet, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if snippet.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return snippet, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(cs *model.CodeSnippet) uint { return cs.UserID })
 }
 
 // Update はスニペットを更新する。所有者のみ更新可能。

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -83,14 +83,7 @@ func (s *LearningGoalService) GetStats(userID uint) (*model.LearningGoalStats, e
 
 // findAndCheckOwnership は学習目標を取得し、指定ユーザーが所有者かを検証する。
 func (s *LearningGoalService) findAndCheckOwnership(id, userID uint) (*model.LearningGoal, error) {
-	goal, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if goal.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return goal, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(g *model.LearningGoal) uint { return g.UserID })
 }
 
 // Update は所有権を検証した後、学習目標を更新する。

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -76,14 +76,7 @@ func validateDuration(duration int) error {
 
 // findAndCheckOwnership は学習ログを取得し、指定ユーザーが所有者かを検証する。
 func (s *LearningLogService) findAndCheckOwnership(id, userID uint) (*model.LearningLog, error) {
-	log, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if log.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return log, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(l *model.LearningLog) uint { return l.UserID })
 }
 
 // Update は所有権を検証した後、学習ログを更新する。

--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -89,14 +89,7 @@ func (s *LearningResourceService) Search(query string, limit, offset int) ([]mod
 
 // findAndCheckOwnership はリソースを取得し、指定ユーザーが所有者かを検証する。
 func (s *LearningResourceService) findAndCheckOwnership(id, userID uint) (*model.LearningResource, error) {
-	resource, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if resource.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return resource, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(r *model.LearningResource) uint { return r.UserID })
 }
 
 // Update は所有権を検証した後、学習リソースを更新する。

--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -48,14 +48,7 @@ func (s *NoteService) GetByFolderID(folderID uint) ([]model.Note, error) {
 // findAndCheckOwnership は指定IDのノートを取得し、所有権を検証する共通ヘルパー。
 // 取得失敗または所有権不一致の場合はエラーを返す。
 func (s *NoteService) findAndCheckOwnership(id, userID uint) (*model.Note, error) {
-	note, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if note.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return note, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(n *model.Note) uint { return n.UserID })
 }
 
 // Update は所有権を検証した後、ノートを更新する。

--- a/backend/internal/service/note_folder.go
+++ b/backend/internal/service/note_folder.go
@@ -52,14 +52,7 @@ func (s *NoteFolderService) GetRootFolders(userID uint) ([]model.NoteFolder, err
 
 // findAndCheckOwnership はフォルダを取得し、指定ユーザーが所有者かを検証する。
 func (s *NoteFolderService) findAndCheckOwnership(id, userID uint) (*model.NoteFolder, error) {
-	folder, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if folder.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return folder, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(f *model.NoteFolder) uint { return f.UserID })
 }
 
 // isDescendant は targetID が ancestorID の子孫かを再帰的にチェックする。

--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -78,14 +78,7 @@ func (s *NoteTemplateService) GetDefaultByUserID(userID uint) (*model.NoteTempla
 
 // findAndCheckOwnership はテンプレートを取得し、指定ユーザーが所有者かを検証する。
 func (s *NoteTemplateService) findAndCheckOwnership(id, userID uint) (*model.NoteTemplate, error) {
-	template, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if template.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return template, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(t *model.NoteTemplate) uint { return t.UserID })
 }
 
 // Update は所有権を検証した後、テンプレートを更新する。

--- a/backend/internal/service/ownership.go
+++ b/backend/internal/service/ownership.go
@@ -1,0 +1,19 @@
+package service
+
+// findAndCheckOwnership はエンティティを取得し、所有権を検証する汎用ヘルパー関数。
+// finder でエンティティを取得し、getOwnerID で所有者IDを取得して userID と比較する。
+// 所有者が一致しない場合は ErrForbidden を返す。
+func checkOwnership[T any](
+	finder func(uint) (*T, error),
+	id, userID uint,
+	getOwnerID func(*T) uint,
+) (*T, error) {
+	entity, err := finder(id)
+	if err != nil {
+		return nil, err
+	}
+	if getOwnerID(entity) != userID {
+		return nil, ErrForbidden
+	}
+	return entity, nil
+}

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -139,14 +139,7 @@ func (s *PostService) Delete(id, userID uint) error {
 
 // findAndCheckOwnership は投稿を取得し、指定ユーザーが所有者かを検証する。
 func (s *PostService) findAndCheckOwnership(id, userID uint) (*model.Post, error) {
-	post, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if post.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return post, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(p *model.Post) uint { return p.UserID })
 }
 
 // findAndPreventSelfAction は投稿を取得し、自己操作でないことを検証する。

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -51,14 +51,7 @@ func (s *PostCollectionService) GetPublicByUserID(userID uint) ([]model.PostColl
 
 // findAndCheckOwnership はコレクションを取得し、指定ユーザーが所有者かを検証する。
 func (s *PostCollectionService) findAndCheckOwnership(id, userID uint) (*model.PostCollection, error) {
-	collection, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if collection.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return collection, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(c *model.PostCollection) uint { return c.UserID })
 }
 
 // Update は所有権を検証した後、コレクションを更新する。

--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -46,14 +46,7 @@ func (s *PostSeriesService) CountByUser(userID uint) (int64, error) {
 
 // findAndCheckOwnership はシリーズを取得し、指定ユーザーが所有者かを検証する。
 func (s *PostSeriesService) findAndCheckOwnership(id, userID uint) (*model.PostSeries, error) {
-	series, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if series.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return series, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(ps *model.PostSeries) uint { return ps.UserID })
 }
 
 // Update は所有権を検証した後、シリーズを更新する。

--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -50,14 +50,7 @@ func (s *ProjectService) GetAll(limit, offset int) ([]model.Project, int64, erro
 
 // findAndCheckOwnership はプロジェクトを取得し、指定ユーザーが所有者かを検証する。
 func (s *ProjectService) findAndCheckOwnership(id, userID uint) (*model.Project, error) {
-	project, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if project.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return project, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(p *model.Project) uint { return p.UserID })
 }
 
 // Update は所有権を検証した後、プロジェクトを更新する。

--- a/backend/internal/service/question.go
+++ b/backend/internal/service/question.go
@@ -55,14 +55,7 @@ func (s *QuestionService) GetUserVote(userID, questionID uint) (int, error) {
 
 // findAndCheckOwnership は質問を取得し、指定ユーザーが所有者かを検証する。
 func (s *QuestionService) findAndCheckOwnership(id, userID uint) (*model.Question, error) {
-	question, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if question.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return question, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(q *model.Question) uint { return q.UserID })
 }
 
 // Update は所有権を検証した後、質問を更新する。

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -74,14 +74,7 @@ func (s *RoadmapService) GetStats(userID uint) (*model.RoadmapStats, error) {
 
 // findAndCheckOwnership は指定IDのロードマップを取得し、所有権を検証する。
 func (s *RoadmapService) findAndCheckOwnership(id, userID uint) (*model.Roadmap, error) {
-	roadmap, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, err
-	}
-	if roadmap.UserID != userID {
-		return nil, ErrForbidden
-	}
-	return roadmap, nil
+	return checkOwnership(s.repo.FindByID, id, userID, func(r *model.Roadmap) uint { return r.UserID })
 }
 
 // findAndCheckStepOwnership はロードマップの所有権とステップの所属を検証する。

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -20,14 +20,14 @@ func NewStudyCircleService(repo repository.StudyCircleRepositoryInterface) *Stud
 }
 
 func (s *StudyCircleService) findAndCheckOwnership(id, userID uint) (*model.StudyCircle, error) {
-	circle, err := s.repo.FindByID(id)
-	if err != nil {
-		return nil, ErrNotFound
+	finder := func(id uint) (*model.StudyCircle, error) {
+		c, err := s.repo.FindByID(id)
+		if err != nil {
+			return nil, ErrNotFound
+		}
+		return c, nil
 	}
-	if circle.OwnerID != userID {
-		return nil, ErrForbidden
-	}
-	return circle, nil
+	return checkOwnership(finder, id, userID, func(c *model.StudyCircle) uint { return c.OwnerID })
 }
 
 func (s *StudyCircleService) findAndCheckStepOwnership(circleID, stepID, userID uint) (*model.StudyCircleStep, error) {


### PR DESCRIPTION
## 概要
- Go genericsを活用した`checkOwnership[T]`関数を`ownership.go`に導入
- 18サービスに重複していた`findAndCheckOwnership`メソッドのロジックを1箇所に集約
- 各サービスのメソッドは`checkOwnership`への1行委譲に簡素化

## 変更内容
- **新規**: `backend/internal/service/ownership.go` — ジェネリック所有権検証ヘルパー
- **変更**: 18サービスファイルの`findAndCheckOwnership`メソッドを簡素化
  - `UserID`チェック: 16サービス（post, note, learning_log 等）
  - `OwnerID`チェック: 2サービス（study_circle, chat_room）
- **削減**: 約120行のボイラープレートコード

## テスト
- [x] `go build ./...` — ビルド成功
- [x] `go test ./internal/service/...` — 全テスト通過
- [x] `go test ./internal/handler/...` — 全テスト通過

closes #1988