### PR TITLE
fix: 内部エラーのログ記録追加

### DIFF
--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -161,7 +162,8 @@ func respondError(c *gin.Context, err error) {
 		return
 	}
 
-	// DomainError でない場合は内部エラーとして扱う（内部エラーの詳細は隠蔽）
+	// DomainError でない場合は内部エラーとして扱う（詳細はログに記録し、クライアントには隠蔽）
+	log.Printf("[ERROR] %s %s: %v", c.Request.Method, c.Request.URL.Path, err)
 	response := domain.NewErrorResponse("内部エラーが発生しました", string(domain.ErrCodeInternal), nil)
 	c.JSON(http.StatusInternalServerError, response)
 }


### PR DESCRIPTION
## 概要
respondErrorでDomainError以外の内部エラー発生時にログ記録を追加。

## 修正内容
- `handler/helpers.go`: `log.Printf` で HTTPメソッド・パス・エラー詳細を記録
- クライアントへのレスポンスは従来通り内部詳細を隠蔽（変更なし）

## ログ出力例
```
[ERROR] GET /api/v1/posts/1: db connection failed
```

Closes #2012