### PR TITLE
test: Handler・Service層のエラーパス・エッジケーステスト強化

### DIFF
--- a/backend/internal/handler/quick_entry_test.go
+++ b/backend/internal/handler/quick_entry_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -44,4 +45,19 @@ func TestGetRecentCategories_Handler_Empty(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	svc.AssertExpectations(t)
+}
+
+func TestGetRecentCategories_Handler_ServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+
+	svc.On("GetRecentCategories", uint(1)).Return([]string(nil), errors.New("db error"))
+
+	r := gin.New()
+	r.GET("/learning-logs/recent-categories", authMiddleware(1), h.GetRecentCategories)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/learning-logs/recent-categories", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/backend/internal/handler/streak_freeze_test.go
+++ b/backend/internal/handler/streak_freeze_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -100,4 +101,52 @@ func TestStreakFreeze_GetStatus_Success(t *testing.T) {
 	if result["remaining"].(float64) != 1 {
 		t.Errorf("expected remaining=1, got %v", result["remaining"])
 	}
+}
+
+func TestStreakFreeze_GetStatus_ServiceError(t *testing.T) {
+	mockSvc := new(MockStreakFreezeService)
+	h := NewStreakFreezeHandler(mockSvc)
+
+	mockSvc.On("GetFreezeStatus", uint(1)).Return(nil, errors.New("db error"))
+
+	r := gin.New()
+	r.GET("/streak-freezes/status", authMiddleware(1), h.GetStatus)
+
+	req, _ := http.NewRequest("GET", "/streak-freezes/status", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestStreakFreeze_UseFreeze_ServiceInternalError(t *testing.T) {
+	mockSvc := new(MockStreakFreezeService)
+	h := NewStreakFreezeHandler(mockSvc)
+
+	mockSvc.On("UseFreeze", uint(1)).Return(errors.New("db error"))
+
+	r := gin.New()
+	r.POST("/streak-freezes", authMiddleware(1), h.UseFreeze)
+
+	req, _ := http.NewRequest("POST", "/streak-freezes", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestStreakFreeze_UseFreeze_MonthlyLimitReached(t *testing.T) {
+	mockSvc := new(MockStreakFreezeService)
+	h := NewStreakFreezeHandler(mockSvc)
+
+	mockSvc.On("UseFreeze", uint(1)).Return(domain.ErrBadRequest)
+
+	r := gin.New()
+	r.POST("/streak-freezes", authMiddleware(1), h.UseFreeze)
+
+	req, _ := http.NewRequest("POST", "/streak-freezes", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
 }

--- a/backend/internal/handler/weekly_challenge_test.go
+++ b/backend/internal/handler/weekly_challenge_test.go
@@ -1,12 +1,15 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -97,4 +100,70 @@ func TestWeeklyChallenge_UpdateProgress_Success(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// ウィークリーチャレンジ: エラーパステスト
+// ============================================================
+
+func TestWeeklyChallenge_GetCurrent_ServiceError(t *testing.T) {
+	h, svc := setupWeeklyChallengeHandler()
+
+	svc.On("GetCurrentChallenge", uint(1)).Return(nil, errors.New("db error"))
+
+	r := gin.New()
+	r.GET("/weekly-challenges/current", authMiddleware(1), h.GetCurrent)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/weekly-challenges/current", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestWeeklyChallenge_GetCurrent_NotFound(t *testing.T) {
+	h, svc := setupWeeklyChallengeHandler()
+
+	svc.On("GetCurrentChallenge", uint(1)).Return(nil, domain.ErrNotFound)
+
+	r := gin.New()
+	r.GET("/weekly-challenges/current", authMiddleware(1), h.GetCurrent)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/weekly-challenges/current", nil)
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestWeeklyChallenge_UpdateProgress_ServiceError(t *testing.T) {
+	h, svc := setupWeeklyChallengeHandler()
+
+	svc.On("UpdateProgress", uint(1), 100).Return(nil, errors.New("db error"))
+
+	r := gin.New()
+	r.PUT("/weekly-challenges/progress", authMiddleware(1), h.UpdateProgress)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/weekly-challenges/progress", jsonBody(map[string]interface{}{
+		"value": 100,
+	}))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestWeeklyChallenge_UpdateProgress_InvalidJSON(t *testing.T) {
+	h, _ := setupWeeklyChallengeHandler()
+
+	r := gin.New()
+	r.PUT("/weekly-challenges/progress", authMiddleware(1), h.UpdateProgress)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("PUT", "/weekly-challenges/progress", strings.NewReader("invalid json"))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 }

--- a/backend/internal/service/streak_freeze_test.go
+++ b/backend/internal/service/streak_freeze_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -131,4 +132,142 @@ func TestGetFreezeStatus_TodayAlreadyUsed(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, status.TodayUsed)
 	assert.False(t, status.CanUseToday)
+}
+
+// ============================================================
+// GetFreezeDates テスト（カバレッジ0%の修正）
+// ============================================================
+
+func TestGetFreezeDates_Success(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	dates := []string{"2026-02-01", "2026-02-15"}
+	mockRepo.On("GetFreezeDates", uint(1)).Return(dates, nil)
+
+	result, err := svc.GetFreezeDates(1)
+	assert.NoError(t, err)
+	assert.Equal(t, dates, result)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestGetFreezeDates_Empty(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	mockRepo.On("GetFreezeDates", uint(1)).Return([]string{}, nil)
+
+	result, err := svc.GetFreezeDates(1)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+}
+
+func TestGetFreezeDates_RepoError(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	mockRepo.On("GetFreezeDates", uint(1)).Return([]string(nil), errors.New("db error"))
+
+	result, err := svc.GetFreezeDates(1)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+}
+
+// ============================================================
+// UseFreeze エラー伝播テスト
+// ============================================================
+
+func TestUseFreeze_HasFreezeOnDateError(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	today := time.Now().Format("2006-01-02")
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(false, errors.New("db error"))
+
+	err := svc.UseFreeze(1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+}
+
+func TestUseFreeze_GetByUserIDAndMonthError(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(false, nil)
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze(nil), errors.New("db error"))
+
+	err := svc.UseFreeze(1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+}
+
+func TestUseFreeze_CreateError(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(false, nil)
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze{}, nil)
+	mockRepo.On("Create", mock.AnythingOfType("*model.StreakFreeze")).Return(errors.New("db error"))
+
+	err := svc.UseFreeze(1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+}
+
+// ============================================================
+// GetFreezeStatus エラー伝播テスト
+// ============================================================
+
+func TestGetFreezeStatus_GetByUserIDAndMonthError(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze(nil), errors.New("db error"))
+
+	status, err := svc.GetFreezeStatus(1)
+	assert.Error(t, err)
+	assert.Nil(t, status)
+}
+
+func TestGetFreezeStatus_HasFreezeOnDateError(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze{}, nil)
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(false, errors.New("db error"))
+
+	status, err := svc.GetFreezeStatus(1)
+	assert.Error(t, err)
+	assert.Nil(t, status)
+}
+
+func TestGetFreezeStatus_NoFreezes(t *testing.T) {
+	mockRepo := new(MockStreakFreezeRepository)
+	svc := NewStreakFreezeService(mockRepo)
+
+	now := time.Now()
+	today := now.Format("2006-01-02")
+	mockRepo.On("GetByUserIDAndMonth", uint(1), now.Year(), int(now.Month())).
+		Return([]model.StreakFreeze{}, nil)
+	mockRepo.On("HasFreezeOnDate", uint(1), today).Return(false, nil)
+
+	status, err := svc.GetFreezeStatus(1)
+	assert.NoError(t, err)
+	assert.Equal(t, model.MaxFreezesPerMonth, status.MaxFreezes)
+	assert.Equal(t, 0, status.UsedFreezes)
+	assert.Equal(t, model.MaxFreezesPerMonth, status.Remaining)
+	assert.False(t, status.TodayUsed)
+	assert.True(t, status.CanUseToday)
+	assert.Empty(t, status.UsedDates)
 }


### PR DESCRIPTION
## 概要
closes #2029

テストカバレッジ分析で特定された弱いテスト箇所を強化。計17テスト追加。

## 変更内容

### Service層（9テスト追加）
- **GetFreezeDates**: Success/Empty/RepoError — カバレッジ0%を解消
- **UseFreeze**: HasFreezeOnDateError/GetByUserIDAndMonthError/CreateError — リポジトリエラー伝播を検証
- **GetFreezeStatus**: GetByUserIDAndMonthError/HasFreezeOnDateError/NoFreezes — エラー伝播+境界値を検証

### Handler層（8テスト追加）
- **StreakFreezeHandler**: GetStatus_ServiceError/UseFreeze_ServiceInternalError/UseFreeze_MonthlyLimitReached
- **WeeklyChallengeHandler**: GetCurrent_ServiceError/GetCurrent_NotFound/UpdateProgress_ServiceError/UpdateProgress_InvalidJSON
- **GetRecentCategories**: ServiceError

## テスト結果
- `go test ./internal/service/... -count=1` ✅ PASS
- `go test ./internal/handler/... -count=1` ✅ PASS