### PR TITLE
fix: upload.goのpanic()をグレースフルなエラー処理に置換

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -221,7 +221,11 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	c.RankingHandler = handler.NewRankingHandler(rankingService)
 	c.MessageHandler = handler.NewMessageHandler(messageService)
 	c.WebSocketHandler = handler.NewWebSocketHandler(hub, authService, parseOrigins(origins))
-	c.UploadHandler = handler.NewUploadHandler()
+	uploadHandler, err := handler.NewUploadHandler()
+	if err != nil {
+		log.Fatalf("アップロードハンドラの初期化に失敗: %v", err)
+	}
+	c.UploadHandler = uploadHandler
 	c.NotificationHandler = handler.NewNotificationHandler(notificationService)
 	c.ZennHandler = handler.NewArticlePlatformHandler[model.ZennArticle, model.ZennStats](zennService, "Zenn")
 	c.QiitaHandler = handler.NewArticlePlatformHandler[model.QiitaArticle, model.QiitaStats](qiitaService, "Qiita")

--- a/backend/internal/domain/validators.go
+++ b/backend/internal/domain/validators.go
@@ -184,7 +184,7 @@ func isBlockedHost(hostname string) bool {
 		return false // ドメイン名の場合はDNS解決前なので許可
 	}
 
-	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast()
+	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }
 
 // ValidateTags はタグのバリデーションを行う

--- a/backend/internal/domain/validators_test.go
+++ b/backend/internal/domain/validators_test.go
@@ -167,6 +167,7 @@ func TestValidateURL(t *testing.T) {
 		{"SSRF: プライベートIP(172.16.x)", "http://172.16.0.1", true},
 		{"SSRF: 0.0.0.0", "http://0.0.0.0", true},
 		{"SSRF: IPv6ループバック", "http://[::1]/path", true},
+		{"SSRF: IPv6 unspecified", "http://[::]/path", true},
 	}
 
 	for _, tt := range tests {

--- a/backend/internal/handler/upload.go
+++ b/backend/internal/handler/upload.go
@@ -50,7 +50,7 @@ type UploadHandler struct {
 
 // NewUploadHandler は新しいUploadHandlerインスタンスを生成する。
 // アップロードディレクトリが存在しない場合は自動で作成する。
-func NewUploadHandler() *UploadHandler {
+func NewUploadHandler() (*UploadHandler, error) {
 	uploadDir := os.Getenv("UPLOAD_DIR")
 	if uploadDir == "" {
 		uploadDir = "./uploads"
@@ -58,10 +58,10 @@ func NewUploadHandler() *UploadHandler {
 
 	// アップロードディレクトリが存在しない場合は作成する
 	if err := os.MkdirAll(uploadDir, uploadDirPerm); err != nil {
-		panic(fmt.Sprintf("Failed to create upload directory: %v", err))
+		return nil, fmt.Errorf("failed to create upload directory: %w", err)
 	}
 
-	return &UploadHandler{uploadDir: uploadDir}
+	return &UploadHandler{uploadDir: uploadDir}, nil
 }
 
 // UploadImage は単一の画像ファイルをアップロードする。


### PR DESCRIPTION
## 概要
- `NewUploadHandler()`の`panic()`を`error`返却に変更し、DIコンテナで`log.Fatal`によるグレースフル終了に変更
- SSRF保護に`ip.IsUnspecified()`チェック追加（IPv6 `::`アドレス対策）
- バリデーターテストにIPv6 unspecifiedケース追加

Closes #2047