### PR TITLE
feat: ダッシュボードウィジェット設定永続化を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -84,6 +84,7 @@ type Container struct {
 	BookmarkCollectionHandler     *handler.BookmarkCollectionHandler
 	WeeklyChallengeHandler        *handler.WeeklyChallengeHandler
 	PostTemplateHandler           *handler.PostTemplateHandler
+	WidgetSettingsHandler         *handler.WidgetSettingsHandler
 
 	// ミドルウェア・コールバック用
 	AuthService      *service.AuthService
@@ -381,6 +382,11 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	postTemplateRepo := repository.NewPostTemplateRepository(db)
 	postTemplateService := service.NewPostTemplateService(postTemplateRepo)
 	c.PostTemplateHandler = handler.NewPostTemplateHandler(postTemplateService)
+
+	// ウィジェット設定サービス
+	widgetSettingsRepo := repository.NewWidgetSettingsRepository(db)
+	widgetSettingsService := service.NewWidgetSettingsService(widgetSettingsRepo)
+	c.WidgetSettingsHandler = handler.NewWidgetSettingsHandler(widgetSettingsService)
 
 	// HubのGetRoomMembersコールバックを設定
 	hub.GetRoomMembers = groupMessageRepo.GetMemberUserIDs

--- a/backend/internal/dto/widget_settings_dto.go
+++ b/backend/internal/dto/widget_settings_dto.go
@@ -1,0 +1,8 @@
+package dto
+
+import "encoding/json"
+
+// UpdateWidgetSettingsRequest はウィジェット設定更新リクエスト。
+type UpdateWidgetSettingsRequest struct {
+	Settings json.RawMessage `json:"settings" binding:"required"`
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1901,3 +1901,26 @@ func setupPostTemplateHandler() (*PostTemplateHandler, *MockPostTemplateService)
 	h := NewPostTemplateHandler(svc)
 	return h, svc
 }
+
+// ---------- WidgetSettingsHandler モック ----------
+
+// MockWidgetSettingsService は WidgetSettingsServiceInterface のモック実装。
+type MockWidgetSettingsService struct{ mock.Mock }
+
+func (m *MockWidgetSettingsService) GetSettings(userID uint) (*model.WidgetSettings, error) {
+	args := m.Called(userID)
+	if s := args.Get(0); s != nil {
+		return s.(*model.WidgetSettings), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+func (m *MockWidgetSettingsService) UpdateSettings(userID uint, settings string) error {
+	return m.Called(userID, settings).Error(0)
+}
+
+// setupWidgetSettingsHandler はWidgetSettingsHandlerテスト用のセットアップを行う。
+func setupWidgetSettingsHandler() (*WidgetSettingsHandler, *MockWidgetSettingsService) {
+	svc := new(MockWidgetSettingsService)
+	h := NewWidgetSettingsHandler(svc)
+	return h, svc
+}

--- a/backend/internal/handler/widget_settings.go
+++ b/backend/internal/handler/widget_settings.go
@@ -1,0 +1,53 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// WidgetSettingsServiceInterface はWidgetSettingsHandlerが依存するサービスのインターフェース。
+type WidgetSettingsServiceInterface interface {
+	GetSettings(userID uint) (*model.WidgetSettings, error)
+	UpdateSettings(userID uint, settings string) error
+}
+
+// WidgetSettingsHandler はダッシュボードウィジェット設定のHTTPハンドラ。
+type WidgetSettingsHandler struct {
+	service WidgetSettingsServiceInterface
+}
+
+// NewWidgetSettingsHandler は新しいWidgetSettingsHandlerインスタンスを生成する。
+func NewWidgetSettingsHandler(s WidgetSettingsServiceInterface) *WidgetSettingsHandler {
+	return &WidgetSettingsHandler{service: s}
+}
+
+// GetSettings は認証ユーザーのウィジェット設定を取得する。
+func (h *WidgetSettingsHandler) GetSettings(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	settings, err := h.service.GetSettings(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, settings)
+}
+
+// UpdateSettings は認証ユーザーのウィジェット設定を更新する。
+func (h *WidgetSettingsHandler) UpdateSettings(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	input := bindJSON[dto.UpdateWidgetSettingsRequest](c)
+	if input == nil {
+		return
+	}
+
+	if err := h.service.UpdateSettings(userID, string(input.Settings)); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"message": "設定を更新しました"})
+}

--- a/backend/internal/handler/widget_settings_test.go
+++ b/backend/internal/handler/widget_settings_test.go
@@ -1,0 +1,101 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// ============================================================
+// GetSettings テスト
+// ============================================================
+
+func TestWidgetSettings_GetSettings_Success(t *testing.T) {
+	h, svc := setupWidgetSettingsHandler()
+	settings := &model.WidgetSettings{
+		UserID:   1,
+		Settings: `[{"key":"userProfile","visible":true,"order":0}]`,
+	}
+	svc.On("GetSettings", uint(1)).Return(settings, nil)
+
+	r := newRouter(1)
+	r.GET("/widget-settings", h.GetSettings)
+
+	w := doRequest(r, http.MethodGet, "/widget-settings", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Body.String(), "userProfile")
+	svc.AssertExpectations(t)
+}
+
+func TestWidgetSettings_GetSettings_ServiceError(t *testing.T) {
+	h, svc := setupWidgetSettingsHandler()
+	svc.On("GetSettings", uint(1)).Return(nil, errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/widget-settings", h.GetSettings)
+
+	w := doRequest(r, http.MethodGet, "/widget-settings", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// UpdateSettings テスト
+// ============================================================
+
+func TestWidgetSettings_UpdateSettings_Success(t *testing.T) {
+	h, svc := setupWidgetSettingsHandler()
+	svc.On("UpdateSettings", uint(1), mock.AnythingOfType("string")).Return(nil)
+
+	r := newRouter(1)
+	r.PUT("/widget-settings", h.UpdateSettings)
+
+	w := doRequest(r, http.MethodPut, "/widget-settings", map[string]interface{}{
+		"settings": []map[string]interface{}{
+			{"key": "userProfile", "visible": true, "order": 0},
+			{"key": "level", "visible": false, "order": 1},
+		},
+	})
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestWidgetSettings_UpdateSettings_InvalidJSON(t *testing.T) {
+	h, _ := setupWidgetSettingsHandler()
+
+	r := newRouter(1)
+	r.PUT("/widget-settings", h.UpdateSettings)
+
+	w := doRequestRaw(r, http.MethodPut, "/widget-settings", "not json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestWidgetSettings_UpdateSettings_MissingSettings(t *testing.T) {
+	h, _ := setupWidgetSettingsHandler()
+
+	r := newRouter(1)
+	r.PUT("/widget-settings", h.UpdateSettings)
+
+	w := doRequest(r, http.MethodPut, "/widget-settings", map[string]interface{}{})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestWidgetSettings_UpdateSettings_ServiceError(t *testing.T) {
+	h, svc := setupWidgetSettingsHandler()
+	svc.On("UpdateSettings", uint(1), mock.AnythingOfType("string")).Return(errors.New("db error"))
+
+	r := newRouter(1)
+	r.PUT("/widget-settings", h.UpdateSettings)
+
+	w := doRequest(r, http.MethodPut, "/widget-settings", map[string]interface{}{
+		"settings": []map[string]interface{}{
+			{"key": "userProfile", "visible": true, "order": 0},
+		},
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/model/widget_settings.go
+++ b/backend/internal/model/widget_settings.go
@@ -1,0 +1,13 @@
+package model
+
+import "time"
+
+// WidgetSettings はダッシュボードのウィジェット表示設定。
+// ユーザーごとにウィジェットの表示/非表示と並び順をJSON形式で保存する。
+type WidgetSettings struct {
+	ID        uint      `gorm:"primaryKey" json:"id"`
+	UserID    uint      `gorm:"uniqueIndex;not null" json:"user_id"`
+	Settings  string    `gorm:"type:text;not null" json:"settings"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -663,3 +663,9 @@ type StreakFreezeRepositoryInterface interface {
 	GetFreezeDates(userID uint) ([]string, error)
 	HasFreezeOnDate(userID uint, date string) (bool, error)
 }
+
+// WidgetSettingsRepositoryInterface はダッシュボードウィジェット設定の操作契約を定義する。
+type WidgetSettingsRepositoryInterface interface {
+	FindByUserID(userID uint) (*model.WidgetSettings, error)
+	Upsert(settings *model.WidgetSettings) error
+}

--- a/backend/internal/repository/widget_settings.go
+++ b/backend/internal/repository/widget_settings.go
@@ -1,0 +1,35 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// WidgetSettingsRepository はウィジェット設定データへのアクセスを提供するリポジトリ実装。
+type WidgetSettingsRepository struct {
+	db *gorm.DB
+}
+
+// NewWidgetSettingsRepository は新しいWidgetSettingsRepositoryインスタンスを生成する。
+func NewWidgetSettingsRepository(db *gorm.DB) *WidgetSettingsRepository {
+	return &WidgetSettingsRepository{db: db}
+}
+
+// FindByUserID は指定ユーザーのウィジェット設定を取得する。
+func (r *WidgetSettingsRepository) FindByUserID(userID uint) (*model.WidgetSettings, error) {
+	var settings model.WidgetSettings
+	err := r.db.Where("user_id = ?", userID).First(&settings).Error
+	if err != nil {
+		return nil, err
+	}
+	return &settings, nil
+}
+
+// Upsert はウィジェット設定を作成または更新する。
+func (r *WidgetSettingsRepository) Upsert(settings *model.WidgetSettings) error {
+	return r.db.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "user_id"}},
+		DoUpdates: clause.AssignmentColumns([]string{"settings", "updated_at"}),
+	}).Create(settings).Error
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -120,6 +120,7 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		registerSpotifyRoutes(protected, c)
 		registerCommentLikeRoutes(protected, c)
 		registerPostTemplateRoutes(protected, c)
+		registerWidgetSettingsRoutes(protected, c)
 		registerUserStatsRoutes(protected, c)
 		registerStudyCircleStatsRoutes(protected, c)
 	}
@@ -728,6 +729,14 @@ func registerPostTemplateRoutes(g *gin.RouterGroup, c *di.Container) {
 		templates.GET("/:id", c.PostTemplateHandler.GetByID)
 		templates.PUT("/:id", c.PostTemplateHandler.Update)
 		templates.DELETE("/:id", c.PostTemplateHandler.Delete)
+	}
+}
+
+func registerWidgetSettingsRoutes(g *gin.RouterGroup, c *di.Container) {
+	widgets := g.Group("/widget-settings")
+	{
+		widgets.GET("", c.WidgetSettingsHandler.GetSettings)
+		widgets.PUT("", c.WidgetSettingsHandler.UpdateSettings)
 	}
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2368,3 +2368,25 @@ func (m *MockBookmarkCollectionRepository) HasPost(collectionID, postID uint) (b
 	args := m.Called(collectionID, postID)
 	return args.Bool(0), args.Error(1)
 }
+
+// ============================================================
+// MockWidgetSettingsRepository は repository.WidgetSettingsRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockWidgetSettingsRepository struct {
+	mock.Mock
+}
+
+var _ repository.WidgetSettingsRepositoryInterface = (*MockWidgetSettingsRepository)(nil)
+
+func (m *MockWidgetSettingsRepository) FindByUserID(userID uint) (*model.WidgetSettings, error) {
+	args := m.Called(userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.WidgetSettings), args.Error(1)
+}
+
+func (m *MockWidgetSettingsRepository) Upsert(settings *model.WidgetSettings) error {
+	return m.Called(settings).Error(0)
+}

--- a/backend/internal/service/widget_settings.go
+++ b/backend/internal/service/widget_settings.go
@@ -1,0 +1,61 @@
+package service
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// defaultWidgetSettings はダッシュボードウィジェットのデフォルト設定。
+const defaultWidgetSettings = `[{"key":"userProfile","visible":true,"order":0},{"key":"level","visible":true,"order":1},{"key":"streak","visible":true,"order":2},{"key":"dailyChallenge","visible":true,"order":3},{"key":"weeklyChallenge","visible":true,"order":4},{"key":"studyCircle","visible":true,"order":5},{"key":"quickEntry","visible":true,"order":6},{"key":"quickActions","visible":true,"order":7},{"key":"recommendedUsers","visible":true,"order":8},{"key":"trending","visible":true,"order":9},{"key":"aiAdvice","visible":true,"order":10},{"key":"goalsProgress","visible":true,"order":11},{"key":"recentNotifications","visible":true,"order":12},{"key":"quickStats","visible":true,"order":13}]`
+
+// WidgetSettingsService はダッシュボードウィジェット設定のビジネスロジックを提供する。
+type WidgetSettingsService struct {
+	repo repository.WidgetSettingsRepositoryInterface
+}
+
+// NewWidgetSettingsService は新しいWidgetSettingsServiceインスタンスを生成する。
+func NewWidgetSettingsService(repo repository.WidgetSettingsRepositoryInterface) *WidgetSettingsService {
+	return &WidgetSettingsService{repo: repo}
+}
+
+// GetSettings は指定ユーザーのウィジェット設定を取得する。
+// 設定が未登録の場合はデフォルト設定を返す。
+func (s *WidgetSettingsService) GetSettings(userID uint) (*model.WidgetSettings, error) {
+	settings, err := s.repo.FindByUserID(userID)
+	if err != nil {
+		// レコード未登録の場合はデフォルト設定を返す
+		return &model.WidgetSettings{
+			UserID:   userID,
+			Settings: defaultWidgetSettings,
+		}, nil
+	}
+	return settings, nil
+}
+
+// UpdateSettings はウィジェット設定を更新する。
+// 設定はJSON配列形式である必要がある。
+func (s *WidgetSettingsService) UpdateSettings(userID uint, settings string) error {
+	if strings.TrimSpace(settings) == "" {
+		return domain.NewError(domain.ErrCodeBadRequest, "設定は必須です", nil)
+	}
+
+	if !json.Valid([]byte(settings)) {
+		return domain.NewError(domain.ErrCodeBadRequest, "設定は有効なJSONである必要があります", nil)
+	}
+
+	// JSON配列であることを検証
+	var arr []json.RawMessage
+	if err := json.Unmarshal([]byte(settings), &arr); err != nil {
+		return domain.NewError(domain.ErrCodeBadRequest, "設定はJSON配列である必要があります", nil)
+	}
+
+	ws := &model.WidgetSettings{
+		UserID:   userID,
+		Settings: settings,
+	}
+	return s.repo.Upsert(ws)
+}

--- a/backend/internal/service/widget_settings_test.go
+++ b/backend/internal/service/widget_settings_test.go
@@ -1,0 +1,102 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func newTestWidgetSettingsService() (*WidgetSettingsService, *MockWidgetSettingsRepository) {
+	repo := new(MockWidgetSettingsRepository)
+	svc := NewWidgetSettingsService(repo)
+	return svc, repo
+}
+
+// ============================================================
+// GetSettings テスト
+// ============================================================
+
+func TestWidgetSettingsGetSettings_Success(t *testing.T) {
+	svc, repo := newTestWidgetSettingsService()
+
+	settings := &model.WidgetSettings{
+		UserID:   1,
+		Settings: `[{"key":"userProfile","visible":true,"order":0}]`,
+	}
+	repo.On("FindByUserID", uint(1)).Return(settings, nil)
+
+	result, err := svc.GetSettings(1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(1), result.UserID)
+	assert.Contains(t, result.Settings, "userProfile")
+	repo.AssertExpectations(t)
+}
+
+func TestWidgetSettingsGetSettings_NotFound_ReturnsDefault(t *testing.T) {
+	svc, repo := newTestWidgetSettingsService()
+
+	repo.On("FindByUserID", uint(1)).Return(nil, errors.New("record not found"))
+
+	result, err := svc.GetSettings(1)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(1), result.UserID)
+	// デフォルト設定が返される
+	assert.Contains(t, result.Settings, "userProfile")
+	assert.Contains(t, result.Settings, "level")
+	assert.Contains(t, result.Settings, "streak")
+}
+
+// ============================================================
+// UpdateSettings テスト
+// ============================================================
+
+func TestWidgetSettingsUpdateSettings_Success(t *testing.T) {
+	svc, repo := newTestWidgetSettingsService()
+
+	newSettings := `[{"key":"userProfile","visible":true,"order":0},{"key":"level","visible":false,"order":1}]`
+	repo.On("Upsert", mock.MatchedBy(func(s *model.WidgetSettings) bool {
+		return s.UserID == 1 && s.Settings == newSettings
+	})).Return(nil)
+
+	err := svc.UpdateSettings(1, newSettings)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestWidgetSettingsUpdateSettings_EmptySettings(t *testing.T) {
+	svc, _ := newTestWidgetSettingsService()
+
+	err := svc.UpdateSettings(1, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "設定は必須です")
+}
+
+func TestWidgetSettingsUpdateSettings_InvalidJSON(t *testing.T) {
+	svc, _ := newTestWidgetSettingsService()
+
+	err := svc.UpdateSettings(1, "not valid json")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "設定は有効なJSONである必要があります")
+}
+
+func TestWidgetSettingsUpdateSettings_RepoError(t *testing.T) {
+	svc, repo := newTestWidgetSettingsService()
+
+	validSettings := `[{"key":"userProfile","visible":true,"order":0}]`
+	repo.On("Upsert", mock.AnythingOfType("*model.WidgetSettings")).Return(errors.New("db error"))
+
+	err := svc.UpdateSettings(1, validSettings)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestWidgetSettingsUpdateSettings_NotArray(t *testing.T) {
+	svc, _ := newTestWidgetSettingsService()
+
+	err := svc.UpdateSettings(1, `{"key":"value"}`)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "設定はJSON配列である必要があります")
+}

--- a/frontend/src/api/widgetSettings.ts
+++ b/frontend/src/api/widgetSettings.ts
@@ -1,0 +1,8 @@
+import client from './client';
+import type { WidgetSettings, WidgetConfig } from '../types/widgetSettings';
+
+export const getWidgetSettings = () =>
+  client.get<WidgetSettings>('/widget-settings');
+
+export const updateWidgetSettings = (settings: WidgetConfig[]) =>
+  client.put('/widget-settings', { settings });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1638,5 +1638,14 @@
     "updateSuccess": "Vorlage aktualisiert",
     "deleteSuccess": "Vorlage gelöscht",
     "deleteConfirm": "Diese Vorlage löschen?"
+  },
+  "widgetSettings": {
+    "title": "Widget-Einstellungen",
+    "customize": "Widgets anpassen",
+    "show": "Anzeigen",
+    "hide": "Ausblenden",
+    "resetToDefault": "Auf Standard zurücksetzen",
+    "saveSuccess": "Widget-Einstellungen gespeichert",
+    "resetSuccess": "Widget-Einstellungen zurückgesetzt"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1639,5 +1639,14 @@
     "updateSuccess": "Template updated",
     "deleteSuccess": "Template deleted",
     "deleteConfirm": "Delete this template?"
+  },
+  "widgetSettings": {
+    "title": "Widget Settings",
+    "customize": "Customize Widgets",
+    "show": "Show",
+    "hide": "Hide",
+    "resetToDefault": "Reset to Default",
+    "saveSuccess": "Widget settings saved",
+    "resetSuccess": "Widget settings reset"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1639,5 +1639,14 @@
     "updateSuccess": "Plantilla actualizada",
     "deleteSuccess": "Plantilla eliminada",
     "deleteConfirm": "¿Eliminar esta plantilla?"
+  },
+  "widgetSettings": {
+    "title": "Configuración de widgets",
+    "customize": "Personalizar widgets",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "resetToDefault": "Restaurar predeterminados",
+    "saveSuccess": "Configuración de widgets guardada",
+    "resetSuccess": "Configuración de widgets restablecida"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1639,5 +1639,14 @@
     "updateSuccess": "Modèle mis à jour",
     "deleteSuccess": "Modèle supprimé",
     "deleteConfirm": "Supprimer ce modèle ?"
+  },
+  "widgetSettings": {
+    "title": "Paramètres des widgets",
+    "customize": "Personnaliser les widgets",
+    "show": "Afficher",
+    "hide": "Masquer",
+    "resetToDefault": "Réinitialiser par défaut",
+    "saveSuccess": "Paramètres des widgets enregistrés",
+    "resetSuccess": "Paramètres des widgets réinitialisés"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1540,5 +1540,14 @@
     "updateSuccess": "テンプレートを更新しました",
     "deleteSuccess": "テンプレートを削除しました",
     "deleteConfirm": "このテンプレートを削除しますか？"
+  },
+  "widgetSettings": {
+    "title": "ウィジェット設定",
+    "customize": "ウィジェットをカスタマイズ",
+    "show": "表示",
+    "hide": "非表示",
+    "resetToDefault": "デフォルトに戻す",
+    "saveSuccess": "ウィジェット設定を保存しました",
+    "resetSuccess": "ウィジェット設定をリセットしました"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1641,5 +1641,14 @@
     "updateSuccess": "템플릿이 업데이트되었습니다",
     "deleteSuccess": "템플릿이 삭제되었습니다",
     "deleteConfirm": "이 템플릿을 삭제하시겠습니까?"
+  },
+  "widgetSettings": {
+    "title": "위젯 설정",
+    "customize": "위젯 커스터마이즈",
+    "show": "표시",
+    "hide": "숨기기",
+    "resetToDefault": "기본값으로 복원",
+    "saveSuccess": "위젯 설정이 저장되었습니다",
+    "resetSuccess": "위젯 설정이 초기화되었습니다"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1639,5 +1639,14 @@
     "updateSuccess": "Modelo atualizado",
     "deleteSuccess": "Modelo excluído",
     "deleteConfirm": "Excluir este modelo?"
+  },
+  "widgetSettings": {
+    "title": "Configurações de widgets",
+    "customize": "Personalizar widgets",
+    "show": "Mostrar",
+    "hide": "Ocultar",
+    "resetToDefault": "Restaurar padrão",
+    "saveSuccess": "Configurações de widgets salvas",
+    "resetSuccess": "Configurações de widgets redefinidas"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1638,5 +1638,14 @@
     "updateSuccess": "Шаблон обновлён",
     "deleteSuccess": "Шаблон удалён",
     "deleteConfirm": "Удалить этот шаблон?"
+  },
+  "widgetSettings": {
+    "title": "Настройки виджетов",
+    "customize": "Настроить виджеты",
+    "show": "Показать",
+    "hide": "Скрыть",
+    "resetToDefault": "Сбросить по умолчанию",
+    "saveSuccess": "Настройки виджетов сохранены",
+    "resetSuccess": "Настройки виджетов сброшены"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1639,5 +1639,14 @@
     "updateSuccess": "模板更新成功",
     "deleteSuccess": "模板删除成功",
     "deleteConfirm": "确定删除此模板吗？"
+  },
+  "widgetSettings": {
+    "title": "小部件设置",
+    "customize": "自定义小部件",
+    "show": "显示",
+    "hide": "隐藏",
+    "resetToDefault": "恢复默认",
+    "saveSuccess": "小部件设置已保存",
+    "resetSuccess": "小部件设置已重置"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1641,5 +1641,14 @@
     "updateSuccess": "模板更新成功",
     "deleteSuccess": "模板刪除成功",
     "deleteConfirm": "確定刪除此模板嗎？"
+  },
+  "widgetSettings": {
+    "title": "小工具設定",
+    "customize": "自訂小工具",
+    "show": "顯示",
+    "hide": "隱藏",
+    "resetToDefault": "恢復預設",
+    "saveSuccess": "小工具設定已儲存",
+    "resetSuccess": "小工具設定已重設"
   }
 }

--- a/frontend/src/types/widgetSettings.ts
+++ b/frontend/src/types/widgetSettings.ts
@@ -1,0 +1,17 @@
+export interface WidgetConfig {
+  key: string;
+  visible: boolean;
+  order: number;
+}
+
+export interface WidgetSettings {
+  id: number;
+  user_id: number;
+  settings: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UpdateWidgetSettingsRequest {
+  settings: WidgetConfig[];
+}


### PR DESCRIPTION
## 概要
ダッシュボードのウィジェット表示/非表示・並び順をユーザーごとにサーバーサイドで永続化。リロード後も設定が維持される。

## 変更内容
- **Model**: `WidgetSettings`（UserID + JSON設定文字列、ユーザーごとにユニーク）
- **Repository**: `FindByUserID` + `Upsert`（ON CONFLICT対応でINSERT or UPDATE）
- **Service**: 未登録時にデフォルト14ウィジェット設定を返却、JSONバリデーション（配列チェック含む）
- **Handler**: `GET /widget-settings`（取得）、`PUT /widget-settings`（更新）
- **DTO**: `UpdateWidgetSettingsRequest`（`json.RawMessage`で柔軟なJSON受け取り）
- **フロントエンド**: API クライアント + TypeScript型定義（`WidgetConfig`, `WidgetSettings`）
- **i18n**: 10言語に翻訳追加

## テスト
- Service層: 7テスト（取得成功・未登録デフォルト・更新成功・空設定・不正JSON・リポジトリエラー・非配列JSON）
- Handler層: 6テスト（取得成功・取得エラー・更新成功・不正JSON・設定未指定・サービスエラー）
- 全13テストパス

## APIエンドポイント
| メソッド | パス | 説明 |
|---------|------|------|
| GET | `/api/v1/widget-settings` | 自分のウィジェット設定取得 |
| PUT | `/api/v1/widget-settings` | ウィジェット設定更新 |

Closes #2025