### PR TITLE
refactor: CRUDハンドラーヘルパー抽出（handleDelete/handleGetByID）

### DIFF
--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -61,18 +61,7 @@ func (h *BookReviewHandler) Create(c *gin.Context) {
 
 // GetByID は指定IDの書籍レビューを取得する。
 func (h *BookReviewHandler) GetByID(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	review, err := h.service.GetByID(id)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, review)
+	handleGetByIDPublic(c, h.service.GetByID)
 }
 
 // GetByUserID は指定ユーザーの書籍レビュー一覧をページネーション付きで取得する。
@@ -255,16 +244,5 @@ func (h *BookReviewHandler) Search(c *gin.Context) {
 
 // Delete は指定IDの書籍レビューを削除する。
 func (h *BookReviewHandler) Delete(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }

--- a/backend/internal/handler/chat_room.go
+++ b/backend/internal/handler/chat_room.go
@@ -75,18 +75,7 @@ func (h *ChatRoomHandler) GetMyRooms(c *gin.Context) {
 
 // GetByID は指定IDのチャットルーム詳細を取得する。
 func (h *ChatRoomHandler) GetByID(c *gin.Context) {
-	userID := c.GetUint("userID")
-	roomID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	room, err := h.service.GetByID(roomID, userID)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-	respondOK(c, room)
+	handleGetByID(c, h.service.GetByID)
 }
 
 // Update は指定IDのチャットルーム情報を更新する。
@@ -112,17 +101,7 @@ func (h *ChatRoomHandler) Update(c *gin.Context) {
 
 // Delete は指定IDのチャットルームを削除する。
 func (h *ChatRoomHandler) Delete(c *gin.Context) {
-	userID := c.GetUint("userID")
-	roomID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Delete(roomID, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // GetMembers は指定チャットルームのメンバー一覧を取得する。

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -109,17 +109,7 @@ func (h *CodeSnippetHandler) Update(c *gin.Context) {
 
 // Delete はスニペットを削除する。所有者のみ削除可能。
 func (h *CodeSnippetHandler) Delete(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // GetComments はスニペットのインラインコメント一覧を返す。

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -218,6 +218,55 @@ func respondPaginated(c *gin.Context, data interface{}, total int64, page, limit
 	c.JSON(http.StatusOK, response)
 }
 
+// handleDelete はリソース削除の共通パターンを実装する。
+// parseID → GetUint("userID") → deleteFn → respondDeleted
+func handleDelete(c *gin.Context, deleteFn func(id, userID uint) error) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	if err := deleteFn(id, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondDeleted(c)
+}
+
+// handleGetByID はID+userIDによるリソース取得の共通パターンを実装する。
+// parseID → GetUint("userID") → getter → respondOK
+func handleGetByID[T any](c *gin.Context, getter func(id, userID uint) (*T, error)) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	result, err := getter(id, userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, result)
+}
+
+// handleGetByIDPublic は公開リソース取得の共通パターンを実装する。
+// parseID → getter → respondOK（userIDチェックなし）
+func handleGetByIDPublic[T any](c *gin.Context, getter func(id uint) (*T, error)) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	result, err := getter(id)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, result)
+}
+
 // handleToggleAction はLike/Unlikeなどのトグル操作を共通化するヘルパー。
 // parseID → サービス呼び出し → レスポンス返却のパターンを統一する。
 func handleToggleAction(c *gin.Context, action func(userID, id uint) error, message string) {

--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -123,35 +123,12 @@ func (h *LearningGoalHandler) Update(c *gin.Context) {
 
 // Delete は指定された学習目標を削除する。
 func (h *LearningGoalHandler) Delete(c *gin.Context) {
-	userID := c.GetUint("userID")
-	goalID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Delete(goalID, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // GetByID は指定されたIDの学習目標を取得する。所有者のみ取得可能。
 func (h *LearningGoalHandler) GetByID(c *gin.Context) {
-	userID := c.GetUint("userID")
-	goalID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	goal, err := h.service.GetByID(goalID, userID)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, goal)
+	handleGetByID(c, h.service.GetByID)
 }
 
 // GetByUserID は指定されたユーザーの学習目標一覧を取得する。

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -107,35 +107,12 @@ func (h *LearningLogHandler) Update(c *gin.Context) {
 
 // Delete は指定された学習ログを削除する。
 func (h *LearningLogHandler) Delete(c *gin.Context) {
-	userID := c.GetUint("userID")
-	logID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Delete(logID, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // GetByID は指定されたIDの学習ログを取得する。
 func (h *LearningLogHandler) GetByID(c *gin.Context) {
-	userID := c.GetUint("userID")
-	logID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	log, err := h.service.GetByID(logID, userID)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, log)
+	handleGetByID(c, h.service.GetByID)
 }
 
 // GetMyLogs は認証ユーザー自身の学習ログ一覧を取得する。

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -217,18 +217,7 @@ func (h *LearningResourceHandler) Update(c *gin.Context) {
 
 // Delete は指定された学習リソースを削除する。
 func (h *LearningResourceHandler) Delete(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // Like は学習リソースにいいねする。

--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -65,19 +65,7 @@ func (h *NoteHandler) Create(c *gin.Context) {
 
 // GetByID は指定IDのノートを所有権検証付きで取得する。
 func (h *NoteHandler) GetByID(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	note, err := h.service.GetByID(id, userID)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, note)
+	handleGetByID(c, h.service.GetByID)
 }
 
 // GetByUserID は現在のユーザーのノート一覧をページネーション付きで取得する。
@@ -140,18 +128,7 @@ func (h *NoteHandler) Update(c *gin.Context) {
 
 // Delete はノートを削除する。
 func (h *NoteHandler) Delete(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // Search はキーワードでノートを検索する（ページネーション付き）。

--- a/backend/internal/handler/note_folder.go
+++ b/backend/internal/handler/note_folder.go
@@ -53,18 +53,7 @@ func (h *NoteFolderHandler) Create(c *gin.Context) {
 
 // GetByID は指定IDのフォルダを取得する。
 func (h *NoteFolderHandler) GetByID(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	folder, err := h.service.GetByID(id)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, folder)
+	handleGetByIDPublic(c, h.service.GetByID)
 }
 
 // GetByUserID は現在のユーザーのフォルダ一覧をページネーション付きで取得する。
@@ -139,16 +128,5 @@ func (h *NoteFolderHandler) Update(c *gin.Context) {
 
 // Delete はフォルダを削除する。
 func (h *NoteFolderHandler) Delete(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -187,17 +187,7 @@ func (h *PostHandler) Update(c *gin.Context) {
 
 // Delete は投稿を削除する。所有者のみ削除可能。
 func (h *PostHandler) Delete(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // Timeline はフォロー中ユーザーの投稿タイムラインを返す。

--- a/backend/internal/handler/post_series.go
+++ b/backend/internal/handler/post_series.go
@@ -54,18 +54,7 @@ func (h *PostSeriesHandler) Create(c *gin.Context) {
 
 // GetByID は指定IDのシリーズを取得する。
 func (h *PostSeriesHandler) GetByID(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	series, err := h.service.GetByID(id)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, series)
+	handleGetByIDPublic(c, h.service.GetByID)
 }
 
 // GetByUserID は指定ユーザーのシリーズ一覧をページネーション付きで取得する。
@@ -121,18 +110,7 @@ func (h *PostSeriesHandler) Update(c *gin.Context) {
 
 // Delete は指定IDのシリーズを削除する。
 func (h *PostSeriesHandler) Delete(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // GetPosts はシリーズ内の投稿一覧を取得する。

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -81,19 +81,7 @@ func (h *ProjectHandler) Create(c *gin.Context) {
 
 // GetByID は指定IDのプロジェクトを取得する。
 func (h *ProjectHandler) GetByID(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	project, err := h.service.GetByID(id, userID)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, project)
+	handleGetByID(c, h.service.GetByID)
 }
 
 // GetByUserID は指定ユーザーのプロジェクト一覧をページネーション付きで取得する。
@@ -206,18 +194,7 @@ func (h *ProjectHandler) Update(c *gin.Context) {
 
 // Delete は指定IDのプロジェクトを削除する。
 func (h *ProjectHandler) Delete(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // GetAll はプロジェクトの一覧をページネーション付きで取得する。

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -171,18 +171,7 @@ func (h *QuestionHandler) Update(c *gin.Context) {
 
 // Delete は指定された質問を削除する。
 func (h *QuestionHandler) Delete(c *gin.Context) {
-	userID := c.GetUint("userID")
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // Vote は質問に投票する。

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -122,20 +122,7 @@ func (h *RoadmapHandler) GetPublicRoadmaps(c *gin.Context) {
 
 // GetByID は指定IDのロードマップをステップ付きで取得する。
 func (h *RoadmapHandler) GetByID(c *gin.Context) {
-	roadmapID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	userID := c.GetUint("userID")
-
-	roadmap, err := h.service.GetByID(roadmapID, userID)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondOK(c, roadmap)
+	handleGetByID(c, h.service.GetByID)
 }
 
 // Update は指定IDのロードマップを更新する。
@@ -185,18 +172,7 @@ func (h *RoadmapHandler) Update(c *gin.Context) {
 
 // Delete は指定IDのロードマップを削除する。
 func (h *RoadmapHandler) Delete(c *gin.Context) {
-	userID := c.GetUint("userID")
-	roadmapID, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-
-	if err := h.service.Delete(roadmapID, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // CopyRoadmap は公開ロードマップをテンプレートとしてコピーする。

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -81,17 +81,7 @@ func (h *StudyCircleHandler) GetMyCircles(c *gin.Context) {
 
 // GetByID はサークル詳細を返す。
 func (h *StudyCircleHandler) GetByID(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-	circle, err := h.service.GetByID(id, userID)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-	respondOK(c, circle)
+	handleGetByID(c, h.service.GetByID)
 }
 
 // Update はサークル情報を更新する。
@@ -115,16 +105,7 @@ func (h *StudyCircleHandler) Update(c *gin.Context) {
 
 // Delete はサークルを削除する。
 func (h *StudyCircleHandler) Delete(c *gin.Context) {
-	id, ok := parseID(c, "id")
-	if !ok {
-		return
-	}
-	userID := c.GetUint("userID")
-	if err := h.service.Delete(id, userID); err != nil {
-		respondError(c, err)
-		return
-	}
-	respondDeleted(c)
+	handleDelete(c, h.service.Delete)
 }
 
 // GetMembers はメンバー一覧を返す。


### PR DESCRIPTION
## 概要
- 14箇所のDeleteパターン、7箇所のGetByID（userID付）パターン、3箇所のGetByID（公開）パターンを3つの汎用ヘルパー関数に統一
- Go Genericsを活用した型安全なリファクタリング

## 追加ヘルパー
- `handleDelete`: `parseID → GetUint("userID") → deleteFn → respondDeleted`
- `handleGetByID[T]`: `parseID → GetUint("userID") → getter → respondOK`
- `handleGetByIDPublic[T]`: `parseID → getter → respondOK`

## 対象ファイル（15ファイル）
book_review, chat_room, code_snippet, learning_goal, learning_log, learning_resource, note, note_folder, post, post_series, project, question, roadmap, study_circle + helpers.go

## 変更量
+73/-288行（215行削減）

## テスト
- `go test ./internal/handler/...` 全テストパス
- `go test ./internal/service/...` 全テストパス

closes #1992