### PR TITLE
refactor: ユーザープロフィール更新の構築ロジックをService層に移動

### DIFF
--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -12,8 +12,7 @@ type UserServiceInterface interface {
 	GetAll(query string) ([]model.User, error)
 	GetByID(id uint) (*model.User, error)
 	GetByUsername(username string) (*model.User, error)
-	Update(user *model.User) error
-	UpdateByOwner(id, userID uint, user *model.User) error
+	UpdateProfile(id, userID uint, input *service.UpdateProfileInput) (*model.User, error)
 	GetProfileCompleteness(userID uint) (*service.ProfileCompleteness, error)
 }
 
@@ -74,7 +73,7 @@ func (h *UserHandler) GetByUsername(c *gin.Context) {
 }
 
 // Update はユーザープロフィールを更新する。
-// 所有権チェックはService層で実施する。
+// 所有権チェック・フィールドマッピング・バリデーションはService層で実施する。
 func (h *UserHandler) Update(c *gin.Context) {
 	id, ok := parseID(c, "id")
 	if !ok {
@@ -82,43 +81,28 @@ func (h *UserHandler) Update(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	existing, err := h.service.GetByID(id)
-	if err != nil {
-		respondNotFound(c, "user not found")
-		return
-	}
-
 	input := bindJSON[dto.UpdateUserRequest](c)
 	if input == nil {
 		return
 	}
 
-	if input.Name != "" {
-		existing.Name = input.Name
-	}
-	existing.Bio = input.Bio
-	existing.AvatarURL = input.AvatarURL
-	if input.SkillsLanguages != nil {
-		existing.SkillsLanguages = *input.SkillsLanguages
-	}
-	if input.SkillsFrameworks != nil {
-		existing.SkillsFrameworks = *input.SkillsFrameworks
-	}
-	if input.AtCoderUsername != nil {
-		existing.AtCoderUsername = *input.AtCoderUsername
-	}
-	if input.PaizaRank != nil {
-		existing.PaizaRank = *input.PaizaRank
-	}
-	if input.OnboardingCompleted != nil {
-		existing.OnboardingCompleted = *input.OnboardingCompleted
+	profileInput := &service.UpdateProfileInput{
+		Name:                input.Name,
+		Bio:                 input.Bio,
+		AvatarURL:           input.AvatarURL,
+		SkillsLanguages:     input.SkillsLanguages,
+		SkillsFrameworks:    input.SkillsFrameworks,
+		AtCoderUsername:     input.AtCoderUsername,
+		PaizaRank:           input.PaizaRank,
+		OnboardingCompleted: input.OnboardingCompleted,
 	}
 
-	if err := h.service.UpdateByOwner(id, userID, existing); err != nil {
+	user, err := h.service.UpdateProfile(id, userID, profileInput)
+	if err != nil {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, existing)
+	respondOK(c, user)
 }
 
 // GetProfileCompleteness は認証ユーザーのプロフィール完成度を返す。

--- a/backend/internal/handler/user_test.go
+++ b/backend/internal/handler/user_test.go
@@ -38,12 +38,12 @@ func (m *MockUserService) GetByUsername(username string) (*model.User, error) {
 	return nil, args.Error(1)
 }
 
-func (m *MockUserService) Update(user *model.User) error {
-	return m.Called(user).Error(0)
-}
-
-func (m *MockUserService) UpdateByOwner(id, userID uint, user *model.User) error {
-	return m.Called(id, userID, user).Error(0)
+func (m *MockUserService) UpdateProfile(id, userID uint, input *service.UpdateProfileInput) (*model.User, error) {
+	args := m.Called(id, userID, input)
+	if user := args.Get(0); user != nil {
+		return user.(*model.User), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 func (m *MockUserService) GetProfileCompleteness(userID uint) (*service.ProfileCompleteness, error) {
@@ -226,9 +226,8 @@ func TestUserHandler_Update(t *testing.T) {
 		r := newRouter(1)
 		r.PUT("/users/:id", h.Update)
 
-		existing := &model.User{ID: 1, Name: "旧名前", Email: "test@test.com"}
-		svc.On("GetByID", uint(1)).Return(existing, nil)
-		svc.On("UpdateByOwner", uint(1), uint(1), mock.AnythingOfType("*model.User")).Return(nil)
+		updated := &model.User{ID: 1, Name: "新名前", Bio: "新しい自己紹介", Email: "test@test.com"}
+		svc.On("UpdateProfile", uint(1), uint(1), mock.AnythingOfType("*service.UpdateProfileInput")).Return(updated, nil)
 
 		w := doRequest(r, "PUT", "/users/1", map[string]interface{}{
 			"name": "新名前",
@@ -243,9 +242,7 @@ func TestUserHandler_Update(t *testing.T) {
 		r := newRouter(2)
 		r.PUT("/users/:id", h.Update)
 
-		existing := &model.User{ID: 1, Name: "旧名前"}
-		svc.On("GetByID", uint(1)).Return(existing, nil)
-		svc.On("UpdateByOwner", uint(1), uint(2), mock.AnythingOfType("*model.User")).Return(domain.ErrForbidden)
+		svc.On("UpdateProfile", uint(1), uint(2), mock.AnythingOfType("*service.UpdateProfileInput")).Return(nil, domain.ErrForbidden)
 
 		w := doRequest(r, "PUT", "/users/1", map[string]interface{}{"name": "不正更新"})
 		assertStatus(t, w, http.StatusForbidden)
@@ -257,7 +254,7 @@ func TestUserHandler_Update(t *testing.T) {
 		r := newRouter(999)
 		r.PUT("/users/:id", h.Update)
 
-		svc.On("GetByID", uint(999)).Return(nil, errors.New("not found"))
+		svc.On("UpdateProfile", uint(999), uint(999), mock.AnythingOfType("*service.UpdateProfileInput")).Return(nil, domain.ErrNotFound)
 
 		w := doRequest(r, "PUT", "/users/999", map[string]interface{}{"name": "テスト"})
 		assertStatus(t, w, http.StatusNotFound)
@@ -274,12 +271,9 @@ func TestUserHandler_Update(t *testing.T) {
 	})
 
 	t.Run("不正なJSONで400を返す", func(t *testing.T) {
-		h, svc := newTestUserHandler()
+		h, _ := newTestUserHandler()
 		r := newRouter(1)
 		r.PUT("/users/:id", h.Update)
-
-		existing := &model.User{ID: 1, Name: "旧名前"}
-		svc.On("GetByID", uint(1)).Return(existing, nil)
 
 		w := doRequestRaw(r, "PUT", "/users/1", "invalid json")
 		assertStatus(t, w, http.StatusBadRequest)
@@ -290,9 +284,7 @@ func TestUserHandler_Update(t *testing.T) {
 		r := newRouter(1)
 		r.PUT("/users/:id", h.Update)
 
-		existing := &model.User{ID: 1, Name: "旧名前"}
-		svc.On("GetByID", uint(1)).Return(existing, nil)
-		svc.On("UpdateByOwner", uint(1), uint(1), mock.AnythingOfType("*model.User")).Return(errors.New("db error"))
+		svc.On("UpdateProfile", uint(1), uint(1), mock.AnythingOfType("*service.UpdateProfileInput")).Return(nil, errors.New("db error"))
 
 		w := doRequest(r, "PUT", "/users/1", map[string]interface{}{"name": "新名前"})
 		assertStatus(t, w, http.StatusInternalServerError)

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -67,6 +67,58 @@ func (s *UserService) Update(user *model.User) error {
 	return s.repo.Update(user)
 }
 
+// UpdateProfileInput はプロフィール更新の入力パラメータ。
+// Handler層のDTOからService層への橋渡しとして使用する。
+type UpdateProfileInput struct {
+	Name                string
+	Bio                 string
+	AvatarURL           string
+	SkillsLanguages     *string
+	SkillsFrameworks    *string
+	AtCoderUsername     *string
+	PaizaRank           *string
+	OnboardingCompleted *bool
+}
+
+// UpdateProfile は所有権チェック・フィールドマッピング・バリデーション・保存を一括処理する。
+func (s *UserService) UpdateProfile(id, userID uint, input *UpdateProfileInput) (*model.User, error) {
+	if id != userID {
+		return nil, domain.ErrForbidden
+	}
+
+	existing, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, domain.NewError(domain.ErrCodeNotFound, "ユーザーが見つかりません", err)
+	}
+
+	if input.Name != "" {
+		existing.Name = input.Name
+	}
+	existing.Bio = input.Bio
+	existing.AvatarURL = input.AvatarURL
+	if input.SkillsLanguages != nil {
+		existing.SkillsLanguages = *input.SkillsLanguages
+	}
+	if input.SkillsFrameworks != nil {
+		existing.SkillsFrameworks = *input.SkillsFrameworks
+	}
+	if input.AtCoderUsername != nil {
+		existing.AtCoderUsername = *input.AtCoderUsername
+	}
+	if input.PaizaRank != nil {
+		existing.PaizaRank = *input.PaizaRank
+	}
+	if input.OnboardingCompleted != nil {
+		existing.OnboardingCompleted = *input.OnboardingCompleted
+	}
+
+	if err := s.Update(existing); err != nil {
+		return nil, err
+	}
+
+	return existing, nil
+}
+
 // ProfileCompleteness はプロフィール完成度の計算結果を表す。
 type ProfileCompleteness struct {
 	Percentage    int      `json:"percentage"`

--- a/backend/internal/service/user_test.go
+++ b/backend/internal/service/user_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // newTestUserService はUserServiceのテスト用インスタンスを生成するヘルパー。
@@ -312,6 +313,97 @@ func TestUserUpdateByOwner_Forbidden(t *testing.T) {
 	err := svc.UpdateByOwner(1, 2, user)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "権限がありません")
+}
+
+// ============================================================
+// UpdateProfile テスト
+// ============================================================
+
+func TestUserUpdateProfile_Success(t *testing.T) {
+	svc, repo := newTestUserService()
+
+	existing := &model.User{ID: 1, Name: "旧名前", Bio: "旧Bio"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.AnythingOfType("*model.User")).Return(nil)
+
+	langs := "Go,TypeScript"
+	input := &UpdateProfileInput{
+		Name:            "新名前",
+		Bio:             "新しいBio",
+		AvatarURL:       "https://example.com/avatar.png",
+		SkillsLanguages: &langs,
+	}
+
+	result, err := svc.UpdateProfile(1, 1, input)
+	assert.NoError(t, err)
+	assert.Equal(t, "新名前", result.Name)
+	assert.Equal(t, "新しいBio", result.Bio)
+	assert.Equal(t, "https://example.com/avatar.png", result.AvatarURL)
+	assert.Equal(t, "Go,TypeScript", result.SkillsLanguages)
+	repo.AssertExpectations(t)
+}
+
+func TestUserUpdateProfile_Forbidden(t *testing.T) {
+	svc, _ := newTestUserService()
+
+	input := &UpdateProfileInput{Name: "不正更新"}
+	_, err := svc.UpdateProfile(1, 2, input)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "権限がありません")
+}
+
+func TestUserUpdateProfile_UserNotFound(t *testing.T) {
+	svc, repo := newTestUserService()
+
+	repo.On("FindByID", uint(999)).Return((*model.User)(nil), errors.New("not found"))
+
+	input := &UpdateProfileInput{Name: "テスト"}
+	_, err := svc.UpdateProfile(999, 999, input)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ユーザーが見つかりません")
+}
+
+func TestUserUpdateProfile_EmptyNameKeepsExisting(t *testing.T) {
+	svc, repo := newTestUserService()
+
+	existing := &model.User{ID: 1, Name: "元の名前"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.AnythingOfType("*model.User")).Return(nil)
+
+	input := &UpdateProfileInput{Name: "", Bio: "新Bio"}
+
+	result, err := svc.UpdateProfile(1, 1, input)
+	assert.NoError(t, err)
+	assert.Equal(t, "元の名前", result.Name)
+	assert.Equal(t, "新Bio", result.Bio)
+}
+
+func TestUserUpdateProfile_OptionalFieldsNilSkipped(t *testing.T) {
+	svc, repo := newTestUserService()
+
+	existing := &model.User{ID: 1, Name: "Alice", SkillsLanguages: "Go", AtCoderUsername: "alice"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.AnythingOfType("*model.User")).Return(nil)
+
+	input := &UpdateProfileInput{Name: "Alice"}
+
+	result, err := svc.UpdateProfile(1, 1, input)
+	assert.NoError(t, err)
+	assert.Equal(t, "Go", result.SkillsLanguages)
+	assert.Equal(t, "alice", result.AtCoderUsername)
+}
+
+func TestUserUpdateProfile_ValidationError(t *testing.T) {
+	svc, repo := newTestUserService()
+
+	existing := &model.User{ID: 1, Name: "Alice"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	input := &UpdateProfileInput{Name: strings.Repeat("あ", 101)}
+
+	_, err := svc.UpdateProfile(1, 1, input)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "名前は100文字以下である必要があります")
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
closes #2027

Handler層（`user.go` 78-115行目）にあったDTO→ModelフィールドマッピングロジックをService層の`UpdateProfile`メソッドに集約し、クリーンアーキテクチャの責務分離を改善。

## 変更内容
- **Service層**: `UpdateProfileInput`構造体と`UpdateProfile`メソッドを追加
  - 所有権チェック → ユーザー取得 → フィールドマッピング → バリデーション → 保存を一括処理
  - ユーザー未発見時は`domain.ErrNotFound`を返却（適切なHTTPステータスマッピング）
- **Handler層**: `Update`メソッドをリクエスト解析・レスポンス返却に専念するよう簡素化
  - `UserServiceInterface`から`Update`/`UpdateByOwner`を削除し`UpdateProfile`に置換
- **テスト**: Service層6件・Handler層6件の`UpdateProfile`テスト全通過

## テスト結果
- `go test ./internal/service/... -v` ✅ PASS
- `go test ./internal/handler/... -v` ✅ PASS