### PR TITLE
fix: ユーザープロフィール更新の認可ロジックをService層に移動

### DIFF
--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -13,6 +13,7 @@ type UserServiceInterface interface {
 	GetByID(id uint) (*model.User, error)
 	GetByUsername(username string) (*model.User, error)
 	Update(user *model.User) error
+	UpdateByOwner(id, userID uint, user *model.User) error
 	GetProfileCompleteness(userID uint) (*service.ProfileCompleteness, error)
 }
 
@@ -73,18 +74,13 @@ func (h *UserHandler) GetByUsername(c *gin.Context) {
 }
 
 // Update はユーザープロフィールを更新する。
-// 本人のみ更新可能（userIDとパスパラメータのIDが一致する必要がある）。
+// 所有権チェックはService層で実施する。
 func (h *UserHandler) Update(c *gin.Context) {
 	id, ok := parseID(c, "id")
 	if !ok {
 		return
 	}
-
 	userID := c.GetUint("userID")
-	if userID != id {
-		respondForbidden(c, "cannot update other user's profile")
-		return
-	}
 
 	existing, err := h.service.GetByID(id)
 	if err != nil {
@@ -118,7 +114,7 @@ func (h *UserHandler) Update(c *gin.Context) {
 		existing.OnboardingCompleted = *input.OnboardingCompleted
 	}
 
-	if err := h.service.Update(existing); err != nil {
+	if err := h.service.UpdateByOwner(id, userID, existing); err != nil {
 		respondError(c, err)
 		return
 	}

--- a/backend/internal/handler/user_test.go
+++ b/backend/internal/handler/user_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
 	"github.com/stretchr/testify/mock"
@@ -39,6 +40,10 @@ func (m *MockUserService) GetByUsername(username string) (*model.User, error) {
 
 func (m *MockUserService) Update(user *model.User) error {
 	return m.Called(user).Error(0)
+}
+
+func (m *MockUserService) UpdateByOwner(id, userID uint, user *model.User) error {
+	return m.Called(id, userID, user).Error(0)
 }
 
 func (m *MockUserService) GetProfileCompleteness(userID uint) (*service.ProfileCompleteness, error) {
@@ -223,7 +228,7 @@ func TestUserHandler_Update(t *testing.T) {
 
 		existing := &model.User{ID: 1, Name: "旧名前", Email: "test@test.com"}
 		svc.On("GetByID", uint(1)).Return(existing, nil)
-		svc.On("Update", mock.AnythingOfType("*model.User")).Return(nil)
+		svc.On("UpdateByOwner", uint(1), uint(1), mock.AnythingOfType("*model.User")).Return(nil)
 
 		w := doRequest(r, "PUT", "/users/1", map[string]interface{}{
 			"name": "新名前",
@@ -234,12 +239,17 @@ func TestUserHandler_Update(t *testing.T) {
 	})
 
 	t.Run("他人のプロフィールは更新できない", func(t *testing.T) {
-		h, _ := newTestUserHandler()
+		h, svc := newTestUserHandler()
 		r := newRouter(2)
 		r.PUT("/users/:id", h.Update)
 
+		existing := &model.User{ID: 1, Name: "旧名前"}
+		svc.On("GetByID", uint(1)).Return(existing, nil)
+		svc.On("UpdateByOwner", uint(1), uint(2), mock.AnythingOfType("*model.User")).Return(domain.ErrForbidden)
+
 		w := doRequest(r, "PUT", "/users/1", map[string]interface{}{"name": "不正更新"})
 		assertStatus(t, w, http.StatusForbidden)
+		svc.AssertExpectations(t)
 	})
 
 	t.Run("存在しないユーザーの更新で404", func(t *testing.T) {
@@ -282,7 +292,7 @@ func TestUserHandler_Update(t *testing.T) {
 
 		existing := &model.User{ID: 1, Name: "旧名前"}
 		svc.On("GetByID", uint(1)).Return(existing, nil)
-		svc.On("Update", mock.AnythingOfType("*model.User")).Return(errors.New("db error"))
+		svc.On("UpdateByOwner", uint(1), uint(1), mock.AnythingOfType("*model.User")).Return(errors.New("db error"))
 
 		w := doRequest(r, "PUT", "/users/1", map[string]interface{}{"name": "新名前"})
 		assertStatus(t, w, http.StatusInternalServerError)

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -39,6 +39,14 @@ func (s *UserService) FindByID(id uint) (*model.User, error) {
 	return s.repo.FindByID(id)
 }
 
+// UpdateByOwner は所有権を検証した後、ユーザー情報を更新する。
+func (s *UserService) UpdateByOwner(id, userID uint, user *model.User) error {
+	if id != userID {
+		return domain.ErrForbidden
+	}
+	return s.Update(user)
+}
+
 // Update はユーザー情報を更新する。
 func (s *UserService) Update(user *model.User) error {
 	if err := domain.ValidateStringLength(user.Name, 1, 100, "名前"); err != nil {

--- a/backend/internal/service/user_test.go
+++ b/backend/internal/service/user_test.go
@@ -290,6 +290,31 @@ func TestGetProfileCompleteness_OnlyFrameworks(t *testing.T) {
 }
 
 // ============================================================
+// UpdateByOwner テスト
+// ============================================================
+
+func TestUserUpdateByOwner_Success(t *testing.T) {
+	svc, repo := newTestUserService()
+
+	user := &model.User{Name: "Alice"}
+	repo.On("Update", user).Return(nil)
+
+	err := svc.UpdateByOwner(1, 1, user)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestUserUpdateByOwner_Forbidden(t *testing.T) {
+	svc, _ := newTestUserService()
+
+	user := &model.User{Name: "Alice"}
+
+	err := svc.UpdateByOwner(1, 2, user)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "権限がありません")
+}
+
+// ============================================================
 // Update — バリデーションテスト
 // ============================================================
 


### PR DESCRIPTION
## 概要
- Handler層にあった所有権チェック（`userID != id`）をService層の`UpdateByOwner`メソッドに移動
- クリーンアーキテクチャの責務分離を改善（認可ロジックはService層で実施）

## 変更内容
- `service/user.go`: `UpdateByOwner(id, userID, user)` メソッド追加（所有権検証 → `Update`呼び出し）
- `handler/user.go`: インターフェースに`UpdateByOwner`追加、Handler側の認可チェック削除
- `handler/user_test.go`: `MockUserService`に`UpdateByOwner`追加、テスト期待値を更新
- `service/user_test.go`: `UpdateByOwner`のSuccess/Forbiddenテスト追加

## テスト
- `go test ./internal/handler/... -v` — 全PASS
- `go test ./internal/service/... -v` — 全PASS

Closes #2013