### PR TITLE
feat: 学習ログのバッチ入力機能を追加

### DIFF
--- a/backend/internal/dto/learning_log_dto.go
+++ b/backend/internal/dto/learning_log_dto.go
@@ -19,6 +19,11 @@ type LearningLogListResponse struct {
 	Offset int                 `json:"offset"`
 }
 
+// BatchCreateLearningLogRequest は学習ログ一括作成リクエスト。
+type BatchCreateLearningLogRequest struct {
+	Logs []CreateLearningLogRequest `json:"logs" binding:"required,min=1,max=50,dive"`
+}
+
 // UpdateLearningLogRequest は学習ログ更新リクエスト。
 type UpdateLearningLogRequest struct {
 	Title    *string `json:"title" binding:"omitempty,max=200"`

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -12,6 +12,7 @@ import (
 // LearningLogServiceInterface はLearningLogHandlerが依存するサービスのインターフェース。
 type LearningLogServiceInterface interface {
 	Create(log *model.LearningLog) error
+	BatchCreate(userID uint, logs []model.LearningLog) ([]model.LearningLog, error)
 	GetByID(id, userID uint) (*model.LearningLog, error)
 	GetByUserID(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	Update(id, userID uint, updates *model.LearningLog) (*model.LearningLog, error)
@@ -67,6 +68,38 @@ func (h *LearningLogHandler) Create(c *gin.Context) {
 	}
 
 	respondCreated(c, log)
+}
+
+// BatchCreate は複数の学習ログを一括作成する。
+func (h *LearningLogHandler) BatchCreate(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	input := bindJSON[dto.BatchCreateLearningLogRequest](c)
+	if input == nil {
+		return
+	}
+
+	logs := make([]model.LearningLog, len(input.Logs))
+	for i, l := range input.Logs {
+		logs[i] = model.LearningLog{
+			Title:    l.Title,
+			Content:  l.Content,
+			Category: model.LogCategory(l.Category),
+			Duration: l.Duration,
+			Source:   model.LogSource(l.Source),
+		}
+		if l.Category == "" {
+			logs[i].Category = model.LogCategoryOther
+		}
+	}
+
+	results, err := h.service.BatchCreate(userID, logs)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, results)
 }
 
 // Update は指定された学習ログを更新する。

--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -498,3 +498,77 @@ func TestLearningLog_Unfavorite_InvalidID(t *testing.T) {
 	w := doRequest(r, http.MethodPut, "/logs/abc/unfavorite", nil)
 	assertStatus(t, w, http.StatusBadRequest)
 }
+
+// ============================================================
+// BatchCreate テスト
+// ============================================================
+
+func TestLearningLog_BatchCreate_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.POST("/logs/batch", h.BatchCreate)
+
+	resultLogs := []model.LearningLog{
+		{Title: "Go基礎", Content: "変数を学んだ", UserID: 1, Duration: 60},
+		{Title: "React入門", Content: "コンポーネント作成", UserID: 1, Duration: 45},
+	}
+	svc.On("BatchCreate", uint(1), mock.AnythingOfType("[]model.LearningLog")).Return(resultLogs, nil)
+
+	w := doRequest(r, http.MethodPost, "/logs/batch", map[string]interface{}{
+		"logs": []map[string]interface{}{
+			{"title": "Go基礎", "content": "変数を学んだ", "duration": 60},
+			{"title": "React入門", "content": "コンポーネント作成", "duration": 45},
+		},
+	})
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_BatchCreate_EmptyLogs(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+	r := newRouter(1)
+	r.POST("/logs/batch", h.BatchCreate)
+
+	w := doRequest(r, http.MethodPost, "/logs/batch", map[string]interface{}{
+		"logs": []map[string]interface{}{},
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestLearningLog_BatchCreate_InvalidJSON(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+	r := newRouter(1)
+	r.POST("/logs/batch", h.BatchCreate)
+
+	w := doRequestRaw(r, http.MethodPost, "/logs/batch", "not json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestLearningLog_BatchCreate_ServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.POST("/logs/batch", h.BatchCreate)
+
+	svc.On("BatchCreate", uint(1), mock.AnythingOfType("[]model.LearningLog")).Return(nil, errors.New("validation error"))
+
+	w := doRequest(r, http.MethodPost, "/logs/batch", map[string]interface{}{
+		"logs": []map[string]interface{}{
+			{"title": "テスト", "content": "内容", "duration": 30},
+		},
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_BatchCreate_MissingTitle(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+	r := newRouter(1)
+	r.POST("/logs/batch", h.BatchCreate)
+
+	w := doRequest(r, http.MethodPost, "/logs/batch", map[string]interface{}{
+		"logs": []map[string]interface{}{
+			{"content": "内容のみ"},
+		},
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1277,6 +1277,13 @@ type MockLearningLogService struct{ mock.Mock }
 func (m *MockLearningLogService) Create(log *model.LearningLog) error {
 	return m.Called(log).Error(0)
 }
+func (m *MockLearningLogService) BatchCreate(userID uint, logs []model.LearningLog) ([]model.LearningLog, error) {
+	args := m.Called(userID, logs)
+	if l := args.Get(0); l != nil {
+		return l.([]model.LearningLog), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
 func (m *MockLearningLogService) GetByID(id, userID uint) (*model.LearningLog, error) {
 	args := m.Called(id, userID)
 	if l := args.Get(0); l != nil {

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -150,6 +150,7 @@ type AnswerRepositoryInterface interface {
 // ストリーク計算やカレンダーデータ取得も含む。
 type LearningLogRepositoryInterface interface {
 	Create(log *model.LearningLog) error
+	CreateBatch(logs []model.LearningLog) error
 	Update(log *model.LearningLog) error
 	Delete(id, userID uint) error
 	FindByID(id uint) (*model.LearningLog, error)

--- a/backend/internal/repository/learning_log.go
+++ b/backend/internal/repository/learning_log.go
@@ -23,6 +23,11 @@ func (r *LearningLogRepository) Create(log *model.LearningLog) error {
 	return r.db.Create(log).Error
 }
 
+// CreateBatch は複数の学習ログをトランザクション内で一括作成する。
+func (r *LearningLogRepository) CreateBatch(logs []model.LearningLog) error {
+	return r.db.Create(&logs).Error
+}
+
 // Update は既存の学習ログを更新する。
 func (r *LearningLogRepository) Update(log *model.LearningLog) error {
 	return r.db.Save(log).Error

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -412,6 +412,7 @@ func registerLearningLogRoutes(g *gin.RouterGroup, c *di.Container) {
 	learningLogs := g.Group("/learning-logs")
 	{
 		learningLogs.POST("", c.LearningLogHandler.Create)
+		learningLogs.POST("/batch", c.LearningLogHandler.BatchCreate)
 		learningLogs.GET("", c.LearningLogHandler.GetMyLogs)
 		learningLogs.GET("/export", c.LearningLogHandler.ExportLogs)
 		learningLogs.GET("/recent-categories", c.LearningLogHandler.GetRecentCategories)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -40,6 +40,38 @@ func (s *LearningLogService) Create(log *model.LearningLog) error {
 	return s.repo.Create(log)
 }
 
+// BatchCreate は複数の学習ログを一括作成する。
+// 各ログのバリデーションを行い、全てパスした場合のみ一括保存する。
+// 最大50件まで。
+func (s *LearningLogService) BatchCreate(userID uint, logs []model.LearningLog) ([]model.LearningLog, error) {
+	if len(logs) == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "学習ログは1件以上指定してください", nil)
+	}
+	if len(logs) > 50 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "学習ログは50件以下で指定してください", nil)
+	}
+
+	for i := range logs {
+		logs[i].UserID = userID
+
+		if err := validateDuration(logs[i].Duration); err != nil {
+			return nil, err
+		}
+		if logs[i].Category != "" && !model.ValidCategories[logs[i].Category] {
+			return nil, ErrBadRequest
+		}
+		if logs[i].Source != "" && !model.ValidSources[logs[i].Source] {
+			return nil, ErrBadRequest
+		}
+	}
+
+	if err := s.repo.CreateBatch(logs); err != nil {
+		return nil, err
+	}
+
+	return logs, nil
+}
+
 // GetByID は指定IDの学習ログを取得する。所有権を検証する。
 func (s *LearningLogService) GetByID(id, userID uint) (*model.LearningLog, error) {
 	return s.findAndCheckOwnership(id, userID)

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -744,6 +744,127 @@ func TestLearningLogExportCSV_BOMPresent(t *testing.T) {
 	assert.Equal(t, byte(0xBF), data[2])
 }
 
+// ============================================================
+// バッチ作成テスト
+// ============================================================
+
+func TestLearningLogBatchCreate_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	logs := []model.LearningLog{
+		{Title: "Go基礎", Content: "変数を学んだ", UserID: 1, Duration: 60, Category: model.LogCategoryCoding},
+		{Title: "React入門", Content: "コンポーネント作成", UserID: 1, Duration: 45, Category: model.LogCategoryCourse},
+	}
+
+	repo.On("CreateBatch", mock.MatchedBy(func(l []model.LearningLog) bool {
+		return len(l) == 2 && l[0].Title == "Go基礎" && l[1].Title == "React入門"
+	})).Return(nil)
+
+	results, err := svc.BatchCreate(1, logs)
+	assert.NoError(t, err)
+	assert.Len(t, results, 2)
+	assert.Equal(t, uint(1), results[0].UserID)
+	assert.Equal(t, uint(1), results[1].UserID)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogBatchCreate_EmptyList(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	results, err := svc.BatchCreate(1, []model.LearningLog{})
+	assert.Error(t, err)
+	assert.Nil(t, results)
+	assert.Contains(t, err.Error(), "1件以上")
+}
+
+func TestLearningLogBatchCreate_ExceedsMaxCount(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	logs := make([]model.LearningLog, 51)
+	for i := range logs {
+		logs[i] = model.LearningLog{Title: "テスト", Content: "内容", Duration: 10}
+	}
+
+	results, err := svc.BatchCreate(1, logs)
+	assert.Error(t, err)
+	assert.Nil(t, results)
+	assert.Contains(t, err.Error(), "50件以下")
+}
+
+func TestLearningLogBatchCreate_InvalidDuration(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	logs := []model.LearningLog{
+		{Title: "正常", Content: "OK", Duration: 60},
+		{Title: "異常", Content: "NG", Duration: -10},
+	}
+
+	results, err := svc.BatchCreate(1, logs)
+	assert.Error(t, err)
+	assert.Nil(t, results)
+}
+
+func TestLearningLogBatchCreate_InvalidCategory(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	logs := []model.LearningLog{
+		{Title: "正常", Content: "OK", Category: model.LogCategoryCoding},
+		{Title: "異常", Content: "NG", Category: model.LogCategory("invalid")},
+	}
+
+	results, err := svc.BatchCreate(1, logs)
+	assert.Error(t, err)
+	assert.Nil(t, results)
+}
+
+func TestLearningLogBatchCreate_InvalidSource(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	logs := []model.LearningLog{
+		{Title: "正常", Content: "OK", Source: model.LogSourceManual},
+		{Title: "異常", Content: "NG", Source: model.LogSource("unknown")},
+	}
+
+	results, err := svc.BatchCreate(1, logs)
+	assert.Error(t, err)
+	assert.Nil(t, results)
+}
+
+func TestLearningLogBatchCreate_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	logs := []model.LearningLog{
+		{Title: "テスト", Content: "内容", Duration: 30},
+	}
+
+	repo.On("CreateBatch", mock.AnythingOfType("[]model.LearningLog")).Return(errors.New("db error"))
+
+	results, err := svc.BatchCreate(1, logs)
+	assert.Error(t, err)
+	assert.Nil(t, results)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogBatchCreate_SetsUserID(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	// UserIDが異なる値でも、全て引数のuserIDに上書きされるべき
+	logs := []model.LearningLog{
+		{Title: "テスト1", Content: "内容1", UserID: 999, Duration: 30},
+		{Title: "テスト2", Content: "内容2", UserID: 0, Duration: 45},
+	}
+
+	repo.On("CreateBatch", mock.MatchedBy(func(l []model.LearningLog) bool {
+		return l[0].UserID == 1 && l[1].UserID == 1
+	})).Return(nil)
+
+	results, err := svc.BatchCreate(1, logs)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(1), results[0].UserID)
+	assert.Equal(t, uint(1), results[1].UserID)
+	repo.AssertExpectations(t)
+}
+
 func TestLearningLogExportCSV_MultipleRows(t *testing.T) {
 	svc, repo := newTestLearningLogService()
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -484,6 +484,11 @@ func (m *MockLearningLogRepository) Create(log *model.LearningLog) error {
 	return args.Error(0)
 }
 
+func (m *MockLearningLogRepository) CreateBatch(logs []model.LearningLog) error {
+	args := m.Called(logs)
+	return args.Error(0)
+}
+
 func (m *MockLearningLogRepository) Update(log *model.LearningLog) error {
 	args := m.Called(log)
 	return args.Error(0)

--- a/frontend/src/api/learningLogs.ts
+++ b/frontend/src/api/learningLogs.ts
@@ -1,8 +1,11 @@
 import client from './client';
-import type { LearningLog, CalendarEntry, CreateLogRequest, UpdateLogRequest, StreakInfo } from '../types/learningLog';
+import type { LearningLog, CalendarEntry, CreateLogRequest, BatchCreateLogRequest, UpdateLogRequest, StreakInfo } from '../types/learningLog';
 
 export const createLog = (data: CreateLogRequest) =>
   client.post<LearningLog>('/learning-logs', data);
+
+export const batchCreateLogs = (data: BatchCreateLogRequest) =>
+  client.post<LearningLog[]>('/learning-logs/batch', data);
 
 export const updateLog = (id: number, data: UpdateLogRequest) =>
   client.put<LearningLog>(`/learning-logs/${id}`, data);

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -712,6 +712,13 @@
     "favorites": "Favoriten",
     "toggleFavorite": "Favorit umschalten"
   },
+  "learningLog": {
+    "batchCreate": "Stapelerstellung",
+    "batchCreateDescription": "Mehrere Lernprotokolle auf einmal registrieren",
+    "batchCreateSuccess": "Lernprotokolle wurden per Stapel erstellt",
+    "addEntry": "Eintrag hinzufügen",
+    "removeEntry": "Eintrag entfernen"
+  },
   "reports": {
     "title": "Aktivitätsberichte",
     "timeline": "Zeitleiste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -713,6 +713,13 @@
     "favorites": "Favorites",
     "toggleFavorite": "Toggle Favorite"
   },
+  "learningLog": {
+    "batchCreate": "Batch Create",
+    "batchCreateDescription": "Register multiple learning logs at once",
+    "batchCreateSuccess": "Learning logs have been batch created",
+    "addEntry": "Add Entry",
+    "removeEntry": "Remove Entry"
+  },
   "reports": {
     "title": "Activity Reports",
     "timeline": "Timeline",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -713,6 +713,13 @@
     "favorites": "Favoritos",
     "toggleFavorite": "Alternar favorito"
   },
+  "learningLog": {
+    "batchCreate": "Creación por lotes",
+    "batchCreateDescription": "Puedes registrar varios registros de aprendizaje a la vez",
+    "batchCreateSuccess": "Los registros de aprendizaje se han creado por lotes",
+    "addEntry": "Agregar entrada",
+    "removeEntry": "Eliminar entrada"
+  },
   "reports": {
     "title": "Informes de Actividad",
     "timeline": "Línea de tiempo",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -713,6 +713,13 @@
     "favorites": "Favoris",
     "toggleFavorite": "Basculer le favori"
   },
+  "learningLog": {
+    "batchCreate": "Création par lot",
+    "batchCreateDescription": "Vous pouvez enregistrer plusieurs journaux d'apprentissage en une seule fois",
+    "batchCreateSuccess": "Les journaux d'apprentissage ont été créés par lot",
+    "addEntry": "Ajouter une entrée",
+    "removeEntry": "Supprimer l'entrée"
+  },
   "reports": {
     "title": "Rapports d'Activité",
     "timeline": "Fil d'actualité",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -697,6 +697,13 @@
     "favorites": "お気に入り",
     "toggleFavorite": "お気に入り切替"
   },
+  "learningLog": {
+    "batchCreate": "一括登録",
+    "batchCreateDescription": "複数の学習ログをまとめて登録できます",
+    "batchCreateSuccess": "学習ログを一括登録しました",
+    "addEntry": "エントリーを追加",
+    "removeEntry": "エントリーを削除"
+  },
   "reports": {
     "title": "アクティビティレポート",
     "weekly": "週間",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -715,6 +715,13 @@
     "favorites": "즐겨찾기",
     "toggleFavorite": "즐겨찾기 전환"
   },
+  "learningLog": {
+    "batchCreate": "일괄 등록",
+    "batchCreateDescription": "여러 학습 로그를 한 번에 등록할 수 있습니다",
+    "batchCreateSuccess": "학습 로그가 일괄 등록되었습니다",
+    "addEntry": "항목 추가",
+    "removeEntry": "항목 삭제"
+  },
   "reports": {
     "title": "활동 리포트",
     "timeline": "타임라인",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -713,6 +713,13 @@
     "favorites": "Favoritos",
     "toggleFavorite": "Alternar favorito"
   },
+  "learningLog": {
+    "batchCreate": "Criação em lote",
+    "batchCreateDescription": "Você pode registrar vários registros de aprendizado de uma vez",
+    "batchCreateSuccess": "Os registros de aprendizado foram criados em lote",
+    "addEntry": "Adicionar entrada",
+    "removeEntry": "Remover entrada"
+  },
   "reports": {
     "title": "Relatórios de Atividade",
     "timeline": "Linha do tempo",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -712,6 +712,13 @@
     "favorites": "Избранное",
     "toggleFavorite": "Переключить избранное"
   },
+  "learningLog": {
+    "batchCreate": "Пакетное создание",
+    "batchCreateDescription": "Можно зарегистрировать несколько журналов обучения за один раз",
+    "batchCreateSuccess": "Журналы обучения были созданы пакетно",
+    "addEntry": "Добавить запись",
+    "removeEntry": "Удалить запись"
+  },
   "reports": {
     "title": "Отчёты об Активности",
     "timeline": "Лента",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -713,6 +713,13 @@
     "favorites": "收藏",
     "toggleFavorite": "切换收藏"
   },
+  "learningLog": {
+    "batchCreate": "批量创建",
+    "batchCreateDescription": "可以一次性登记多条学习日志",
+    "batchCreateSuccess": "学习日志已批量创建",
+    "addEntry": "添加条目",
+    "removeEntry": "删除条目"
+  },
   "reports": {
     "title": "活动报告",
     "timeline": "时间线",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -715,6 +715,13 @@
     "favorites": "收藏",
     "toggleFavorite": "切換收藏"
   },
+  "learningLog": {
+    "batchCreate": "批量建立",
+    "batchCreateDescription": "可以一次登記多筆學習日誌",
+    "batchCreateSuccess": "學習日誌已批量建立",
+    "addEntry": "新增項目",
+    "removeEntry": "刪除項目"
+  },
   "reports": {
     "title": "活動報告",
     "timeline": "時間線",

--- a/frontend/src/types/learningLog.ts
+++ b/frontend/src/types/learningLog.ts
@@ -28,6 +28,10 @@ export interface CreateLogRequest {
   source?: LogSource;
 }
 
+export interface BatchCreateLogRequest {
+  logs: CreateLogRequest[];
+}
+
 export interface UpdateLogRequest {
   title?: string;
   content?: string;


### PR DESCRIPTION
## 概要
複数の学習ログを一括で登録できるAPIを追加。数日間ログをつけ忘れた場合にまとめて登録でき、ストリーク維持のモチベーション向上を目的とする。

## 変更内容
- `POST /api/v1/learning-logs/batch` エンドポイント追加
- Service層: バリデーション（件数上限50件、Duration、Category、Source検証）
- Repository層: `CreateBatch` メソッド（一括作成）
- Handler層: `BatchCreate` ハンドラー
- DTO: `BatchCreateLearningLogRequest` 追加
- フロントエンド: APIクライアント・型定義追加
- i18n: 全10言語に `learningLog` セクション追加

## テスト計画
- [x] Service層ユニットテスト 8件（正常系・異常系・バリデーション）
- [x] Handler層ユニットテスト 5件（正常系・異常系・バリデーション）
- [x] 全既存テスト回帰確認済み

closes #2018