### PR TITLE
fix: ノートフォルダのIDOR脆弱性修正（所有権チェック追加）

### DIFF
--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -13,7 +13,7 @@ type NoteServiceInterface interface {
 	Create(note *model.Note) error
 	GetByID(id, userID uint) (*model.Note, error)
 	GetByUserID(userID uint, page, limit int) ([]model.Note, error)
-	GetByFolderID(folderID uint) ([]model.Note, error)
+	GetByFolderID(folderID, userID uint) ([]model.Note, error)
 	Update(id, userID uint, title, content, tags string, folderID *uint) (*model.Note, error)
 	Delete(id, userID uint) error
 	Search(userID uint, query string, page, limit int) ([]model.Note, int64, error)
@@ -88,14 +88,15 @@ func (h *NoteHandler) GetByUserID(c *gin.Context) {
 	respondPaginated(c, notes, total, page, limit)
 }
 
-// GetByFolderID は指定フォルダ内のノート一覧を取得する。
+// GetByFolderID は指定フォルダ内のノート一覧を所有権検証付きで取得する。
 func (h *NoteHandler) GetByFolderID(c *gin.Context) {
 	folderID, ok := parseID(c, "folderId")
 	if !ok {
 		return
 	}
+	userID := c.GetUint("userID")
 
-	notes, err := h.service.GetByFolderID(folderID)
+	notes, err := h.service.GetByFolderID(folderID, userID)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -31,8 +31,8 @@ func (m *MockNoteService) GetByUserID(userID uint, page, limit int) ([]model.Not
 	return args.Get(0).([]model.Note), args.Error(1)
 }
 
-func (m *MockNoteService) GetByFolderID(folderID uint) ([]model.Note, error) {
-	args := m.Called(folderID)
+func (m *MockNoteService) GetByFolderID(folderID, userID uint) ([]model.Note, error) {
+	args := m.Called(folderID, userID)
 	return args.Get(0).([]model.Note), args.Error(1)
 }
 
@@ -263,7 +263,7 @@ func TestNoteHandler_GetByFolderID(t *testing.T) {
 			{ID: 2, UserID: 1, Title: "フォルダ内ノート2"},
 		}
 
-		svc.On("GetByFolderID", uint(5)).Return(notes, nil)
+		svc.On("GetByFolderID", uint(5), uint(1)).Return(notes, nil)
 
 		w := doRequest(r, "GET", "/folders/5/notes", nil)
 		assertStatus(t, w, http.StatusOK)
@@ -284,7 +284,7 @@ func TestNoteHandler_GetByFolderID(t *testing.T) {
 		r := newRouter(1)
 		r.GET("/folders/:folderId/notes", h.GetByFolderID)
 
-		svc.On("GetByFolderID", uint(5)).Return([]model.Note{}, errors.New("error"))
+		svc.On("GetByFolderID", uint(5), uint(1)).Return([]model.Note{}, errors.New("error"))
 
 		w := doRequest(r, "GET", "/folders/5/notes", nil)
 		assertStatus(t, w, http.StatusInternalServerError)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -448,7 +448,7 @@ type NoteRepositoryInterface interface {
 	Create(note *model.Note) error
 	FindByID(id uint) (*model.Note, error)
 	FindByUserID(userID uint, page, limit int) ([]model.Note, error)
-	FindByFolderID(folderID uint) ([]model.Note, error)
+	FindByFolderID(folderID, userID uint) ([]model.Note, error)
 	Update(note *model.Note) error
 	Delete(id uint) error
 	Search(userID uint, query string, limit, offset int) ([]model.Note, int64, error)

--- a/backend/internal/repository/note.go
+++ b/backend/internal/repository/note.go
@@ -40,10 +40,10 @@ func (r *NoteRepository) FindByUserID(userID uint, page, limit int) ([]model.Not
 	return notes, err
 }
 
-// FindByFolderID は指定フォルダ内のノート一覧を取得する。
-func (r *NoteRepository) FindByFolderID(folderID uint) ([]model.Note, error) {
+// FindByFolderID は指定フォルダ内のノート一覧を所有権付きで取得する。
+func (r *NoteRepository) FindByFolderID(folderID, userID uint) ([]model.Note, error) {
 	var notes []model.Note
-	err := r.db.Where("folder_id = ?", folderID).
+	err := r.db.Where("folder_id = ? AND user_id = ?", folderID, userID).
 		Order("updated_at DESC").
 		Find(&notes).Error
 	return notes, err

--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -40,9 +40,9 @@ func (s *NoteService) GetByUserID(userID uint, page, limit int) ([]model.Note, e
 	return s.repo.FindByUserID(userID, page, limit)
 }
 
-// GetByFolderID は指定フォルダ内のノート一覧を取得する。
-func (s *NoteService) GetByFolderID(folderID uint) ([]model.Note, error) {
-	return s.repo.FindByFolderID(folderID)
+// GetByFolderID は指定フォルダ内のノート一覧を所有権検証付きで取得する。
+func (s *NoteService) GetByFolderID(folderID, userID uint) ([]model.Note, error) {
+	return s.repo.FindByFolderID(folderID, userID)
 }
 
 // findAndCheckOwnership は指定IDのノートを取得し、所有権を検証する共通ヘルパー。

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -32,8 +32,8 @@ func (m *MockNoteRepository) FindByUserID(userID uint, page, limit int) ([]model
 	return args.Get(0).([]model.Note), args.Error(1)
 }
 
-func (m *MockNoteRepository) FindByFolderID(folderID uint) ([]model.Note, error) {
-	args := m.Called(folderID)
+func (m *MockNoteRepository) FindByFolderID(folderID, userID uint) ([]model.Note, error) {
+	args := m.Called(folderID, userID)
 	return args.Get(0).([]model.Note), args.Error(1)
 }
 
@@ -333,9 +333,9 @@ func TestNoteService_GetByFolderID(t *testing.T) {
 		{ID: 2, UserID: 1, Title: "フォルダ内ノート2"},
 	}
 
-	repo.On("FindByFolderID", uint(5)).Return(notes, nil)
+	repo.On("FindByFolderID", uint(5), uint(1)).Return(notes, nil)
 
-	result, err := svc.GetByFolderID(5)
+	result, err := svc.GetByFolderID(5, 1)
 	assert.NoError(t, err)
 	assert.Len(t, result, 2)
 	repo.AssertExpectations(t)


### PR DESCRIPTION
## 概要
`GetByFolderID` に所有権チェックがなく、任意のフォルダIDで他ユーザーのノートを閲覧できるIDOR脆弱性を修正。

## 修正内容
- `FindByFolderID` にuserIDパラメータを追加
- リポジトリクエリに `user_id = ?` 条件を追加
- Handler層でuserIDを取得してServiceに渡すように変更
- 既存テストを更新

## 影響範囲
- `repository/interfaces.go` — インターフェース更新
- `repository/note.go` — クエリにuserIDフィルタ追加
- `service/note.go` — シグネチャ更新
- `handler/note.go` — userIDを渡すように修正

Closes #2009