### PR TITLE
refactor: CRUDフック共通パターンをuseCRUDList/useLocalListに集約

### DIFF
--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,4 +1,5 @@
 export { useAsyncData } from './useAsyncData';
+export { useCRUDList, useLocalList } from './useCRUDList';
 export { useGoals } from './useGoals';
 export { usePosts } from './usePosts';
 export { usePostDetail } from './usePostDetail';

--- a/frontend/src/hooks/useCRUDList.ts
+++ b/frontend/src/hooks/useCRUDList.ts
@@ -1,0 +1,119 @@
+import { useState, useCallback } from 'react';
+import toast from 'react-hot-toast';
+import { useAsyncData } from './useAsyncData';
+
+// ── useLocalList ────────────────────────────────────────────────
+// サーバーデータの上にローカル状態を重ねる汎用コンポーザブル。
+// 楽観的更新によりAPI完了を待たずに即座にUIを反映できる。
+
+export function useLocalList<T>(serverData: T[]) {
+  const [local, setLocal] = useState<T[] | null>(null);
+  const items = local ?? serverData;
+
+  const setItems = useCallback((updater: T[] | ((prev: T[]) => T[])) => {
+    setLocal(prev => {
+      const current = prev ?? serverData;
+      return typeof updater === 'function' ? updater(current) : updater;
+    });
+  }, [serverData]);
+
+  const resetLocal = useCallback(() => setLocal(null), []);
+
+  return { items, setItems, resetLocal };
+}
+
+// ── useCRUDList ─────────────────────────────────────────────────
+// useAsyncData + useLocalList + CRUD操作を統合した汎用フック。
+// シンプルなリスト型CRUDの共通パターンを1箇所に集約する。
+
+interface CRUDListOptions<T> {
+  fetcher: () => Promise<T[]>;
+  deps?: unknown[];
+  enabled?: boolean;
+  initialData?: T[];
+}
+
+interface MutateOptions {
+  successMsg?: string;
+  errorMsg?: string;
+  trackSaving?: boolean;
+}
+
+export function useCRUDList<T extends { id: number }>(options: CRUDListOptions<T>) {
+  const { data, loading, refetch } = useAsyncData(options.fetcher, {
+    initialData: options.initialData ?? ([] as T[]),
+    deps: options.deps,
+    enabled: options.enabled,
+  });
+
+  const { items, setItems, resetLocal } = useLocalList(data);
+  const [saving, setSaving] = useState(false);
+
+  // リストの先頭に新アイテムを追加する
+  const addItem = useCallback(async (
+    apiCall: () => Promise<T>,
+    opts?: MutateOptions,
+  ): Promise<T | null> => {
+    if (opts?.trackSaving !== false) setSaving(true);
+    try {
+      const newItem = await apiCall();
+      setItems(prev => [newItem, ...prev]);
+      if (opts?.successMsg) toast.success(opts.successMsg);
+      return newItem;
+    } catch {
+      if (opts?.errorMsg) toast.error(opts.errorMsg);
+      return null;
+    } finally {
+      if (opts?.trackSaving !== false) setSaving(false);
+    }
+  }, [setItems]);
+
+  // IDマッチングでアイテムを差し替え更新する
+  const updateItem = useCallback(async (
+    apiCall: () => Promise<T>,
+    opts?: MutateOptions,
+  ): Promise<T | null> => {
+    if (opts?.trackSaving) setSaving(true);
+    try {
+      const updated = await apiCall();
+      setItems(prev => prev.map(i => i.id === updated.id ? updated : i));
+      if (opts?.successMsg) toast.success(opts.successMsg);
+      return updated;
+    } catch {
+      if (opts?.errorMsg) toast.error(opts.errorMsg);
+      return null;
+    } finally {
+      if (opts?.trackSaving) setSaving(false);
+    }
+  }, [setItems]);
+
+  // IDマッチングでアイテムを除去する
+  const removeItem = useCallback(async (
+    id: number,
+    apiCall: () => Promise<unknown>,
+    opts?: MutateOptions,
+  ): Promise<boolean> => {
+    try {
+      await apiCall();
+      setItems(prev => prev.filter(i => i.id !== id));
+      if (opts?.successMsg) toast.success(opts.successMsg);
+      return true;
+    } catch {
+      if (opts?.errorMsg) toast.error(opts.errorMsg);
+      return false;
+    }
+  }, [setItems]);
+
+  return {
+    items,
+    data,
+    loading,
+    saving,
+    setItems,
+    resetLocal,
+    refetch,
+    addItem,
+    updateItem,
+    removeItem,
+  };
+}

--- a/frontend/src/hooks/useGoals.ts
+++ b/frontend/src/hooks/useGoals.ts
@@ -1,6 +1,5 @@
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import toast from 'react-hot-toast';
 import {
   getMyGoals,
   createGoal,
@@ -11,30 +10,19 @@ import {
   type GoalCategory,
   type GoalStatus,
 } from '../api/goals';
-import { useAsyncData } from './useAsyncData';
+import { useCRUDList } from './useCRUDList';
 
 export function useGoals() {
   const { t } = useTranslation();
-  const [saving, setSaving] = useState(false);
 
-  const { data: goals, loading, refetch } = useAsyncData(
-    async () => {
+  const { items: goals, loading, saving, addItem, updateItem, removeItem, refetch } = useCRUDList<LearningGoal>({
+    fetcher: async () => {
       const { data } = await getMyGoals();
       return data || [];
     },
-    { initialData: [] as LearningGoal[] }
-  );
+  });
 
-  const [localGoals, setLocalGoals] = useState<LearningGoal[] | null>(null);
-  const currentGoals = localGoals ?? goals;
-
-  // Sync localGoals when remote data changes
-  const setGoals = useCallback((updater: LearningGoal[] | ((prev: LearningGoal[]) => LearningGoal[])) => {
-    setLocalGoals(prev => {
-      const current = prev ?? goals;
-      return typeof updater === 'function' ? updater(current) : updater;
-    });
-  }, [goals]);
+  const errMsg = t('errors.somethingWrong');
 
   const handleCreate = useCallback(async (data: {
     title: string;
@@ -42,19 +30,11 @@ export function useGoals() {
     category: GoalCategory;
     target_date?: string;
   }) => {
-    setSaving(true);
-    try {
-      const { data: newGoal } = await createGoal(data);
-      setGoals(prev => [newGoal, ...prev]);
-      toast.success(t('goals.created'));
-      return newGoal;
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-      return null;
-    } finally {
-      setSaving(false);
-    }
-  }, [t, setGoals]);
+    return addItem(
+      async () => { const { data: g } = await createGoal(data); return g; },
+      { successMsg: t('goals.created'), errorMsg: errMsg },
+    );
+  }, [addItem, t, errMsg]);
 
   const handleUpdate = useCallback(async (goalId: number, data: {
     title?: string;
@@ -64,51 +44,29 @@ export function useGoals() {
     progress?: number;
     status?: GoalStatus;
   }) => {
-    try {
-      const { data: updated } = await updateGoal(goalId, data);
-      setGoals(prev => prev.map(g => g.id === updated.id ? updated : g));
-      if (data.progress === 100) {
-        toast.success(t('goals.completed'));
-      } else {
-        toast.success(t('goals.updated'));
-      }
-      return updated;
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-      return null;
-    }
-  }, [t, setGoals]);
+    return updateItem(
+      async () => { const { data: g } = await updateGoal(goalId, data); return g; },
+      { successMsg: data.progress === 100 ? t('goals.completed') : t('goals.updated'), errorMsg: errMsg },
+    );
+  }, [updateItem, t, errMsg]);
 
   const handleDelete = useCallback(async (id: number) => {
-    try {
-      await deleteGoal(id);
-      setGoals(prev => prev.filter(g => g.id !== id));
-      toast.success(t('goals.deleted'));
-      return true;
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-      return false;
-    }
-  }, [t, setGoals]);
+    return removeItem(id, () => deleteGoal(id), { successMsg: t('goals.deleted'), errorMsg: errMsg });
+  }, [removeItem, t, errMsg]);
 
   const handleDuplicate = useCallback(async (id: number) => {
-    try {
-      const { data: newGoal } = await duplicateGoal(id);
-      setGoals(prev => [newGoal, ...prev]);
-      toast.success(t('goals.duplicated'));
-      return newGoal;
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-      return null;
-    }
-  }, [t, setGoals]);
+    return addItem(
+      async () => { const { data: g } = await duplicateGoal(id); return g; },
+      { successMsg: t('goals.duplicated'), errorMsg: errMsg, trackSaving: false },
+    );
+  }, [addItem, t, errMsg]);
 
-  const activeGoals = currentGoals.filter(g => g.status === 'active');
-  const completedGoals = currentGoals.filter(g => g.status === 'completed');
-  const pausedGoals = currentGoals.filter(g => g.status === 'paused');
+  const activeGoals = goals.filter(g => g.status === 'active');
+  const completedGoals = goals.filter(g => g.status === 'completed');
+  const pausedGoals = goals.filter(g => g.status === 'paused');
 
   return {
-    goals: currentGoals,
+    goals,
     loading,
     saving,
     activeGoals,

--- a/frontend/src/hooks/useLearningLogs.ts
+++ b/frontend/src/hooks/useLearningLogs.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import {
@@ -14,28 +14,18 @@ import {
 } from '../api/learningLogs';
 import type { LearningLog, CalendarEntry, LogCategory, StreakInfo } from '../types/learningLog';
 import { useAsyncData } from './useAsyncData';
+import { useCRUDList } from './useCRUDList';
 
 export function useLearningLogs() {
   const { t } = useTranslation();
-  const [saving, setSaving] = useState(false);
+  const errMsg = t('errors.somethingWrong');
 
-  const { data: logs, loading, refetch } = useAsyncData(
-    async () => {
+  const { items: logs, loading, saving, setItems, addItem, updateItem, removeItem, refetch } = useCRUDList<LearningLog>({
+    fetcher: async () => {
       const { data } = await getMyLogs();
       return data || [];
     },
-    { initialData: [] as LearningLog[] }
-  );
-
-  const [localLogs, setLocalLogs] = useState<LearningLog[] | null>(null);
-  const currentLogs = localLogs ?? logs;
-
-  const setLogs = useCallback((updater: LearningLog[] | ((prev: LearningLog[]) => LearningLog[])) => {
-    setLocalLogs(prev => {
-      const current = prev ?? logs;
-      return typeof updater === 'function' ? updater(current) : updater;
-    });
-  }, [logs]);
+  });
 
   const handleCreate = useCallback(async (data: {
     title: string;
@@ -43,19 +33,11 @@ export function useLearningLogs() {
     category?: LogCategory;
     duration?: number;
   }) => {
-    setSaving(true);
-    try {
-      const { data: newLog } = await createLog(data);
-      setLogs(prev => [newLog, ...prev]);
-      toast.success(t('learningLogs.created'));
-      return newLog;
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-      return null;
-    } finally {
-      setSaving(false);
-    }
-  }, [t, setLogs]);
+    return addItem(
+      async () => { const { data: l } = await createLog(data); return l; },
+      { successMsg: t('learningLogs.created'), errorMsg: errMsg },
+    );
+  }, [addItem, t, errMsg]);
 
   const handleUpdate = useCallback(async (logId: number, data: {
     title?: string;
@@ -63,45 +45,32 @@ export function useLearningLogs() {
     category?: LogCategory;
     duration?: number;
   }) => {
-    try {
-      const { data: updated } = await updateLog(logId, data);
-      setLogs(prev => prev.map(l => l.id === updated.id ? updated : l));
-      toast.success(t('learningLogs.updated'));
-      return updated;
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-      return null;
-    }
-  }, [t, setLogs]);
+    return updateItem(
+      async () => { const { data: l } = await updateLog(logId, data); return l; },
+      { successMsg: t('learningLogs.updated'), errorMsg: errMsg },
+    );
+  }, [updateItem, t, errMsg]);
 
   const handleDelete = useCallback(async (id: number) => {
     if (!confirm(t('learningLogs.confirmDelete'))) return false;
-    try {
-      await deleteLog(id);
-      setLogs(prev => prev.filter(l => l.id !== id));
-      toast.success(t('learningLogs.deleted'));
-      return true;
-    } catch {
-      toast.error(t('errors.somethingWrong'));
-      return false;
-    }
-  }, [t, setLogs]);
+    return removeItem(id, () => deleteLog(id), { successMsg: t('learningLogs.deleted'), errorMsg: errMsg });
+  }, [removeItem, t, errMsg]);
 
   const handleToggleFavorite = useCallback(async (id: number) => {
-    const log = currentLogs.find(l => l.id === id);
+    const log = logs.find(l => l.id === id);
     if (!log) return;
     try {
       const { data: updated } = log.is_favorite
         ? await unfavoriteLog(id)
         : await favoriteLog(id);
-      setLogs(prev => prev.map(l => l.id === updated.id ? updated : l));
+      setItems(prev => prev.map(l => l.id === updated.id ? updated : l));
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
     }
-  }, [currentLogs, t, setLogs]);
+  }, [logs, errMsg, setItems]);
 
   return {
-    logs: currentLogs,
+    logs,
     loading,
     saving,
     createLog: handleCreate,

--- a/frontend/src/hooks/useNotes.ts
+++ b/frontend/src/hooks/useNotes.ts
@@ -17,9 +17,11 @@ import {
   type UpdateNoteRequest,
 } from '../api/notes';
 import { useAsyncData } from './useAsyncData';
+import { useLocalList } from './useCRUDList';
 
 export function useNotes(page = 1, limit = 20) {
   const { t } = useTranslation();
+  const errMsg = t('errors.somethingWrong');
   const [saving, setSaving] = useState(false);
 
   const { data: notesData, loading, refetch } = useAsyncData(
@@ -30,16 +32,7 @@ export function useNotes(page = 1, limit = 20) {
     { initialData: { data: [], total: 0, page: 1, limit: 20 } }
   );
 
-  const [localNotes, setLocalNotes] = useState<Note[] | null>(null);
-  const currentNotes = localNotes ?? notesData.data;
-
-  // Sync localNotes when remote data changes
-  const setNotes = useCallback((updater: Note[] | ((prev: Note[]) => Note[])) => {
-    setLocalNotes(prev => {
-      const current = prev ?? notesData.data;
-      return typeof updater === 'function' ? updater(current) : updater;
-    });
-  }, [notesData.data]);
+  const { items: currentNotes, setItems: setNotes } = useLocalList(notesData.data);
 
   const handleCreate = useCallback(async (data: CreateNoteRequest) => {
     setSaving(true);
@@ -49,12 +42,12 @@ export function useNotes(page = 1, limit = 20) {
       toast.success(t('notes.created'));
       return newNote;
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
       return null;
     } finally {
       setSaving(false);
     }
-  }, [t, setNotes]);
+  }, [t, setNotes, errMsg]);
 
   const handleUpdate = useCallback(async (noteId: number, data: UpdateNoteRequest) => {
     setSaving(true);
@@ -64,12 +57,12 @@ export function useNotes(page = 1, limit = 20) {
       toast.success(t('notes.updated'));
       return updated;
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
       return null;
     } finally {
       setSaving(false);
     }
-  }, [t, setNotes]);
+  }, [t, setNotes, errMsg]);
 
   const handleDelete = useCallback(async (id: number) => {
     if (!confirm(t('notes.confirmDelete'))) return false;
@@ -79,10 +72,10 @@ export function useNotes(page = 1, limit = 20) {
       toast.success(t('notes.deleted'));
       return true;
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
       return false;
     }
-  }, [t, setNotes]);
+  }, [t, setNotes, errMsg]);
 
   const handleToggleFavorite = useCallback(async (id: number) => {
     try {
@@ -93,10 +86,10 @@ export function useNotes(page = 1, limit = 20) {
       toast.success(t('notes.favoriteToggled'));
       return true;
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
       return false;
     }
-  }, [t, setNotes]);
+  }, [t, setNotes, errMsg]);
 
   const handleArchive = useCallback(async (id: number) => {
     try {
@@ -105,10 +98,10 @@ export function useNotes(page = 1, limit = 20) {
       toast.success(t('notes.archived', { defaultValue: 'ノートをアーカイブしました' }));
       return true;
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
       return false;
     }
-  }, [t, setNotes]);
+  }, [t, setNotes, errMsg]);
 
   const handleUnarchive = useCallback(async (id: number) => {
     try {
@@ -117,10 +110,10 @@ export function useNotes(page = 1, limit = 20) {
       toast.success(t('notes.unarchived', { defaultValue: 'ノートのアーカイブを解除しました' }));
       return true;
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
       return false;
     }
-  }, [t, setNotes]);
+  }, [t, setNotes, errMsg]);
 
   const handleDuplicate = useCallback(async (id: number) => {
     try {
@@ -129,10 +122,10 @@ export function useNotes(page = 1, limit = 20) {
       toast.success(t('notes.duplicated', { defaultValue: 'ノートを複製しました' }));
       return duplicate;
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
       return null;
     }
-  }, [t, setNotes]);
+  }, [t, setNotes, errMsg]);
 
   const favoriteNotes = currentNotes.filter(n => n.is_favorite);
 
@@ -178,6 +171,7 @@ export function useNoteSearch(query: string, page = 1, limit = 20) {
 
 export function useArchivedNotes(page = 1, limit = 20) {
   const { t } = useTranslation();
+  const errMsg = t('errors.somethingWrong');
 
   const { data: archivedData, loading, refetch } = useAsyncData(
     async () => {
@@ -187,15 +181,7 @@ export function useArchivedNotes(page = 1, limit = 20) {
     { initialData: { data: [], total: 0, page: 1, limit: 20 }, deps: [page, limit] }
   );
 
-  const [localNotes, setLocalNotes] = useState<Note[] | null>(null);
-  const currentNotes = localNotes ?? archivedData.data;
-
-  const setNotes = useCallback((updater: Note[] | ((prev: Note[]) => Note[])) => {
-    setLocalNotes(prev => {
-      const current = prev ?? archivedData.data;
-      return typeof updater === 'function' ? updater(current) : updater;
-    });
-  }, [archivedData.data]);
+  const { items: currentNotes, setItems: setNotes } = useLocalList(archivedData.data);
 
   const handleUnarchive = useCallback(async (id: number) => {
     try {
@@ -204,10 +190,10 @@ export function useArchivedNotes(page = 1, limit = 20) {
       toast.success(t('notes.unarchived', { defaultValue: 'ノートのアーカイブを解除しました' }));
       return true;
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
       return false;
     }
-  }, [t, setNotes]);
+  }, [t, setNotes, errMsg]);
 
   const handleDelete = useCallback(async (id: number) => {
     if (!confirm(t('notes.confirmDelete', { defaultValue: 'このノートを完全に削除しますか？' }))) return false;
@@ -217,10 +203,10 @@ export function useArchivedNotes(page = 1, limit = 20) {
       toast.success(t('notes.deleted', { defaultValue: 'ノートを削除しました' }));
       return true;
     } catch {
-      toast.error(t('errors.somethingWrong'));
+      toast.error(errMsg);
       return false;
     }
-  }, [t, setNotes]);
+  }, [t, setNotes, errMsg]);
 
   return {
     notes: currentNotes,

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { useAuthStore } from '../store/authStore';
@@ -7,11 +7,11 @@ import type { GitHubRepository } from '../types/github';
 import { getProjectsByUserId, createProject, updateProject, deleteProject } from '../api/projects';
 import { getRepos } from '../api/github';
 import { useAsyncData } from './useAsyncData';
+import { useLocalList } from './useCRUDList';
 
 export function useProjects() {
   const { t } = useTranslation();
   const user = useAuthStore((s) => s.user);
-  const [saving, setSaving] = useState(false);
 
   const { data, loading, refetch } = useAsyncData(
     async () => {
@@ -31,56 +31,49 @@ export function useProjects() {
   const projects = data?.projects ?? [];
   const repos = data?.repos ?? [];
 
-  const [localProjects, setLocalProjects] = useState<Project[] | null>(null);
-  const currentProjects = localProjects ?? projects;
+  const { items: currentProjects, setItems: setLocalProjects } = useLocalList(projects);
 
   const handleCreate = useCallback(async (reqData: CreateProjectRequest) => {
-    setSaving(true);
     try {
       const newProject = await createProject(reqData);
-      setLocalProjects(prev => [newProject, ...(prev ?? projects)]);
+      setLocalProjects(prev => [newProject, ...prev]);
       toast.success(t('projects.createSuccess'));
       return newProject;
     } catch {
       toast.error(t('projects.createFailed'));
       return null;
-    } finally {
-      setSaving(false);
     }
-  }, [t, projects]);
+  }, [t, setLocalProjects]);
 
   const handleUpdate = useCallback(async (projectId: number, reqData: CreateProjectRequest) => {
-    setSaving(true);
     try {
       const updated = await updateProject(projectId, reqData);
-      setLocalProjects(prev => (prev ?? projects).map(p => p.id === updated.id ? updated : p));
+      setLocalProjects(prev => prev.map(p => p.id === updated.id ? updated : p));
       toast.success(t('projects.updateSuccess'));
       return updated;
     } catch {
       toast.error(t('projects.updateFailed'));
       return null;
-    } finally {
-      setSaving(false);
     }
-  }, [t, projects]);
+  }, [t, setLocalProjects]);
 
   const handleDelete = useCallback(async (project: Project) => {
     try {
       await deleteProject(project.id);
-      setLocalProjects(prev => (prev ?? projects).filter(p => p.id !== project.id));
+      setLocalProjects(prev => prev.filter(p => p.id !== project.id));
       toast.success(t('projects.deleteSuccess'));
       return true;
     } catch {
       toast.error(t('projects.deleteFailed'));
       return false;
     }
-  }, [t, projects]);
+  }, [t, setLocalProjects]);
 
   return {
     projects: currentProjects,
     repos,
     loading,
-    saving,
+    saving: false,
     createProject: handleCreate,
     updateProject: handleUpdate,
     deleteProject: handleDelete,

--- a/frontend/src/hooks/useQuestions.ts
+++ b/frontend/src/hooks/useQuestions.ts
@@ -10,6 +10,7 @@ import {
   deleteQuestion,
 } from '../api/qa';
 import { useAsyncData } from './useAsyncData';
+import { useLocalList } from './useCRUDList';
 
 type SortType = 'newest' | 'votes' | 'unanswered';
 type SolvedFilter = 'all' | 'solved' | 'unsolved';
@@ -37,8 +38,7 @@ export function useQuestions() {
   const questions = data?.questions ?? [];
   const total = data?.total ?? 0;
 
-  const [localQuestions, setLocalQuestions] = useState<Question[] | null>(null);
-  const allQuestions = localQuestions ?? questions;
+  const { items: allQuestions, setItems: setLocalQuestions, resetLocal } = useLocalList(questions);
   const currentQuestions = solvedFilter === 'all'
     ? allQuestions
     : allQuestions.filter(q => solvedFilter === 'solved' ? q.is_solved : !q.is_solved);
@@ -52,7 +52,7 @@ export function useQuestions() {
     setSaving(true);
     try {
       const newQuestion = await createQuestion(reqData);
-      setLocalQuestions(prev => [newQuestion, ...(prev ?? questions)]);
+      setLocalQuestions(prev => [newQuestion, ...prev]);
       toast.success(t('qa.createSuccess'));
       return newQuestion;
     } catch {
@@ -61,13 +61,13 @@ export function useQuestions() {
     } finally {
       setSaving(false);
     }
-  }, [t, questions]);
+  }, [t, setLocalQuestions]);
 
   const handleUpdate = useCallback(async (questionId: number, reqData: CreateQuestionRequest) => {
     setSaving(true);
     try {
       const updated = await updateQuestion(questionId, reqData);
-      setLocalQuestions(prev => (prev ?? questions).map(q => q.id === updated.id ? updated : q));
+      setLocalQuestions(prev => prev.map(q => q.id === updated.id ? updated : q));
       toast.success(t('qa.updateSuccess'));
       return updated;
     } catch {
@@ -76,25 +76,25 @@ export function useQuestions() {
     } finally {
       setSaving(false);
     }
-  }, [t, questions]);
+  }, [t, setLocalQuestions]);
 
   const handleDelete = useCallback(async (question: Question) => {
     try {
       await deleteQuestion(question.id);
-      setLocalQuestions(prev => (prev ?? questions).filter(q => q.id !== question.id));
+      setLocalQuestions(prev => prev.filter(q => q.id !== question.id));
       toast.success(t('qa.deleteSuccess'));
       return true;
     } catch {
       toast.error(t('qa.deleteFailed'));
       return false;
     }
-  }, [t, questions]);
+  }, [t, setLocalQuestions]);
 
   const changeSort = useCallback((newSort: SortType) => {
     setSort(newSort);
     setPage(0);
-    setLocalQuestions(null);
-  }, []);
+    resetLocal();
+  }, [resetLocal]);
 
   const changeSolvedFilter = useCallback((f: SolvedFilter) => {
     setSolvedFilter(f);
@@ -109,7 +109,7 @@ export function useQuestions() {
     searchQuery,
     setSearchQuery,
     tagFilter,
-    setTagFilter: (v: string) => { setTagFilter(v); setPage(0); setLocalQuestions(null); },
+    setTagFilter: (v: string) => { setTagFilter(v); setPage(0); resetLocal(); },
     sort,
     setSort: changeSort,
     solvedFilter,


### PR DESCRIPTION
## 概要
- `useCRUDList<T>` と `useLocalList<T>` の2つのコンポーザブルを新規作成
- 5つのCRUDフックの重複コードを集約・削減

## 変更内容
- **新規**: `frontend/src/hooks/useCRUDList.ts`
  - `useLocalList<T>` — サーバーデータ上のローカル状態オーバーレイ
  - `useCRUDList<T>` — useAsyncData + useLocalList + addItem/updateItem/removeItem
- **リファクタリング対象**:
  - `useGoals` — useCRUDListで統合（123→85行）
  - `useLearningLogs` — useCRUDListで統合（113→80行）
  - `useNotes`/`useArchivedNotes` — useLocalListで状態管理共通化
  - `useProjects` — useLocalListで状態管理共通化
  - `useQuestions` — useLocalListで状態管理共通化（resetLocal活用）

## テスト
- [x] `npx tsc --noEmit` — 型チェック通過
- [x] 全フックの戻り値・API互換性を維持

closes #1989