### PR TITLE
refactor: Handler層のビジネスロジック・エラーレスポンスをService層に移動 (#2043)

### DIFF
--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -69,7 +69,7 @@ func (h *AIAdviceHandler) MarkAsRead(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	if err := h.service.MarkAsRead(id, userID); err != nil {
-		respondNotFound(c, "advice not found")
+		respondError(c, err)
 		return
 	}
 

--- a/backend/internal/handler/ai_advice_test.go
+++ b/backend/internal/handler/ai_advice_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -62,7 +63,7 @@ func TestAIAdvice_MarkAsRead_Success(t *testing.T) {
 
 func TestAIAdvice_MarkAsRead_NotFound(t *testing.T) {
 	h, svc := setupAIAdviceHandler()
-	svc.On("MarkAsRead", uint(99), uint(1)).Return(errors.New("not found"))
+	svc.On("MarkAsRead", uint(99), uint(1)).Return(domain.NewError(domain.ErrCodeNotFound, "not found", nil))
 
 	r := gin.New()
 	r.PUT("/advice/:id/read", authMiddleware(1), h.MarkAsRead)

--- a/backend/internal/handler/post_collection.go
+++ b/backend/internal/handler/post_collection.go
@@ -12,6 +12,7 @@ type PostCollectionServiceInterface interface {
 	GetByID(id uint) (*model.PostCollection, error)
 	GetByUserID(userID uint, limit, offset int) ([]model.PostCollection, int64, error)
 	GetPublicByUserID(userID uint) ([]model.PostCollection, error)
+	GetCollectionsForViewer(viewerID, targetUserID uint, limit, offset int) ([]model.PostCollection, int64, error)
 	Update(id, userID uint, title, description string, isPublic bool) (*model.PostCollection, error)
 	Delete(id, userID uint) error
 	AddPost(collectionID, userID, postID uint, note string) error
@@ -71,37 +72,27 @@ func (h *PostCollectionHandler) GetByID(c *gin.Context) {
 }
 
 // GetByUserID は指定ユーザーのコレクション一覧を取得する。
-// 自分のコレクションはページネーション付きで全件、他人のコレクションは公開のみ返す。
+// 表示権限の判定（自分=全件/他人=公開のみ）はService層に委譲する。
 func (h *PostCollectionHandler) GetByUserID(c *gin.Context) {
 	currentUserID := c.GetUint("userID")
 	targetUserID, ok := parseID(c, "userId")
 	if !ok {
 		return
 	}
+	limit, offset := parseLimitOffset(c)
 
-	if currentUserID == targetUserID {
-		limit, offset := parseLimitOffset(c)
-		collections, total, err := h.service.GetByUserID(targetUserID, limit, offset)
-		if err != nil {
-			respondError(c, err)
-			return
-		}
-		respondOK(c, dto.PostCollectionListResponse{
-			Collections: ensureSlice(collections),
-			Total:       total,
-			Limit:       limit,
-			Offset:      offset,
-		})
-		return
-	}
-
-	collections, err := h.service.GetPublicByUserID(targetUserID)
+	collections, total, err := h.service.GetCollectionsForViewer(currentUserID, targetUserID, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return
 	}
 
-	respondOK(c, ensureSlice(collections))
+	respondOK(c, dto.PostCollectionListResponse{
+		Collections: ensureSlice(collections),
+		Total:       total,
+		Limit:       limit,
+		Offset:      offset,
+	})
 }
 
 // Update は指定IDのコレクションを更新する。

--- a/backend/internal/handler/post_collection_test.go
+++ b/backend/internal/handler/post_collection_test.go
@@ -57,6 +57,10 @@ func (m *MockPostCollectionService) AddPost(collectionID, userID, postID uint, n
 func (m *MockPostCollectionService) RemovePost(collectionID, userID, postID uint) error {
 	return m.Called(collectionID, userID, postID).Error(0)
 }
+func (m *MockPostCollectionService) GetCollectionsForViewer(viewerID, targetUserID uint, limit, offset int) ([]model.PostCollection, int64, error) {
+	args := m.Called(viewerID, targetUserID, limit, offset)
+	return args.Get(0).([]model.PostCollection), args.Get(1).(int64), args.Error(2)
+}
 func (m *MockPostCollectionService) GetPosts(collectionID uint) ([]model.PostCollectionItem, error) {
 	args := m.Called(collectionID)
 	if v := args.Get(0); v != nil {
@@ -162,7 +166,7 @@ func TestPostCollectionGetByID_ServiceError(t *testing.T) {
 func TestPostCollectionGetByUserID_OwnCollections(t *testing.T) {
 	h, svc := setupPostCollectionHandler()
 	collections := []model.PostCollection{{Title: "My Collection", UserID: 1}}
-	svc.On("GetByUserID", uint(1), 20, 0).Return(collections, int64(1), nil)
+	svc.On("GetCollectionsForViewer", uint(1), uint(1), 20, 0).Return(collections, int64(1), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:userId/collections", h.GetByUserID)
@@ -175,7 +179,7 @@ func TestPostCollectionGetByUserID_OwnCollections(t *testing.T) {
 func TestPostCollectionGetByUserID_OtherUserPublicOnly(t *testing.T) {
 	h, svc := setupPostCollectionHandler()
 	collections := []model.PostCollection{{Title: "Public Collection", UserID: 2, IsPublic: true}}
-	svc.On("GetPublicByUserID", uint(2)).Return(collections, nil)
+	svc.On("GetCollectionsForViewer", uint(1), uint(2), 20, 0).Return(collections, int64(1), nil)
 
 	r := newRouter(1)
 	r.GET("/users/:userId/collections", h.GetByUserID)
@@ -197,7 +201,7 @@ func TestPostCollectionGetByUserID_InvalidID(t *testing.T) {
 
 func TestPostCollectionGetByUserID_ServiceError(t *testing.T) {
 	h, svc := setupPostCollectionHandler()
-	svc.On("GetByUserID", uint(1), 20, 0).Return(nil, int64(0), errors.New("db error"))
+	svc.On("GetCollectionsForViewer", uint(1), uint(1), 20, 0).Return([]model.PostCollection(nil), int64(0), errors.New("db error"))
 
 	r := newRouter(1)
 	r.GET("/users/:userId/collections", h.GetByUserID)

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -50,7 +50,7 @@ func (h *UserHandler) GetByID(c *gin.Context) {
 
 	user, err := h.service.GetByID(id)
 	if err != nil {
-		respondNotFound(c, "user not found")
+		respondError(c, err)
 		return
 	}
 	respondOK(c, user)
@@ -66,7 +66,7 @@ func (h *UserHandler) GetByUsername(c *gin.Context) {
 
 	user, err := h.service.GetByUsername(username)
 	if err != nil {
-		respondNotFound(c, "user not found")
+		respondError(c, err)
 		return
 	}
 	respondOK(c, user)

--- a/backend/internal/handler/user_test.go
+++ b/backend/internal/handler/user_test.go
@@ -168,7 +168,7 @@ func TestUserHandler_GetByID(t *testing.T) {
 		r := newRouter(1)
 		r.GET("/users/:id", h.GetByID)
 
-		svc.On("GetByID", uint(999)).Return(nil, errors.New("not found"))
+		svc.On("GetByID", uint(999)).Return(nil, domain.NewError(domain.ErrCodeNotFound, "not found", nil))
 
 		w := doRequest(r, "GET", "/users/999", nil)
 		assertStatus(t, w, http.StatusNotFound)
@@ -208,7 +208,7 @@ func TestUserHandler_GetByUsername(t *testing.T) {
 		r := newRouter(1)
 		r.GET("/users/username/:username", h.GetByUsername)
 
-		svc.On("GetByUsername", "nonexistent").Return(nil, errors.New("not found"))
+		svc.On("GetByUsername", "nonexistent").Return(nil, domain.NewError(domain.ErrCodeNotFound, "not found", nil))
 
 		w := doRequest(r, "GET", "/users/username/nonexistent", nil)
 		assertStatus(t, w, http.StatusNotFound)

--- a/backend/internal/service/ai_advice.go
+++ b/backend/internal/service/ai_advice.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -56,7 +57,10 @@ func (s *AIAdviceService) GetUnreadAdvice(userID uint) ([]model.AIAdvice, error)
 
 // MarkAsRead はアドバイスを既読にする。
 func (s *AIAdviceService) MarkAsRead(id, userID uint) error {
-	return s.adviceRepo.MarkAsRead(id, userID)
+	if err := s.adviceRepo.MarkAsRead(id, userID); err != nil {
+		return domain.NewError(domain.ErrCodeNotFound, "アドバイスが見つかりません", err)
+	}
+	return nil
 }
 
 // IsLLMAvailable はLLMクライアントが設定されているかどうかを返す。

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -49,6 +49,19 @@ func (s *PostCollectionService) GetPublicByUserID(userID uint) ([]model.PostColl
 	return s.repo.FindPublicByUserID(userID)
 }
 
+// GetCollectionsForViewer は閲覧者の立場に応じたコレクション一覧を返す。
+// 自分のコレクションは全件（ページネーション付き）、他人のコレクションは公開のみ返す。
+func (s *PostCollectionService) GetCollectionsForViewer(viewerID, targetUserID uint, limit, offset int) ([]model.PostCollection, int64, error) {
+	if viewerID == targetUserID {
+		return s.repo.FindByUserID(targetUserID, limit, offset)
+	}
+	collections, err := s.repo.FindPublicByUserID(targetUserID)
+	if err != nil {
+		return nil, 0, err
+	}
+	return collections, int64(len(collections)), nil
+}
+
 // findAndCheckOwnership はコレクションを取得し、指定ユーザーが所有者かを検証する。
 func (s *PostCollectionService) findAndCheckOwnership(id, userID uint) (*model.PostCollection, error) {
 	return checkOwnership(s.repo.FindByID, id, userID, func(c *model.PostCollection) uint { return c.UserID })

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -26,12 +26,20 @@ func (s *UserService) GetAll(query string) ([]model.User, error) {
 
 // GetByID は指定IDのユーザーを取得する。
 func (s *UserService) GetByID(id uint) (*model.User, error) {
-	return s.repo.FindByID(id)
+	user, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, domain.NewError(domain.ErrCodeNotFound, "ユーザーが見つかりません", err)
+	}
+	return user, nil
 }
 
 // GetByUsername は指定ユーザー名のユーザーを取得する。
 func (s *UserService) GetByUsername(username string) (*model.User, error) {
-	return s.repo.FindByUsername(username)
+	user, err := s.repo.FindByUsername(username)
+	if err != nil {
+		return nil, domain.NewError(domain.ErrCodeNotFound, "ユーザーが見つかりません", err)
+	}
+	return user, nil
 }
 
 // FindByID は指定IDのユーザーを取得する（リポジトリ互換エイリアス）。


### PR DESCRIPTION
## 概要
クリーンアーキテクチャの原則に従い、Handler層で直接行われていたビジネスロジック・エラー判定をService層に移動。

## 変更内容
- **user.go**: `respondNotFound` → `respondError` に統一。Service層の`GetByID`/`GetByUsername`で`domain.ErrCodeNotFound`をラップ
- **ai_advice.go**: `respondNotFound` → `respondError` に統一。Service層の`MarkAsRead`で`domain.ErrCodeNotFound`をラップ
- **post_collection.go**: 表示権限の判定ロジック（自分=全件/他人=公開のみ）をService層の`GetCollectionsForViewer`メソッドに移動
- テスト: domain errorを返すモックに更新

## テスト
- 全既存テストパス確認済み（service + handler）

closes #2043