### PR TITLE
feat: プロジェクトのマイルストーン管理機能を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -88,6 +88,7 @@ type Container struct {
 	WeeklyGoalHandler            *handler.WeeklyGoalHandler
 	NoteVersionHandler           *handler.NoteVersionHandler
 	ResourceProgressHandler      *handler.ResourceProgressHandler
+	ProjectMilestoneHandler      *handler.ProjectMilestoneHandler
 
 	// ミドルウェア・コールバック用
 	AuthService      *service.AuthService
@@ -407,6 +408,11 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	resourceProgressRepo := repository.NewResourceProgressRepository(db)
 	resourceProgressService := service.NewResourceProgressService(resourceProgressRepo, learningResourceRepo)
 	c.ResourceProgressHandler = handler.NewResourceProgressHandler(resourceProgressService)
+
+	// プロジェクトマイルストーンサービス
+	projectMilestoneRepo := repository.NewProjectMilestoneRepository(db)
+	projectMilestoneService := service.NewProjectMilestoneService(projectMilestoneRepo, projectRepo)
+	c.ProjectMilestoneHandler = handler.NewProjectMilestoneHandler(projectMilestoneService)
 
 	// HubのGetRoomMembersコールバックを設定
 	hub.GetRoomMembers = groupMessageRepo.GetMemberUserIDs

--- a/backend/internal/dto/project_milestone_dto.go
+++ b/backend/internal/dto/project_milestone_dto.go
@@ -1,0 +1,23 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// CreateMilestoneRequest はマイルストーン作成のリクエストボディ。
+type CreateMilestoneRequest struct {
+	Title       string `json:"title" binding:"required,max=200"`
+	Description string `json:"description" binding:"omitempty,max=5000"`
+	DueDate     string `json:"due_date" binding:"omitempty,max=20"`
+}
+
+// UpdateMilestoneRequest はマイルストーン更新のリクエストボディ。
+type UpdateMilestoneRequest struct {
+	Title       string `json:"title" binding:"omitempty,max=200"`
+	Description string `json:"description" binding:"omitempty,max=5000"`
+	DueDate     string `json:"due_date" binding:"omitempty,max=20"`
+	Status      string `json:"status" binding:"omitempty"`
+}
+
+// MilestoneListResponse はマイルストーン一覧レスポンス。
+type MilestoneListResponse struct {
+	Milestones []model.ProjectMilestone `json:"milestones"`
+}

--- a/backend/internal/handler/project_milestone.go
+++ b/backend/internal/handler/project_milestone.go
@@ -1,0 +1,124 @@
+package handler
+
+import (
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// ProjectMilestoneServiceInterface はマイルストーンサービスの抽象インターフェース。
+type ProjectMilestoneServiceInterface interface {
+	Create(userID, projectID uint, title, description string, dueDate *time.Time) error
+	GetByProjectID(projectID uint) ([]model.ProjectMilestone, error)
+	Update(userID, milestoneID uint, title, description string, dueDate *time.Time, status string) (*model.ProjectMilestone, error)
+	Delete(userID, milestoneID uint) error
+}
+
+// ProjectMilestoneHandler はマイルストーン関連のHTTPハンドラ。
+type ProjectMilestoneHandler struct {
+	service ProjectMilestoneServiceInterface
+}
+
+// NewProjectMilestoneHandler は新しいProjectMilestoneHandlerインスタンスを生成する。
+func NewProjectMilestoneHandler(s ProjectMilestoneServiceInterface) *ProjectMilestoneHandler {
+	return &ProjectMilestoneHandler{service: s}
+}
+
+// Create はマイルストーンを作成する。
+func (h *ProjectMilestoneHandler) Create(c *gin.Context) {
+	userID := c.GetUint("userID")
+	projectID, ok := parseID(c, "projectId")
+	if !ok {
+		return
+	}
+
+	req := bindJSON[dto.CreateMilestoneRequest](c)
+	if req == nil {
+		return
+	}
+
+	var dueDate *time.Time
+	if req.DueDate != "" {
+		d, err := parseDate(req.DueDate)
+		if err != nil {
+			respondBadRequest(c, "日付の形式が不正です（YYYY-MM-DD）")
+			return
+		}
+		dueDate = &d
+	}
+
+	if err := h.service.Create(userID, projectID, req.Title, req.Description, dueDate); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, gin.H{"message": "マイルストーンを作成しました"})
+}
+
+// GetByProjectID はプロジェクトのマイルストーン一覧を取得する。
+func (h *ProjectMilestoneHandler) GetByProjectID(c *gin.Context) {
+	projectID, ok := parseID(c, "projectId")
+	if !ok {
+		return
+	}
+
+	milestones, err := h.service.GetByProjectID(projectID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.MilestoneListResponse{
+		Milestones: ensureSlice(milestones),
+	})
+}
+
+// Update はマイルストーンを更新する。
+func (h *ProjectMilestoneHandler) Update(c *gin.Context) {
+	userID := c.GetUint("userID")
+	milestoneID, ok := parseID(c, "milestoneId")
+	if !ok {
+		return
+	}
+
+	req := bindJSON[dto.UpdateMilestoneRequest](c)
+	if req == nil {
+		return
+	}
+
+	var dueDate *time.Time
+	if req.DueDate != "" {
+		d, err := parseDate(req.DueDate)
+		if err != nil {
+			respondBadRequest(c, "日付の形式が不正です（YYYY-MM-DD）")
+			return
+		}
+		dueDate = &d
+	}
+
+	result, err := h.service.Update(userID, milestoneID, req.Title, req.Description, dueDate, req.Status)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, result)
+}
+
+// Delete はマイルストーンを削除する。
+func (h *ProjectMilestoneHandler) Delete(c *gin.Context) {
+	userID := c.GetUint("userID")
+	milestoneID, ok := parseID(c, "milestoneId")
+	if !ok {
+		return
+	}
+
+	if err := h.service.Delete(userID, milestoneID); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"message": "マイルストーンを削除しました"})
+}

--- a/backend/internal/handler/project_milestone_test.go
+++ b/backend/internal/handler/project_milestone_test.go
@@ -1,0 +1,163 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/mock"
+)
+
+// --- Mock ---
+
+type MockProjectMilestoneService struct{ mock.Mock }
+
+func (m *MockProjectMilestoneService) Create(userID, projectID uint, title, description string, dueDate *time.Time) error {
+	return m.Called(userID, projectID, title, description, dueDate).Error(0)
+}
+
+func (m *MockProjectMilestoneService) GetByProjectID(projectID uint) ([]model.ProjectMilestone, error) {
+	args := m.Called(projectID)
+	return args.Get(0).([]model.ProjectMilestone), args.Error(1)
+}
+
+func (m *MockProjectMilestoneService) Update(userID, milestoneID uint, title, description string, dueDate *time.Time, status string) (*model.ProjectMilestone, error) {
+	args := m.Called(userID, milestoneID, title, description, dueDate, status)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.ProjectMilestone), args.Error(1)
+}
+
+func (m *MockProjectMilestoneService) Delete(userID, milestoneID uint) error {
+	return m.Called(userID, milestoneID).Error(0)
+}
+
+func setupMilestoneHandler() (*ProjectMilestoneHandler, *MockProjectMilestoneService) {
+	svc := new(MockProjectMilestoneService)
+	h := NewProjectMilestoneHandler(svc)
+	return h, svc
+}
+
+// --- Create ---
+
+func TestProjectMilestoneHandler_Create_Success(t *testing.T) {
+	h, svc := setupMilestoneHandler()
+
+	svc.On("Create", uint(1), uint(10), "v1.0リリース", "初回リリース", (*time.Time)(nil)).Return(nil)
+
+	r := newRouter(1)
+	r.POST("/projects/:projectId/milestones", h.Create)
+
+	w := doRequest(r, "POST", "/projects/10/milestones", map[string]interface{}{
+		"title":       "v1.0リリース",
+		"description": "初回リリース",
+	})
+	assertStatus(t, w, 201)
+}
+
+func TestProjectMilestoneHandler_Create_InvalidJSON(t *testing.T) {
+	h, _ := setupMilestoneHandler()
+
+	r := newRouter(1)
+	r.POST("/projects/:projectId/milestones", h.Create)
+
+	w := doRequestRaw(r, "POST", "/projects/10/milestones", "{invalid}")
+	assertStatus(t, w, 400)
+}
+
+func TestProjectMilestoneHandler_Create_Forbidden(t *testing.T) {
+	h, svc := setupMilestoneHandler()
+
+	svc.On("Create", uint(1), uint(10), "v1.0", "", (*time.Time)(nil)).Return(service.ErrForbidden)
+
+	r := newRouter(1)
+	r.POST("/projects/:projectId/milestones", h.Create)
+
+	w := doRequest(r, "POST", "/projects/10/milestones", map[string]interface{}{
+		"title": "v1.0",
+	})
+	assertStatus(t, w, 403)
+}
+
+// --- GetByProjectID ---
+
+func TestProjectMilestoneHandler_GetByProjectID_Success(t *testing.T) {
+	h, svc := setupMilestoneHandler()
+
+	svc.On("GetByProjectID", uint(10)).Return([]model.ProjectMilestone{
+		{ID: 1, ProjectID: 10, Title: "v1.0"},
+		{ID: 2, ProjectID: 10, Title: "v2.0"},
+	}, nil)
+
+	r := newRouter(1)
+	r.GET("/projects/:projectId/milestones", h.GetByProjectID)
+
+	w := doRequest(r, "GET", "/projects/10/milestones", nil)
+	assertStatus(t, w, 200)
+	data := parseJSON(t, w)
+	milestones := data["milestones"].([]interface{})
+	if len(milestones) != 2 {
+		t.Errorf("expected 2 milestones, got %d", len(milestones))
+	}
+}
+
+// --- Update ---
+
+func TestProjectMilestoneHandler_Update_Success(t *testing.T) {
+	h, svc := setupMilestoneHandler()
+
+	svc.On("Update", uint(1), uint(5), "updated", "", (*time.Time)(nil), "in_progress").Return(&model.ProjectMilestone{
+		ID: 5, Title: "updated", Status: model.MilestoneInProgress,
+	}, nil)
+
+	r := newRouter(1)
+	r.PUT("/milestones/:milestoneId", h.Update)
+
+	w := doRequest(r, "PUT", "/milestones/5", map[string]interface{}{
+		"title":  "updated",
+		"status": "in_progress",
+	})
+	assertStatus(t, w, 200)
+}
+
+func TestProjectMilestoneHandler_Update_NotFound(t *testing.T) {
+	h, svc := setupMilestoneHandler()
+
+	svc.On("Update", uint(1), uint(999), "new", "", (*time.Time)(nil), "").Return(nil, service.ErrNotFound)
+
+	r := newRouter(1)
+	r.PUT("/milestones/:milestoneId", h.Update)
+
+	w := doRequest(r, "PUT", "/milestones/999", map[string]interface{}{
+		"title": "new",
+	})
+	assertStatus(t, w, 404)
+}
+
+// --- Delete ---
+
+func TestProjectMilestoneHandler_Delete_Success(t *testing.T) {
+	h, svc := setupMilestoneHandler()
+
+	svc.On("Delete", uint(1), uint(5)).Return(nil)
+
+	r := newRouter(1)
+	r.DELETE("/milestones/:milestoneId", h.Delete)
+
+	w := doRequest(r, "DELETE", "/milestones/5", nil)
+	assertStatus(t, w, 200)
+}
+
+func TestProjectMilestoneHandler_Delete_Forbidden(t *testing.T) {
+	h, svc := setupMilestoneHandler()
+
+	svc.On("Delete", uint(1), uint(5)).Return(service.ErrForbidden)
+
+	r := newRouter(1)
+	r.DELETE("/milestones/:milestoneId", h.Delete)
+
+	w := doRequest(r, "DELETE", "/milestones/5", nil)
+	assertStatus(t, w, 403)
+}

--- a/backend/internal/model/project_milestone.go
+++ b/backend/internal/model/project_milestone.go
@@ -1,0 +1,25 @@
+package model
+
+import "time"
+
+// MilestoneStatus はマイルストーンのステータスを表す型。
+type MilestoneStatus string
+
+const (
+	MilestoneNotStarted MilestoneStatus = "not_started"
+	MilestoneInProgress MilestoneStatus = "in_progress"
+	MilestoneCompleted  MilestoneStatus = "completed"
+)
+
+// ProjectMilestone はプロジェクトのマイルストーンを管理する。
+type ProjectMilestone struct {
+	ID          uint            `json:"id" gorm:"primaryKey"`
+	ProjectID   uint            `json:"project_id" gorm:"not null;index"`
+	Title       string          `json:"title" gorm:"size:200;not null"`
+	Description string          `json:"description" gorm:"type:text"`
+	Status      MilestoneStatus `json:"status" gorm:"size:20;default:'not_started'"`
+	DueDate     *time.Time      `json:"due_date"`
+	CompletedAt *time.Time      `json:"completed_at"`
+	CreatedAt   time.Time       `json:"created_at"`
+	UpdatedAt   time.Time       `json:"updated_at"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -232,6 +232,15 @@ type LearningResourceRepositoryInterface interface {
 	FindByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error)
 }
 
+// ProjectMilestoneRepositoryInterface はプロジェクトマイルストーンデータ操作の契約を定義する。
+type ProjectMilestoneRepositoryInterface interface {
+	Create(milestone *model.ProjectMilestone) error
+	FindByID(id uint) (*model.ProjectMilestone, error)
+	FindByProjectID(projectID uint) ([]model.ProjectMilestone, error)
+	Update(milestone *model.ProjectMilestone) error
+	Delete(id uint) error
+}
+
 // ResourceProgressRepositoryInterface は学習リソース進捗データ操作の契約を定義する。
 type ResourceProgressRepositoryInterface interface {
 	Upsert(progress *model.ResourceProgress) error

--- a/backend/internal/repository/project_milestone.go
+++ b/backend/internal/repository/project_milestone.go
@@ -1,0 +1,49 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// ProjectMilestoneRepository はプロジェクトマイルストーンのデータアクセスを提供する。
+type ProjectMilestoneRepository struct {
+	db *gorm.DB
+}
+
+// NewProjectMilestoneRepository は新しいProjectMilestoneRepositoryインスタンスを生成する。
+func NewProjectMilestoneRepository(db *gorm.DB) *ProjectMilestoneRepository {
+	return &ProjectMilestoneRepository{db: db}
+}
+
+// Create はマイルストーンを作成する。
+func (r *ProjectMilestoneRepository) Create(milestone *model.ProjectMilestone) error {
+	return r.db.Create(milestone).Error
+}
+
+// FindByID は指定IDのマイルストーンを取得する。
+func (r *ProjectMilestoneRepository) FindByID(id uint) (*model.ProjectMilestone, error) {
+	var milestone model.ProjectMilestone
+	if err := r.db.First(&milestone, id).Error; err != nil {
+		return nil, err
+	}
+	return &milestone, nil
+}
+
+// FindByProjectID は指定プロジェクトのマイルストーン一覧を期日順で取得する。
+func (r *ProjectMilestoneRepository) FindByProjectID(projectID uint) ([]model.ProjectMilestone, error) {
+	var milestones []model.ProjectMilestone
+	if err := r.db.Where("project_id = ?", projectID).Order("due_date ASC NULLS LAST, created_at ASC").Find(&milestones).Error; err != nil {
+		return nil, err
+	}
+	return milestones, nil
+}
+
+// Update はマイルストーンを更新する。
+func (r *ProjectMilestoneRepository) Update(milestone *model.ProjectMilestone) error {
+	return r.db.Save(milestone).Error
+}
+
+// Delete はマイルストーンを削除する。
+func (r *ProjectMilestoneRepository) Delete(id uint) error {
+	return r.db.Delete(&model.ProjectMilestone{}, id).Error
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -383,6 +383,12 @@ func registerProjectRoutes(g *gin.RouterGroup, c *di.Container) {
 		projects.DELETE("/:id", c.ProjectHandler.Delete)
 		projects.GET("/user/:userId", c.ProjectHandler.GetByUserID)
 		projects.GET("/user/:userId/featured", c.ProjectHandler.GetFeatured)
+
+		// マイルストーン
+		projects.POST("/:projectId/milestones", c.ProjectMilestoneHandler.Create)
+		projects.GET("/:projectId/milestones", c.ProjectMilestoneHandler.GetByProjectID)
+		projects.PUT("/milestones/:milestoneId", c.ProjectMilestoneHandler.Update)
+		projects.DELETE("/milestones/:milestoneId", c.ProjectMilestoneHandler.Delete)
 	}
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2460,3 +2460,38 @@ func (m *MockResourceProgressRepository) FindByUserID(userID uint, status string
 	args := m.Called(userID, status, limit, offset)
 	return args.Get(0).([]model.ResourceProgress), args.Get(1).(int64), args.Error(2)
 }
+
+// ============================================================
+// MockProjectMilestoneRepository は repository.ProjectMilestoneRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockProjectMilestoneRepository struct {
+	mock.Mock
+}
+
+var _ repository.ProjectMilestoneRepositoryInterface = (*MockProjectMilestoneRepository)(nil)
+
+func (m *MockProjectMilestoneRepository) Create(milestone *model.ProjectMilestone) error {
+	return m.Called(milestone).Error(0)
+}
+
+func (m *MockProjectMilestoneRepository) FindByID(id uint) (*model.ProjectMilestone, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.ProjectMilestone), args.Error(1)
+}
+
+func (m *MockProjectMilestoneRepository) FindByProjectID(projectID uint) ([]model.ProjectMilestone, error) {
+	args := m.Called(projectID)
+	return args.Get(0).([]model.ProjectMilestone), args.Error(1)
+}
+
+func (m *MockProjectMilestoneRepository) Update(milestone *model.ProjectMilestone) error {
+	return m.Called(milestone).Error(0)
+}
+
+func (m *MockProjectMilestoneRepository) Delete(id uint) error {
+	return m.Called(id).Error(0)
+}

--- a/backend/internal/service/project_milestone.go
+++ b/backend/internal/service/project_milestone.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// validMilestoneStatuses は有効なマイルストーンステータスの一覧。
+var validMilestoneStatuses = map[string]bool{
+	string(model.MilestoneNotStarted): true,
+	string(model.MilestoneInProgress): true,
+	string(model.MilestoneCompleted):  true,
+}
+
+// ProjectMilestoneService はプロジェクトマイルストーンのビジネスロジックを提供する。
+type ProjectMilestoneService struct {
+	milestoneRepo repository.ProjectMilestoneRepositoryInterface
+	projectRepo   repository.ProjectRepositoryInterface
+}
+
+// NewProjectMilestoneService は新しいProjectMilestoneServiceインスタンスを生成する。
+func NewProjectMilestoneService(milestoneRepo repository.ProjectMilestoneRepositoryInterface, projectRepo repository.ProjectRepositoryInterface) *ProjectMilestoneService {
+	return &ProjectMilestoneService{milestoneRepo: milestoneRepo, projectRepo: projectRepo}
+}
+
+// checkProjectOwnership はプロジェクトの所有権を検証する。
+func (s *ProjectMilestoneService) checkProjectOwnership(userID, projectID uint) error {
+	project, err := s.projectRepo.FindByID(projectID)
+	if err != nil {
+		return domain.NewError(domain.ErrCodeNotFound, "プロジェクトが見つかりません", err)
+	}
+	if project.UserID != userID {
+		return domain.NewError(domain.ErrCodeForbidden, "このプロジェクトを編集する権限がありません", nil)
+	}
+	return nil
+}
+
+// Create はマイルストーンを作成する。
+func (s *ProjectMilestoneService) Create(userID, projectID uint, title, description string, dueDate *time.Time) error {
+	if err := s.checkProjectOwnership(userID, projectID); err != nil {
+		return err
+	}
+
+	if title == "" {
+		return domain.NewError(domain.ErrCodeValidation, "タイトルは必須です", nil)
+	}
+	if len([]rune(title)) > 200 {
+		return domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+	}
+
+	milestone := &model.ProjectMilestone{
+		ProjectID:   projectID,
+		Title:       title,
+		Description: description,
+		DueDate:     dueDate,
+		Status:      model.MilestoneNotStarted,
+	}
+
+	return s.milestoneRepo.Create(milestone)
+}
+
+// GetByProjectID はプロジェクトのマイルストーン一覧を取得する。
+func (s *ProjectMilestoneService) GetByProjectID(projectID uint) ([]model.ProjectMilestone, error) {
+	return s.milestoneRepo.FindByProjectID(projectID)
+}
+
+// Update はマイルストーンを更新する。
+func (s *ProjectMilestoneService) Update(userID, milestoneID uint, title, description string, dueDate *time.Time, status string) (*model.ProjectMilestone, error) {
+	milestone, err := s.milestoneRepo.FindByID(milestoneID)
+	if err != nil {
+		return nil, domain.NewError(domain.ErrCodeNotFound, "マイルストーンが見つかりません", err)
+	}
+
+	if err := s.checkProjectOwnership(userID, milestone.ProjectID); err != nil {
+		return nil, err
+	}
+
+	if title != "" {
+		if len([]rune(title)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		}
+		milestone.Title = title
+	}
+	if description != "" {
+		milestone.Description = description
+	}
+	if dueDate != nil {
+		milestone.DueDate = dueDate
+	}
+	if status != "" {
+		if !validMilestoneStatuses[status] {
+			return nil, domain.NewError(domain.ErrCodeValidation, "無効なステータスです。not_started, in_progress, completed のいずれかを指定してください", nil)
+		}
+		milestone.Status = model.MilestoneStatus(status)
+		if status == string(model.MilestoneCompleted) {
+			now := time.Now()
+			milestone.CompletedAt = &now
+		} else {
+			milestone.CompletedAt = nil
+		}
+	}
+
+	if err := s.milestoneRepo.Update(milestone); err != nil {
+		return nil, err
+	}
+	return milestone, nil
+}
+
+// Delete はマイルストーンを削除する。
+func (s *ProjectMilestoneService) Delete(userID, milestoneID uint) error {
+	milestone, err := s.milestoneRepo.FindByID(milestoneID)
+	if err != nil {
+		return domain.NewError(domain.ErrCodeNotFound, "マイルストーンが見つかりません", err)
+	}
+
+	if err := s.checkProjectOwnership(userID, milestone.ProjectID); err != nil {
+		return err
+	}
+
+	return s.milestoneRepo.Delete(milestoneID)
+}

--- a/backend/internal/service/project_milestone_test.go
+++ b/backend/internal/service/project_milestone_test.go
@@ -1,0 +1,198 @@
+package service
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func newTestProjectMilestoneService() (*ProjectMilestoneService, *MockProjectMilestoneRepository, *MockProjectRepository) {
+	milestoneRepo := new(MockProjectMilestoneRepository)
+	projectRepo := new(MockProjectRepository)
+	svc := NewProjectMilestoneService(milestoneRepo, projectRepo)
+	return svc, milestoneRepo, projectRepo
+}
+
+// --- Create ---
+
+func TestProjectMilestoneService_Create_Success(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	projectRepo.On("FindByID", uint(1)).Return(&model.Project{ID: 1, UserID: 10}, nil)
+	milestoneRepo.On("Create", mock.MatchedBy(func(m *model.ProjectMilestone) bool {
+		return m.ProjectID == 1 && m.Title == "v1.0リリース"
+	})).Return(nil)
+
+	err := svc.Create(10, 1, "v1.0リリース", "初回リリース", nil)
+	assert.NoError(t, err)
+}
+
+func TestProjectMilestoneService_Create_Forbidden(t *testing.T) {
+	svc, _, projectRepo := newTestProjectMilestoneService()
+
+	projectRepo.On("FindByID", uint(1)).Return(&model.Project{ID: 1, UserID: 99}, nil)
+
+	err := svc.Create(10, 1, "v1.0リリース", "", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "権限")
+}
+
+func TestProjectMilestoneService_Create_ProjectNotFound(t *testing.T) {
+	svc, _, projectRepo := newTestProjectMilestoneService()
+
+	projectRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.Create(10, 999, "v1.0", "", nil)
+	assert.Error(t, err)
+}
+
+func TestProjectMilestoneService_Create_TitleTooLong(t *testing.T) {
+	svc, _, projectRepo := newTestProjectMilestoneService()
+
+	projectRepo.On("FindByID", uint(1)).Return(&model.Project{ID: 1, UserID: 10}, nil)
+
+	longTitle := make([]rune, 201)
+	for i := range longTitle {
+		longTitle[i] = 'あ'
+	}
+	err := svc.Create(10, 1, string(longTitle), "", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "タイトル")
+}
+
+func TestProjectMilestoneService_Create_EmptyTitle(t *testing.T) {
+	svc, _, projectRepo := newTestProjectMilestoneService()
+
+	projectRepo.On("FindByID", uint(1)).Return(&model.Project{ID: 1, UserID: 10}, nil)
+
+	err := svc.Create(10, 1, "", "", nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "タイトル")
+}
+
+// --- GetByProjectID ---
+
+func TestProjectMilestoneService_GetByProjectID_Success(t *testing.T) {
+	svc, milestoneRepo, _ := newTestProjectMilestoneService()
+
+	milestoneRepo.On("FindByProjectID", uint(1)).Return([]model.ProjectMilestone{
+		{ID: 1, ProjectID: 1, Title: "v1.0"},
+		{ID: 2, ProjectID: 1, Title: "v2.0"},
+	}, nil)
+
+	list, err := svc.GetByProjectID(1)
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+}
+
+// --- Update ---
+
+func TestProjectMilestoneService_Update_Success(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	milestoneRepo.On("FindByID", uint(1)).Return(&model.ProjectMilestone{ID: 1, ProjectID: 5, Title: "old"}, nil)
+	projectRepo.On("FindByID", uint(5)).Return(&model.Project{ID: 5, UserID: 10}, nil)
+	milestoneRepo.On("Update", mock.MatchedBy(func(m *model.ProjectMilestone) bool {
+		return m.Title == "new title"
+	})).Return(nil)
+
+	result, err := svc.Update(10, 1, "new title", "desc", nil, "")
+	assert.NoError(t, err)
+	assert.Equal(t, "new title", result.Title)
+}
+
+func TestProjectMilestoneService_Update_Forbidden(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	milestoneRepo.On("FindByID", uint(1)).Return(&model.ProjectMilestone{ID: 1, ProjectID: 5}, nil)
+	projectRepo.On("FindByID", uint(5)).Return(&model.Project{ID: 5, UserID: 99}, nil)
+
+	_, err := svc.Update(10, 1, "new", "", nil, "")
+	assert.Error(t, err)
+}
+
+func TestProjectMilestoneService_Update_StatusCompleted(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	milestoneRepo.On("FindByID", uint(1)).Return(&model.ProjectMilestone{ID: 1, ProjectID: 5, Title: "v1.0"}, nil)
+	projectRepo.On("FindByID", uint(5)).Return(&model.Project{ID: 5, UserID: 10}, nil)
+	milestoneRepo.On("Update", mock.MatchedBy(func(m *model.ProjectMilestone) bool {
+		return m.Status == model.MilestoneCompleted && m.CompletedAt != nil
+	})).Return(nil)
+
+	result, err := svc.Update(10, 1, "", "", nil, string(model.MilestoneCompleted))
+	assert.NoError(t, err)
+	assert.Equal(t, model.MilestoneCompleted, result.Status)
+	assert.NotNil(t, result.CompletedAt)
+}
+
+func TestProjectMilestoneService_Update_InvalidStatus(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	milestoneRepo.On("FindByID", uint(1)).Return(&model.ProjectMilestone{ID: 1, ProjectID: 5}, nil)
+	projectRepo.On("FindByID", uint(5)).Return(&model.Project{ID: 5, UserID: 10}, nil)
+
+	_, err := svc.Update(10, 1, "", "", nil, "invalid")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ステータス")
+}
+
+func TestProjectMilestoneService_Update_NotFound(t *testing.T) {
+	svc, milestoneRepo, _ := newTestProjectMilestoneService()
+
+	milestoneRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	_, err := svc.Update(10, 999, "new", "", nil, "")
+	assert.Error(t, err)
+}
+
+// --- Delete ---
+
+func TestProjectMilestoneService_Delete_Success(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	milestoneRepo.On("FindByID", uint(1)).Return(&model.ProjectMilestone{ID: 1, ProjectID: 5}, nil)
+	projectRepo.On("FindByID", uint(5)).Return(&model.Project{ID: 5, UserID: 10}, nil)
+	milestoneRepo.On("Delete", uint(1)).Return(nil)
+
+	err := svc.Delete(10, 1)
+	assert.NoError(t, err)
+}
+
+func TestProjectMilestoneService_Delete_Forbidden(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	milestoneRepo.On("FindByID", uint(1)).Return(&model.ProjectMilestone{ID: 1, ProjectID: 5}, nil)
+	projectRepo.On("FindByID", uint(5)).Return(&model.Project{ID: 5, UserID: 99}, nil)
+
+	err := svc.Delete(10, 1)
+	assert.Error(t, err)
+}
+
+func TestProjectMilestoneService_Delete_NotFound(t *testing.T) {
+	svc, milestoneRepo, _ := newTestProjectMilestoneService()
+
+	milestoneRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	err := svc.Delete(10, 999)
+	assert.Error(t, err)
+}
+
+// --- Create with DueDate ---
+
+func TestProjectMilestoneService_Create_WithDueDate(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	dueDate := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	projectRepo.On("FindByID", uint(1)).Return(&model.Project{ID: 1, UserID: 10}, nil)
+	milestoneRepo.On("Create", mock.MatchedBy(func(m *model.ProjectMilestone) bool {
+		return m.DueDate != nil && m.DueDate.Equal(dueDate)
+	})).Return(nil)
+
+	err := svc.Create(10, 1, "v1.0", "", &dueDate)
+	assert.NoError(t, err)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -110,6 +110,7 @@ func main() {
 		&model.WeeklyChallenge{},
 		&model.NoteVersion{},
 		&model.ResourceProgress{},
+		&model.ProjectMilestone{},
 	); err != nil {
 		log.Fatalf("failed to run migrations: %v", err)
 	}

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -34,3 +34,48 @@ export const updateProject = async (id: number, data: UpdateProjectRequest): Pro
 export const deleteProject = async (id: number): Promise<void> => {
   await client.delete(`/projects/${id}`);
 };
+
+// --- マイルストーン ---
+
+export interface ProjectMilestone {
+  id: number;
+  project_id: number;
+  title: string;
+  description: string;
+  status: 'not_started' | 'in_progress' | 'completed';
+  due_date: string | null;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateMilestoneRequest {
+  title: string;
+  description?: string;
+  due_date?: string;
+}
+
+export interface UpdateMilestoneRequest {
+  title?: string;
+  description?: string;
+  due_date?: string;
+  status?: 'not_started' | 'in_progress' | 'completed';
+}
+
+export const createMilestone = async (projectId: number, data: CreateMilestoneRequest): Promise<void> => {
+  await client.post(`/projects/${projectId}/milestones`, data);
+};
+
+export const getMilestones = async (projectId: number): Promise<ProjectMilestone[]> => {
+  const res = await client.get(`/projects/${projectId}/milestones`);
+  return res.data.milestones;
+};
+
+export const updateMilestone = async (milestoneId: number, data: UpdateMilestoneRequest): Promise<ProjectMilestone> => {
+  const res = await client.put(`/projects/milestones/${milestoneId}`, data);
+  return res.data;
+};
+
+export const deleteMilestone = async (milestoneId: number): Promise<void> => {
+  await client.delete(`/projects/milestones/${milestoneId}`);
+};

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1720,5 +1720,27 @@
     "noProgress": "Noch kein Fortschritt",
     "allStatuses": "Alle Status",
     "trackProgress": "Fortschritt Erfassen"
+  },
+  "milestones": {
+    "title": "Meilensteine",
+    "addMilestone": "Meilenstein Hinzufügen",
+    "editMilestone": "Meilenstein Bearbeiten",
+    "milestoneTitle": "Titel",
+    "milestoneTitlePlaceholder": "Meilensteintitel",
+    "description": "Beschreibung",
+    "descriptionPlaceholder": "Meilensteinbeschreibung...",
+    "dueDate": "Fälligkeitsdatum",
+    "status": "Status",
+    "notStarted": "Nicht Gestartet",
+    "inProgress": "In Bearbeitung",
+    "completed": "Abgeschlossen",
+    "noMilestones": "Noch keine Meilensteine",
+    "createSuccess": "Meilenstein erstellt",
+    "updateSuccess": "Meilenstein aktualisiert",
+    "deleteSuccess": "Meilenstein gelöscht",
+    "createFailed": "Meilenstein konnte nicht erstellt werden",
+    "updateFailed": "Meilenstein konnte nicht aktualisiert werden",
+    "deleteFailed": "Meilenstein konnte nicht gelöscht werden",
+    "confirmDelete": "Möchten Sie diesen Meilenstein wirklich löschen?"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1721,5 +1721,27 @@
     "noProgress": "No progress yet",
     "allStatuses": "All Statuses",
     "trackProgress": "Track Progress"
+  },
+  "milestones": {
+    "title": "Milestones",
+    "addMilestone": "Add Milestone",
+    "editMilestone": "Edit Milestone",
+    "milestoneTitle": "Title",
+    "milestoneTitlePlaceholder": "Milestone title",
+    "description": "Description",
+    "descriptionPlaceholder": "Milestone description...",
+    "dueDate": "Due Date",
+    "status": "Status",
+    "notStarted": "Not Started",
+    "inProgress": "In Progress",
+    "completed": "Completed",
+    "noMilestones": "No milestones yet",
+    "createSuccess": "Milestone created",
+    "updateSuccess": "Milestone updated",
+    "deleteSuccess": "Milestone deleted",
+    "createFailed": "Failed to create milestone",
+    "updateFailed": "Failed to update milestone",
+    "deleteFailed": "Failed to delete milestone",
+    "confirmDelete": "Are you sure you want to delete this milestone?"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1721,5 +1721,27 @@
     "noProgress": "Aún no hay progreso",
     "allStatuses": "Todos los estados",
     "trackProgress": "Registrar Progreso"
+  },
+  "milestones": {
+    "title": "Hitos",
+    "addMilestone": "Agregar Hito",
+    "editMilestone": "Editar Hito",
+    "milestoneTitle": "Título",
+    "milestoneTitlePlaceholder": "Título del hito",
+    "description": "Descripción",
+    "descriptionPlaceholder": "Descripción del hito...",
+    "dueDate": "Fecha Límite",
+    "status": "Estado",
+    "notStarted": "No Iniciado",
+    "inProgress": "En Progreso",
+    "completed": "Completado",
+    "noMilestones": "No hay hitos aún",
+    "createSuccess": "Hito creado",
+    "updateSuccess": "Hito actualizado",
+    "deleteSuccess": "Hito eliminado",
+    "createFailed": "Error al crear el hito",
+    "updateFailed": "Error al actualizar el hito",
+    "deleteFailed": "Error al eliminar el hito",
+    "confirmDelete": "¿Estás seguro de que quieres eliminar este hito?"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1721,5 +1721,27 @@
     "noProgress": "Pas encore de progression",
     "allStatuses": "Tous les statuts",
     "trackProgress": "Suivre la Progression"
+  },
+  "milestones": {
+    "title": "Jalons",
+    "addMilestone": "Ajouter un Jalon",
+    "editMilestone": "Modifier le Jalon",
+    "milestoneTitle": "Titre",
+    "milestoneTitlePlaceholder": "Titre du jalon",
+    "description": "Description",
+    "descriptionPlaceholder": "Description du jalon...",
+    "dueDate": "Date Limite",
+    "status": "Statut",
+    "notStarted": "Non Commencé",
+    "inProgress": "En Cours",
+    "completed": "Terminé",
+    "noMilestones": "Pas encore de jalons",
+    "createSuccess": "Jalon créé",
+    "updateSuccess": "Jalon mis à jour",
+    "deleteSuccess": "Jalon supprimé",
+    "createFailed": "Échec de la création du jalon",
+    "updateFailed": "Échec de la mise à jour du jalon",
+    "deleteFailed": "Échec de la suppression du jalon",
+    "confirmDelete": "Êtes-vous sûr de vouloir supprimer ce jalon ?"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1623,5 +1623,27 @@
     "noProgress": "まだ進捗がありません",
     "allStatuses": "全ステータス",
     "trackProgress": "進捗を記録"
+  },
+  "milestones": {
+    "title": "マイルストーン",
+    "addMilestone": "マイルストーンを追加",
+    "editMilestone": "マイルストーンを編集",
+    "milestoneTitle": "タイトル",
+    "milestoneTitlePlaceholder": "マイルストーンのタイトル",
+    "description": "説明",
+    "descriptionPlaceholder": "マイルストーンの説明...",
+    "dueDate": "期日",
+    "status": "ステータス",
+    "notStarted": "未着手",
+    "inProgress": "進行中",
+    "completed": "完了",
+    "noMilestones": "マイルストーンがありません",
+    "createSuccess": "マイルストーンを作成しました",
+    "updateSuccess": "マイルストーンを更新しました",
+    "deleteSuccess": "マイルストーンを削除しました",
+    "createFailed": "マイルストーンの作成に失敗しました",
+    "updateFailed": "マイルストーンの更新に失敗しました",
+    "deleteFailed": "マイルストーンの削除に失敗しました",
+    "confirmDelete": "このマイルストーンを削除してもよろしいですか？"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1723,5 +1723,27 @@
     "noProgress": "아직 진행률이 없습니다",
     "allStatuses": "모든 상태",
     "trackProgress": "진행률 기록"
+  },
+  "milestones": {
+    "title": "마일스톤",
+    "addMilestone": "마일스톤 추가",
+    "editMilestone": "마일스톤 편집",
+    "milestoneTitle": "제목",
+    "milestoneTitlePlaceholder": "마일스톤 제목",
+    "description": "설명",
+    "descriptionPlaceholder": "마일스톤 설명...",
+    "dueDate": "마감일",
+    "status": "상태",
+    "notStarted": "미시작",
+    "inProgress": "진행 중",
+    "completed": "완료",
+    "noMilestones": "마일스톤이 없습니다",
+    "createSuccess": "마일스톤이 생성되었습니다",
+    "updateSuccess": "마일스톤이 업데이트되었습니다",
+    "deleteSuccess": "마일스톤이 삭제되었습니다",
+    "createFailed": "마일스톤 생성에 실패했습니다",
+    "updateFailed": "마일스톤 업데이트에 실패했습니다",
+    "deleteFailed": "마일스톤 삭제에 실패했습니다",
+    "confirmDelete": "이 마일스톤을 삭제하시겠습니까?"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1721,5 +1721,27 @@
     "noProgress": "Nenhum progresso ainda",
     "allStatuses": "Todos os status",
     "trackProgress": "Registrar Progresso"
+  },
+  "milestones": {
+    "title": "Marcos",
+    "addMilestone": "Adicionar Marco",
+    "editMilestone": "Editar Marco",
+    "milestoneTitle": "Título",
+    "milestoneTitlePlaceholder": "Título do marco",
+    "description": "Descrição",
+    "descriptionPlaceholder": "Descrição do marco...",
+    "dueDate": "Data Limite",
+    "status": "Status",
+    "notStarted": "Não Iniciado",
+    "inProgress": "Em Andamento",
+    "completed": "Concluído",
+    "noMilestones": "Nenhum marco ainda",
+    "createSuccess": "Marco criado",
+    "updateSuccess": "Marco atualizado",
+    "deleteSuccess": "Marco excluído",
+    "createFailed": "Falha ao criar o marco",
+    "updateFailed": "Falha ao atualizar o marco",
+    "deleteFailed": "Falha ao excluir o marco",
+    "confirmDelete": "Tem certeza de que deseja excluir este marco?"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1720,5 +1720,27 @@
     "noProgress": "Прогресс пока отсутствует",
     "allStatuses": "Все статусы",
     "trackProgress": "Записать Прогресс"
+  },
+  "milestones": {
+    "title": "Вехи",
+    "addMilestone": "Добавить Веху",
+    "editMilestone": "Редактировать Веху",
+    "milestoneTitle": "Название",
+    "milestoneTitlePlaceholder": "Название вехи",
+    "description": "Описание",
+    "descriptionPlaceholder": "Описание вехи...",
+    "dueDate": "Срок",
+    "status": "Статус",
+    "notStarted": "Не Начато",
+    "inProgress": "В Процессе",
+    "completed": "Завершено",
+    "noMilestones": "Пока нет вех",
+    "createSuccess": "Веха создана",
+    "updateSuccess": "Веха обновлена",
+    "deleteSuccess": "Веха удалена",
+    "createFailed": "Не удалось создать веху",
+    "updateFailed": "Не удалось обновить веху",
+    "deleteFailed": "Не удалось удалить веху",
+    "confirmDelete": "Вы уверены, что хотите удалить эту веху?"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1721,5 +1721,27 @@
     "noProgress": "暂无进度",
     "allStatuses": "所有状态",
     "trackProgress": "记录进度"
+  },
+  "milestones": {
+    "title": "里程碑",
+    "addMilestone": "添加里程碑",
+    "editMilestone": "编辑里程碑",
+    "milestoneTitle": "标题",
+    "milestoneTitlePlaceholder": "里程碑标题",
+    "description": "描述",
+    "descriptionPlaceholder": "里程碑描述...",
+    "dueDate": "截止日期",
+    "status": "状态",
+    "notStarted": "未开始",
+    "inProgress": "进行中",
+    "completed": "已完成",
+    "noMilestones": "暂无里程碑",
+    "createSuccess": "里程碑已创建",
+    "updateSuccess": "里程碑已更新",
+    "deleteSuccess": "里程碑已删除",
+    "createFailed": "创建里程碑失败",
+    "updateFailed": "更新里程碑失败",
+    "deleteFailed": "删除里程碑失败",
+    "confirmDelete": "确定要删除这个里程碑吗？"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1723,5 +1723,27 @@
     "noProgress": "暫無進度",
     "allStatuses": "所有狀態",
     "trackProgress": "記錄進度"
+  },
+  "milestones": {
+    "title": "里程碑",
+    "addMilestone": "新增里程碑",
+    "editMilestone": "編輯里程碑",
+    "milestoneTitle": "標題",
+    "milestoneTitlePlaceholder": "里程碑標題",
+    "description": "描述",
+    "descriptionPlaceholder": "里程碑描述...",
+    "dueDate": "截止日期",
+    "status": "狀態",
+    "notStarted": "未開始",
+    "inProgress": "進行中",
+    "completed": "已完成",
+    "noMilestones": "暫無里程碑",
+    "createSuccess": "里程碑已建立",
+    "updateSuccess": "里程碑已更新",
+    "deleteSuccess": "里程碑已刪除",
+    "createFailed": "建立里程碑失敗",
+    "updateFailed": "更新里程碑失敗",
+    "deleteFailed": "刪除里程碑失敗",
+    "confirmDelete": "確定要刪除這個里程碑嗎？"
   }
 }


### PR DESCRIPTION
## 概要
- プロジェクトにマイルストーン（未着手/進行中/完了）を追加・管理
- ProjectMilestoneモデル・リポジトリ（期日順ソート）
- Service層: プロジェクト所有権検証・バリデーション
- Handler: POST/GET /projects/:projectId/milestones, PUT/DELETE /projects/milestones/:milestoneId
- TDD: サービステスト15件 + ハンドラーテスト8件（全パス）
- フロントエンドAPI関数・型定義
- 10言語i18n対応（milestonesセクション）

## テスト計画
- [x] サービス層ユニットテスト（15件）
- [x] ハンドラー層ユニットテスト（8件）
- [x] TypeScript型チェック
- [x] Goビルド確認

Closes #2053