### PR TITLE
feat: 書籍レビューに読書進捗トラッキングを追加

### DIFF
--- a/backend/internal/dto/book_review_dto.go
+++ b/backend/internal/dto/book_review_dto.go
@@ -4,12 +4,13 @@ import "github.com/norman6464/devsync/backend/internal/model"
 
 // CreateBookReviewRequest は書籍レビュー作成のリクエストボディ。
 type CreateBookReviewRequest struct {
-	Title    string `json:"title" binding:"required,min=1,max=300" validate:"required,min=1,max=300"`
-	Author   string `json:"author" binding:"max=200" validate:"max=200"`
-	ISBN     string `json:"isbn" binding:"max=20" validate:"max=20"`
-	Rating   int    `json:"rating" binding:"required,min=1,max=5" validate:"required,min=1,max=5"`
-	Review   string `json:"review" binding:"omitempty,max=5000"`
-	ImageURL string `json:"image_url" binding:"omitempty,http_url,max=2000"`
+	Title      string `json:"title" binding:"required,min=1,max=300" validate:"required,min=1,max=300"`
+	Author     string `json:"author" binding:"max=200" validate:"max=200"`
+	ISBN       string `json:"isbn" binding:"max=20" validate:"max=20"`
+	Rating     int    `json:"rating" binding:"required,min=1,max=5" validate:"required,min=1,max=5"`
+	Review     string `json:"review" binding:"omitempty,max=5000"`
+	ImageURL   string `json:"image_url" binding:"omitempty,http_url,max=2000"`
+	TotalPages *int   `json:"total_pages" binding:"omitempty,min=0"`
 }
 
 // UpdateBookReviewRequest は書籍レビュー更新のリクエストボディ。
@@ -20,6 +21,11 @@ type UpdateBookReviewRequest struct {
 	Rating   *int   `json:"rating" binding:"omitempty,min=1,max=5" validate:"omitempty,min=1,max=5"`
 	Review   string `json:"review" binding:"omitempty,min=1,max=5000"`
 	ImageURL string `json:"image_url" binding:"omitempty,http_url,max=2000"`
+}
+
+// UpdateReadingProgressRequest は読書進捗更新リクエスト。
+type UpdateReadingProgressRequest struct {
+	CurrentPage int `json:"current_page" binding:"required,min=0"`
 }
 
 // UpdateBookReviewStatusRequest は書籍レビューの読書状態更新リクエスト。

--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -18,6 +18,7 @@ type BookReviewServiceInterface interface {
 	ArchiveReview(id, userID uint) error
 	UnarchiveReview(id, userID uint) error
 	UpdateStatus(id, userID uint, status model.ReviewStatus) error
+	UpdateProgress(id, userID uint, currentPage int) (*model.BookReview, error)
 	Search(query string, limit, offset int) ([]model.BookReview, int64, error)
 }
 
@@ -49,6 +50,9 @@ func (h *BookReviewHandler) Create(c *gin.Context) {
 		Rating:   req.Rating,
 		Review:   req.Review,
 		ImageURL: req.ImageURL,
+	}
+	if req.TotalPages != nil {
+		review.TotalPages = *req.TotalPages
 	}
 
 	if err := h.service.Create(review); err != nil {
@@ -221,6 +225,28 @@ func (h *BookReviewHandler) UpdateStatus(c *gin.Context) {
 	}
 
 	respondOK(c, gin.H{"message": "読書状態を更新しました"})
+}
+
+// UpdateProgress は書籍レビューの読書進捗を更新する。
+func (h *BookReviewHandler) UpdateProgress(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	req := bindJSON[dto.UpdateReadingProgressRequest](c)
+	if req == nil {
+		return
+	}
+
+	review, err := h.service.UpdateProgress(id, userID, req.CurrentPage)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, review)
 }
 
 // Search は書籍レビューをキーワード検索する。

--- a/backend/internal/handler/book_review_test.go
+++ b/backend/internal/handler/book_review_test.go
@@ -516,6 +516,78 @@ func TestBookReviewSearch_ServiceError(t *testing.T) {
 }
 
 // ============================================================
+// UpdateProgress テスト
+// ============================================================
+
+func TestBookReviewUpdateProgress_Success(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id/progress", h.UpdateProgress)
+
+	review := &model.BookReview{Title: "Go本", TotalPages: 300, CurrentPage: 150, Status: model.ReviewStatusReading}
+	review.ID = 1
+	svc.On("UpdateProgress", uint(1), uint(1), 150).Return(review, nil)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/1/progress", map[string]interface{}{
+		"current_page": 150,
+	})
+	assertStatus(t, w, http.StatusOK)
+
+	body := parseJSON(t, w)
+	assert.Equal(t, float64(150), body["current_page"])
+	assert.Equal(t, float64(300), body["total_pages"])
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewUpdateProgress_InvalidJSON(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id/progress", h.UpdateProgress)
+
+	w := doRequestRaw(r, http.MethodPut, "/book-reviews/1/progress", "not json")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookReviewUpdateProgress_InvalidID(t *testing.T) {
+	h, _ := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id/progress", h.UpdateProgress)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/abc/progress", map[string]interface{}{
+		"current_page": 50,
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookReviewUpdateProgress_Forbidden(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id/progress", h.UpdateProgress)
+
+	svc.On("UpdateProgress", uint(5), uint(1), 50).Return(nil, service.ErrForbidden)
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/5/progress", map[string]interface{}{
+		"current_page": 50,
+	})
+	assertStatus(t, w, http.StatusForbidden)
+	svc.AssertExpectations(t)
+}
+
+func TestBookReviewUpdateProgress_ServiceError(t *testing.T) {
+	h, svc := setupBookReviewHandler()
+	r := newRouter(1)
+	r.PUT("/book-reviews/:id/progress", h.UpdateProgress)
+
+	svc.On("UpdateProgress", uint(1), uint(1), 50).Return(nil, errors.New("db error"))
+
+	w := doRequest(r, http.MethodPut, "/book-reviews/1/progress", map[string]interface{}{
+		"current_page": 50,
+	})
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
 // ImageURL バリデーションテスト
 // ============================================================
 

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -774,6 +774,13 @@ func (m *MockBookReviewService) UnarchiveReview(id, userID uint) error {
 func (m *MockBookReviewService) UpdateStatus(id, userID uint, status model.ReviewStatus) error {
 	return m.Called(id, userID, status).Error(0)
 }
+func (m *MockBookReviewService) UpdateProgress(id, userID uint, currentPage int) (*model.BookReview, error) {
+	args := m.Called(id, userID, currentPage)
+	if r := args.Get(0); r != nil {
+		return r.(*model.BookReview), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
 func (m *MockBookReviewService) Search(query string, limit, offset int) ([]model.BookReview, int64, error) {
 	args := m.Called(query, limit, offset)
 	return args.Get(0).([]model.BookReview), args.Get(1).(int64), args.Error(2)

--- a/backend/internal/model/book_review.go
+++ b/backend/internal/model/book_review.go
@@ -33,6 +33,8 @@ type BookReview struct {
 	ISBN      string         `json:"isbn" gorm:"size:20"`                     // ISBNコード
 	Rating    int            `json:"rating" gorm:"not null"`                  // 評価（1〜5の整数）
 	Review    string         `json:"review" gorm:"type:text"`                 // レビュー本文
+	TotalPages  int            `json:"total_pages" gorm:"default:0"`              // 総ページ数
+	CurrentPage int            `json:"current_page" gorm:"default:0"`             // 現在の読書ページ
 	ImageURL   string         `json:"image_url" gorm:"size:500"`               // 書籍カバー画像URL
 	Status     ReviewStatus   `json:"status" gorm:"default:'not_started'"`     // 読書状態
 	IsArchived bool           `json:"is_archived" gorm:"default:false"`        // アーカイブ済みフラグ

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -556,6 +556,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		bookReviews.PUT("/:id/archive", c.BookReviewHandler.Archive)
 		bookReviews.PUT("/:id/unarchive", c.BookReviewHandler.Unarchive)
 		bookReviews.PUT("/:id/status", c.BookReviewHandler.UpdateStatus)
+		bookReviews.PUT("/:id/progress", c.BookReviewHandler.UpdateProgress)
 	}
 
 	// バッジ

--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -152,6 +152,42 @@ func (s *BookReviewService) UnarchiveReview(id, userID uint) error {
 	return s.repo.Update(review)
 }
 
+// UpdateProgress は所有権を検証した後、読書進捗を更新する。
+// 総ページ数に到達した場合は自動的にステータスを「読了」に変更する。
+// 未読状態で進捗が1以上になった場合は自動的に「読中」に変更する。
+func (s *BookReviewService) UpdateProgress(id, userID uint, currentPage int) (*model.BookReview, error) {
+	if currentPage < 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "ページ数は0以上で指定してください", nil)
+	}
+
+	review, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	if review.TotalPages == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "総ページ数が設定されていません", nil)
+	}
+
+	if currentPage > review.TotalPages {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "総ページ数を超えることはできません", nil)
+	}
+
+	review.CurrentPage = currentPage
+
+	// ステータス自動更新
+	if currentPage >= review.TotalPages {
+		review.Status = model.ReviewStatusCompleted
+	} else if currentPage > 0 && review.Status == model.ReviewStatusNotStarted {
+		review.Status = model.ReviewStatusReading
+	}
+
+	if err := s.repo.Update(review); err != nil {
+		return nil, err
+	}
+	return review, nil
+}
+
 // Delete は所有権を検証した後、書籍レビューを削除する。
 func (s *BookReviewService) Delete(id, userID uint) error {
 	if _, err := s.findAndCheckOwnership(id, userID); err != nil {

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -576,6 +576,125 @@ func TestBookReviewSearch_RepoError(t *testing.T) {
 }
 
 // ============================================================
+// 読書進捗更新テスト
+// ============================================================
+
+func TestBookReviewUpdateProgress_Success(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Go本", TotalPages: 300, CurrentPage: 50, Status: model.ReviewStatusReading}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.MatchedBy(func(r *model.BookReview) bool {
+		return r.ID == 1 && r.CurrentPage == 150 && r.Status == model.ReviewStatusReading
+	})).Return(nil)
+
+	result, err := svc.UpdateProgress(1, 1, 150)
+	assert.NoError(t, err)
+	assert.Equal(t, 150, result.CurrentPage)
+	assert.Equal(t, model.ReviewStatusReading, result.Status)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewUpdateProgress_AutoComplete(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Go本", TotalPages: 300, CurrentPage: 200, Status: model.ReviewStatusReading}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.MatchedBy(func(r *model.BookReview) bool {
+		return r.ID == 1 && r.CurrentPage == 300 && r.Status == model.ReviewStatusCompleted
+	})).Return(nil)
+
+	result, err := svc.UpdateProgress(1, 1, 300)
+	assert.NoError(t, err)
+	assert.Equal(t, 300, result.CurrentPage)
+	assert.Equal(t, model.ReviewStatusCompleted, result.Status)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewUpdateProgress_ExceedsTotalPages(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Go本", TotalPages: 300, CurrentPage: 200}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.UpdateProgress(1, 1, 350)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "総ページ数を超えることはできません")
+}
+
+func TestBookReviewUpdateProgress_NegativePage(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	_, err := svc.UpdateProgress(1, 1, -1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ページ数は0以上")
+}
+
+func TestBookReviewUpdateProgress_NoTotalPages(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Go本", TotalPages: 0, CurrentPage: 0, Status: model.ReviewStatusNotStarted}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.UpdateProgress(1, 1, 50)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "総ページ数が設定されていません")
+}
+
+func TestBookReviewUpdateProgress_Forbidden(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 99, Title: "他人の本"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.UpdateProgress(1, 1, 50)
+	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+func TestBookReviewUpdateProgress_NotFound(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	_, err := svc.UpdateProgress(99, 1, 50)
+	assert.Error(t, err)
+}
+
+func TestBookReviewUpdateProgress_AutoStartReading(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Go本", TotalPages: 300, CurrentPage: 0, Status: model.ReviewStatusNotStarted}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.MatchedBy(func(r *model.BookReview) bool {
+		return r.ID == 1 && r.CurrentPage == 50 && r.Status == model.ReviewStatusReading
+	})).Return(nil)
+
+	result, err := svc.UpdateProgress(1, 1, 50)
+	assert.NoError(t, err)
+	assert.Equal(t, 50, result.CurrentPage)
+	assert.Equal(t, model.ReviewStatusReading, result.Status)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewUpdateProgress_RepoError(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Go本", TotalPages: 300, CurrentPage: 0, Status: model.ReviewStatusReading}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.AnythingOfType("*model.BookReview")).Return(errors.New("db error"))
+
+	_, err := svc.UpdateProgress(1, 1, 100)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+}
+
+// ============================================================
 // タイトル・レビュー本文の文字数バリデーションテスト
 // ============================================================
 

--- a/frontend/src/api/bookReviews.ts
+++ b/frontend/src/api/bookReviews.ts
@@ -54,3 +54,8 @@ export const updateBookReviewStatus = async (id: number, status: ReviewStatus): 
   const res = await client.put(`/book-reviews/${id}/status`, { status });
   return res.data;
 };
+
+export const updateReadingProgress = async (id: number, currentPage: number): Promise<BookReview> => {
+  const res = await client.put(`/book-reviews/${id}/progress`, { current_page: currentPage });
+  return res.data;
+};

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -943,6 +943,13 @@
     "unarchiveFailed": "Entarchivierung fehlgeschlagen",
     "statusUpdated": "Status aktualisiert",
     "statusUpdateFailed": "Statusaktualisierung fehlgeschlagen",
+    "totalPages": "Gesamtseitenzahl",
+    "currentPage": "Aktuelle Seite",
+    "progress": "Lesefortschritt",
+    "progressPercent": "{{percent}}% abgeschlossen",
+    "progressUpdate": "Fortschritt aktualisieren",
+    "progressUpdated": "Lesefortschritt aktualisiert",
+    "progressUpdateFailed": "Lesefortschritt konnte nicht aktualisiert werden",
     "sort": {
       "newest": "Neueste",
       "oldest": "Älteste",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -944,6 +944,13 @@
     "unarchiveFailed": "Failed to unarchive",
     "statusUpdated": "Status updated",
     "statusUpdateFailed": "Failed to update status",
+    "totalPages": "Total Pages",
+    "currentPage": "Current Page",
+    "progress": "Reading Progress",
+    "progressPercent": "{{percent}}% Complete",
+    "progressUpdate": "Update Progress",
+    "progressUpdated": "Reading progress updated",
+    "progressUpdateFailed": "Failed to update reading progress",
     "sort": {
       "newest": "Newest",
       "oldest": "Oldest",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -944,6 +944,13 @@
     "unarchiveFailed": "Error al desarchivar",
     "statusUpdated": "Estado actualizado",
     "statusUpdateFailed": "Error al actualizar el estado",
+    "totalPages": "Total de páginas",
+    "currentPage": "Página actual",
+    "progress": "Progreso de lectura",
+    "progressPercent": "{{percent}}% completado",
+    "progressUpdate": "Actualizar progreso",
+    "progressUpdated": "Progreso de lectura actualizado",
+    "progressUpdateFailed": "Error al actualizar el progreso de lectura",
     "sort": {
       "newest": "Más reciente",
       "oldest": "Más antiguo",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -944,6 +944,13 @@
     "unarchiveFailed": "Échec du désarchivage",
     "statusUpdated": "Statut mis à jour",
     "statusUpdateFailed": "Échec de la mise à jour du statut",
+    "totalPages": "Nombre total de pages",
+    "currentPage": "Page actuelle",
+    "progress": "Progression de lecture",
+    "progressPercent": "{{percent}}% terminé",
+    "progressUpdate": "Mettre à jour la progression",
+    "progressUpdated": "Progression de lecture mise à jour",
+    "progressUpdateFailed": "Échec de la mise à jour de la progression",
     "sort": {
       "newest": "Plus récent",
       "oldest": "Plus ancien",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -898,6 +898,13 @@
     "unarchiveFailed": "アーカイブ解除に失敗しました",
     "statusUpdated": "ステータスを更新しました",
     "statusUpdateFailed": "ステータスの更新に失敗しました",
+    "totalPages": "総ページ数",
+    "currentPage": "現在のページ",
+    "progress": "読書進捗",
+    "progressPercent": "{{percent}}% 完了",
+    "progressUpdate": "進捗を更新",
+    "progressUpdated": "読書進捗を更新しました",
+    "progressUpdateFailed": "読書進捗の更新に失敗しました",
     "sort": {
       "newest": "新着順",
       "oldest": "古い順",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -946,6 +946,13 @@
     "unarchiveFailed": "보관 해제에 실패했습니다",
     "statusUpdated": "상태가 업데이트되었습니다",
     "statusUpdateFailed": "상태 업데이트에 실패했습니다",
+    "totalPages": "총 페이지 수",
+    "currentPage": "현재 페이지",
+    "progress": "독서 진행률",
+    "progressPercent": "{{percent}}% 완료",
+    "progressUpdate": "진행률 업데이트",
+    "progressUpdated": "독서 진행률이 업데이트되었습니다",
+    "progressUpdateFailed": "독서 진행률 업데이트에 실패했습니다",
     "sort": {
       "newest": "최신순",
       "oldest": "오래된순",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -944,6 +944,13 @@
     "unarchiveFailed": "Falha ao desarquivar",
     "statusUpdated": "Status atualizado",
     "statusUpdateFailed": "Falha ao atualizar status",
+    "totalPages": "Total de páginas",
+    "currentPage": "Página atual",
+    "progress": "Progresso de leitura",
+    "progressPercent": "{{percent}}% concluído",
+    "progressUpdate": "Atualizar progresso",
+    "progressUpdated": "Progresso de leitura atualizado",
+    "progressUpdateFailed": "Falha ao atualizar progresso de leitura",
     "sort": {
       "newest": "Mais recente",
       "oldest": "Mais antigo",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -943,6 +943,13 @@
     "unarchiveFailed": "Не удалось разархивировать",
     "statusUpdated": "Статус обновлён",
     "statusUpdateFailed": "Не удалось обновить статус",
+    "totalPages": "Всего страниц",
+    "currentPage": "Текущая страница",
+    "progress": "Прогресс чтения",
+    "progressPercent": "{{percent}}% завершено",
+    "progressUpdate": "Обновить прогресс",
+    "progressUpdated": "Прогресс чтения обновлён",
+    "progressUpdateFailed": "Не удалось обновить прогресс чтения",
     "sort": {
       "newest": "Новые",
       "oldest": "Старые",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -944,6 +944,13 @@
     "unarchiveFailed": "取消归档失败",
     "statusUpdated": "状态已更新",
     "statusUpdateFailed": "状态更新失败",
+    "totalPages": "总页数",
+    "currentPage": "当前页码",
+    "progress": "阅读进度",
+    "progressPercent": "{{percent}}% 完成",
+    "progressUpdate": "更新进度",
+    "progressUpdated": "阅读进度已更新",
+    "progressUpdateFailed": "阅读进度更新失败",
     "sort": {
       "newest": "最新",
       "oldest": "最旧",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -946,6 +946,13 @@
     "unarchiveFailed": "取消封存失敗",
     "statusUpdated": "狀態已更新",
     "statusUpdateFailed": "狀態更新失敗",
+    "totalPages": "總頁數",
+    "currentPage": "目前頁碼",
+    "progress": "閱讀進度",
+    "progressPercent": "{{percent}}% 完成",
+    "progressUpdate": "更新進度",
+    "progressUpdated": "閱讀進度已更新",
+    "progressUpdateFailed": "閱讀進度更新失敗",
     "sort": {
       "newest": "最新",
       "oldest": "最舊",

--- a/frontend/src/types/bookReview.ts
+++ b/frontend/src/types/bookReview.ts
@@ -11,6 +11,8 @@ export interface BookReview {
   isbn: string;
   rating: number; // 1-5
   review: string;
+  total_pages: number;
+  current_page: number;
   image_url: string;
   status: ReviewStatus;
   is_archived: boolean;
@@ -25,6 +27,7 @@ export interface CreateBookReviewRequest {
   rating: number;
   review?: string;
   image_url?: string;
+  total_pages?: number;
 }
 
 export interface UpdateBookReviewRequest extends Partial<CreateBookReviewRequest> {}


### PR DESCRIPTION
## 概要
書籍レビューにページベースの読書進捗管理機能を追加。

- BookReviewモデルに`total_pages`/`current_page`フィールド追加
- `PUT /book-reviews/:id/progress` エンドポイント追加
- 進捗更新時のステータス自動遷移（未読→読中→読了）
- Service層9テスト、Handler層5テスト追加（TDD）
- フロントエンド型定義・API関数・i18n（10言語）更新

## テスト計画
- [x] Service層テスト（9件）: 成功・自動完了・超過・負数・総ページ未設定・権限・Not Found・自動読中開始・DBエラー
- [x] Handler層テスト（5件）: 成功・不正JSON・不正ID・権限エラー・サービスエラー
- [x] TypeScript型チェック通過

Closes #2033