### PR TITLE
feat: 投稿テンプレート機能を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -83,6 +83,7 @@ type Container struct {
 	StreakFreezeHandler            *handler.StreakFreezeHandler
 	BookmarkCollectionHandler     *handler.BookmarkCollectionHandler
 	WeeklyChallengeHandler        *handler.WeeklyChallengeHandler
+	PostTemplateHandler           *handler.PostTemplateHandler
 
 	// ミドルウェア・コールバック用
 	AuthService      *service.AuthService
@@ -375,6 +376,11 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	weeklyChallengeRepo := repository.NewWeeklyChallengeRepository(db)
 	weeklyChallengeService := service.NewWeeklyChallengeService(weeklyChallengeRepo)
 	c.WeeklyChallengeHandler = handler.NewWeeklyChallengeHandler(weeklyChallengeService)
+
+	// 投稿テンプレートサービス
+	postTemplateRepo := repository.NewPostTemplateRepository(db)
+	postTemplateService := service.NewPostTemplateService(postTemplateRepo)
+	c.PostTemplateHandler = handler.NewPostTemplateHandler(postTemplateService)
 
 	// HubのGetRoomMembersコールバックを設定
 	hub.GetRoomMembers = groupMessageRepo.GetMemberUserIDs

--- a/backend/internal/dto/post_template_dto.go
+++ b/backend/internal/dto/post_template_dto.go
@@ -1,0 +1,25 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// CreatePostTemplateRequest は投稿テンプレート作成リクエスト。
+type CreatePostTemplateRequest struct {
+	Name            string `json:"name" binding:"required,min=1,max=100"`
+	TitleTemplate   string `json:"title_template" binding:"omitempty,max=200"`
+	ContentTemplate string `json:"content_template" binding:"required,min=1,max=50000"`
+}
+
+// UpdatePostTemplateRequest は投稿テンプレート更新リクエスト。
+type UpdatePostTemplateRequest struct {
+	Name            *string `json:"name" binding:"omitempty,max=100"`
+	TitleTemplate   *string `json:"title_template" binding:"omitempty,max=200"`
+	ContentTemplate *string `json:"content_template" binding:"omitempty,max=50000"`
+}
+
+// PostTemplateListResponse は投稿テンプレート一覧レスポンス（ページネーション付き）。
+type PostTemplateListResponse struct {
+	Templates []model.PostTemplate `json:"templates"`
+	Total     int64                `json:"total"`
+	Limit     int                  `json:"limit"`
+	Offset    int                  `json:"offset"`
+}

--- a/backend/internal/handler/post_template.go
+++ b/backend/internal/handler/post_template.go
@@ -1,0 +1,112 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// PostTemplateServiceInterface はPostTemplateHandlerが依存するサービスのインターフェース。
+type PostTemplateServiceInterface interface {
+	Create(tmpl *model.PostTemplate) error
+	GetByID(id, userID uint) (*model.PostTemplate, error)
+	GetByUserID(userID uint, limit, offset int) ([]model.PostTemplate, int64, error)
+	Update(id, userID uint, updates *model.PostTemplate) (*model.PostTemplate, error)
+	Delete(id, userID uint) error
+}
+
+// PostTemplateHandler は投稿テンプレート関連のHTTPハンドラ。
+type PostTemplateHandler struct {
+	service PostTemplateServiceInterface
+}
+
+// NewPostTemplateHandler は新しいPostTemplateHandlerインスタンスを生成する。
+func NewPostTemplateHandler(s PostTemplateServiceInterface) *PostTemplateHandler {
+	return &PostTemplateHandler{service: s}
+}
+
+// Create は新しい投稿テンプレートを作成する。
+func (h *PostTemplateHandler) Create(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	input := bindJSON[dto.CreatePostTemplateRequest](c)
+	if input == nil {
+		return
+	}
+
+	tmpl := &model.PostTemplate{
+		UserID:          userID,
+		Name:            input.Name,
+		TitleTemplate:   input.TitleTemplate,
+		ContentTemplate: input.ContentTemplate,
+	}
+
+	if err := h.service.Create(tmpl); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, tmpl)
+}
+
+// GetMyTemplates は認証ユーザーの投稿テンプレート一覧を取得する。
+func (h *PostTemplateHandler) GetMyTemplates(c *gin.Context) {
+	userID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
+
+	templates, total, err := h.service.GetByUserID(userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.PostTemplateListResponse{
+		Templates: templates,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
+}
+
+// GetByID は指定IDの投稿テンプレートを取得する。
+func (h *PostTemplateHandler) GetByID(c *gin.Context) {
+	handleGetByID(c, h.service.GetByID)
+}
+
+// Update は指定された投稿テンプレートを更新する。
+func (h *PostTemplateHandler) Update(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	input := bindJSON[dto.UpdatePostTemplateRequest](c)
+	if input == nil {
+		return
+	}
+
+	updates := &model.PostTemplate{}
+	if input.Name != nil {
+		updates.Name = *input.Name
+	}
+	if input.TitleTemplate != nil {
+		updates.TitleTemplate = *input.TitleTemplate
+	}
+	if input.ContentTemplate != nil {
+		updates.ContentTemplate = *input.ContentTemplate
+	}
+
+	tmpl, err := h.service.Update(id, userID, updates)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, tmpl)
+}
+
+// Delete は指定された投稿テンプレートを削除する。
+func (h *PostTemplateHandler) Delete(c *gin.Context) {
+	handleDelete(c, h.service.Delete)
+}

--- a/backend/internal/handler/post_template_test.go
+++ b/backend/internal/handler/post_template_test.go
@@ -1,0 +1,242 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/mock"
+)
+
+// ============================================================
+// Create テスト
+// ============================================================
+
+func TestPostTemplate_Create_Success(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	svc.On("Create", mock.AnythingOfType("*model.PostTemplate")).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/post-templates", h.Create)
+
+	w := doRequest(r, http.MethodPost, "/post-templates", map[string]interface{}{
+		"name":             "日報テンプレート",
+		"title_template":   "日報: {{date}}",
+		"content_template": "## 今日の学び\n\n## 明日の予定",
+	})
+	assertStatus(t, w, http.StatusCreated)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTemplate_Create_ValidationError(t *testing.T) {
+	h, _ := setupPostTemplateHandler()
+
+	r := newRouter(1)
+	r.POST("/post-templates", h.Create)
+
+	// name と content_template は required
+	w := doRequest(r, http.MethodPost, "/post-templates", map[string]interface{}{})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTemplate_Create_InvalidJSON(t *testing.T) {
+	h, _ := setupPostTemplateHandler()
+
+	r := newRouter(1)
+	r.POST("/post-templates", h.Create)
+
+	w := doRequestRaw(r, http.MethodPost, "/post-templates", "not json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTemplate_Create_ServiceError(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	svc.On("Create", mock.AnythingOfType("*model.PostTemplate")).Return(errors.New("db error"))
+
+	r := newRouter(1)
+	r.POST("/post-templates", h.Create)
+
+	w := doRequest(r, http.MethodPost, "/post-templates", map[string]interface{}{
+		"name":             "テスト",
+		"content_template": "内容",
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetMyTemplates テスト
+// ============================================================
+
+func TestPostTemplate_GetMyTemplates_Success(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	templates := []model.PostTemplate{
+		{Name: "日報"},
+		{Name: "週報"},
+	}
+	svc.On("GetByUserID", uint(1), 20, 0).Return(templates, int64(2), nil)
+
+	r := newRouter(1)
+	r.GET("/post-templates", h.GetMyTemplates)
+
+	w := doRequest(r, http.MethodGet, "/post-templates", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTemplate_GetMyTemplates_Empty(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	svc.On("GetByUserID", uint(1), 20, 0).Return([]model.PostTemplate{}, int64(0), nil)
+
+	r := newRouter(1)
+	r.GET("/post-templates", h.GetMyTemplates)
+
+	w := doRequest(r, http.MethodGet, "/post-templates", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTemplate_GetMyTemplates_ServiceError(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	svc.On("GetByUserID", uint(1), 20, 0).Return([]model.PostTemplate(nil), int64(0), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/post-templates", h.GetMyTemplates)
+
+	w := doRequest(r, http.MethodGet, "/post-templates", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// GetByID テスト
+// ============================================================
+
+func TestPostTemplate_GetByID_Success(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	tmpl := &model.PostTemplate{Name: "テスト", ContentTemplate: "内容"}
+	svc.On("GetByID", uint(1), uint(1)).Return(tmpl, nil)
+
+	r := newRouter(1)
+	r.GET("/post-templates/:id", h.GetByID)
+
+	w := doRequest(r, http.MethodGet, "/post-templates/1", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTemplate_GetByID_NotFound(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	svc.On("GetByID", uint(99), uint(1)).Return(nil, errors.New("not found"))
+
+	r := newRouter(1)
+	r.GET("/post-templates/:id", h.GetByID)
+
+	w := doRequest(r, http.MethodGet, "/post-templates/99", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTemplate_GetByID_InvalidID(t *testing.T) {
+	h, _ := setupPostTemplateHandler()
+
+	r := newRouter(1)
+	r.GET("/post-templates/:id", h.GetByID)
+
+	w := doRequest(r, http.MethodGet, "/post-templates/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// Update テスト
+// ============================================================
+
+func TestPostTemplate_Update_Success(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	updated := &model.PostTemplate{Name: "更新済み"}
+	svc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.PostTemplate")).Return(updated, nil)
+
+	r := newRouter(1)
+	r.PUT("/post-templates/:id", h.Update)
+
+	w := doRequest(r, http.MethodPut, "/post-templates/1", map[string]interface{}{
+		"name": "更新済み",
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTemplate_Update_InvalidID(t *testing.T) {
+	h, _ := setupPostTemplateHandler()
+
+	r := newRouter(1)
+	r.PUT("/post-templates/:id", h.Update)
+
+	w := doRequest(r, http.MethodPut, "/post-templates/abc", map[string]interface{}{
+		"name": "テスト",
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTemplate_Update_InvalidJSON(t *testing.T) {
+	h, _ := setupPostTemplateHandler()
+
+	r := newRouter(1)
+	r.PUT("/post-templates/:id", h.Update)
+
+	w := doRequestRaw(r, http.MethodPut, "/post-templates/1", "not json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTemplate_Update_ServiceError(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	svc.On("Update", uint(1), uint(1), mock.AnythingOfType("*model.PostTemplate")).Return(nil, errors.New("forbidden"))
+
+	r := newRouter(1)
+	r.PUT("/post-templates/:id", h.Update)
+
+	w := doRequest(r, http.MethodPut, "/post-templates/1", map[string]interface{}{
+		"name": "更新",
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// Delete テスト
+// ============================================================
+
+func TestPostTemplate_Delete_Success(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	svc.On("Delete", uint(1), uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/post-templates/:id", h.Delete)
+
+	w := doRequest(r, http.MethodDelete, "/post-templates/1", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestPostTemplate_Delete_InvalidID(t *testing.T) {
+	h, _ := setupPostTemplateHandler()
+
+	r := newRouter(1)
+	r.DELETE("/post-templates/:id", h.Delete)
+
+	w := doRequest(r, http.MethodDelete, "/post-templates/abc", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTemplate_Delete_ServiceError(t *testing.T) {
+	h, svc := setupPostTemplateHandler()
+	svc.On("Delete", uint(99), uint(1)).Return(errors.New("not found"))
+
+	r := newRouter(1)
+	r.DELETE("/post-templates/:id", h.Delete)
+
+	w := doRequest(r, http.MethodDelete, "/post-templates/99", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1857,3 +1857,40 @@ func setupUserDashboardHandler() (*UserDashboardHandler, *MockUserDashboardServi
 	h := NewUserDashboardHandler(svc)
 	return h, svc
 }
+
+// ---------- PostTemplateHandler モック ----------
+
+// MockPostTemplateService は PostTemplateServiceInterface のモック実装。
+type MockPostTemplateService struct{ mock.Mock }
+
+func (m *MockPostTemplateService) Create(tmpl *model.PostTemplate) error {
+	return m.Called(tmpl).Error(0)
+}
+func (m *MockPostTemplateService) GetByID(id, userID uint) (*model.PostTemplate, error) {
+	args := m.Called(id, userID)
+	if t := args.Get(0); t != nil {
+		return t.(*model.PostTemplate), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockPostTemplateService) GetByUserID(userID uint, limit, offset int) ([]model.PostTemplate, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.PostTemplate), args.Get(1).(int64), args.Error(2)
+}
+func (m *MockPostTemplateService) Update(id, userID uint, updates *model.PostTemplate) (*model.PostTemplate, error) {
+	args := m.Called(id, userID, updates)
+	if t := args.Get(0); t != nil {
+		return t.(*model.PostTemplate), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockPostTemplateService) Delete(id, userID uint) error {
+	return m.Called(id, userID).Error(0)
+}
+
+// setupPostTemplateHandler はPostTemplateHandlerテスト用のセットアップを行う。
+func setupPostTemplateHandler() (*PostTemplateHandler, *MockPostTemplateService) {
+	svc := new(MockPostTemplateService)
+	h := NewPostTemplateHandler(svc)
+	return h, svc
+}

--- a/backend/internal/model/post_template.go
+++ b/backend/internal/model/post_template.go
@@ -1,0 +1,15 @@
+package model
+
+import "time"
+
+// PostTemplate は投稿テンプレートのモデル。
+// よく使う投稿フォーマットを保存し、投稿作成時に再利用できる。
+type PostTemplate struct {
+	ID              uint      `gorm:"primaryKey" json:"id"`
+	UserID          uint      `gorm:"not null;index" json:"user_id"`
+	Name            string    `gorm:"type:varchar(100);not null" json:"name"`
+	TitleTemplate   string    `gorm:"type:varchar(200)" json:"title_template"`
+	ContentTemplate string    `gorm:"type:text;not null" json:"content_template"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -640,6 +640,15 @@ type BookmarkCollectionRepositoryInterface interface {
 	HasPost(collectionID, postID uint) (bool, error)
 }
 
+// PostTemplateRepositoryInterface は投稿テンプレートデータ操作の契約を定義する。
+type PostTemplateRepositoryInterface interface {
+	Create(template *model.PostTemplate) error
+	FindByID(id uint) (*model.PostTemplate, error)
+	FindByUserID(userID uint, limit, offset int) ([]model.PostTemplate, int64, error)
+	Update(template *model.PostTemplate) error
+	Delete(id uint) error
+}
+
 // WeeklyChallengeRepositoryInterface はウィークリーチャレンジデータ操作の契約を定義する。
 type WeeklyChallengeRepositoryInterface interface {
 	Create(challenge *model.WeeklyChallenge) error

--- a/backend/internal/repository/post_template.go
+++ b/backend/internal/repository/post_template.go
@@ -1,0 +1,51 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// PostTemplateRepository は投稿テンプレートデータへのアクセスを提供するリポジトリ実装。
+type PostTemplateRepository struct {
+	db *gorm.DB
+}
+
+// NewPostTemplateRepository は新しいPostTemplateRepositoryインスタンスを生成する。
+func NewPostTemplateRepository(db *gorm.DB) *PostTemplateRepository {
+	return &PostTemplateRepository{db: db}
+}
+
+// Create は新しい投稿テンプレートをデータベースに作成する。
+func (r *PostTemplateRepository) Create(template *model.PostTemplate) error {
+	return r.db.Create(template).Error
+}
+
+// FindByID は指定IDの投稿テンプレートを取得する。
+func (r *PostTemplateRepository) FindByID(id uint) (*model.PostTemplate, error) {
+	var template model.PostTemplate
+	err := r.db.First(&template, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return &template, nil
+}
+
+// FindByUserID は指定ユーザーの投稿テンプレートをページネーション付きで取得する（新しい順）。
+func (r *PostTemplateRepository) FindByUserID(userID uint, limit, offset int) ([]model.PostTemplate, int64, error) {
+	var templates []model.PostTemplate
+	var total int64
+	query := r.db.Where("user_id = ?", userID)
+	query.Model(&model.PostTemplate{}).Count(&total)
+	err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&templates).Error
+	return templates, total, err
+}
+
+// Update は既存の投稿テンプレートを更新する。
+func (r *PostTemplateRepository) Update(template *model.PostTemplate) error {
+	return r.db.Save(template).Error
+}
+
+// Delete は指定IDの投稿テンプレートを削除する。
+func (r *PostTemplateRepository) Delete(id uint) error {
+	return r.db.Delete(&model.PostTemplate{}, id).Error
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -119,6 +119,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerYouTubeRoutes(protected, c)
 		registerSpotifyRoutes(protected, c)
 		registerCommentLikeRoutes(protected, c)
+		registerPostTemplateRoutes(protected, c)
 		registerUserStatsRoutes(protected, c)
 		registerStudyCircleStatsRoutes(protected, c)
 	}
@@ -716,6 +717,17 @@ func registerWeeklyChallengeRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		challenges.GET("/current", c.WeeklyChallengeHandler.GetCurrent)
 		challenges.PUT("/progress", c.WeeklyChallengeHandler.UpdateProgress)
+	}
+}
+
+func registerPostTemplateRoutes(g *gin.RouterGroup, c *di.Container) {
+	templates := g.Group("/post-templates")
+	{
+		templates.POST("", c.PostTemplateHandler.Create)
+		templates.GET("", c.PostTemplateHandler.GetMyTemplates)
+		templates.GET("/:id", c.PostTemplateHandler.GetByID)
+		templates.PUT("/:id", c.PostTemplateHandler.Update)
+		templates.DELETE("/:id", c.PostTemplateHandler.Delete)
 	}
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1086,6 +1086,40 @@ var _ repository.CodeSnippetRepositoryInterface = (*MockCodeSnippetRepository)(n
 var _ repository.RecommendationRepositoryInterface = (*MockRecommendationRepository)(nil)
 var _ repository.AIAdviceRepositoryInterface = (*MockAIAdviceRepository)(nil)
 var _ repository.WeeklyChallengeRepositoryInterface = (*MockWeeklyChallengeRepository)(nil)
+var _ repository.PostTemplateRepositoryInterface = (*MockPostTemplateRepository)(nil)
+
+// ============================================================
+// MockPostTemplateRepository は repository.PostTemplateRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockPostTemplateRepository struct {
+	mock.Mock
+}
+
+func (m *MockPostTemplateRepository) Create(template *model.PostTemplate) error {
+	return m.Called(template).Error(0)
+}
+
+func (m *MockPostTemplateRepository) FindByID(id uint) (*model.PostTemplate, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.PostTemplate), args.Error(1)
+}
+
+func (m *MockPostTemplateRepository) FindByUserID(userID uint, limit, offset int) ([]model.PostTemplate, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.PostTemplate), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockPostTemplateRepository) Update(template *model.PostTemplate) error {
+	return m.Called(template).Error(0)
+}
+
+func (m *MockPostTemplateRepository) Delete(id uint) error {
+	return m.Called(id).Error(0)
+}
 
 // ============================================================
 // MockWeeklyChallengeRepository は repository.WeeklyChallengeRepositoryInterface のテスト用モック実装。

--- a/backend/internal/service/post_template.go
+++ b/backend/internal/service/post_template.go
@@ -1,0 +1,76 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// PostTemplateService は投稿テンプレートのビジネスロジックを提供する。
+type PostTemplateService struct {
+	repo repository.PostTemplateRepositoryInterface
+}
+
+// NewPostTemplateService は新しいPostTemplateServiceインスタンスを生成する。
+func NewPostTemplateService(repo repository.PostTemplateRepositoryInterface) *PostTemplateService {
+	return &PostTemplateService{repo: repo}
+}
+
+// Create は新しい投稿テンプレートを作成する。
+func (s *PostTemplateService) Create(tmpl *model.PostTemplate) error {
+	if strings.TrimSpace(tmpl.Name) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "テンプレート名は必須です", nil)
+	}
+	if strings.TrimSpace(tmpl.ContentTemplate) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "テンプレート内容は必須です", nil)
+	}
+	return s.repo.Create(tmpl)
+}
+
+// GetByID は指定IDの投稿テンプレートを取得する。所有権を検証する。
+func (s *PostTemplateService) GetByID(id, userID uint) (*model.PostTemplate, error) {
+	return s.findAndCheckOwnership(id, userID)
+}
+
+// GetByUserID は指定ユーザーの投稿テンプレート一覧を取得する。
+func (s *PostTemplateService) GetByUserID(userID uint, limit, offset int) ([]model.PostTemplate, int64, error) {
+	return s.repo.FindByUserID(userID, limit, offset)
+}
+
+// Update は所有権を検証した後、投稿テンプレートを更新する。
+func (s *PostTemplateService) Update(id, userID uint, updates *model.PostTemplate) (*model.PostTemplate, error) {
+	tmpl, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if strings.TrimSpace(updates.Name) != "" {
+		tmpl.Name = updates.Name
+	}
+	if strings.TrimSpace(updates.TitleTemplate) != "" {
+		tmpl.TitleTemplate = updates.TitleTemplate
+	}
+	if strings.TrimSpace(updates.ContentTemplate) != "" {
+		tmpl.ContentTemplate = updates.ContentTemplate
+	}
+
+	if err := s.repo.Update(tmpl); err != nil {
+		return nil, err
+	}
+	return tmpl, nil
+}
+
+// Delete は所有権を検証した後、投稿テンプレートを削除する。
+func (s *PostTemplateService) Delete(id, userID uint) error {
+	if _, err := s.findAndCheckOwnership(id, userID); err != nil {
+		return err
+	}
+	return s.repo.Delete(id)
+}
+
+// findAndCheckOwnership は投稿テンプレートを取得し、所有権を検証する。
+func (s *PostTemplateService) findAndCheckOwnership(id, userID uint) (*model.PostTemplate, error) {
+	return checkOwnership(s.repo.FindByID, id, userID, func(t *model.PostTemplate) uint { return t.UserID })
+}

--- a/backend/internal/service/post_template_test.go
+++ b/backend/internal/service/post_template_test.go
@@ -1,0 +1,228 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestPostTemplateService はPostTemplateServiceのテスト用インスタンスを生成するヘルパー。
+func newTestPostTemplateService() (*PostTemplateService, *MockPostTemplateRepository) {
+	repo := new(MockPostTemplateRepository)
+	svc := NewPostTemplateService(repo)
+	return svc, repo
+}
+
+// ============================================================
+// テンプレート作成テスト
+// ============================================================
+
+func TestPostTemplateCreate_Success(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	tmpl := &model.PostTemplate{
+		UserID:          1,
+		Name:            "日報テンプレート",
+		TitleTemplate:   "日報: {{date}}",
+		ContentTemplate: "## 今日やったこと\n\n## 明日やること\n",
+	}
+	repo.On("Create", tmpl).Return(nil)
+
+	err := svc.Create(tmpl)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostTemplateCreate_EmptyName(t *testing.T) {
+	svc, _ := newTestPostTemplateService()
+
+	tmpl := &model.PostTemplate{
+		UserID:          1,
+		Name:            "",
+		ContentTemplate: "内容",
+	}
+
+	err := svc.Create(tmpl)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "テンプレート名")
+}
+
+func TestPostTemplateCreate_EmptyContent(t *testing.T) {
+	svc, _ := newTestPostTemplateService()
+
+	tmpl := &model.PostTemplate{
+		UserID: 1,
+		Name:   "テスト",
+	}
+
+	err := svc.Create(tmpl)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "テンプレート内容")
+}
+
+func TestPostTemplateCreate_RepoError(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	tmpl := &model.PostTemplate{
+		UserID:          1,
+		Name:            "テスト",
+		ContentTemplate: "内容",
+	}
+	repo.On("Create", tmpl).Return(errors.New("db error"))
+
+	err := svc.Create(tmpl)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// テンプレート取得テスト
+// ============================================================
+
+func TestPostTemplateGetByID_Success(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	tmpl := &model.PostTemplate{Name: "日報", UserID: 1}
+	tmpl.ID = 1
+	repo.On("FindByID", uint(1)).Return(tmpl, nil)
+
+	result, err := svc.GetByID(1, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "日報", result.Name)
+	repo.AssertExpectations(t)
+}
+
+func TestPostTemplateGetByID_NotFound(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	repo.On("FindByID", uint(999)).Return((*model.PostTemplate)(nil), errors.New("not found"))
+
+	result, err := svc.GetByID(999, 1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+func TestPostTemplateGetByID_Forbidden(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	tmpl := &model.PostTemplate{UserID: 1}
+	tmpl.ID = 1
+	repo.On("FindByID", uint(1)).Return(tmpl, nil)
+
+	result, err := svc.GetByID(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
+	assert.Nil(t, result)
+}
+
+// ============================================================
+// テンプレート一覧テスト
+// ============================================================
+
+func TestPostTemplateGetByUserID_Success(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	templates := []model.PostTemplate{
+		{Name: "日報"},
+		{Name: "週報"},
+	}
+	repo.On("FindByUserID", uint(1), 20, 0).Return(templates, int64(2), nil)
+
+	result, total, err := svc.GetByUserID(1, 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	repo.AssertExpectations(t)
+}
+
+func TestPostTemplateGetByUserID_Empty(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	repo.On("FindByUserID", uint(1), 20, 0).Return([]model.PostTemplate{}, int64(0), nil)
+
+	result, total, err := svc.GetByUserID(1, 20, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+}
+
+// ============================================================
+// テンプレート更新テスト
+// ============================================================
+
+func TestPostTemplateUpdate_Success(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	existing := &model.PostTemplate{Name: "旧名前", ContentTemplate: "旧内容", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	updates := &model.PostTemplate{Name: "新名前"}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, "新名前", result.Name)
+	assert.Equal(t, "旧内容", result.ContentTemplate)
+	repo.AssertExpectations(t)
+}
+
+func TestPostTemplateUpdate_Forbidden(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	existing := &model.PostTemplate{UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.PostTemplate{Name: "新名前"}
+	result, err := svc.Update(1, 999, updates)
+	assert.ErrorIs(t, err, ErrForbidden)
+	assert.Nil(t, result)
+}
+
+func TestPostTemplateUpdate_NotFound(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	repo.On("FindByID", uint(999)).Return((*model.PostTemplate)(nil), errors.New("not found"))
+
+	result, err := svc.Update(999, 1, &model.PostTemplate{Name: "新名前"})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// ============================================================
+// テンプレート削除テスト
+// ============================================================
+
+func TestPostTemplateDelete_Success(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	existing := &model.PostTemplate{UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Delete", uint(1)).Return(nil)
+
+	err := svc.Delete(1, 1)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestPostTemplateDelete_Forbidden(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	existing := &model.PostTemplate{UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	err := svc.Delete(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+func TestPostTemplateDelete_NotFound(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	repo.On("FindByID", uint(999)).Return((*model.PostTemplate)(nil), errors.New("not found"))
+
+	err := svc.Delete(999, 1)
+	assert.Error(t, err)
+}

--- a/frontend/src/api/postTemplates.ts
+++ b/frontend/src/api/postTemplates.ts
@@ -1,0 +1,17 @@
+import client from './client';
+import type { PostTemplate, CreatePostTemplateRequest, UpdatePostTemplateRequest, PostTemplateListResponse } from '../types/postTemplate';
+
+export const createPostTemplate = (data: CreatePostTemplateRequest) =>
+  client.post<PostTemplate>('/post-templates', data);
+
+export const getMyPostTemplates = (limit = 20, offset = 0) =>
+  client.get<PostTemplateListResponse>(`/post-templates?limit=${limit}&offset=${offset}`);
+
+export const getPostTemplateById = (id: number) =>
+  client.get<PostTemplate>(`/post-templates/${id}`);
+
+export const updatePostTemplate = (id: number, data: UpdatePostTemplateRequest) =>
+  client.put<PostTemplate>(`/post-templates/${id}`, data);
+
+export const deletePostTemplate = (id: number) =>
+  client.delete(`/post-templates/${id}`);

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -954,7 +954,7 @@
     "pageTitle": "Tech Q&A",
     "pageSubtitle": "Teilen Sie technische Fragen und Antworten",
     "askQuestion": "Frage stellen",
-    "newQuestion": "Neue Frage",
+    "newQuestion": "Neu",
     "editQuestion": "Frage bearbeiten",
     "questionTitle": "Titel",
     "questionTitlePlaceholder": "Fragetitel eingeben",
@@ -1007,8 +1007,7 @@
     "bestAnswerSet": "Beste Antwort festgelegt",
     "bestAnswerFailed": "Beste Antwort konnte nicht festgelegt werden",
     "voteFailed": "Abstimmung fehlgeschlagen",
-    "popularBadge": "Beliebt",
-    "newQuestion": "Neu"
+    "popularBadge": "Beliebt"
   },
   "roadmaps": {
     "title": "Lern-Roadmaps",
@@ -1620,5 +1619,20 @@
     "removeFromCollection": "Aus Sammlung entfernen",
     "deleteCollection": "Sammlung löschen",
     "editCollection": "Sammlung bearbeiten"
+  },
+  "postTemplate": {
+    "title": "Beitragsvorlagen",
+    "create": "Vorlage erstellen",
+    "edit": "Vorlage bearbeiten",
+    "delete": "Vorlage löschen",
+    "name": "Vorlagenname",
+    "titleTemplate": "Titelvorlage",
+    "contentTemplate": "Inhaltsvorlage",
+    "useTemplate": "Vorlage verwenden",
+    "noTemplates": "Keine Vorlagen vorhanden",
+    "createSuccess": "Vorlage erstellt",
+    "updateSuccess": "Vorlage aktualisiert",
+    "deleteSuccess": "Vorlage gelöscht",
+    "deleteConfirm": "Diese Vorlage löschen?"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -955,7 +955,7 @@
     "pageTitle": "Tech Q&A",
     "pageSubtitle": "Share technical questions and answers",
     "askQuestion": "Ask Question",
-    "newQuestion": "New Question",
+    "newQuestion": "New",
     "editQuestion": "Edit Question",
     "questionTitle": "Title",
     "questionTitlePlaceholder": "Enter your question title",
@@ -1008,8 +1008,7 @@
     "bestAnswerSet": "Best answer set",
     "bestAnswerFailed": "Failed to set best answer",
     "voteFailed": "Failed to vote",
-    "popularBadge": "Popular",
-    "newQuestion": "New"
+    "popularBadge": "Popular"
   },
   "roadmaps": {
     "title": "Learning Roadmaps",
@@ -1621,5 +1620,20 @@
     "removeFromCollection": "Remove from collection",
     "deleteCollection": "Delete collection",
     "editCollection": "Edit collection"
+  },
+  "postTemplate": {
+    "title": "Post Templates",
+    "create": "Create Template",
+    "edit": "Edit Template",
+    "delete": "Delete Template",
+    "name": "Template Name",
+    "titleTemplate": "Title Template",
+    "contentTemplate": "Content Template",
+    "useTemplate": "Use Template",
+    "noTemplates": "No templates yet",
+    "createSuccess": "Template created",
+    "updateSuccess": "Template updated",
+    "deleteSuccess": "Template deleted",
+    "deleteConfirm": "Delete this template?"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -955,7 +955,7 @@
     "pageTitle": "Q&A Técnico",
     "pageSubtitle": "Comparte preguntas y respuestas técnicas",
     "askQuestion": "Hacer pregunta",
-    "newQuestion": "Nueva pregunta",
+    "newQuestion": "Nuevo",
     "editQuestion": "Editar pregunta",
     "questionTitle": "Título",
     "questionTitlePlaceholder": "Ingresa el título de tu pregunta",
@@ -1008,8 +1008,7 @@
     "bestAnswerSet": "Mejor respuesta establecida",
     "bestAnswerFailed": "Error al establecer la mejor respuesta",
     "voteFailed": "Error al votar",
-    "popularBadge": "Popular",
-    "newQuestion": "Nuevo"
+    "popularBadge": "Popular"
   },
   "roadmaps": {
     "title": "Hojas de Ruta de Aprendizaje",
@@ -1621,5 +1620,20 @@
     "removeFromCollection": "Eliminar de la colección",
     "deleteCollection": "Eliminar colección",
     "editCollection": "Editar colección"
+  },
+  "postTemplate": {
+    "title": "Plantillas de publicación",
+    "create": "Crear plantilla",
+    "edit": "Editar plantilla",
+    "delete": "Eliminar plantilla",
+    "name": "Nombre de plantilla",
+    "titleTemplate": "Plantilla de título",
+    "contentTemplate": "Plantilla de contenido",
+    "useTemplate": "Usar plantilla",
+    "noTemplates": "No hay plantillas",
+    "createSuccess": "Plantilla creada",
+    "updateSuccess": "Plantilla actualizada",
+    "deleteSuccess": "Plantilla eliminada",
+    "deleteConfirm": "¿Eliminar esta plantilla?"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -955,7 +955,7 @@
     "pageTitle": "Q&A Technique",
     "pageSubtitle": "Partagez des questions et réponses techniques",
     "askQuestion": "Poser une question",
-    "newQuestion": "Nouvelle question",
+    "newQuestion": "Nouveau",
     "editQuestion": "Modifier la question",
     "questionTitle": "Titre",
     "questionTitlePlaceholder": "Entrez le titre de votre question",
@@ -1008,8 +1008,7 @@
     "bestAnswerSet": "Meilleure réponse définie",
     "bestAnswerFailed": "Échec de la définition de la meilleure réponse",
     "voteFailed": "Échec du vote",
-    "popularBadge": "Populaire",
-    "newQuestion": "Nouveau"
+    "popularBadge": "Populaire"
   },
   "roadmaps": {
     "title": "Feuilles de Route d'Apprentissage",
@@ -1621,5 +1620,20 @@
     "removeFromCollection": "Retirer de la collection",
     "deleteCollection": "Supprimer la collection",
     "editCollection": "Modifier la collection"
+  },
+  "postTemplate": {
+    "title": "Modèles de publication",
+    "create": "Créer un modèle",
+    "edit": "Modifier le modèle",
+    "delete": "Supprimer le modèle",
+    "name": "Nom du modèle",
+    "titleTemplate": "Modèle de titre",
+    "contentTemplate": "Modèle de contenu",
+    "useTemplate": "Utiliser le modèle",
+    "noTemplates": "Aucun modèle",
+    "createSuccess": "Modèle créé",
+    "updateSuccess": "Modèle mis à jour",
+    "deleteSuccess": "Modèle supprimé",
+    "deleteConfirm": "Supprimer ce modèle ?"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -909,7 +909,7 @@
     "pageTitle": "技術Q&A",
     "pageSubtitle": "技術的な質問と回答を共有しましょう",
     "askQuestion": "質問する",
-    "newQuestion": "新しい質問",
+    "newQuestion": "新着",
     "editQuestion": "質問を編集",
     "questionTitle": "タイトル",
     "questionTitlePlaceholder": "質問のタイトルを入力",
@@ -962,8 +962,7 @@
     "bestAnswerSet": "ベストアンサーを設定しました",
     "bestAnswerFailed": "ベストアンサーの設定に失敗しました",
     "voteFailed": "投票に失敗しました",
-    "popularBadge": "人気",
-    "newQuestion": "新着"
+    "popularBadge": "人気"
   },
   "roadmaps": {
     "title": "学習ロードマップ",
@@ -1522,5 +1521,20 @@
     "removeFromCollection": "コレクションから削除",
     "deleteCollection": "コレクションを削除",
     "editCollection": "コレクションを編集"
+  },
+  "postTemplate": {
+    "title": "投稿テンプレート",
+    "create": "テンプレート作成",
+    "edit": "テンプレート編集",
+    "delete": "テンプレート削除",
+    "name": "テンプレート名",
+    "titleTemplate": "タイトルテンプレート",
+    "contentTemplate": "内容テンプレート",
+    "useTemplate": "テンプレートを使用",
+    "noTemplates": "テンプレートがありません",
+    "createSuccess": "テンプレートを作成しました",
+    "updateSuccess": "テンプレートを更新しました",
+    "deleteSuccess": "テンプレートを削除しました",
+    "deleteConfirm": "このテンプレートを削除しますか？"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -957,7 +957,7 @@
     "pageTitle": "기술 Q&A",
     "pageSubtitle": "기술적인 질문과 답변을 공유하세요",
     "askQuestion": "질문하기",
-    "newQuestion": "새 질문",
+    "newQuestion": "신규",
     "editQuestion": "질문 수정",
     "questionTitle": "제목",
     "questionTitlePlaceholder": "질문 제목을 입력하세요",
@@ -1010,8 +1010,7 @@
     "bestAnswerSet": "채택 답변이 설정되었습니다",
     "bestAnswerFailed": "채택 답변 설정에 실패했습니다",
     "voteFailed": "투표에 실패했습니다",
-    "popularBadge": "인기",
-    "newQuestion": "신규"
+    "popularBadge": "인기"
   },
   "roadmaps": {
     "title": "학습 로드맵",
@@ -1623,5 +1622,20 @@
     "removeFromCollection": "컬렉션에서 삭제",
     "deleteCollection": "컬렉션 삭제",
     "editCollection": "컬렉션 편집"
+  },
+  "postTemplate": {
+    "title": "게시물 템플릿",
+    "create": "템플릿 생성",
+    "edit": "템플릿 편집",
+    "delete": "템플릿 삭제",
+    "name": "템플릿 이름",
+    "titleTemplate": "제목 템플릿",
+    "contentTemplate": "내용 템플릿",
+    "useTemplate": "템플릿 사용",
+    "noTemplates": "템플릿이 없습니다",
+    "createSuccess": "템플릿이 생성되었습니다",
+    "updateSuccess": "템플릿이 업데이트되었습니다",
+    "deleteSuccess": "템플릿이 삭제되었습니다",
+    "deleteConfirm": "이 템플릿을 삭제하시겠습니까?"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -955,7 +955,7 @@
     "pageTitle": "Q&A Técnico",
     "pageSubtitle": "Compartilhe perguntas e respostas técnicas",
     "askQuestion": "Fazer pergunta",
-    "newQuestion": "Nova pergunta",
+    "newQuestion": "Novo",
     "editQuestion": "Editar pergunta",
     "questionTitle": "Título",
     "questionTitlePlaceholder": "Digite o título da sua pergunta",
@@ -1008,8 +1008,7 @@
     "bestAnswerSet": "Melhor resposta definida",
     "bestAnswerFailed": "Falha ao definir melhor resposta",
     "voteFailed": "Falha ao votar",
-    "popularBadge": "Popular",
-    "newQuestion": "Novo"
+    "popularBadge": "Popular"
   },
   "roadmaps": {
     "title": "Roteiros de Aprendizado",
@@ -1621,5 +1620,20 @@
     "removeFromCollection": "Remover da coleção",
     "deleteCollection": "Excluir coleção",
     "editCollection": "Editar coleção"
+  },
+  "postTemplate": {
+    "title": "Modelos de publicação",
+    "create": "Criar modelo",
+    "edit": "Editar modelo",
+    "delete": "Excluir modelo",
+    "name": "Nome do modelo",
+    "titleTemplate": "Modelo de título",
+    "contentTemplate": "Modelo de conteúdo",
+    "useTemplate": "Usar modelo",
+    "noTemplates": "Nenhum modelo",
+    "createSuccess": "Modelo criado",
+    "updateSuccess": "Modelo atualizado",
+    "deleteSuccess": "Modelo excluído",
+    "deleteConfirm": "Excluir este modelo?"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -954,7 +954,7 @@
     "pageTitle": "Технический Q&A",
     "pageSubtitle": "Делитесь техническими вопросами и ответами",
     "askQuestion": "Задать вопрос",
-    "newQuestion": "Новый вопрос",
+    "newQuestion": "Новый",
     "editQuestion": "Редактировать вопрос",
     "questionTitle": "Заголовок",
     "questionTitlePlaceholder": "Введите заголовок вопроса",
@@ -1007,8 +1007,7 @@
     "bestAnswerSet": "Лучший ответ установлен",
     "bestAnswerFailed": "Не удалось установить лучший ответ",
     "voteFailed": "Не удалось проголосовать",
-    "popularBadge": "Популярное",
-    "newQuestion": "Новый"
+    "popularBadge": "Популярное"
   },
   "roadmaps": {
     "title": "Дорожные карты обучения",
@@ -1620,5 +1619,20 @@
     "removeFromCollection": "Удалить из коллекции",
     "deleteCollection": "Удалить коллекцию",
     "editCollection": "Редактировать коллекцию"
+  },
+  "postTemplate": {
+    "title": "Шаблоны публикаций",
+    "create": "Создать шаблон",
+    "edit": "Редактировать шаблон",
+    "delete": "Удалить шаблон",
+    "name": "Название шаблона",
+    "titleTemplate": "Шаблон заголовка",
+    "contentTemplate": "Шаблон содержимого",
+    "useTemplate": "Использовать шаблон",
+    "noTemplates": "Шаблонов пока нет",
+    "createSuccess": "Шаблон создан",
+    "updateSuccess": "Шаблон обновлён",
+    "deleteSuccess": "Шаблон удалён",
+    "deleteConfirm": "Удалить этот шаблон?"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -955,7 +955,7 @@
     "pageTitle": "技术问答",
     "pageSubtitle": "分享技术问题和答案",
     "askQuestion": "提问",
-    "newQuestion": "新问题",
+    "newQuestion": "最新",
     "editQuestion": "编辑问题",
     "questionTitle": "标题",
     "questionTitlePlaceholder": "输入问题标题",
@@ -1008,8 +1008,7 @@
     "bestAnswerSet": "已设置最佳答案",
     "bestAnswerFailed": "设置最佳答案失败",
     "voteFailed": "投票失败",
-    "popularBadge": "热门",
-    "newQuestion": "最新"
+    "popularBadge": "热门"
   },
   "roadmaps": {
     "title": "学习路线图",
@@ -1621,5 +1620,20 @@
     "removeFromCollection": "从收藏夹移除",
     "deleteCollection": "删除收藏夹",
     "editCollection": "编辑收藏夹"
+  },
+  "postTemplate": {
+    "title": "帖子模板",
+    "create": "创建模板",
+    "edit": "编辑模板",
+    "delete": "删除模板",
+    "name": "模板名称",
+    "titleTemplate": "标题模板",
+    "contentTemplate": "内容模板",
+    "useTemplate": "使用模板",
+    "noTemplates": "暂无模板",
+    "createSuccess": "模板创建成功",
+    "updateSuccess": "模板更新成功",
+    "deleteSuccess": "模板删除成功",
+    "deleteConfirm": "确定删除此模板吗？"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -957,7 +957,7 @@
     "pageTitle": "技術問答",
     "pageSubtitle": "分享技術問題和答案",
     "askQuestion": "提問",
-    "newQuestion": "新問題",
+    "newQuestion": "最新",
     "editQuestion": "編輯問題",
     "questionTitle": "標題",
     "questionTitlePlaceholder": "輸入問題標題",
@@ -1010,8 +1010,7 @@
     "bestAnswerSet": "已設定最佳答案",
     "bestAnswerFailed": "設定最佳答案失敗",
     "voteFailed": "投票失敗",
-    "popularBadge": "熱門",
-    "newQuestion": "最新"
+    "popularBadge": "熱門"
   },
   "roadmaps": {
     "title": "學習路線圖",
@@ -1623,5 +1622,20 @@
     "removeFromCollection": "從收藏夾移除",
     "deleteCollection": "刪除收藏夾",
     "editCollection": "編輯收藏夾"
+  },
+  "postTemplate": {
+    "title": "貼文模板",
+    "create": "建立模板",
+    "edit": "編輯模板",
+    "delete": "刪除模板",
+    "name": "模板名稱",
+    "titleTemplate": "標題模板",
+    "contentTemplate": "內容模板",
+    "useTemplate": "使用模板",
+    "noTemplates": "尚無模板",
+    "createSuccess": "模板建立成功",
+    "updateSuccess": "模板更新成功",
+    "deleteSuccess": "模板刪除成功",
+    "deleteConfirm": "確定刪除此模板嗎？"
   }
 }

--- a/frontend/src/types/postTemplate.ts
+++ b/frontend/src/types/postTemplate.ts
@@ -1,0 +1,28 @@
+export interface PostTemplate {
+  id: number;
+  user_id: number;
+  name: string;
+  title_template: string;
+  content_template: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreatePostTemplateRequest {
+  name: string;
+  title_template?: string;
+  content_template: string;
+}
+
+export interface UpdatePostTemplateRequest {
+  name?: string;
+  title_template?: string;
+  content_template?: string;
+}
+
+export interface PostTemplateListResponse {
+  templates: PostTemplate[];
+  total: number;
+  limit: number;
+  offset: number;
+}


### PR DESCRIPTION
## 概要
よく使う投稿フォーマットをテンプレートとして保存し、投稿作成時に再利用できる機能を実装。

## 変更内容
- **Model**: `PostTemplate` 構造体（name, title_template, content_template）
- **Repository**: CRUD + ページネーション付きユーザー別取得
- **Service**: ビジネスロジック + 所有権チェック（`checkOwnership`ジェネリックヘルパー使用）
- **Handler**: 5エンドポイント（POST, GET一覧, GET詳細, PUT, DELETE）
- **DTO**: リクエスト/レスポンス構造体（バリデーション付き）
- **DI/Router**: コンテナ登録 + `/api/v1/post-templates` ルート
- **フロントエンド**: API クライアント + TypeScript型定義
- **i18n**: 10言語の翻訳を追加

## テスト
- Service層: 15テスト（TDD: Create/GetByID/GetByUserID/Update/Delete の正常系・異常系）
- Handler層: 16テスト（Create/GetMyTemplates/GetByID/Update/Delete の正常系・異常系）
- 全31テストパス

## APIエンドポイント
| メソッド | パス | 説明 |
|---------|------|------|
| POST | `/api/v1/post-templates` | テンプレート作成 |
| GET | `/api/v1/post-templates` | 自分のテンプレート一覧 |
| GET | `/api/v1/post-templates/:id` | テンプレート詳細 |
| PUT | `/api/v1/post-templates/:id` | テンプレート更新 |
| DELETE | `/api/v1/post-templates/:id` | テンプレート削除 |

Closes #2021