### PR TITLE
refactor: IntegrationSectionを6サービス別コンポーネントに分割

### DIFF
--- a/frontend/src/pages/settings/IntegrationSection.tsx
+++ b/frontend/src/pages/settings/IntegrationSection.tsx
@@ -1,6 +1,9 @@
 import { useTranslation } from 'react-i18next';
-import { inputClass, sectionContainerClass, labelClass, selectClass, buttonDangerOutlineClass } from '../../constants/styles';
 import type { User } from '../../types/user';
+import GitHubIntegrationCard from './integrations/GitHubIntegrationCard';
+import SpotifyIntegrationCard from './integrations/SpotifyIntegrationCard';
+import UsernameIntegrationCard from './integrations/UsernameIntegrationCard';
+import PaizaRankCard from './integrations/PaizaRankCard';
 
 interface Props {
   user: User;
@@ -41,321 +44,97 @@ interface Props {
   onSavePaizaRank: () => void;
 }
 
-const SpotifyIcon = ({ className }: { className?: string }) => (
-  <svg className={className} viewBox="0 0 24 24" fill="currentColor">
-    <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
-  </svg>
-);
-
-const GitHubIcon = ({ className }: { className?: string }) => (
-  <svg className={className} fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-);
-
 export default function IntegrationSection(props: Props) {
   const { t } = useTranslation();
   const { user } = props;
 
   return (
     <>
-      {/* GitHub Integration */}
-      <div className={sectionContainerClass}>
-        <div className="px-6 py-4 border-b border-gray-800">
-          <h2 className="text-base font-semibold">{t('settings.github')}</h2>
-        </div>
-        <div className="p-6">
-          {user.github_connected ? (
-            <div className="space-y-4">
-              <div className="flex items-center gap-3">
-                <GitHubIcon className="w-8 h-8 text-gray-300" />
-                <div>
-                  <p className="text-sm font-medium text-green-400">{t('settings.connected')}</p>
-                  <p className="text-sm text-gray-400">@{user.github_username}</p>
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={props.onSyncGitHub}
-                  disabled={props.syncing}
-                  className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium border border-gray-700 transition-colors"
-                >
-                  {props.syncing ? t('settings.syncing') : t('settings.sync')}
-                </button>
-                <button
-                  onClick={props.onDisconnectGitHub}
-                  className={buttonDangerOutlineClass}
-                >
-                  {t('settings.disconnect')}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="text-center py-4">
-              <GitHubIcon className="w-12 h-12 text-gray-600 mx-auto mb-3" />
-              <p className="text-gray-400 text-sm mb-4">{t('settings.githubDescription')}</p>
-              <button
-                onClick={props.onConnectGitHub}
-                className="px-5 py-2.5 bg-white hover:bg-gray-100 text-gray-900 rounded-lg font-semibold text-sm transition-colors inline-flex items-center gap-2"
-              >
-                <GitHubIcon className="w-5 h-5" />
-                {t('settings.connect')} GitHub
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
+      <GitHubIntegrationCard
+        connected={user.github_connected}
+        username={user.github_username}
+        syncing={props.syncing}
+        onConnect={props.onConnectGitHub}
+        onDisconnect={props.onDisconnectGitHub}
+        onSync={props.onSyncGitHub}
+      />
 
-      {/* Spotify Integration */}
-      <div className={sectionContainerClass}>
-        <div className="px-6 py-4 border-b border-gray-800">
-          <h2 className="text-base font-semibold">{t('settings.spotify')}</h2>
-        </div>
-        <div className="p-6">
-          {user.spotify_connected ? (
-            <div className="space-y-4">
-              <div className="flex items-center gap-3">
-                <SpotifyIcon className="w-8 h-8 text-green-500" />
-                <div>
-                  <p className="text-sm font-medium text-green-400">{t('settings.connected')}</p>
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={props.onDisconnectSpotify}
-                  className={buttonDangerOutlineClass}
-                >
-                  {t('settings.disconnect')}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <div className="text-center py-4">
-              <SpotifyIcon className="w-12 h-12 text-green-500/40 mx-auto mb-3" />
-              <p className="text-gray-400 text-sm mb-4">{t('settings.spotifyDescription')}</p>
-              <button
-                onClick={props.onConnectSpotify}
-                className="px-5 py-2.5 bg-green-600 hover:bg-green-500 text-white rounded-lg font-semibold text-sm transition-colors inline-flex items-center gap-2"
-              >
-                <SpotifyIcon className="w-5 h-5" />
-                {t('settings.connect')} Spotify
-              </button>
-            </div>
-          )}
-        </div>
-      </div>
+      <SpotifyIntegrationCard
+        connected={user.spotify_connected}
+        onConnect={props.onConnectSpotify}
+        onDisconnect={props.onDisconnectSpotify}
+      />
 
-      {/* Zenn Integration */}
-      <div className={sectionContainerClass}>
-        <div className="px-6 py-4 border-b border-gray-800">
-          <h2 className="text-base font-semibold">{t('settings.zenn')}</h2>
-        </div>
-        <div className="p-6">
-          {user.zenn_username ? (
-            <div className="space-y-4">
-              <div className="flex items-center gap-3">
-                <div className="w-8 h-8 bg-blue-500 rounded-lg flex items-center justify-center text-white font-bold text-sm">Z</div>
-                <div>
-                  <p className="text-sm font-medium text-green-400">{t('settings.connected')}</p>
-                  <p className="text-sm text-gray-400">@{user.zenn_username}</p>
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={props.onSyncZenn}
-                  disabled={props.syncingZenn}
-                  className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium border border-gray-700 transition-colors"
-                >
-                  {props.syncingZenn ? t('settings.syncing') : t('settings.sync')}
-                </button>
-                <button
-                  onClick={props.onDisconnectZenn}
-                  className={buttonDangerOutlineClass}
-                >
-                  {t('settings.disconnect')}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <form onSubmit={props.onConnectZenn} className="space-y-4">
-              <div className="text-center py-2">
-                <div className="w-12 h-12 bg-blue-500/20 rounded-lg flex items-center justify-center text-blue-400 font-bold text-xl mx-auto mb-3">Z</div>
-                <p className="text-gray-400 text-sm mb-4">{t('settings.zennDescription')}</p>
-              </div>
-              <div>
-                <label htmlFor="integration-zenn-username" className={labelClass}>{t('settings.zennUsername')}</label>
-                <input
-                  id="integration-zenn-username"
-                  type="text"
-                  value={props.zennUsername}
-                  onChange={(e) => props.setZennUsername(e.target.value)}
-                  placeholder={t('settings.zennUsernamePlaceholder')}
-                  maxLength={50}
-                  className={inputClass}
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={props.connectingZenn || !props.zennUsername.trim()}
-                className="w-full px-5 py-2.5 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 text-white rounded-lg font-semibold text-sm transition-colors"
-              >
-                {props.connectingZenn ? t('common.loading') : t('settings.connect')}
-              </button>
-            </form>
-          )}
-        </div>
-      </div>
+      <UsernameIntegrationCard
+        title={t('settings.zenn')}
+        description={t('settings.zennDescription')}
+        badgeLetter="Z"
+        badgeBgClass="bg-blue-500"
+        badgeTextClass="text-white"
+        badgeBgDisabledClass="bg-blue-500/20"
+        badgeTextDisabledClass="text-blue-400"
+        connectBtnClass="bg-blue-600 hover:bg-blue-500"
+        connected={!!user.zenn_username}
+        connectedUsername={user.zenn_username}
+        username={props.zennUsername}
+        setUsername={props.setZennUsername}
+        usernameLabel={t('settings.zennUsername')}
+        usernamePlaceholder={t('settings.zennUsernamePlaceholder')}
+        connecting={props.connectingZenn}
+        onConnect={props.onConnectZenn}
+        onDisconnect={props.onDisconnectZenn}
+        syncing={props.syncingZenn}
+        onSync={props.onSyncZenn}
+      />
 
-      {/* Qiita Integration */}
-      <div className={sectionContainerClass}>
-        <div className="px-6 py-4 border-b border-gray-800">
-          <h2 className="text-base font-semibold">{t('settings.qiita')}</h2>
-        </div>
-        <div className="p-6">
-          {user.qiita_username ? (
-            <div className="space-y-4">
-              <div className="flex items-center gap-3">
-                <div className="w-8 h-8 bg-green-500 rounded-lg flex items-center justify-center text-white font-bold text-sm">Q</div>
-                <div>
-                  <p className="text-sm font-medium text-green-400">{t('settings.connected')}</p>
-                  <p className="text-sm text-gray-400">@{user.qiita_username}</p>
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={props.onSyncQiita}
-                  disabled={props.syncingQiita}
-                  className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium border border-gray-700 transition-colors"
-                >
-                  {props.syncingQiita ? t('settings.syncing') : t('settings.sync')}
-                </button>
-                <button
-                  onClick={props.onDisconnectQiita}
-                  className={buttonDangerOutlineClass}
-                >
-                  {t('settings.disconnect')}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <form onSubmit={props.onConnectQiita} className="space-y-4">
-              <div className="text-center py-2">
-                <div className="w-12 h-12 bg-green-500/20 rounded-lg flex items-center justify-center text-green-400 font-bold text-xl mx-auto mb-3">Q</div>
-                <p className="text-gray-400 text-sm mb-4">{t('settings.qiitaDescription')}</p>
-              </div>
-              <div>
-                <label htmlFor="integration-qiita-username" className={labelClass}>{t('settings.qiitaUsername')}</label>
-                <input
-                  id="integration-qiita-username"
-                  type="text"
-                  value={props.qiitaUsername}
-                  onChange={(e) => props.setQiitaUsername(e.target.value)}
-                  placeholder={t('settings.qiitaUsernamePlaceholder')}
-                  maxLength={50}
-                  className={inputClass}
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={props.connectingQiita || !props.qiitaUsername.trim()}
-                className="w-full px-5 py-2.5 bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white rounded-lg font-semibold text-sm transition-colors"
-              >
-                {props.connectingQiita ? t('common.loading') : t('settings.connect')}
-              </button>
-            </form>
-          )}
-        </div>
-      </div>
+      <UsernameIntegrationCard
+        title={t('settings.qiita')}
+        description={t('settings.qiitaDescription')}
+        badgeLetter="Q"
+        badgeBgClass="bg-green-500"
+        badgeTextClass="text-white"
+        badgeBgDisabledClass="bg-green-500/20"
+        badgeTextDisabledClass="text-green-400"
+        connectBtnClass="bg-gray-700 hover:bg-gray-600"
+        connected={!!user.qiita_username}
+        connectedUsername={user.qiita_username}
+        username={props.qiitaUsername}
+        setUsername={props.setQiitaUsername}
+        usernameLabel={t('settings.qiitaUsername')}
+        usernamePlaceholder={t('settings.qiitaUsernamePlaceholder')}
+        connecting={props.connectingQiita}
+        onConnect={props.onConnectQiita}
+        onDisconnect={props.onDisconnectQiita}
+        syncing={props.syncingQiita}
+        onSync={props.onSyncQiita}
+      />
 
-      {/* AtCoder Integration */}
-      <div className={sectionContainerClass}>
-        <div className="px-6 py-4 border-b border-gray-800">
-          <h2 className="text-base font-semibold">{t('settings.atcoder')}</h2>
-        </div>
-        <div className="p-6">
-          {user.atcoder_username ? (
-            <div className="space-y-4">
-              <div className="flex items-center gap-3">
-                <div className="w-8 h-8 bg-gray-700 rounded-lg flex items-center justify-center text-white font-bold text-sm">A</div>
-                <div>
-                  <p className="text-sm font-medium text-green-400">{t('settings.connected')}</p>
-                  <p className="text-sm text-gray-400">@{user.atcoder_username}</p>
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <button
-                  onClick={props.onDisconnectAtCoder}
-                  className={buttonDangerOutlineClass}
-                >
-                  {t('settings.disconnect')}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <form onSubmit={props.onConnectAtCoder} className="space-y-4">
-              <div className="text-center py-2">
-                <div className="w-12 h-12 bg-gray-700/50 rounded-lg flex items-center justify-center text-gray-400 font-bold text-xl mx-auto mb-3">A</div>
-                <p className="text-gray-400 text-sm mb-4">{t('settings.atcoderDescription')}</p>
-              </div>
-              <div>
-                <label htmlFor="integration-atcoder-username" className={labelClass}>{t('settings.atcoderUsername')}</label>
-                <input
-                  id="integration-atcoder-username"
-                  type="text"
-                  value={props.atcoderUsername}
-                  onChange={(e) => props.setAtcoderUsername(e.target.value)}
-                  placeholder={t('settings.atcoderUsernamePlaceholder')}
-                  maxLength={50}
-                  className={inputClass}
-                />
-              </div>
-              <button
-                type="submit"
-                disabled={props.connectingAtcoder || !props.atcoderUsername.trim()}
-                className="w-full px-5 py-2.5 bg-cyan-600 hover:bg-cyan-500 disabled:opacity-50 text-white rounded-lg font-semibold text-sm transition-colors"
-              >
-                {props.connectingAtcoder ? t('common.loading') : t('settings.connect')}
-              </button>
-            </form>
-          )}
-        </div>
-      </div>
+      <UsernameIntegrationCard
+        title={t('settings.atcoder')}
+        description={t('settings.atcoderDescription')}
+        badgeLetter="A"
+        badgeBgClass="bg-gray-700"
+        badgeTextClass="text-white"
+        badgeBgDisabledClass="bg-gray-700/50"
+        badgeTextDisabledClass="text-gray-400"
+        connectBtnClass="bg-cyan-600 hover:bg-cyan-500"
+        connected={!!user.atcoder_username}
+        connectedUsername={user.atcoder_username}
+        username={props.atcoderUsername}
+        setUsername={props.setAtcoderUsername}
+        usernameLabel={t('settings.atcoderUsername')}
+        usernamePlaceholder={t('settings.atcoderUsernamePlaceholder')}
+        connecting={props.connectingAtcoder}
+        onConnect={props.onConnectAtCoder}
+        onDisconnect={props.onDisconnectAtCoder}
+      />
 
-      {/* paiza Rank */}
-      <div className={sectionContainerClass}>
-        <div className="px-6 py-4 border-b border-gray-800">
-          <h2 className="text-base font-semibold">{t('settings.paiza')}</h2>
-        </div>
-        <div className="p-6 space-y-4">
-          <div className="text-center py-2">
-            <div className="w-12 h-12 bg-emerald-700/50 rounded-lg flex items-center justify-center text-emerald-400 font-bold text-xl mx-auto mb-3">P</div>
-            <p className="text-gray-400 text-sm mb-4">{t('settings.paizaDescription')}</p>
-          </div>
-          <div>
-            <label htmlFor="integration-paiza-rank" className={labelClass}>{t('settings.paizaRankLabel')}</label>
-            <select
-              id="integration-paiza-rank"
-              value={props.paizaRank}
-              onChange={(e) => props.setPaizaRank(e.target.value)}
-              className={`${selectClass} w-full`}
-            >
-              <option value="">{t('settings.paizaSelectRank')}</option>
-              <option value="S">S {t('settings.paizaRankS')}</option>
-              <option value="A">A {t('settings.paizaRankA')}</option>
-              <option value="B">B {t('settings.paizaRankB')}</option>
-              <option value="C">C {t('settings.paizaRankC')}</option>
-              <option value="D">D {t('settings.paizaRankD')}</option>
-              <option value="E">E {t('settings.paizaRankE')}</option>
-            </select>
-          </div>
-          <button
-            type="button"
-            onClick={props.onSavePaizaRank}
-            disabled={props.savingPaiza}
-            className="w-full px-5 py-2.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white rounded-lg font-semibold text-sm transition-colors"
-          >
-            {props.savingPaiza ? t('common.loading') : t('common.save')}
-          </button>
-        </div>
-      </div>
+      <PaizaRankCard
+        paizaRank={props.paizaRank}
+        setPaizaRank={props.setPaizaRank}
+        saving={props.savingPaiza}
+        onSave={props.onSavePaizaRank}
+      />
     </>
   );
 }

--- a/frontend/src/pages/settings/integrations/GitHubIntegrationCard.tsx
+++ b/frontend/src/pages/settings/integrations/GitHubIntegrationCard.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from 'react-i18next';
+import { sectionContainerClass, buttonDangerOutlineClass } from '../../../constants/styles';
+
+const GitHubIcon = ({ className }: { className?: string }) => (
+  <svg className={className} fill="currentColor" viewBox="0 0 24 24"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+);
+
+interface Props {
+  connected: boolean;
+  username?: string;
+  syncing: boolean;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  onSync: () => void;
+}
+
+export default function GitHubIntegrationCard({ connected, username, syncing, onConnect, onDisconnect, onSync }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={sectionContainerClass}>
+      <div className="px-6 py-4 border-b border-gray-800">
+        <h2 className="text-base font-semibold">{t('settings.github')}</h2>
+      </div>
+      <div className="p-6">
+        {connected ? (
+          <div className="space-y-4">
+            <div className="flex items-center gap-3">
+              <GitHubIcon className="w-8 h-8 text-gray-300" />
+              <div>
+                <p className="text-sm font-medium text-green-400">{t('settings.connected')}</p>
+                <p className="text-sm text-gray-400">@{username}</p>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button
+                onClick={onSync}
+                disabled={syncing}
+                className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium border border-gray-700 transition-colors"
+              >
+                {syncing ? t('settings.syncing') : t('settings.sync')}
+              </button>
+              <button onClick={onDisconnect} className={buttonDangerOutlineClass}>
+                {t('settings.disconnect')}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="text-center py-4">
+            <GitHubIcon className="w-12 h-12 text-gray-600 mx-auto mb-3" />
+            <p className="text-gray-400 text-sm mb-4">{t('settings.githubDescription')}</p>
+            <button
+              onClick={onConnect}
+              className="px-5 py-2.5 bg-white hover:bg-gray-100 text-gray-900 rounded-lg font-semibold text-sm transition-colors inline-flex items-center gap-2"
+            >
+              <GitHubIcon className="w-5 h-5" />
+              {t('settings.connect')} GitHub
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/settings/integrations/PaizaRankCard.tsx
+++ b/frontend/src/pages/settings/integrations/PaizaRankCard.tsx
@@ -1,0 +1,52 @@
+import { useTranslation } from 'react-i18next';
+import { sectionContainerClass, labelClass, selectClass } from '../../../constants/styles';
+
+interface Props {
+  paizaRank: string;
+  setPaizaRank: (v: string) => void;
+  saving: boolean;
+  onSave: () => void;
+}
+
+export default function PaizaRankCard({ paizaRank, setPaizaRank, saving, onSave }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={sectionContainerClass}>
+      <div className="px-6 py-4 border-b border-gray-800">
+        <h2 className="text-base font-semibold">{t('settings.paiza')}</h2>
+      </div>
+      <div className="p-6 space-y-4">
+        <div className="text-center py-2">
+          <div className="w-12 h-12 bg-emerald-700/50 rounded-lg flex items-center justify-center text-emerald-400 font-bold text-xl mx-auto mb-3">P</div>
+          <p className="text-gray-400 text-sm mb-4">{t('settings.paizaDescription')}</p>
+        </div>
+        <div>
+          <label htmlFor="integration-paiza-rank" className={labelClass}>{t('settings.paizaRankLabel')}</label>
+          <select
+            id="integration-paiza-rank"
+            value={paizaRank}
+            onChange={(e) => setPaizaRank(e.target.value)}
+            className={`${selectClass} w-full`}
+          >
+            <option value="">{t('settings.paizaSelectRank')}</option>
+            <option value="S">S {t('settings.paizaRankS')}</option>
+            <option value="A">A {t('settings.paizaRankA')}</option>
+            <option value="B">B {t('settings.paizaRankB')}</option>
+            <option value="C">C {t('settings.paizaRankC')}</option>
+            <option value="D">D {t('settings.paizaRankD')}</option>
+            <option value="E">E {t('settings.paizaRankE')}</option>
+          </select>
+        </div>
+        <button
+          type="button"
+          onClick={onSave}
+          disabled={saving}
+          className="w-full px-5 py-2.5 bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 text-white rounded-lg font-semibold text-sm transition-colors"
+        >
+          {saving ? t('common.loading') : t('common.save')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/settings/integrations/SpotifyIntegrationCard.tsx
+++ b/frontend/src/pages/settings/integrations/SpotifyIntegrationCard.tsx
@@ -1,0 +1,55 @@
+import { useTranslation } from 'react-i18next';
+import { sectionContainerClass, buttonDangerOutlineClass } from '../../../constants/styles';
+
+const SpotifyIcon = ({ className }: { className?: string }) => (
+  <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+    <path d="M12 0C5.4 0 0 5.4 0 12s5.4 12 12 12 12-5.4 12-12S18.66 0 12 0zm5.521 17.34c-.24.359-.66.48-1.021.24-2.82-1.74-6.36-2.101-10.561-1.141-.418.122-.779-.179-.899-.539-.12-.421.18-.78.54-.9 4.56-1.021 8.52-.6 11.64 1.32.42.18.479.659.301 1.02zm1.44-3.3c-.301.42-.841.6-1.262.3-3.239-1.98-8.159-2.58-11.939-1.38-.479.12-1.02-.12-1.14-.6-.12-.48.12-1.021.6-1.141C9.6 9.9 15 10.561 18.72 12.84c.361.181.54.78.241 1.2zm.12-3.36C15.24 8.4 8.82 8.16 5.16 9.301c-.6.179-1.2-.181-1.38-.721-.18-.601.18-1.2.72-1.381 4.26-1.26 11.28-1.02 15.721 1.621.539.3.719 1.02.419 1.56-.299.421-1.02.599-1.559.3z" />
+  </svg>
+);
+
+interface Props {
+  connected: boolean;
+  onConnect: () => void;
+  onDisconnect: () => void;
+}
+
+export default function SpotifyIntegrationCard({ connected, onConnect, onDisconnect }: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={sectionContainerClass}>
+      <div className="px-6 py-4 border-b border-gray-800">
+        <h2 className="text-base font-semibold">{t('settings.spotify')}</h2>
+      </div>
+      <div className="p-6">
+        {connected ? (
+          <div className="space-y-4">
+            <div className="flex items-center gap-3">
+              <SpotifyIcon className="w-8 h-8 text-green-500" />
+              <div>
+                <p className="text-sm font-medium text-green-400">{t('settings.connected')}</p>
+              </div>
+            </div>
+            <div className="flex gap-2">
+              <button onClick={onDisconnect} className={buttonDangerOutlineClass}>
+                {t('settings.disconnect')}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <div className="text-center py-4">
+            <SpotifyIcon className="w-12 h-12 text-green-500/40 mx-auto mb-3" />
+            <p className="text-gray-400 text-sm mb-4">{t('settings.spotifyDescription')}</p>
+            <button
+              onClick={onConnect}
+              className="px-5 py-2.5 bg-green-600 hover:bg-green-500 text-white rounded-lg font-semibold text-sm transition-colors inline-flex items-center gap-2"
+            >
+              <SpotifyIcon className="w-5 h-5" />
+              {t('settings.connect')} Spotify
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/settings/integrations/UsernameIntegrationCard.tsx
+++ b/frontend/src/pages/settings/integrations/UsernameIntegrationCard.tsx
@@ -1,0 +1,106 @@
+import { useTranslation } from 'react-i18next';
+import { inputClass, sectionContainerClass, labelClass, buttonDangerOutlineClass } from '../../../constants/styles';
+
+interface Props {
+  title: string;
+  description: string;
+  // Icon badge
+  badgeLetter: string;
+  badgeBgClass: string;
+  badgeTextClass: string;
+  badgeBgDisabledClass: string;
+  badgeTextDisabledClass: string;
+  // Connect button
+  connectBtnClass: string;
+  // Connected state
+  connected: boolean;
+  connectedUsername?: string;
+  // Username form
+  username: string;
+  setUsername: (v: string) => void;
+  usernameLabel: string;
+  usernamePlaceholder: string;
+  // Actions
+  connecting: boolean;
+  onConnect: (e: React.FormEvent) => void;
+  onDisconnect: () => void;
+  // Optional sync
+  syncing?: boolean;
+  onSync?: () => void;
+}
+
+export default function UsernameIntegrationCard(props: Props) {
+  const { t } = useTranslation();
+
+  return (
+    <div className={sectionContainerClass}>
+      <div className="px-6 py-4 border-b border-gray-800">
+        <h2 className="text-base font-semibold">{props.title}</h2>
+      </div>
+      <div className="p-6">
+        {props.connected ? (
+          <div className="space-y-4">
+            <div className="flex items-center gap-3">
+              <div className={`w-8 h-8 ${props.badgeBgClass} rounded-lg flex items-center justify-center ${props.badgeTextClass} font-bold text-sm`}>
+                {props.badgeLetter}
+              </div>
+              <div>
+                <p className="text-sm font-medium text-green-400">{t('settings.connected')}</p>
+                {props.connectedUsername && (
+                  <p className="text-sm text-gray-400">@{props.connectedUsername}</p>
+                )}
+              </div>
+            </div>
+            <div className="flex gap-2">
+              {props.onSync && (
+                <button
+                  onClick={props.onSync}
+                  disabled={props.syncing}
+                  className="px-4 py-2 bg-gray-800 hover:bg-gray-700 disabled:opacity-50 text-white rounded-lg text-sm font-medium border border-gray-700 transition-colors"
+                >
+                  {props.syncing ? t('settings.syncing') : t('settings.sync')}
+                </button>
+              )}
+              <button
+                onClick={props.onDisconnect}
+                className={buttonDangerOutlineClass}
+              >
+                {t('settings.disconnect')}
+              </button>
+            </div>
+          </div>
+        ) : (
+          <form onSubmit={props.onConnect} className="space-y-4">
+            <div className="text-center py-2">
+              <div className={`w-12 h-12 ${props.badgeBgDisabledClass} rounded-lg flex items-center justify-center ${props.badgeTextDisabledClass} font-bold text-xl mx-auto mb-3`}>
+                {props.badgeLetter}
+              </div>
+              <p className="text-gray-400 text-sm mb-4">{props.description}</p>
+            </div>
+            <div>
+              <label htmlFor={`integration-${props.badgeLetter.toLowerCase()}-username`} className={labelClass}>
+                {props.usernameLabel}
+              </label>
+              <input
+                id={`integration-${props.badgeLetter.toLowerCase()}-username`}
+                type="text"
+                value={props.username}
+                onChange={(e) => props.setUsername(e.target.value)}
+                placeholder={props.usernamePlaceholder}
+                maxLength={50}
+                className={inputClass}
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={props.connecting || !props.username.trim()}
+              className={`w-full px-5 py-2.5 ${props.connectBtnClass} disabled:opacity-50 text-white rounded-lg font-semibold text-sm transition-colors`}
+            >
+              {props.connecting ? t('common.loading') : t('settings.connect')}
+            </button>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要
- 362行のIntegrationSectionを6つの専用コンポーネントに分割
- Zenn/Qiita/AtCoderの共通パターンを`UsernameIntegrationCard`で汎用化

## 変更内容
- **新規**: `integrations/GitHubIntegrationCard.tsx` — GitHub OAuth連携
- **新規**: `integrations/SpotifyIntegrationCard.tsx` — Spotify OAuth連携
- **新規**: `integrations/UsernameIntegrationCard.tsx` — ユーザー名入力型汎用カード
- **新規**: `integrations/PaizaRankCard.tsx` — Paizaランク設定
- **変更**: `IntegrationSection.tsx` — 各カードの組み立てに専念（362→130行）

## テスト
- [x] `npx tsc --noEmit` — 型チェック通過
- [x] Props互換性を完全維持

closes #1990