### PR TITLE
refactor: フォームバリデーション定数とCharCountコンポーネントの共通化

### DIFF
--- a/frontend/src/components/common/CharCount.tsx
+++ b/frontend/src/components/common/CharCount.tsx
@@ -1,0 +1,8 @@
+/** フィールドの文字数カウンター表示。フォームのインプット下に配置する。 */
+export default function CharCount({ value, max }: { value: string; max: number }) {
+  return (
+    <p className="text-xs text-gray-500 text-right mt-1">
+      {value.length}/{max}
+    </p>
+  );
+}

--- a/frontend/src/components/common/index.ts
+++ b/frontend/src/components/common/index.ts
@@ -7,3 +7,4 @@ export { default as Modal } from './Modal';
 export { default as Pagination } from './Pagination';
 export { default as SearchInput } from './SearchInput';
 export { default as PageHeader } from './PageHeader';
+export { default as CharCount } from './CharCount';

--- a/frontend/src/components/goals/GoalFormModal.tsx
+++ b/frontend/src/components/goals/GoalFormModal.tsx
@@ -3,6 +3,8 @@ import { type GoalCategory } from '../../api/goals';
 import { Modal } from '../common';
 import { CATEGORIES } from './GoalCard';
 import { inputClass, buttonSecondaryClass, labelClass } from '../../constants/styles';
+import { MAX_LENGTH } from '../../utils/formValidation';
+import { CharCount } from '../common';
 
 interface GoalFormModalProps {
   isOpen: boolean;
@@ -46,7 +48,7 @@ export default function GoalFormModal({
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder={t('goals.titlePlaceholder')}
-            maxLength={200}
+            maxLength={MAX_LENGTH.goalTitle}
             className={inputClass}
             required
           />
@@ -61,10 +63,10 @@ export default function GoalFormModal({
             onChange={(e) => setDescription(e.target.value)}
             placeholder={t('goals.descriptionPlaceholder')}
             rows={3}
-            maxLength={2000}
+            maxLength={MAX_LENGTH.goalDescription}
             className={`${inputClass} resize-none`}
           />
-          <p className="text-xs text-gray-500 text-right mt-1">{description.length}/2000</p>
+          <CharCount value={description} max={MAX_LENGTH.goalDescription} />
         </div>
         <div>
           <label htmlFor="goal-category" className={labelClass}>

--- a/frontend/src/components/learning-logs/LogFormModal.tsx
+++ b/frontend/src/components/learning-logs/LogFormModal.tsx
@@ -5,6 +5,8 @@ import type { LearningLog } from '../../types/learningLog';
 import { CATEGORIES } from './LogCard';
 import { Modal } from '../common';
 import { inputClass, buttonSecondaryClass, labelClass } from '../../constants/styles';
+import { MAX_LENGTH } from '../../utils/formValidation';
+import { CharCount } from '../common';
 
 interface LogFormModalProps {
   isOpen: boolean;
@@ -51,7 +53,7 @@ export default function LogFormModal({
             value={title}
             onChange={handleTitleChange}
             placeholder={t('learningLogs.titlePlaceholder')}
-            maxLength={200}
+            maxLength={MAX_LENGTH.logTitle}
             className={inputClass}
             required
           />
@@ -66,11 +68,11 @@ export default function LogFormModal({
             onChange={handleContentChange}
             placeholder={t('learningLogs.contentPlaceholder')}
             rows={4}
-            maxLength={5000}
+            maxLength={MAX_LENGTH.logContent}
             className={`${inputClass} resize-none`}
             required
           />
-          <p className="text-xs text-gray-500 text-right mt-1">{content.length}/5000</p>
+          <CharCount value={content} max={MAX_LENGTH.logContent} />
         </div>
         <div className="grid grid-cols-2 gap-4">
           <div>

--- a/frontend/src/components/posts/PostForm.tsx
+++ b/frontend/src/components/posts/PostForm.tsx
@@ -5,6 +5,8 @@ import { Plus } from 'lucide-react';
 import { inputClass } from '../../constants/styles';
 import { useConfirm } from '../../hooks';
 import { parseJsonArray } from '../../utils/json';
+import { MAX_LENGTH } from '../../utils/formValidation';
+import { CharCount } from '../common';
 import ConfirmDialog from '../common/ConfirmDialog';
 import MarkdownEditor from './MarkdownEditor';
 import CodeSnippetInput, { type SnippetInputData } from './CodeSnippetInput';
@@ -87,10 +89,10 @@ export default function PostForm({ post, onSubmit, onCancel, loading: externalLo
         onChange={(e) => setTitle(e.target.value)}
         onFocus={() => setExpanded(true)}
         placeholder={t('post.createTitle')}
-        maxLength={300}
+        maxLength={MAX_LENGTH.postTitle}
         className={inputClass}
       />
-      <p className="text-xs text-gray-500 text-right mt-1">{title.length}/300</p>
+      <CharCount value={title} max={MAX_LENGTH.postTitle} />
       {expanded && (
         <>
           <div className="mt-3">

--- a/frontend/src/components/qa/QuestionForm.tsx
+++ b/frontend/src/components/qa/QuestionForm.tsx
@@ -2,6 +2,8 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Question, CreateQuestionRequest } from '../../types/qa';
 import { buttonSecondaryClass, inputClass, labelClass, textareaClass } from '../../constants/styles';
+import { MAX_LENGTH } from '../../utils/formValidation';
+import { CharCount } from '../common';
 
 interface QuestionFormProps {
   question?: Question;
@@ -47,11 +49,11 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           required
-          maxLength={500}
+          maxLength={MAX_LENGTH.questionTitle}
           className={inputClass}
           placeholder={t('qa.questionTitlePlaceholder')}
         />
-        <p className="text-xs text-gray-500 text-right mt-1">{title.length}/500</p>
+        <CharCount value={title} max={MAX_LENGTH.questionTitle} />
       </div>
 
       {/* Body */}
@@ -65,11 +67,11 @@ export default function QuestionForm({ question, onSubmit, onCancel, loading }: 
           onChange={(e) => setBody(e.target.value)}
           required
           rows={8}
-          maxLength={5000}
+          maxLength={MAX_LENGTH.questionBody}
           className={textareaClass}
           placeholder={t('qa.questionBodyPlaceholder')}
         />
-        <p className="text-xs text-gray-500 text-right mt-1">{body.length}/5000</p>
+        <CharCount value={body} max={MAX_LENGTH.questionBody} />
       </div>
 
       {/* Tags */}

--- a/frontend/src/utils/formValidation.ts
+++ b/frontend/src/utils/formValidation.ts
@@ -1,0 +1,48 @@
+// フォームバリデーション定数・ユーティリティ
+
+/** 各フォームのフィールドごとの最大文字数定義 */
+export const MAX_LENGTH = {
+  // 投稿
+  postTitle: 300,
+  postContent: 5000,
+  // ノート
+  noteTitle: 200,
+  noteContent: 10000,
+  noteTags: 500,
+  // 学習ログ
+  logTitle: 200,
+  logContent: 5000,
+  // 学習目標
+  goalTitle: 200,
+  goalDescription: 2000,
+  // Q&A
+  questionTitle: 500,
+  questionBody: 5000,
+  questionTags: 500,
+  answerBody: 5000,
+  // 書籍レビュー
+  bookTitle: 300,
+  bookAuthor: 200,
+  bookIsbn: 20,
+  bookReview: 2000,
+  // リソース
+  resourceTitle: 300,
+  resourceDescription: 1000,
+  // プロジェクト
+  projectTitle: 200,
+  projectDescription: 2000,
+  projectRole: 100,
+  // 共通
+  url: 2048,
+  message: 1000,
+} as const;
+
+/** 値がトリム後に空でないことを検証する */
+export function isRequired(value: string): boolean {
+  return value.trim().length > 0;
+}
+
+/** 複数フィールドがすべて必須入力済みかを検証する */
+export function areAllRequired(...values: string[]): boolean {
+  return values.every(isRequired);
+}


### PR DESCRIPTION
## 概要
- `MAX_LENGTH` 定数を `utils/formValidation.ts` に集約
- `CharCount` 共通コンポーネントで文字数カウンター表示を統一
- 4つのフォームコンポーネントに適用

## 変更内容
- **新規**: `utils/formValidation.ts` — MAX_LENGTH定数、isRequired/areAllRequiredヘルパー
- **新規**: `components/common/CharCount.tsx` — 文字数カウンター表示コンポーネント
- **適用**: PostForm, GoalFormModal, QuestionForm, LogFormModal

## テスト
- [x] `npx tsc --noEmit` — 型チェック通過

closes #1991