### PR TITLE
fix: 認証済みAPI全体へのレート制限追加とメモリリーク対策

### DIFF
--- a/backend/internal/middleware/rate_limit.go
+++ b/backend/internal/middleware/rate_limit.go
@@ -68,6 +68,15 @@ func (s *RateLimitStore) Cleanup(windowSeconds int) {
 	}
 }
 
+// StartCleanup は定期的に古いエントリを削除するgoroutineを起動する。
+func StartCleanup(store *RateLimitStore, windowSeconds int) {
+	ticker := time.NewTicker(10 * time.Minute)
+	defer ticker.Stop()
+	for range ticker.C {
+		store.Cleanup(windowSeconds)
+	}
+}
+
 // RateLimit はIPごとのレート制限ミドルウェアを返す。
 func RateLimit(store *RateLimitStore, maxRequests int, windowSeconds int) gin.HandlerFunc {
 	return func(c *gin.Context) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -63,10 +63,15 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 
 	api := r.Group("/api/v1")
 
-	// レート制限（認証エンドポイント: 10リクエスト/60秒）
+	// レート制限ストア
 	authRateLimitStore := middleware.NewRateLimitStore()
+	apiRateLimitStore := middleware.NewRateLimitStore()
 
-	// 認証ルート（公開）
+	// 定期クリーンアップ（メモリリーク対策）
+	go middleware.StartCleanup(authRateLimitStore, 60)
+	go middleware.StartCleanup(apiRateLimitStore, 60)
+
+	// 認証ルート（公開: 10リクエスト/60秒）
 	auth := api.Group("/auth")
 	auth.Use(middleware.RateLimit(authRateLimitStore, 10, 60))
 	{
@@ -80,9 +85,10 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 	api.GET("/github/callback", c.GitHubHandler.Callback)
 	api.GET("/spotify/callback", c.SpotifyHandler.Callback)
 
-	// 認証必須ルート
+	// 認証必須ルート（100リクエスト/60秒）
 	protected := api.Group("")
 	protected.Use(middleware.AuthRequired(c.AuthService))
+	protected.Use(middleware.RateLimit(apiRateLimitStore, 100, 60))
 	{
 		protected.GET("/auth/me", c.AuthHandler.Me)
 		protected.POST("/auth/logout", c.AuthHandler.Logout)


### PR DESCRIPTION
## 概要
- 認証済みエンドポイント全体に100リクエスト/分のレート制限を追加
- RateLimitStoreの定期クリーンアップを追加しメモリリーク防止

## 修正内容
- `middleware/rate_limit.go`: `StartCleanup` 関数追加（10分ごとにクリーンアップ実行）
- `router/router.go`: 認証済みAPI用レート制限ストア追加、`protected`グループにレート制限適用

## レート制限の適用
| エンドポイント | 制限 |
|---------------|------|
| `/api/v1/auth/*` | 10リクエスト/60秒 |
| 認証済みAPI全体 | 100リクエスト/60秒 |

Closes #2010
Closes #2011