### PR TITLE
feat: ユーザーリアクションサマリーAPI追加

### DIFF
--- a/backend/internal/handler/reaction_stats.go
+++ b/backend/internal/handler/reaction_stats.go
@@ -8,6 +8,7 @@ import (
 // ReactionStatsServiceInterface はReactionStatsHandlerが依存するサービスメソッドを定義する。
 type ReactionStatsServiceInterface interface {
 	GetReactionStats(userID uint) (*model.ReactionStats, error)
+	GetReactionSummary(userID uint) (*model.ReactionSummary, error)
 }
 
 // ReactionStatsHandler はユーザーリアクション統計関連のHTTPハンドラ。
@@ -34,4 +35,20 @@ func (h *ReactionStatsHandler) GetStats(c *gin.Context) {
 	}
 
 	respondOK(c, stats)
+}
+
+// GetSummary は指定ユーザーのリアクションサマリー（絵文字別集計＋トップ投稿）を返す。
+func (h *ReactionStatsHandler) GetSummary(c *gin.Context) {
+	userID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	summary, err := h.service.GetReactionSummary(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, summary)
 }

--- a/backend/internal/handler/stats_test.go
+++ b/backend/internal/handler/stats_test.go
@@ -637,6 +637,14 @@ func (m *MockReactionStatsService) GetReactionStats(userID uint) (*model.Reactio
 	return nil, args.Error(1)
 }
 
+func (m *MockReactionStatsService) GetReactionSummary(userID uint) (*model.ReactionSummary, error) {
+	args := m.Called(userID)
+	if v := args.Get(0); v != nil {
+		return v.(*model.ReactionSummary), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
 func TestReactionStats_GetStats_Success(t *testing.T) {
 	svc := new(MockReactionStatsService)
 	h := NewReactionStatsHandler(svc)
@@ -664,6 +672,41 @@ func TestReactionStats_GetStats_ServiceError(t *testing.T) {
 	r := newRouter(1)
 	r.GET("/users/:id/stats/reactions", h.GetStats)
 	w := doRequest(r, http.MethodGet, "/users/5/stats/reactions", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+func TestReactionStats_GetSummary_Success(t *testing.T) {
+	svc := new(MockReactionStatsService)
+	h := NewReactionStatsHandler(svc)
+	svc.On("GetReactionSummary", uint(5)).Return(&model.ReactionSummary{
+		TotalReactions: 10,
+		EmojiCounts:    []model.ReactionCount{{Emoji: "👍", Count: 5}},
+		TopPosts:       []model.TopReactedPost{{ID: 1, Title: "Test", ReactionCount: 5}},
+	}, nil)
+	r := newRouter(1)
+	r.GET("/users/:id/reaction-summary", h.GetSummary)
+	w := doRequest(r, http.MethodGet, "/users/5/reaction-summary", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestReactionStats_GetSummary_InvalidID(t *testing.T) {
+	svc := new(MockReactionStatsService)
+	h := NewReactionStatsHandler(svc)
+	r := newRouter(1)
+	r.GET("/users/:id/reaction-summary", h.GetSummary)
+	w := doRequest(r, http.MethodGet, "/users/abc/reaction-summary", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestReactionStats_GetSummary_ServiceError(t *testing.T) {
+	svc := new(MockReactionStatsService)
+	h := NewReactionStatsHandler(svc)
+	svc.On("GetReactionSummary", uint(5)).Return(nil, errors.New("db error"))
+	r := newRouter(1)
+	r.GET("/users/:id/reaction-summary", h.GetSummary)
+	w := doRequest(r, http.MethodGet, "/users/5/reaction-summary", nil)
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }

--- a/backend/internal/model/post.go
+++ b/backend/internal/model/post.go
@@ -57,6 +57,20 @@ type ReactionCount struct {
 	Count int    `json:"count"`
 }
 
+// TopReactedPost はリアクション数が多い投稿の要約。
+type TopReactedPost struct {
+	ID            uint   `json:"id"`
+	Title         string `json:"title"`
+	ReactionCount int    `json:"reaction_count"`
+}
+
+// ReactionSummary はユーザーのリアクションサマリー。
+type ReactionSummary struct {
+	EmojiCounts    []ReactionCount  `json:"emoji_counts"`
+	TopPosts       []TopReactedPost `json:"top_posts"`
+	TotalReactions int              `json:"total_reactions"`
+}
+
 // PostSeries は関連する投稿をシリーズとしてグループ化する。
 type PostSeries struct {
 	ID          uint      `json:"id" gorm:"primaryKey"`

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -620,6 +620,8 @@ type MentionStatsRepositoryInterface interface {
 // ReactionStatsRepositoryInterface はユーザーリアクション集計統計データ操作の契約を定義する。
 type ReactionStatsRepositoryInterface interface {
 	GetReactionStats(userID uint) (*model.ReactionStats, error)
+	GetEmojiBreakdown(userID uint) ([]model.ReactionCount, error)
+	GetTopReactedPosts(userID uint, limit int) ([]model.TopReactedPost, error)
 }
 
 // BookmarkStatsRepositoryInterface はユーザーブックマーク集計統計データ操作の契約を定義する。

--- a/backend/internal/repository/reaction_stats.go
+++ b/backend/internal/repository/reaction_stats.go
@@ -50,3 +50,30 @@ func (r *ReactionStatsRepository) GetReactionStats(userID uint) (*model.Reaction
 
 	return &stats, nil
 }
+
+// GetEmojiBreakdown は指定ユーザーの全投稿に対する絵文字別リアクション集計を返す。
+func (r *ReactionStatsRepository) GetEmojiBreakdown(userID uint) ([]model.ReactionCount, error) {
+	var counts []model.ReactionCount
+	err := r.db.Model(&model.Reaction{}).
+		Select("reactions.emoji, COUNT(*) as count").
+		Joins("JOIN posts ON posts.id = reactions.post_id").
+		Where("posts.user_id = ?", userID).
+		Group("reactions.emoji").
+		Order("count DESC").
+		Find(&counts).Error
+	return counts, err
+}
+
+// GetTopReactedPosts は指定ユーザーの投稿のうちリアクション数が多い順にlimit件返す。
+func (r *ReactionStatsRepository) GetTopReactedPosts(userID uint, limit int) ([]model.TopReactedPost, error) {
+	var posts []model.TopReactedPost
+	err := r.db.Model(&model.Reaction{}).
+		Select("posts.id, posts.title, COUNT(*) as reaction_count").
+		Joins("JOIN posts ON posts.id = reactions.post_id").
+		Where("posts.user_id = ?", userID).
+		Group("posts.id, posts.title").
+		Order("reaction_count DESC").
+		Limit(limit).
+		Find(&posts).Error
+	return posts, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -697,6 +697,7 @@ func registerUserStatsRoutes(g *gin.RouterGroup, c *di.Container) {
 		users.GET("/:id/message-stats", c.MessageStatsHandler.GetStats)
 		users.GET("/:id/mention-stats", c.MentionStatsHandler.GetStats)
 		users.GET("/:id/reaction-stats", c.ReactionStatsHandler.GetStats)
+		users.GET("/:id/reaction-summary", c.ReactionStatsHandler.GetSummary)
 		users.GET("/:id/bookmark-stats", c.BookmarkStatsHandler.GetStats)
 	}
 }

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2266,6 +2266,16 @@ func (m *MockReactionStatsRepository) GetReactionStats(userID uint) (*model.Reac
 	return args.Get(0).(*model.ReactionStats), args.Error(1)
 }
 
+func (m *MockReactionStatsRepository) GetEmojiBreakdown(userID uint) ([]model.ReactionCount, error) {
+	args := m.Called(userID)
+	return args.Get(0).([]model.ReactionCount), args.Error(1)
+}
+
+func (m *MockReactionStatsRepository) GetTopReactedPosts(userID uint, limit int) ([]model.TopReactedPost, error) {
+	args := m.Called(userID, limit)
+	return args.Get(0).([]model.TopReactedPost), args.Error(1)
+}
+
 // MockBookmarkStatsRepository は repository.BookmarkStatsRepositoryInterface のテスト用モック実装。
 // ============================================================
 

--- a/backend/internal/service/reaction_stats.go
+++ b/backend/internal/service/reaction_stats.go
@@ -22,3 +22,31 @@ func (s *ReactionStatsService) GetReactionStats(userID uint) (*model.ReactionSta
 	}
 	return s.repo.GetReactionStats(userID)
 }
+
+// GetReactionSummary は指定ユーザーのリアクションサマリー（絵文字別集計＋トップ投稿）を取得する。
+func (s *ReactionStatsService) GetReactionSummary(userID uint) (*model.ReactionSummary, error) {
+	if err := validateRequiredID(userID, "userID"); err != nil {
+		return nil, err
+	}
+
+	emojiCounts, err := s.repo.GetEmojiBreakdown(userID)
+	if err != nil {
+		return nil, err
+	}
+
+	topPosts, err := s.repo.GetTopReactedPosts(userID, 5)
+	if err != nil {
+		return nil, err
+	}
+
+	total := 0
+	for _, ec := range emojiCounts {
+		total += ec.Count
+	}
+
+	return &model.ReactionSummary{
+		EmojiCounts:    emojiCounts,
+		TopPosts:       topPosts,
+		TotalReactions: total,
+	}, nil
+}

--- a/backend/internal/service/reaction_stats_test.go
+++ b/backend/internal/service/reaction_stats_test.go
@@ -46,6 +46,76 @@ func TestReactionStatsService_GetStats_RepoError(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+// ============================================================
+// リアクションサマリーテスト
+// ============================================================
+
+func TestReactionStatsService_GetSummary_Success(t *testing.T) {
+	svc, repo := newReactionStatsTestService()
+
+	emojiCounts := []model.ReactionCount{
+		{Emoji: "🔥", Count: 15},
+		{Emoji: "👍", Count: 12},
+	}
+	topPosts := []model.TopReactedPost{
+		{ID: 1, Title: "Go入門", ReactionCount: 10},
+		{ID: 2, Title: "React入門", ReactionCount: 5},
+	}
+	repo.On("GetEmojiBreakdown", uint(1)).Return(emojiCounts, nil)
+	repo.On("GetTopReactedPosts", uint(1), 5).Return(topPosts, nil)
+
+	result, err := svc.GetReactionSummary(1)
+	assert.NoError(t, err)
+	assert.Len(t, result.EmojiCounts, 2)
+	assert.Equal(t, "🔥", result.EmojiCounts[0].Emoji)
+	assert.Len(t, result.TopPosts, 2)
+	assert.Equal(t, 27, result.TotalReactions)
+	repo.AssertExpectations(t)
+}
+
+func TestReactionStatsService_GetSummary_InvalidUserID(t *testing.T) {
+	svc, _ := newReactionStatsTestService()
+
+	_, err := svc.GetReactionSummary(0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "userIDは必須です")
+}
+
+func TestReactionStatsService_GetSummary_EmojiBreakdownError(t *testing.T) {
+	svc, repo := newReactionStatsTestService()
+
+	repo.On("GetEmojiBreakdown", uint(1)).Return([]model.ReactionCount(nil), errors.New("db error"))
+
+	_, err := svc.GetReactionSummary(1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+}
+
+func TestReactionStatsService_GetSummary_TopPostsError(t *testing.T) {
+	svc, repo := newReactionStatsTestService()
+
+	emojiCounts := []model.ReactionCount{{Emoji: "👍", Count: 5}}
+	repo.On("GetEmojiBreakdown", uint(1)).Return(emojiCounts, nil)
+	repo.On("GetTopReactedPosts", uint(1), 5).Return([]model.TopReactedPost(nil), errors.New("db error"))
+
+	_, err := svc.GetReactionSummary(1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "db error")
+}
+
+func TestReactionStatsService_GetSummary_Empty(t *testing.T) {
+	svc, repo := newReactionStatsTestService()
+
+	repo.On("GetEmojiBreakdown", uint(99)).Return([]model.ReactionCount{}, nil)
+	repo.On("GetTopReactedPosts", uint(99), 5).Return([]model.TopReactedPost{}, nil)
+
+	result, err := svc.GetReactionSummary(99)
+	assert.NoError(t, err)
+	assert.Empty(t, result.EmojiCounts)
+	assert.Empty(t, result.TopPosts)
+	assert.Equal(t, 0, result.TotalReactions)
+}
+
 func TestReactionStatsService_GetStats_NoActivity(t *testing.T) {
 	svc, repo := newReactionStatsTestService()
 	expected := &model.ReactionStats{}

--- a/frontend/src/api/reactionStats.ts
+++ b/frontend/src/api/reactionStats.ts
@@ -1,0 +1,5 @@
+import client from './client';
+import type { ReactionSummary } from '../types/post';
+
+export const getReactionSummary = (userId: number) =>
+  client.get<ReactionSummary>(`/users/${userId}/reaction-summary`);

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -902,7 +902,7 @@
     "title": "Buchrezensionen",
     "timeline": "Zeitleiste",
     "profile": "Profil",
-    "progress": "Fortschritt",
+    "progress": "Lesefortschritt",
     "activities": "Aktivitäten",
     "recommendations": "Empfehlungen",
     "subtitle": "Teile deine Meinung zu Technikbüchern",
@@ -945,7 +945,6 @@
     "statusUpdateFailed": "Statusaktualisierung fehlgeschlagen",
     "totalPages": "Gesamtseitenzahl",
     "currentPage": "Aktuelle Seite",
-    "progress": "Lesefortschritt",
     "progressPercent": "{{percent}}% abgeschlossen",
     "progressUpdate": "Fortschritt aktualisieren",
     "progressUpdated": "Lesefortschritt aktualisiert",
@@ -1654,5 +1653,13 @@
     "resetToDefault": "Auf Standard zurücksetzen",
     "saveSuccess": "Widget-Einstellungen gespeichert",
     "resetSuccess": "Widget-Einstellungen zurückgesetzt"
+  },
+  "reactionSummary": {
+    "title": "Reaktionszusammenfassung",
+    "totalReactions": "Gesamte Reaktionen",
+    "emojiBreakdown": "Emoji-Aufschlüsselung",
+    "topPosts": "Meistbeachtete Beiträge",
+    "noReactions": "Noch keine Reaktionen",
+    "loadFailed": "Laden der Reaktionszusammenfassung fehlgeschlagen"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -903,7 +903,7 @@
     "title": "Book Reviews",
     "timeline": "Timeline",
     "profile": "Profile",
-    "progress": "Progress",
+    "progress": "Reading Progress",
     "activities": "Activities",
     "recommendations": "Recommendations",
     "subtitle": "Share your thoughts on tech books",
@@ -946,7 +946,6 @@
     "statusUpdateFailed": "Failed to update status",
     "totalPages": "Total Pages",
     "currentPage": "Current Page",
-    "progress": "Reading Progress",
     "progressPercent": "{{percent}}% Complete",
     "progressUpdate": "Update Progress",
     "progressUpdated": "Reading progress updated",
@@ -1655,5 +1654,13 @@
     "resetToDefault": "Reset to Default",
     "saveSuccess": "Widget settings saved",
     "resetSuccess": "Widget settings reset"
+  },
+  "reactionSummary": {
+    "title": "Reaction Summary",
+    "totalReactions": "Total Reactions",
+    "emojiBreakdown": "Emoji Breakdown",
+    "topPosts": "Top Reacted Posts",
+    "noReactions": "No reactions yet",
+    "loadFailed": "Failed to load reaction summary"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -903,7 +903,7 @@
     "title": "Reseñas de Libros",
     "timeline": "Línea de tiempo",
     "profile": "Perfil",
-    "progress": "Progreso",
+    "progress": "Progreso de lectura",
     "activities": "Actividades",
     "recommendations": "Recomendaciones",
     "subtitle": "Comparte tus opiniones sobre libros de tecnología",
@@ -946,7 +946,6 @@
     "statusUpdateFailed": "Error al actualizar el estado",
     "totalPages": "Total de páginas",
     "currentPage": "Página actual",
-    "progress": "Progreso de lectura",
     "progressPercent": "{{percent}}% completado",
     "progressUpdate": "Actualizar progreso",
     "progressUpdated": "Progreso de lectura actualizado",
@@ -1655,5 +1654,13 @@
     "resetToDefault": "Restaurar predeterminados",
     "saveSuccess": "Configuración de widgets guardada",
     "resetSuccess": "Configuración de widgets restablecida"
+  },
+  "reactionSummary": {
+    "title": "Resumen de reacciones",
+    "totalReactions": "Total de reacciones",
+    "emojiBreakdown": "Desglose por emoji",
+    "topPosts": "Publicaciones más reaccionadas",
+    "noReactions": "Aún no hay reacciones",
+    "loadFailed": "Error al cargar el resumen de reacciones"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -903,7 +903,7 @@
     "title": "Critiques de Livres",
     "timeline": "Fil d'actualité",
     "profile": "Profil",
-    "progress": "Progrès",
+    "progress": "Progression de lecture",
     "activities": "Activités",
     "recommendations": "Recommandations",
     "subtitle": "Partagez vos avis sur les livres techniques",
@@ -946,7 +946,6 @@
     "statusUpdateFailed": "Échec de la mise à jour du statut",
     "totalPages": "Nombre total de pages",
     "currentPage": "Page actuelle",
-    "progress": "Progression de lecture",
     "progressPercent": "{{percent}}% terminé",
     "progressUpdate": "Mettre à jour la progression",
     "progressUpdated": "Progression de lecture mise à jour",
@@ -1655,5 +1654,13 @@
     "resetToDefault": "Réinitialiser par défaut",
     "saveSuccess": "Paramètres des widgets enregistrés",
     "resetSuccess": "Paramètres des widgets réinitialisés"
+  },
+  "reactionSummary": {
+    "title": "Résumé des réactions",
+    "totalReactions": "Total des réactions",
+    "emojiBreakdown": "Répartition par emoji",
+    "topPosts": "Publications les plus réagies",
+    "noReactions": "Aucune réaction pour le moment",
+    "loadFailed": "Échec du chargement du résumé des réactions"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1556,5 +1556,13 @@
     "resetToDefault": "デフォルトに戻す",
     "saveSuccess": "ウィジェット設定を保存しました",
     "resetSuccess": "ウィジェット設定をリセットしました"
+  },
+  "reactionSummary": {
+    "title": "リアクションサマリー",
+    "totalReactions": "リアクション合計",
+    "emojiBreakdown": "絵文字別集計",
+    "topPosts": "リアクション上位の投稿",
+    "noReactions": "まだリアクションがありません",
+    "loadFailed": "リアクションサマリーの読み込みに失敗しました"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -905,7 +905,7 @@
     "title": "도서 리뷰",
     "timeline": "타임라인",
     "profile": "프로필",
-    "progress": "진행 상황",
+    "progress": "독서 진행률",
     "activities": "활동",
     "recommendations": "추천",
     "subtitle": "기술 서적에 대한 생각을 공유하세요",
@@ -948,7 +948,6 @@
     "statusUpdateFailed": "상태 업데이트에 실패했습니다",
     "totalPages": "총 페이지 수",
     "currentPage": "현재 페이지",
-    "progress": "독서 진행률",
     "progressPercent": "{{percent}}% 완료",
     "progressUpdate": "진행률 업데이트",
     "progressUpdated": "독서 진행률이 업데이트되었습니다",
@@ -1657,5 +1656,13 @@
     "resetToDefault": "기본값으로 복원",
     "saveSuccess": "위젯 설정이 저장되었습니다",
     "resetSuccess": "위젯 설정이 초기화되었습니다"
+  },
+  "reactionSummary": {
+    "title": "리액션 요약",
+    "totalReactions": "총 리액션",
+    "emojiBreakdown": "이모지별 집계",
+    "topPosts": "리액션 상위 게시물",
+    "noReactions": "아직 리액션이 없습니다",
+    "loadFailed": "리액션 요약을 불러오지 못했습니다"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -903,7 +903,7 @@
     "title": "Resenhas de Livros",
     "timeline": "Linha do tempo",
     "profile": "Perfil",
-    "progress": "Progresso",
+    "progress": "Progresso de leitura",
     "activities": "Atividades",
     "recommendations": "Recomendações",
     "subtitle": "Compartilhe suas opiniões sobre livros de tecnologia",
@@ -946,7 +946,6 @@
     "statusUpdateFailed": "Falha ao atualizar status",
     "totalPages": "Total de páginas",
     "currentPage": "Página atual",
-    "progress": "Progresso de leitura",
     "progressPercent": "{{percent}}% concluído",
     "progressUpdate": "Atualizar progresso",
     "progressUpdated": "Progresso de leitura atualizado",
@@ -1655,5 +1654,13 @@
     "resetToDefault": "Restaurar padrão",
     "saveSuccess": "Configurações de widgets salvas",
     "resetSuccess": "Configurações de widgets redefinidas"
+  },
+  "reactionSummary": {
+    "title": "Resumo de reações",
+    "totalReactions": "Total de reações",
+    "emojiBreakdown": "Detalhamento por emoji",
+    "topPosts": "Publicações mais reagidas",
+    "noReactions": "Ainda não há reações",
+    "loadFailed": "Falha ao carregar resumo de reações"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -902,7 +902,7 @@
     "title": "Обзоры книг",
     "timeline": "Лента",
     "profile": "Профиль",
-    "progress": "Прогресс",
+    "progress": "Прогресс чтения",
     "activities": "Активности",
     "recommendations": "Рекомендации",
     "subtitle": "Поделитесь своим мнением о технических книгах",
@@ -945,7 +945,6 @@
     "statusUpdateFailed": "Не удалось обновить статус",
     "totalPages": "Всего страниц",
     "currentPage": "Текущая страница",
-    "progress": "Прогресс чтения",
     "progressPercent": "{{percent}}% завершено",
     "progressUpdate": "Обновить прогресс",
     "progressUpdated": "Прогресс чтения обновлён",
@@ -1654,5 +1653,13 @@
     "resetToDefault": "Сбросить по умолчанию",
     "saveSuccess": "Настройки виджетов сохранены",
     "resetSuccess": "Настройки виджетов сброшены"
+  },
+  "reactionSummary": {
+    "title": "Сводка реакций",
+    "totalReactions": "Всего реакций",
+    "emojiBreakdown": "Разбивка по эмодзи",
+    "topPosts": "Самые реагируемые посты",
+    "noReactions": "Реакций пока нет",
+    "loadFailed": "Не удалось загрузить сводку реакций"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -903,7 +903,7 @@
     "title": "书评",
     "timeline": "时间线",
     "profile": "个人资料",
-    "progress": "进度",
+    "progress": "阅读进度",
     "activities": "活动",
     "recommendations": "推荐",
     "subtitle": "分享你对技术书籍的看法",
@@ -946,7 +946,6 @@
     "statusUpdateFailed": "状态更新失败",
     "totalPages": "总页数",
     "currentPage": "当前页码",
-    "progress": "阅读进度",
     "progressPercent": "{{percent}}% 完成",
     "progressUpdate": "更新进度",
     "progressUpdated": "阅读进度已更新",
@@ -1655,5 +1654,13 @@
     "resetToDefault": "恢复默认",
     "saveSuccess": "小部件设置已保存",
     "resetSuccess": "小部件设置已重置"
+  },
+  "reactionSummary": {
+    "title": "反应摘要",
+    "totalReactions": "反应总数",
+    "emojiBreakdown": "表情分类统计",
+    "topPosts": "反应最多的帖子",
+    "noReactions": "还没有反应",
+    "loadFailed": "加载反应摘要失败"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -905,7 +905,7 @@
     "title": "書評",
     "timeline": "時間線",
     "profile": "個人資料",
-    "progress": "進度",
+    "progress": "閱讀進度",
     "activities": "活動",
     "recommendations": "推薦",
     "subtitle": "分享你對技術書籍的看法",
@@ -948,7 +948,6 @@
     "statusUpdateFailed": "狀態更新失敗",
     "totalPages": "總頁數",
     "currentPage": "目前頁碼",
-    "progress": "閱讀進度",
     "progressPercent": "{{percent}}% 完成",
     "progressUpdate": "更新進度",
     "progressUpdated": "閱讀進度已更新",
@@ -1657,5 +1656,13 @@
     "resetToDefault": "恢復預設",
     "saveSuccess": "小工具設定已儲存",
     "resetSuccess": "小工具設定已重設"
+  },
+  "reactionSummary": {
+    "title": "反應摘要",
+    "totalReactions": "反應總數",
+    "emojiBreakdown": "表情分類統計",
+    "topPosts": "反應最多的貼文",
+    "noReactions": "還沒有反應",
+    "loadFailed": "載入反應摘要失敗"
   }
 }

--- a/frontend/src/types/post.ts
+++ b/frontend/src/types/post.ts
@@ -138,3 +138,15 @@ export interface SnippetComment {
   created_at: string;
   updated_at: string;
 }
+
+export interface TopReactedPost {
+  id: number;
+  title: string;
+  reaction_count: number;
+}
+
+export interface ReactionSummary {
+  emoji_counts: ReactionCount[];
+  top_posts: TopReactedPost[];
+  total_reactions: number;
+}


### PR DESCRIPTION
## 概要
- ユーザーの投稿に対するリアクションのサマリー情報を取得するAPIエンドポイントを追加
- 絵文字別リアクション集計とリアクション数上位の投稿を返す

## 変更内容
- `GET /users/:id/reaction-summary` エンドポイント追加
- Service層: `GetReactionSummary` メソッド（絵文字別集計 + トップ5投稿 + 合計数）
- Repository層: `GetEmojiBreakdown`, `GetTopReactedPosts` メソッド
- Handler層: `GetSummary` ハンドラー
- フロントエンド: `TopReactedPost`, `ReactionSummary` 型 + API関数
- i18n: 全10言語に `reactionSummary` セクション追加

## テスト
- Service層: 5テスト（Success, InvalidUserID, EmojiBreakdownError, TopPostsError, Empty）
- Handler層: 3テスト（Success, InvalidID, ServiceError）
- 既存テスト含め全テストPASS

closes #2035