### PR TITLE
feat: コードスニペットのフォーク機能を追加

### DIFF
--- a/backend/internal/dto/code_snippet_dto.go
+++ b/backend/internal/dto/code_snippet_dto.go
@@ -14,6 +14,11 @@ type UpdateCodeSnippetRequest struct {
 	Code     string `json:"code" binding:"omitempty,max=50000"`
 }
 
+// ForkSnippetRequest はスニペットフォークリクエスト。
+type ForkSnippetRequest struct {
+	TargetPostID uint `json:"target_post_id" binding:"required"`
+}
+
 // CreateSnippetCommentRequest はスニペットコメント作成リクエスト。
 type CreateSnippetCommentRequest struct {
 	LineNumber int    `json:"line_number" binding:"required" validate:"required"`

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -16,6 +16,7 @@ type CodeSnippetHandlerServiceInterface interface {
 	GetComments(snippetID uint) ([]model.SnippetComment, error)
 	CreateComment(comment *model.SnippetComment) error
 	DeleteComment(id, userID uint) error
+	Fork(userID, snippetID, targetPostID uint) (*model.CodeSnippet, error)
 }
 
 // CodeSnippetHandler はコードスニペット関連のHTTPハンドラ。
@@ -166,6 +167,28 @@ func (h *CodeSnippetHandler) DeleteComment(c *gin.Context) {
 		return
 	}
 	respondDeleted(c)
+}
+
+// Fork はスニペットをフォークして指定投稿にコピーする。
+func (h *CodeSnippetHandler) Fork(c *gin.Context) {
+	snippetID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	req := bindJSON[dto.ForkSnippetRequest](c)
+	if req == nil {
+		return
+	}
+
+	forked, err := h.service.Fork(userID, snippetID, req.TargetPostID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, forked)
 }
 
 // GetByUserLanguage は認証ユーザーのスニペットを言語でフィルタリングして取得する。

--- a/backend/internal/handler/code_snippet_test.go
+++ b/backend/internal/handler/code_snippet_test.go
@@ -362,3 +362,63 @@ func TestCodeSnippetDeleteComment_InvalidID(t *testing.T) {
 
 	assertStatus(t, w, http.StatusBadRequest)
 }
+
+// ---------- Fork ----------
+
+func TestCodeSnippetFork_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+
+	forkedID := uint(10)
+	svc.On("Fork", uint(1), uint(10), uint(20)).Return(&model.CodeSnippet{
+		ID: 99, PostID: 20, UserID: 1, Language: "go", Code: "package main", ForkedFromID: &forkedID,
+	}, nil)
+
+	r := newRouter(1)
+	r.POST("/snippets/:id/fork", h.Fork)
+	w := doRequest(r, "POST", "/snippets/10/fork", map[string]interface{}{
+		"target_post_id": 20,
+	})
+
+	assertStatus(t, w, http.StatusCreated)
+	data := parseJSON(t, w)
+	assert.Equal(t, float64(99), data["id"])
+	assert.Equal(t, float64(10), data["forked_from_id"])
+}
+
+func TestCodeSnippetFork_InvalidJSON(t *testing.T) {
+	h, _ := setupCodeSnippetHandler()
+
+	r := newRouter(1)
+	r.POST("/snippets/:id/fork", h.Fork)
+	w := doRequestRaw(r, "POST", "/snippets/10/fork", "{invalid}")
+
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestCodeSnippetFork_Forbidden(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+
+	svc.On("Fork", uint(1), uint(10), uint(20)).Return(nil, service.ErrForbidden)
+
+	r := newRouter(1)
+	r.POST("/snippets/:id/fork", h.Fork)
+	w := doRequest(r, "POST", "/snippets/10/fork", map[string]interface{}{
+		"target_post_id": 20,
+	})
+
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+func TestCodeSnippetFork_NotFound(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+
+	svc.On("Fork", uint(1), uint(999), uint(20)).Return(nil, service.ErrNotFound)
+
+	r := newRouter(1)
+	r.POST("/snippets/:id/fork", h.Fork)
+	w := doRequest(r, "POST", "/snippets/999/fork", map[string]interface{}{
+		"target_post_id": 20,
+	})
+
+	assertStatus(t, w, http.StatusNotFound)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -233,6 +233,9 @@ func (m *MockCodeSnippetRepository) FindByUserIDAndLanguage(userID uint, languag
 	args := m.Called(userID, language)
 	return args.Get(0).([]model.CodeSnippet), args.Error(1)
 }
+func (m *MockCodeSnippetRepository) IncrementForkCount(id uint) error {
+	return m.Called(id).Error(0)
+}
 
 // MockQuestionRepository は QuestionRepositoryInterface のモック実装。
 type MockQuestionRepository struct{ mock.Mock }
@@ -1715,6 +1718,13 @@ func (m *MockCodeSnippetHandlerService) DeleteComment(id, userID uint) error {
 func (m *MockCodeSnippetHandlerService) GetByUserLanguage(userID uint, language string) ([]model.CodeSnippet, error) {
 	args := m.Called(userID, language)
 	return args.Get(0).([]model.CodeSnippet), args.Error(1)
+}
+func (m *MockCodeSnippetHandlerService) Fork(userID, snippetID, targetPostID uint) (*model.CodeSnippet, error) {
+	args := m.Called(userID, snippetID, targetPostID)
+	if s := args.Get(0); s != nil {
+		return s.(*model.CodeSnippet), args.Error(1)
+	}
+	return nil, args.Error(1)
 }
 
 // setupCodeSnippetHandler はCodeSnippetHandlerテスト用のセットアップを行う。

--- a/backend/internal/model/code_snippet.go
+++ b/backend/internal/model/code_snippet.go
@@ -13,6 +13,8 @@ type CodeSnippet struct {
 	FileName     string    `json:"file_name"`
 	Code         string    `json:"code" gorm:"type:text;not null"`
 	CommentCount int       `json:"comment_count" gorm:"default:0"`
+	ForkedFromID *uint     `json:"forked_from_id" gorm:"index"`
+	ForkCount    int       `json:"fork_count" gorm:"default:0"`
 	CreatedAt    time.Time `json:"created_at"`
 	UpdatedAt    time.Time `json:"updated_at"`
 }

--- a/backend/internal/repository/code_snippet.go
+++ b/backend/internal/repository/code_snippet.go
@@ -85,3 +85,9 @@ func (r *CodeSnippetRepository) DeleteComment(id, userID uint) error {
 		UpdateColumn("comment_count", gorm.Expr("GREATEST(comment_count - 1, 0)"))
 	return r.db.Delete(&comment).Error
 }
+
+// IncrementForkCount はスニペットのfork_countをインクリメントする。
+func (r *CodeSnippetRepository) IncrementForkCount(id uint) error {
+	return r.db.Model(&model.CodeSnippet{}).Where("id = ?", id).
+		UpdateColumn("fork_count", gorm.Expr("fork_count + 1")).Error
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -302,6 +302,7 @@ type CodeSnippetRepositoryInterface interface {
 	CreateComment(comment *model.SnippetComment) error
 	GetComments(snippetID uint) ([]model.SnippetComment, error)
 	DeleteComment(id, userID uint) error
+	IncrementForkCount(id uint) error
 }
 
 // GitHubRepositoryInterface はGitHub連携データ操作の契約を定義する。

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -258,6 +258,7 @@ func registerSnippetRoutes(g *gin.RouterGroup, c *di.Container) {
 		snippets.POST("/:id/comments", c.CodeSnippetHandler.CreateComment)
 		snippets.DELETE("/:id/comments/:commentId", c.CodeSnippetHandler.DeleteComment)
 		snippets.GET("/language/:language", c.CodeSnippetHandler.GetByUserLanguage)
+		snippets.POST("/:id/fork", c.CodeSnippetHandler.Fork)
 	}
 }
 

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -128,3 +128,38 @@ func (s *CodeSnippetService) GetComments(snippetID uint) ([]model.SnippetComment
 func (s *CodeSnippetService) DeleteComment(id, userID uint) error {
 	return s.repo.DeleteComment(id, userID)
 }
+
+// Fork は既存スニペットをコピーして指定投稿に新しいスニペットとして作成する。
+func (s *CodeSnippetService) Fork(userID, snippetID, targetPostID uint) (*model.CodeSnippet, error) {
+	original, err := s.repo.FindByID(snippetID)
+	if err != nil {
+		return nil, domain.NewError(domain.ErrCodeNotFound, "スニペットが見つかりません", err)
+	}
+
+	// 対象投稿の存在確認と所有権チェック
+	post, err := s.postRepo.FindByID(targetPostID)
+	if err != nil {
+		return nil, domain.NewError(domain.ErrCodeNotFound, "投稿が見つかりません", err)
+	}
+	if post.UserID != userID {
+		return nil, domain.NewError(domain.ErrCodeForbidden, "自分の投稿にのみフォークできます。投稿の編集権限がありません", nil)
+	}
+
+	forked := &model.CodeSnippet{
+		PostID:       targetPostID,
+		UserID:       userID,
+		Language:     original.Language,
+		FileName:     original.FileName,
+		Code:         original.Code,
+		ForkedFromID: &snippetID,
+	}
+
+	if err := s.repo.Create(forked); err != nil {
+		return nil, err
+	}
+
+	// フォーク元のカウンターをインクリメント
+	_ = s.repo.IncrementForkCount(snippetID)
+
+	return forked, nil
+}

--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -498,3 +498,90 @@ func TestSnippetCreateComment_ContentTooLong(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "コメント内容は2000文字以下")
 }
+
+// ---------- フォーク ----------
+
+func TestSnippetFork_Success(t *testing.T) {
+	svc, snippetRepo, postRepo := newTestCodeSnippetService()
+
+	original := &model.CodeSnippet{
+		ID: 1, PostID: 5, UserID: 99, Language: "go", FileName: "main.go", Code: "package main",
+	}
+	snippetRepo.On("FindByID", uint(1)).Return(original, nil)
+
+	targetPost := &model.Post{UserID: 10}
+	targetPost.ID = 20
+	postRepo.On("FindByID", uint(20)).Return(targetPost, nil)
+
+	snippetRepo.On("Create", mock.MatchedBy(func(s *model.CodeSnippet) bool {
+		return s.UserID == 10 && s.PostID == 20 && s.Language == "go" && s.ForkedFromID != nil && *s.ForkedFromID == 1
+	})).Return(nil)
+	snippetRepo.On("IncrementForkCount", uint(1)).Return(nil)
+
+	forked, err := svc.Fork(10, 1, 20)
+	assert.NoError(t, err)
+	assert.Equal(t, uint(10), forked.UserID)
+	assert.Equal(t, uint(20), forked.PostID)
+	assert.Equal(t, "go", forked.Language)
+	assert.NotNil(t, forked.ForkedFromID)
+	assert.Equal(t, uint(1), *forked.ForkedFromID)
+}
+
+func TestSnippetFork_SnippetNotFound(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippetRepo.On("FindByID", uint(999)).Return(nil, gorm.ErrRecordNotFound)
+
+	_, err := svc.Fork(10, 999, 20)
+	assert.Error(t, err)
+}
+
+func TestSnippetFork_PostNotFound(t *testing.T) {
+	svc, snippetRepo, postRepo := newTestCodeSnippetService()
+
+	snippetRepo.On("FindByID", uint(1)).Return(&model.CodeSnippet{
+		ID: 1, PostID: 5, UserID: 99, Language: "go", Code: "code",
+	}, nil)
+	postRepo.On("FindByID", uint(999)).Return(nil, gorm.ErrRecordNotFound)
+
+	_, err := svc.Fork(10, 1, 999)
+	assert.Error(t, err)
+}
+
+func TestSnippetFork_NotOwnPost(t *testing.T) {
+	svc, snippetRepo, postRepo := newTestCodeSnippetService()
+
+	snippetRepo.On("FindByID", uint(1)).Return(&model.CodeSnippet{
+		ID: 1, PostID: 5, UserID: 99, Language: "go", Code: "code",
+	}, nil)
+
+	// Post belongs to another user
+	targetPost := &model.Post{UserID: 88}
+	targetPost.ID = 20
+	postRepo.On("FindByID", uint(20)).Return(targetPost, nil)
+
+	_, err := svc.Fork(10, 1, 20)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "権限")
+}
+
+func TestSnippetFork_SelfFork(t *testing.T) {
+	svc, snippetRepo, postRepo := newTestCodeSnippetService()
+
+	// Original owned by same user
+	snippetRepo.On("FindByID", uint(1)).Return(&model.CodeSnippet{
+		ID: 1, PostID: 5, UserID: 10, Language: "go", Code: "code",
+	}, nil)
+
+	targetPost := &model.Post{UserID: 10}
+	targetPost.ID = 20
+	postRepo.On("FindByID", uint(20)).Return(targetPost, nil)
+
+	snippetRepo.On("Create", mock.Anything).Return(nil)
+	snippetRepo.On("IncrementForkCount", uint(1)).Return(nil)
+
+	// Self-fork should be allowed (forking your own snippet to another post)
+	forked, err := svc.Fork(10, 1, 20)
+	assert.NoError(t, err)
+	assert.NotNil(t, forked)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1072,6 +1072,10 @@ func (m *MockCodeSnippetRepository) DeleteComment(id, userID uint) error {
 	return args.Error(0)
 }
 
+func (m *MockCodeSnippetRepository) IncrementForkCount(id uint) error {
+	return m.Called(id).Error(0)
+}
+
 // ============================================================
 // インターフェース適合チェック（コンパイル時検証）
 // ============================================================

--- a/frontend/src/api/snippets.ts
+++ b/frontend/src/api/snippets.ts
@@ -21,3 +21,6 @@ export const createSnippetComment = (snippetId: number, data: { line_number: num
 
 export const deleteSnippetComment = (snippetId: number, commentId: number) =>
   client.delete(`/snippets/${snippetId}/comments/${commentId}`);
+
+export const forkSnippet = (snippetId: number, targetPostId: number) =>
+  client.post<CodeSnippet>(`/snippets/${snippetId}/fork`, { target_post_id: targetPostId });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1742,5 +1742,14 @@
     "updateFailed": "Meilenstein konnte nicht aktualisiert werden",
     "deleteFailed": "Meilenstein konnte nicht gelöscht werden",
     "confirmDelete": "Möchten Sie diesen Meilenstein wirklich löschen?"
+  },
+  "snippetFork": {
+    "fork": "Forken",
+    "forkSnippet": "Snippet Forken",
+    "forkSuccess": "Snippet erfolgreich geforkt",
+    "forkFailed": "Snippet konnte nicht geforkt werden",
+    "forkedFrom": "Geforkt von",
+    "forkCount": "Forks",
+    "selectTargetPost": "Zielbeitrag auswählen"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1743,5 +1743,14 @@
     "updateFailed": "Failed to update milestone",
     "deleteFailed": "Failed to delete milestone",
     "confirmDelete": "Are you sure you want to delete this milestone?"
+  },
+  "snippetFork": {
+    "fork": "Fork",
+    "forkSnippet": "Fork Snippet",
+    "forkSuccess": "Snippet forked successfully",
+    "forkFailed": "Failed to fork snippet",
+    "forkedFrom": "Forked from",
+    "forkCount": "Forks",
+    "selectTargetPost": "Select target post"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1743,5 +1743,14 @@
     "updateFailed": "Error al actualizar el hito",
     "deleteFailed": "Error al eliminar el hito",
     "confirmDelete": "¿Estás seguro de que quieres eliminar este hito?"
+  },
+  "snippetFork": {
+    "fork": "Bifurcar",
+    "forkSnippet": "Bifurcar Fragmento",
+    "forkSuccess": "Fragmento bifurcado exitosamente",
+    "forkFailed": "Error al bifurcar el fragmento",
+    "forkedFrom": "Bifurcado de",
+    "forkCount": "Bifurcaciones",
+    "selectTargetPost": "Seleccionar publicación destino"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1743,5 +1743,14 @@
     "updateFailed": "Échec de la mise à jour du jalon",
     "deleteFailed": "Échec de la suppression du jalon",
     "confirmDelete": "Êtes-vous sûr de vouloir supprimer ce jalon ?"
+  },
+  "snippetFork": {
+    "fork": "Dupliquer",
+    "forkSnippet": "Dupliquer l'extrait",
+    "forkSuccess": "Extrait dupliqué avec succès",
+    "forkFailed": "Échec de la duplication de l'extrait",
+    "forkedFrom": "Dupliqué depuis",
+    "forkCount": "Duplications",
+    "selectTargetPost": "Sélectionner la publication cible"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1645,5 +1645,14 @@
     "updateFailed": "マイルストーンの更新に失敗しました",
     "deleteFailed": "マイルストーンの削除に失敗しました",
     "confirmDelete": "このマイルストーンを削除してもよろしいですか？"
+  },
+  "snippetFork": {
+    "fork": "フォーク",
+    "forkSnippet": "スニペットをフォーク",
+    "forkSuccess": "スニペットをフォークしました",
+    "forkFailed": "スニペットのフォークに失敗しました",
+    "forkedFrom": "フォーク元",
+    "forkCount": "フォーク数",
+    "selectTargetPost": "フォーク先の投稿を選択"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1745,5 +1745,14 @@
     "updateFailed": "마일스톤 업데이트에 실패했습니다",
     "deleteFailed": "마일스톤 삭제에 실패했습니다",
     "confirmDelete": "이 마일스톤을 삭제하시겠습니까?"
+  },
+  "snippetFork": {
+    "fork": "포크",
+    "forkSnippet": "스니펫 포크",
+    "forkSuccess": "스니펫이 포크되었습니다",
+    "forkFailed": "스니펫 포크에 실패했습니다",
+    "forkedFrom": "포크 원본",
+    "forkCount": "포크 수",
+    "selectTargetPost": "대상 게시물 선택"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1743,5 +1743,14 @@
     "updateFailed": "Falha ao atualizar o marco",
     "deleteFailed": "Falha ao excluir o marco",
     "confirmDelete": "Tem certeza de que deseja excluir este marco?"
+  },
+  "snippetFork": {
+    "fork": "Bifurcar",
+    "forkSnippet": "Bifurcar Trecho",
+    "forkSuccess": "Trecho bifurcado com sucesso",
+    "forkFailed": "Falha ao bifurcar o trecho",
+    "forkedFrom": "Bifurcado de",
+    "forkCount": "Bifurcações",
+    "selectTargetPost": "Selecionar publicação de destino"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1742,5 +1742,14 @@
     "updateFailed": "Не удалось обновить веху",
     "deleteFailed": "Не удалось удалить веху",
     "confirmDelete": "Вы уверены, что хотите удалить эту веху?"
+  },
+  "snippetFork": {
+    "fork": "Форк",
+    "forkSnippet": "Форкнуть сниппет",
+    "forkSuccess": "Сниппет успешно форкнут",
+    "forkFailed": "Не удалось форкнуть сниппет",
+    "forkedFrom": "Форк из",
+    "forkCount": "Форков",
+    "selectTargetPost": "Выберите целевую публикацию"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1743,5 +1743,14 @@
     "updateFailed": "更新里程碑失败",
     "deleteFailed": "删除里程碑失败",
     "confirmDelete": "确定要删除这个里程碑吗？"
+  },
+  "snippetFork": {
+    "fork": "派生",
+    "forkSnippet": "派生代码片段",
+    "forkSuccess": "代码片段已派生",
+    "forkFailed": "派生代码片段失败",
+    "forkedFrom": "派生自",
+    "forkCount": "派生数",
+    "selectTargetPost": "选择目标帖子"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1745,5 +1745,14 @@
     "updateFailed": "更新里程碑失敗",
     "deleteFailed": "刪除里程碑失敗",
     "confirmDelete": "確定要刪除這個里程碑嗎？"
+  },
+  "snippetFork": {
+    "fork": "派生",
+    "forkSnippet": "派生程式碼片段",
+    "forkSuccess": "程式碼片段已派生",
+    "forkFailed": "派生程式碼片段失敗",
+    "forkedFrom": "派生自",
+    "forkCount": "派生數",
+    "selectTargetPost": "選擇目標貼文"
   }
 }


### PR DESCRIPTION
## 概要
- 他ユーザーのコードスニペットをフォーク（コピー）して自分の投稿に追加
- CodeSnippetモデルにforked_from_id, fork_countフィールド追加
- Service層: フォーク元存在確認・投稿所有権検証・フォークカウンター管理
- Handler: POST /snippets/:id/fork
- TDD: サービステスト5件 + ハンドラーテスト4件（全パス）
- フロントエンドAPI関数
- 10言語i18n対応（snippetForkセクション）

## テスト計画
- [x] サービス層ユニットテスト（5件）
- [x] ハンドラー層ユニットテスト（4件）
- [x] 全テストスイートPASS
- [x] TypeScript型チェック
- [x] Goビルド確認

Closes #2055