### PR TITLE
test: Service/Handler層のテストカバレッジ向上 (#2045)

### DIFF
--- a/backend/internal/handler/bookmark_collection_test.go
+++ b/backend/internal/handler/bookmark_collection_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -209,4 +210,167 @@ func TestBookmarkCollection_GetPosts_Success(t *testing.T) {
 	if result["total"].(float64) != 2 {
 		t.Errorf("expected total=2, got %v", result["total"])
 	}
+}
+
+// ============================================================
+// RemovePost テスト
+// ============================================================
+
+func TestBookmarkCollection_RemovePost_Success(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("RemovePost", uint(1), uint(10), uint(1)).Return(nil)
+
+	r := gin.New()
+	r.DELETE("/bookmark-collections/:id/posts/:postId", authMiddleware(1), h.RemovePost)
+
+	req, _ := http.NewRequest("DELETE", "/bookmark-collections/1/posts/10", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusOK)
+	mockSvc.AssertExpectations(t)
+}
+
+func TestBookmarkCollection_RemovePost_InvalidCollectionID(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	r := gin.New()
+	r.DELETE("/bookmark-collections/:id/posts/:postId", authMiddleware(1), h.RemovePost)
+
+	req, _ := http.NewRequest("DELETE", "/bookmark-collections/abc/posts/10", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookmarkCollection_RemovePost_InvalidPostID(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	r := gin.New()
+	r.DELETE("/bookmark-collections/:id/posts/:postId", authMiddleware(1), h.RemovePost)
+
+	req, _ := http.NewRequest("DELETE", "/bookmark-collections/1/posts/abc", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookmarkCollection_RemovePost_ServiceError(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("RemovePost", uint(1), uint(10), uint(1)).Return(domain.ErrForbidden)
+
+	r := gin.New()
+	r.DELETE("/bookmark-collections/:id/posts/:postId", authMiddleware(1), h.RemovePost)
+
+	req, _ := http.NewRequest("DELETE", "/bookmark-collections/1/posts/10", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+// ============================================================
+// エラーケース追加テスト
+// ============================================================
+
+func TestBookmarkCollection_Create_ServiceError(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("Create", mock.AnythingOfType("*model.BookmarkCollection")).Return(errors.New("db error"))
+
+	r := gin.New()
+	r.POST("/bookmark-collections", authMiddleware(1), h.Create)
+
+	body := jsonBody(map[string]string{"name": "Test"})
+	req, _ := http.NewRequest("POST", "/bookmark-collections", body)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestBookmarkCollection_GetMyCollections_ServiceError(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("GetByUserID", uint(1)).Return([]model.BookmarkCollection(nil), errors.New("db error"))
+
+	r := gin.New()
+	r.GET("/bookmark-collections", authMiddleware(1), h.GetMyCollections)
+
+	req, _ := http.NewRequest("GET", "/bookmark-collections", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestBookmarkCollection_Delete_ServiceError(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("Delete", uint(1), uint(1)).Return(domain.ErrForbidden)
+
+	r := gin.New()
+	r.DELETE("/bookmark-collections/:id", authMiddleware(1), h.Delete)
+
+	req, _ := http.NewRequest("DELETE", "/bookmark-collections/1", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+func TestBookmarkCollection_Delete_InvalidID(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	r := gin.New()
+	r.DELETE("/bookmark-collections/:id", authMiddleware(1), h.Delete)
+
+	req, _ := http.NewRequest("DELETE", "/bookmark-collections/abc", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestBookmarkCollection_GetPosts_ServiceError(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("GetPosts", uint(1), 20, 0).Return([]model.Post(nil), int64(0), errors.New("db error"))
+
+	r := gin.New()
+	r.GET("/bookmark-collections/:id/posts", h.GetPosts)
+
+	req, _ := http.NewRequest("GET", "/bookmark-collections/1/posts", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+func TestBookmarkCollection_GetPosts_InvalidID(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	r := gin.New()
+	r.GET("/bookmark-collections/:id/posts", h.GetPosts)
+
+	req, _ := http.NewRequest("GET", "/bookmark-collections/abc/posts", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusBadRequest)
 }

--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -462,3 +462,50 @@ func TestPostCollectionUpdate_DescriptionTooLong(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "説明は1000文字以下")
 }
+
+// ============================================================
+// GetCollectionsForViewer テスト
+// ============================================================
+
+func TestGetCollectionsForViewer_OwnCollections(t *testing.T) {
+	svc, repo := newTestPostCollectionService()
+
+	collections := []model.PostCollection{
+		{Title: "Private集", UserID: 1, IsPublic: false},
+		{Title: "Public集", UserID: 1, IsPublic: true},
+	}
+	repo.On("FindByUserID", uint(1), 20, 0).Return(collections, int64(2), nil)
+
+	result, total, err := svc.GetCollectionsForViewer(1, 1, 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	repo.AssertExpectations(t)
+}
+
+func TestGetCollectionsForViewer_OtherUserPublicOnly(t *testing.T) {
+	svc, repo := newTestPostCollectionService()
+
+	collections := []model.PostCollection{
+		{Title: "Public集", UserID: 2, IsPublic: true},
+	}
+	repo.On("FindPublicByUserID", uint(2)).Return(collections, nil)
+
+	result, total, err := svc.GetCollectionsForViewer(1, 2, 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
+	repo.AssertExpectations(t)
+}
+
+func TestGetCollectionsForViewer_OtherUserRepoError(t *testing.T) {
+	svc, repo := newTestPostCollectionService()
+
+	repo.On("FindPublicByUserID", uint(2)).Return([]model.PostCollection(nil), errors.New("db error"))
+
+	result, total, err := svc.GetCollectionsForViewer(1, 2, 20, 0)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
テストカバレッジが不足している箇所にテストを追加。

## 変更内容
- PostCollectionService.GetCollectionsForViewer テスト3件追加
- BookmarkCollectionHandler テスト10件追加（RemovePost全ケース、各ハンドラーのエラーケース）

## カバレッジ改善
- Service: 86.3% → 86.5%
- Handler: 91.1% → 91.7%

closes #2045