### PR TITLE
fix: LIKE検索エスケープ漏れとパスワード最小長不整合を修正

### DIFF
--- a/backend/internal/dto/auth_dto.go
+++ b/backend/internal/dto/auth_dto.go
@@ -13,7 +13,7 @@ type RegisterRequest struct {
 	Name            string `json:"name" binding:"required,max=50" validate:"required,max=50"`
 	Username        string `json:"username" binding:"required,max=30" validate:"required,max=30"`
 	Email           string `json:"email" binding:"required,email,max=255" validate:"required,email,max=255"`
-	Password        string `json:"password" binding:"required,min=6" validate:"required,min=6"`
+	Password        string `json:"password" binding:"required,min=8" validate:"required,min=8"`
 	ConfirmPassword string `json:"confirm_password" binding:"required" validate:"required"`
 }
 
@@ -31,7 +31,7 @@ type PasswordResetRequest struct {
 // ResetPasswordRequest はトークンによるパスワードリセットリクエスト
 type ResetPasswordRequest struct {
 	Token       string `json:"token" binding:"required" validate:"required"`
-	NewPassword string `json:"new_password" binding:"required,min=6" validate:"required,min=6"`
+	NewPassword string `json:"new_password" binding:"required,min=8" validate:"required,min=8"`
 }
 
 // DeleteAccountRequest はアカウント削除リクエスト

--- a/backend/internal/repository/book_review.go
+++ b/backend/internal/repository/book_review.go
@@ -68,7 +68,7 @@ func (r *BookReviewRepository) FindByRating(userID uint, minRating, maxRating in
 func (r *BookReviewRepository) Search(query string, limit, offset int) ([]model.BookReview, int64, error) {
 	var reviews []model.BookReview
 	var total int64
-	like := "%" + query + "%"
+	like := EscapeLikePattern(query)
 	q := r.db.Where("title ILIKE ? OR author ILIKE ? OR isbn ILIKE ?", like, like, like)
 	q.Model(&model.BookReview{}).Count(&total)
 	err := q.Preload("User").Order("created_at DESC").Limit(limit).Offset(offset).Find(&reviews).Error

--- a/backend/internal/repository/recommendation.go
+++ b/backend/internal/repository/recommendation.go
@@ -32,7 +32,7 @@ func (r *RecommendationRepository) GetRecommendedUsers(userID uint, skills []str
 	var args []interface{}
 	for _, skill := range skills {
 		conditions = append(conditions, "skills_languages LIKE ? OR skills_frameworks LIKE ?")
-		pattern := "%" + skill + "%"
+		pattern := "%" + EscapeLikeChars(skill) + "%"
 		args = append(args, pattern, pattern)
 	}
 

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -35,7 +35,7 @@ type RegisterInput struct {
 	Name     string `json:"name" binding:"required"`
 	Username string `json:"username" binding:"required"`
 	Email    string `json:"email" binding:"required,email"`
-	Password string `json:"password" binding:"required,min=6"`
+	Password string `json:"password" binding:"required,min=8"`
 }
 
 // LoginInput はログインリクエストの入力値を表す。


### PR DESCRIPTION
## 概要
closes #2031

セキュリティ分析で検出された中深刻度の脆弱性2件+低深刻度1件を修正。

## 修正内容

### 1. LIKE検索エスケープ漏れ（中深刻度）
- **book_review.go**: `"%" + query + "%"` → `EscapeLikePattern(query)`
- **recommendation.go**: `"%" + skill + "%"` → `"%" + EscapeLikeChars(skill) + "%"`
- `%` や `_` を含む入力がワイルドカードとして解釈される問題を修正

### 2. パスワード最小長不整合（中深刻度）
- **auth_dto.go**: RegisterRequest.Password `min=6` → `min=8`
- **auth_dto.go**: ResetPasswordRequest.NewPassword `min=6` → `min=8`
- **service/auth.go**: RegisterInput.Password `min=6` → `min=8`
- `domain.MinPasswordLength = 8` との整合性を確保

## テスト結果
- `go test ./internal/service/... -count=1` ✅ PASS
- `go test ./internal/handler/... -count=1` ✅ PASS
- `go test ./internal/dto/... -count=1` ✅ PASS