### PR TITLE
feat: 学習ログエクスポートにJSON形式を追加

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -20,6 +20,7 @@ type LearningLogServiceInterface interface {
 	GetStreakInfo(userID uint) (*model.StreakInfo, error)
 	GetCalendarData(userID uint) ([]model.CalendarEntry, error)
 	ExportCSV(userID uint, days int) ([]byte, error)
+	ExportJSON(userID uint, days int) ([]byte, error)
 	GetByCategory(userID uint, category string) ([]model.LearningLog, error)
 	GetBySource(userID uint, source string) ([]model.LearningLog, error)
 	GetWeeklyDuration(userID uint) (int, error)
@@ -249,8 +250,8 @@ func (h *LearningLogHandler) GetBySource(c *gin.Context) {
 	respondOK(c, ensureSlice(logs))
 }
 
-// ExportLogs は学習ログをCSV形式でダウンロードする。
-// クエリパラメータ: period=7|30|90|all（デフォルト30日）
+// ExportLogs は学習ログをCSVまたはJSON形式でダウンロードする。
+// クエリパラメータ: period=7|30|90|all（デフォルト30日）、format=csv|json（デフォルトcsv）
 func (h *LearningLogHandler) ExportLogs(c *gin.Context) {
 	userID := c.GetUint("userID")
 
@@ -259,19 +260,37 @@ func (h *LearningLogHandler) ExportLogs(c *gin.Context) {
 		return
 	}
 
-	csvBytes, err := h.service.ExportCSV(userID, days)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
+	format := c.DefaultQuery("format", "csv")
+	timestamp := time.Now().Format("20060102")
 
-	filename := fmt.Sprintf("learning-logs-%ddays-%s.csv", days, time.Now().Format("20060102"))
-	if days == 0 {
-		filename = fmt.Sprintf("learning-logs-all-%s.csv", time.Now().Format("20060102"))
+	switch format {
+	case "json":
+		jsonBytes, err := h.service.ExportJSON(userID, days)
+		if err != nil {
+			respondError(c, err)
+			return
+		}
+		filename := fmt.Sprintf("learning-logs-%ddays-%s.json", days, timestamp)
+		if days == 0 {
+			filename = fmt.Sprintf("learning-logs-all-%s.json", timestamp)
+		}
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
+		c.Data(200, "application/json; charset=utf-8", jsonBytes)
+	case "csv":
+		csvBytes, err := h.service.ExportCSV(userID, days)
+		if err != nil {
+			respondError(c, err)
+			return
+		}
+		filename := fmt.Sprintf("learning-logs-%ddays-%s.csv", days, timestamp)
+		if days == 0 {
+			filename = fmt.Sprintf("learning-logs-all-%s.csv", timestamp)
+		}
+		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
+		c.Data(200, "text/csv; charset=utf-8", csvBytes)
+	default:
+		respondBadRequest(c, "formatはcsv/jsonのいずれかを指定してください")
 	}
-
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%s", filename))
-	c.Data(200, "text/csv; charset=utf-8", csvBytes)
 }
 
 // GetWeeklyDuration は指定ユーザーの過去7日間の学習時間合計を返す。

--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -408,6 +408,62 @@ func TestLearningLog_ExportLogs_ServiceError(t *testing.T) {
 }
 
 // ============================================================
+// ExportLogs JSON形式テスト
+// ============================================================
+
+func TestLearningLog_ExportLogs_JSONSuccess(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/learning-logs/export", h.ExportLogs)
+
+	jsonData := []byte(`[{"date":"2026-02-19","title":"Go基礎","category":"coding","duration":60,"content":"変数を学んだ"}]`)
+	svc.On("ExportJSON", uint(1), 30).Return(jsonData, nil)
+
+	w := doRequest(r, http.MethodGet, "/learning-logs/export?format=json", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "attachment")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".json")
+	assert.Contains(t, w.Header().Get("Content-Type"), "application/json")
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_ExportLogs_JSONAllPeriod(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/learning-logs/export", h.ExportLogs)
+
+	jsonData := []byte(`[]`)
+	svc.On("ExportJSON", uint(1), 0).Return(jsonData, nil)
+
+	w := doRequest(r, http.MethodGet, "/learning-logs/export?format=json&period=all", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "learning-logs-all-")
+	assert.Contains(t, w.Header().Get("Content-Disposition"), ".json")
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_ExportLogs_JSONServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/learning-logs/export", h.ExportLogs)
+
+	svc.On("ExportJSON", uint(1), 30).Return(nil, errors.New("export error"))
+
+	w := doRequest(r, http.MethodGet, "/learning-logs/export?format=json", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_ExportLogs_InvalidFormat(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/learning-logs/export", h.ExportLogs)
+
+	w := doRequest(r, http.MethodGet, "/learning-logs/export?format=xml", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
 // GetWeeklyDuration テスト
 // ============================================================
 

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1324,6 +1324,13 @@ func (m *MockLearningLogService) ExportCSV(userID uint, days int) ([]byte, error
 	}
 	return args.Get(0).([]byte), args.Error(1)
 }
+func (m *MockLearningLogService) ExportJSON(userID uint, days int) ([]byte, error) {
+	args := m.Called(userID, days)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]byte), args.Error(1)
+}
 func (m *MockLearningLogService) GetByCategory(userID uint, category string) ([]model.LearningLog, error) {
 	args := m.Called(userID, category)
 	return args.Get(0).([]model.LearningLog), args.Error(1)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -3,6 +3,7 @@ package service
 import (
 	"bytes"
 	"encoding/csv"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -228,4 +229,39 @@ func (s *LearningLogService) ExportCSV(userID uint, days int) ([]byte, error) {
 	}
 
 	return buf.Bytes(), nil
+}
+
+// jsonLogEntry はJSONエクスポート用の構造体。
+type jsonLogEntry struct {
+	Date     string `json:"date"`
+	Title    string `json:"title"`
+	Category string `json:"category"`
+	Duration int    `json:"duration"`
+	Content  string `json:"content"`
+}
+
+// ExportJSON は指定ユーザーの学習ログをJSON形式でエクスポートする。
+// days: 取得する過去の日数（0は全期間）。負の値はバリデーションエラー。
+func (s *LearningLogService) ExportJSON(userID uint, days int) ([]byte, error) {
+	if days < 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "期間は0以上の値を指定してください", nil)
+	}
+
+	logs, err := s.repo.GetByPeriod(userID, days)
+	if err != nil {
+		return nil, err
+	}
+
+	entries := make([]jsonLogEntry, len(logs))
+	for i, log := range logs {
+		entries[i] = jsonLogEntry{
+			Date:     log.CreatedAt.Format("2006-01-02"),
+			Title:    log.Title,
+			Category: string(log.Category),
+			Duration: log.Duration,
+			Content:  log.Content,
+		}
+	}
+
+	return json.Marshal(entries)
 }

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -891,3 +891,80 @@ func TestLearningLogExportCSV_MultipleRows(t *testing.T) {
 	assert.Contains(t, content, "React")
 	assert.Contains(t, content, "Docker")
 }
+
+// ============================================================
+// ExportJSON テスト
+// ============================================================
+
+func TestLearningLogExportJSON_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	now := time.Date(2026, 2, 19, 10, 30, 0, 0, time.UTC)
+	logs := []model.LearningLog{
+		{Title: "Go基礎", Content: "変数を学んだ", Category: model.LogCategoryCoding, Duration: 60, CreatedAt: now},
+		{Title: "設計復習", Content: "DDD読んだ", Category: model.LogCategoryReading, Duration: 30, CreatedAt: now},
+	}
+	repo.On("GetByPeriod", uint(1), 30).Return(logs, nil)
+
+	data, err := svc.ExportJSON(1, 30)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, data)
+
+	content := string(data)
+	assert.Contains(t, content, "Go基礎")
+	assert.Contains(t, content, "設計復習")
+	assert.Contains(t, content, "coding")
+	assert.Contains(t, content, "reading")
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogExportJSON_EmptyLogs(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+	repo.On("GetByPeriod", uint(1), 0).Return([]model.LearningLog{}, nil)
+
+	data, err := svc.ExportJSON(1, 0)
+	assert.NoError(t, err)
+	// 空配列 "[]" が返される
+	assert.Equal(t, "[]", string(data))
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogExportJSON_NegativeDays(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	_, err := svc.ExportJSON(1, -1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "期間は0以上の値")
+}
+
+func TestLearningLogExportJSON_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+	repo.On("GetByPeriod", uint(1), 7).Return([]model.LearningLog{}, errors.New("db error"))
+
+	_, err := svc.ExportJSON(1, 7)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogExportJSON_ValidJSON(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	now := time.Date(2026, 2, 20, 0, 0, 0, 0, time.UTC)
+	logs := []model.LearningLog{
+		{Title: "テスト", Content: "内容", Category: model.LogCategoryCoding, Duration: 45, CreatedAt: now},
+	}
+	repo.On("GetByPeriod", uint(1), 30).Return(logs, nil)
+
+	data, err := svc.ExportJSON(1, 30)
+	assert.NoError(t, err)
+
+	// 有効なJSONであることを確認
+	content := string(data)
+	assert.True(t, strings.HasPrefix(content, "["))
+	assert.True(t, strings.HasSuffix(content, "]"))
+	assert.Contains(t, content, `"title"`)
+	assert.Contains(t, content, `"date"`)
+	assert.Contains(t, content, `"category"`)
+	assert.Contains(t, content, `"duration"`)
+	repo.AssertExpectations(t)
+}

--- a/frontend/src/api/learningLogs.ts
+++ b/frontend/src/api/learningLogs.ts
@@ -47,6 +47,13 @@ export const getRecentCategories = () =>
   client.get<string[]>('/learning-logs/recent-categories');
 
 export type ExportPeriod = '7' | '30' | '90' | 'all';
+export type ExportFormat = 'csv' | 'json';
 
 export const exportLogsCSV = (period: ExportPeriod = '30') =>
   client.get<Blob>(`/learning-logs/export?period=${period}`, { responseType: 'blob' });
+
+export const exportLogsJSON = (period: ExportPeriod = '30') =>
+  client.get<Blob>(`/learning-logs/export?format=json&period=${period}`, { responseType: 'blob' });
+
+export const exportLogs = (period: ExportPeriod = '30', format: ExportFormat = 'csv') =>
+  client.get<Blob>(`/learning-logs/export?format=${format}&period=${period}`, { responseType: 'blob' });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -717,7 +717,11 @@
     "batchCreateDescription": "Mehrere Lernprotokolle auf einmal registrieren",
     "batchCreateSuccess": "Lernprotokolle wurden per Stapel erstellt",
     "addEntry": "Eintrag hinzufügen",
-    "removeEntry": "Eintrag entfernen"
+    "removeEntry": "Eintrag entfernen",
+    "exportJSON": "Als JSON exportieren",
+    "exportFormat": "Exportformat",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "Aktivitätsberichte",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -718,7 +718,11 @@
     "batchCreateDescription": "Register multiple learning logs at once",
     "batchCreateSuccess": "Learning logs have been batch created",
     "addEntry": "Add Entry",
-    "removeEntry": "Remove Entry"
+    "removeEntry": "Remove Entry",
+    "exportJSON": "Export as JSON",
+    "exportFormat": "Export format",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "Activity Reports",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -718,7 +718,11 @@
     "batchCreateDescription": "Puedes registrar varios registros de aprendizaje a la vez",
     "batchCreateSuccess": "Los registros de aprendizaje se han creado por lotes",
     "addEntry": "Agregar entrada",
-    "removeEntry": "Eliminar entrada"
+    "removeEntry": "Eliminar entrada",
+    "exportJSON": "Exportar como JSON",
+    "exportFormat": "Formato de exportación",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "Informes de Actividad",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -718,7 +718,11 @@
     "batchCreateDescription": "Vous pouvez enregistrer plusieurs journaux d'apprentissage en une seule fois",
     "batchCreateSuccess": "Les journaux d'apprentissage ont été créés par lot",
     "addEntry": "Ajouter une entrée",
-    "removeEntry": "Supprimer l'entrée"
+    "removeEntry": "Supprimer l'entrée",
+    "exportJSON": "Exporter en JSON",
+    "exportFormat": "Format d'exportation",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "Rapports d'Activité",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -702,7 +702,11 @@
     "batchCreateDescription": "複数の学習ログをまとめて登録できます",
     "batchCreateSuccess": "学習ログを一括登録しました",
     "addEntry": "エントリーを追加",
-    "removeEntry": "エントリーを削除"
+    "removeEntry": "エントリーを削除",
+    "exportJSON": "JSON形式でエクスポート",
+    "exportFormat": "エクスポート形式",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "アクティビティレポート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -720,7 +720,11 @@
     "batchCreateDescription": "여러 학습 로그를 한 번에 등록할 수 있습니다",
     "batchCreateSuccess": "학습 로그가 일괄 등록되었습니다",
     "addEntry": "항목 추가",
-    "removeEntry": "항목 삭제"
+    "removeEntry": "항목 삭제",
+    "exportJSON": "JSON으로 내보내기",
+    "exportFormat": "내보내기 형식",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "활동 리포트",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -718,7 +718,11 @@
     "batchCreateDescription": "Você pode registrar vários registros de aprendizado de uma vez",
     "batchCreateSuccess": "Os registros de aprendizado foram criados em lote",
     "addEntry": "Adicionar entrada",
-    "removeEntry": "Remover entrada"
+    "removeEntry": "Remover entrada",
+    "exportJSON": "Exportar como JSON",
+    "exportFormat": "Formato de exportação",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "Relatórios de Atividade",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -717,7 +717,11 @@
     "batchCreateDescription": "Можно зарегистрировать несколько журналов обучения за один раз",
     "batchCreateSuccess": "Журналы обучения были созданы пакетно",
     "addEntry": "Добавить запись",
-    "removeEntry": "Удалить запись"
+    "removeEntry": "Удалить запись",
+    "exportJSON": "Экспорт в JSON",
+    "exportFormat": "Формат экспорта",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "Отчёты об Активности",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -718,7 +718,11 @@
     "batchCreateDescription": "可以一次性登记多条学习日志",
     "batchCreateSuccess": "学习日志已批量创建",
     "addEntry": "添加条目",
-    "removeEntry": "删除条目"
+    "removeEntry": "删除条目",
+    "exportJSON": "导出为JSON",
+    "exportFormat": "导出格式",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "活动报告",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -720,7 +720,11 @@
     "batchCreateDescription": "可以一次登記多筆學習日誌",
     "batchCreateSuccess": "學習日誌已批量建立",
     "addEntry": "新增項目",
-    "removeEntry": "刪除項目"
+    "removeEntry": "刪除項目",
+    "exportJSON": "匯出為JSON",
+    "exportFormat": "匯出格式",
+    "formatCSV": "CSV",
+    "formatJSON": "JSON"
   },
   "reports": {
     "title": "活動報告",


### PR DESCRIPTION
## 概要
既存のCSVエクスポート機能に加え、JSON形式でのエクスポートをサポート。`format=json` クエリパラメータで切り替え可能。

## 変更内容
- **Service層**: `ExportJSON` メソッド追加（日付・タイトル・カテゴリ・学習時間・メモの構造化JSON出力）
- **Handler層**: `format=csv|json` パラメータで形式切り替え（デフォルトCSVで後方互換性維持）
- **フロントエンド**: `exportLogsJSON`, `exportLogs` API関数追加、`ExportFormat` 型追加
- **i18n**: 10言語に翻訳追加（exportJSON, exportFormat, formatCSV, formatJSON）

## テスト
- Service層: ExportJSON 5テスト（成功・空・負の日数・リポジトリエラー・有効なJSON検証）
- Handler層: JSON形式 4テスト追加（成功・全期間・サービスエラー・不正フォーマット）
- 既存CSVテストの後方互換性確認済み

## API
```
GET /api/v1/learning-logs/export?format=json&period=30
GET /api/v1/learning-logs/export?format=csv&period=30  # 既存互換
GET /api/v1/learning-logs/export?period=30              # デフォルトCSV
```

Closes #2023