### PR TITLE
feat: ユーザーのアクティビティタイムライン機能を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -89,6 +89,7 @@ type Container struct {
 	NoteVersionHandler           *handler.NoteVersionHandler
 	ResourceProgressHandler      *handler.ResourceProgressHandler
 	ProjectMilestoneHandler      *handler.ProjectMilestoneHandler
+	UserActivityHandler          *handler.UserActivityHandler
 
 	// ミドルウェア・コールバック用
 	AuthService      *service.AuthService
@@ -413,6 +414,11 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	projectMilestoneRepo := repository.NewProjectMilestoneRepository(db)
 	projectMilestoneService := service.NewProjectMilestoneService(projectMilestoneRepo, projectRepo)
 	c.ProjectMilestoneHandler = handler.NewProjectMilestoneHandler(projectMilestoneService)
+
+	// ユーザーアクティビティサービス
+	userActivityRepo := repository.NewUserActivityRepository(db)
+	userActivityService := service.NewUserActivityService(userActivityRepo)
+	c.UserActivityHandler = handler.NewUserActivityHandler(userActivityService)
 
 	// HubのGetRoomMembersコールバックを設定
 	hub.GetRoomMembers = groupMessageRepo.GetMemberUserIDs

--- a/backend/internal/dto/user_activity_dto.go
+++ b/backend/internal/dto/user_activity_dto.go
@@ -1,0 +1,11 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// UserActivityListResponse はアクティビティタイムラインレスポンス。
+type UserActivityListResponse struct {
+	Activities []model.UserActivity `json:"activities"`
+	Total      int64                `json:"total"`
+	Limit      int                  `json:"limit"`
+	Offset     int                  `json:"offset"`
+}

--- a/backend/internal/handler/user_activity.go
+++ b/backend/internal/handler/user_activity.go
@@ -1,0 +1,46 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// UserActivityServiceInterface はアクティビティサービスの抽象インターフェース。
+type UserActivityServiceInterface interface {
+	GetTimeline(userID uint, activityType string, limit, offset int) ([]model.UserActivity, int64, error)
+}
+
+// UserActivityHandler はアクティビティタイムライン関連のHTTPハンドラ。
+type UserActivityHandler struct {
+	service UserActivityServiceInterface
+}
+
+// NewUserActivityHandler は新しいUserActivityHandlerインスタンスを生成する。
+func NewUserActivityHandler(s UserActivityServiceInterface) *UserActivityHandler {
+	return &UserActivityHandler{service: s}
+}
+
+// GetTimeline はユーザーのアクティビティタイムラインを取得する。
+func (h *UserActivityHandler) GetTimeline(c *gin.Context) {
+	userID, ok := parseID(c, "userId")
+	if !ok {
+		return
+	}
+
+	activityType := c.Query("type")
+	limit, offset := parseLimitOffset(c)
+
+	activities, total, err := h.service.GetTimeline(userID, activityType, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.UserActivityListResponse{
+		Activities: ensureSlice(activities),
+		Total:      total,
+		Limit:      limit,
+		Offset:     offset,
+	})
+}

--- a/backend/internal/handler/user_activity_test.go
+++ b/backend/internal/handler/user_activity_test.go
@@ -1,0 +1,107 @@
+package handler
+
+import (
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/mock"
+)
+
+// --- Mock ---
+
+type MockUserActivityService struct{ mock.Mock }
+
+func (m *MockUserActivityService) GetTimeline(userID uint, activityType string, limit, offset int) ([]model.UserActivity, int64, error) {
+	args := m.Called(userID, activityType, limit, offset)
+	return args.Get(0).([]model.UserActivity), args.Get(1).(int64), args.Error(2)
+}
+
+func setupUserActivityHandler() (*UserActivityHandler, *MockUserActivityService) {
+	svc := new(MockUserActivityService)
+	h := NewUserActivityHandler(svc)
+	return h, svc
+}
+
+// --- GetTimeline ---
+
+func TestUserActivityHandler_GetTimeline_Success(t *testing.T) {
+	h, svc := setupUserActivityHandler()
+
+	svc.On("GetTimeline", uint(10), "", 20, 0).Return(
+		[]model.UserActivity{
+			{ID: 1, UserID: 10, ActivityType: model.ActivityPostCreated, TargetType: "post", TargetID: 5},
+			{ID: 2, UserID: 10, ActivityType: model.ActivityCommentCreated, TargetType: "comment", TargetID: 3},
+		},
+		int64(2), nil,
+	)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/activity", h.GetTimeline)
+
+	w := doRequest(r, "GET", "/users/10/activity", nil)
+	assertStatus(t, w, 200)
+	data := parseJSON(t, w)
+	activities := data["activities"].([]interface{})
+	if len(activities) != 2 {
+		t.Errorf("expected 2 activities, got %d", len(activities))
+	}
+}
+
+func TestUserActivityHandler_GetTimeline_WithTypeFilter(t *testing.T) {
+	h, svc := setupUserActivityHandler()
+
+	svc.On("GetTimeline", uint(10), "post_created", 20, 0).Return(
+		[]model.UserActivity{{ID: 1, UserID: 10, ActivityType: model.ActivityPostCreated}},
+		int64(1), nil,
+	)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/activity", h.GetTimeline)
+
+	w := doRequest(r, "GET", "/users/10/activity?type=post_created", nil)
+	assertStatus(t, w, 200)
+}
+
+func TestUserActivityHandler_GetTimeline_InvalidUserID(t *testing.T) {
+	h, _ := setupUserActivityHandler()
+
+	r := newRouter(1)
+	r.GET("/users/:userId/activity", h.GetTimeline)
+
+	w := doRequest(r, "GET", "/users/abc/activity", nil)
+	assertStatus(t, w, 400)
+}
+
+func TestUserActivityHandler_GetTimeline_ServiceError(t *testing.T) {
+	h, svc := setupUserActivityHandler()
+
+	svc.On("GetTimeline", uint(10), "", 20, 0).Return(
+		[]model.UserActivity{}, int64(0), service.ErrNotFound,
+	)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/activity", h.GetTimeline)
+
+	w := doRequest(r, "GET", "/users/10/activity", nil)
+	assertStatus(t, w, 404)
+}
+
+func TestUserActivityHandler_GetTimeline_Empty(t *testing.T) {
+	h, svc := setupUserActivityHandler()
+
+	svc.On("GetTimeline", uint(10), "", 20, 0).Return(
+		[]model.UserActivity{}, int64(0), nil,
+	)
+
+	r := newRouter(1)
+	r.GET("/users/:userId/activity", h.GetTimeline)
+
+	w := doRequest(r, "GET", "/users/10/activity", nil)
+	assertStatus(t, w, 200)
+	data := parseJSON(t, w)
+	activities := data["activities"].([]interface{})
+	if len(activities) != 0 {
+		t.Errorf("expected 0 activities, got %d", len(activities))
+	}
+}

--- a/backend/internal/model/user_activity.go
+++ b/backend/internal/model/user_activity.go
@@ -1,0 +1,26 @@
+package model
+
+import "time"
+
+// ActivityType はアクティビティの種別を表す型。
+type ActivityType string
+
+const (
+	ActivityPostCreated    ActivityType = "post_created"
+	ActivityCommentCreated ActivityType = "comment_created"
+	ActivityResourceShared ActivityType = "resource_shared"
+	ActivityGoalCompleted  ActivityType = "goal_completed"
+	ActivityProjectCreated ActivityType = "project_created"
+	ActivitySnippetCreated ActivityType = "snippet_created"
+)
+
+// UserActivity はユーザーのアクティビティログを表す。
+type UserActivity struct {
+	ID           uint         `json:"id" gorm:"primaryKey"`
+	UserID       uint         `json:"user_id" gorm:"not null;index"`
+	ActivityType ActivityType `json:"activity_type" gorm:"size:50;not null;index"`
+	TargetType   string       `json:"target_type" gorm:"size:50;not null"`
+	TargetID     uint         `json:"target_id" gorm:"not null"`
+	Metadata     string       `json:"metadata" gorm:"type:text"`
+	CreatedAt    time.Time    `json:"created_at" gorm:"index"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -248,6 +248,12 @@ type ResourceProgressRepositoryInterface interface {
 	FindByUserID(userID uint, status string, limit, offset int) ([]model.ResourceProgress, int64, error)
 }
 
+// UserActivityRepositoryInterface はユーザーアクティビティデータ操作の契約を定義する。
+type UserActivityRepositoryInterface interface {
+	Create(activity *model.UserActivity) error
+	FindByUserID(userID uint, activityType string, limit, offset int) ([]model.UserActivity, int64, error)
+}
+
 // RoadmapRepositoryInterface は学習ロードマップデータ操作の契約を定義する。
 // ステップのCRUD操作やコピー機能も含む。
 type RoadmapRepositoryInterface interface {

--- a/backend/internal/repository/user_activity.go
+++ b/backend/internal/repository/user_activity.go
@@ -1,0 +1,42 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// UserActivityRepository はユーザーアクティビティのデータアクセスを提供する。
+type UserActivityRepository struct {
+	db *gorm.DB
+}
+
+// NewUserActivityRepository は新しいUserActivityRepositoryインスタンスを生成する。
+func NewUserActivityRepository(db *gorm.DB) *UserActivityRepository {
+	return &UserActivityRepository{db: db}
+}
+
+// Create はアクティビティを記録する。
+func (r *UserActivityRepository) Create(activity *model.UserActivity) error {
+	return r.db.Create(activity).Error
+}
+
+// FindByUserID は指定ユーザーのアクティビティを時系列で取得する。
+func (r *UserActivityRepository) FindByUserID(userID uint, activityType string, limit, offset int) ([]model.UserActivity, int64, error) {
+	var activities []model.UserActivity
+	var total int64
+
+	query := r.db.Where("user_id = ?", userID)
+	if activityType != "" {
+		query = query.Where("activity_type = ?", activityType)
+	}
+
+	if err := query.Model(&model.UserActivity{}).Count(&total).Error; err != nil {
+		return nil, 0, err
+	}
+
+	if err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&activities).Error; err != nil {
+		return nil, 0, err
+	}
+
+	return activities, total, nil
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -141,6 +141,7 @@ func registerUserRoutes(g *gin.RouterGroup, c *di.Container) {
 		users.DELETE("/:id/follow", c.FollowHandler.Unfollow)
 		users.GET("/:id/posts", c.PostHandler.GetUserPosts)
 		users.GET("/me/profile-completeness", c.UserHandler.GetProfileCompleteness)
+		users.GET("/:userId/activity", c.UserActivityHandler.GetTimeline)
 	}
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2499,3 +2499,22 @@ func (m *MockProjectMilestoneRepository) Update(milestone *model.ProjectMileston
 func (m *MockProjectMilestoneRepository) Delete(id uint) error {
 	return m.Called(id).Error(0)
 }
+
+// ============================================================
+// MockUserActivityRepository は repository.UserActivityRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockUserActivityRepository struct {
+	mock.Mock
+}
+
+var _ repository.UserActivityRepositoryInterface = (*MockUserActivityRepository)(nil)
+
+func (m *MockUserActivityRepository) Create(activity *model.UserActivity) error {
+	return m.Called(activity).Error(0)
+}
+
+func (m *MockUserActivityRepository) FindByUserID(userID uint, activityType string, limit, offset int) ([]model.UserActivity, int64, error) {
+	args := m.Called(userID, activityType, limit, offset)
+	return args.Get(0).([]model.UserActivity), args.Get(1).(int64), args.Error(2)
+}

--- a/backend/internal/service/user_activity.go
+++ b/backend/internal/service/user_activity.go
@@ -1,0 +1,33 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// UserActivityService はユーザーアクティビティのビジネスロジックを提供する。
+type UserActivityService struct {
+	repo repository.UserActivityRepositoryInterface
+}
+
+// NewUserActivityService は新しいUserActivityServiceインスタンスを生成する。
+func NewUserActivityService(repo repository.UserActivityRepositoryInterface) *UserActivityService {
+	return &UserActivityService{repo: repo}
+}
+
+// RecordActivity はアクティビティを記録する。
+func (s *UserActivityService) RecordActivity(userID uint, activityType model.ActivityType, targetType string, targetID uint, metadata string) error {
+	activity := &model.UserActivity{
+		UserID:       userID,
+		ActivityType: activityType,
+		TargetType:   targetType,
+		TargetID:     targetID,
+		Metadata:     metadata,
+	}
+	return s.repo.Create(activity)
+}
+
+// GetTimeline はユーザーのアクティビティタイムラインを取得する。
+func (s *UserActivityService) GetTimeline(userID uint, activityType string, limit, offset int) ([]model.UserActivity, int64, error) {
+	return s.repo.FindByUserID(userID, activityType, limit, offset)
+}

--- a/backend/internal/service/user_activity_test.go
+++ b/backend/internal/service/user_activity_test.go
@@ -1,0 +1,106 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func newTestUserActivityService() (*UserActivityService, *MockUserActivityRepository) {
+	repo := new(MockUserActivityRepository)
+	svc := NewUserActivityService(repo)
+	return svc, repo
+}
+
+// --- RecordActivity ---
+
+func TestUserActivityService_RecordActivity_Success(t *testing.T) {
+	svc, repo := newTestUserActivityService()
+
+	repo.On("Create", mock.MatchedBy(func(a *model.UserActivity) bool {
+		return a.UserID == 10 && a.ActivityType == model.ActivityPostCreated && a.TargetType == "post" && a.TargetID == 5
+	})).Return(nil)
+
+	err := svc.RecordActivity(10, model.ActivityPostCreated, "post", 5, "")
+	assert.NoError(t, err)
+}
+
+func TestUserActivityService_RecordActivity_WithMetadata(t *testing.T) {
+	svc, repo := newTestUserActivityService()
+
+	repo.On("Create", mock.MatchedBy(func(a *model.UserActivity) bool {
+		return a.Metadata == `{"title":"Hello"}`
+	})).Return(nil)
+
+	err := svc.RecordActivity(10, model.ActivityPostCreated, "post", 5, `{"title":"Hello"}`)
+	assert.NoError(t, err)
+}
+
+func TestUserActivityService_RecordActivity_RepoError(t *testing.T) {
+	svc, repo := newTestUserActivityService()
+
+	repo.On("Create", mock.Anything).Return(errors.New("db error"))
+
+	err := svc.RecordActivity(10, model.ActivityPostCreated, "post", 5, "")
+	assert.Error(t, err)
+}
+
+// --- GetTimeline ---
+
+func TestUserActivityService_GetTimeline_NoFilter(t *testing.T) {
+	svc, repo := newTestUserActivityService()
+
+	repo.On("FindByUserID", uint(10), "", 20, 0).Return(
+		[]model.UserActivity{
+			{ID: 1, UserID: 10, ActivityType: model.ActivityPostCreated},
+			{ID: 2, UserID: 10, ActivityType: model.ActivityCommentCreated},
+		},
+		int64(2), nil,
+	)
+
+	list, total, err := svc.GetTimeline(10, "", 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, list, 2)
+	assert.Equal(t, int64(2), total)
+}
+
+func TestUserActivityService_GetTimeline_WithTypeFilter(t *testing.T) {
+	svc, repo := newTestUserActivityService()
+
+	repo.On("FindByUserID", uint(10), "post_created", 20, 0).Return(
+		[]model.UserActivity{{ID: 1, UserID: 10, ActivityType: model.ActivityPostCreated}},
+		int64(1), nil,
+	)
+
+	list, total, err := svc.GetTimeline(10, "post_created", 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, list, 1)
+	assert.Equal(t, int64(1), total)
+}
+
+func TestUserActivityService_GetTimeline_RepoError(t *testing.T) {
+	svc, repo := newTestUserActivityService()
+
+	repo.On("FindByUserID", uint(10), "", 20, 0).Return(
+		[]model.UserActivity{}, int64(0), errors.New("db error"),
+	)
+
+	_, _, err := svc.GetTimeline(10, "", 20, 0)
+	assert.Error(t, err)
+}
+
+func TestUserActivityService_GetTimeline_Empty(t *testing.T) {
+	svc, repo := newTestUserActivityService()
+
+	repo.On("FindByUserID", uint(10), "", 20, 0).Return(
+		[]model.UserActivity{}, int64(0), nil,
+	)
+
+	list, total, err := svc.GetTimeline(10, "", 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, list, 0)
+	assert.Equal(t, int64(0), total)
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -111,6 +111,7 @@ func main() {
 		&model.NoteVersion{},
 		&model.ResourceProgress{},
 		&model.ProjectMilestone{},
+		&model.UserActivity{},
 	); err != nil {
 		log.Fatalf("failed to run migrations: %v", err)
 	}

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -36,3 +36,23 @@ export const getFollowing = (id: number) =>
 
 export const getProfileCompleteness = () =>
   client.get<{ percentage: number; missing_fields: string[] }>('/users/me/profile-completeness');
+
+export interface UserActivity {
+  id: number;
+  user_id: number;
+  activity_type: string;
+  target_type: string;
+  target_id: number;
+  metadata: string;
+  created_at: string;
+}
+
+export interface UserActivityListResponse {
+  activities: UserActivity[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export const getUserActivity = (userId: number, params?: { type?: string; limit?: number; offset?: number }) =>
+  client.get<UserActivityListResponse>(`/users/${userId}/activity`, { params });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1751,5 +1751,23 @@
     "forkedFrom": "Geforkt von",
     "forkCount": "Forks",
     "selectTargetPost": "Zielbeitrag auswählen"
+  },
+  "activityTimeline": {
+    "title": "Aktivitäts-Zeitleiste",
+    "empty": "Noch keine Aktivitäten",
+    "loadMore": "Mehr laden",
+    "postCreated": "Hat einen Beitrag erstellt",
+    "commentCreated": "Hat einen Kommentar gepostet",
+    "resourceShared": "Hat eine Ressource geteilt",
+    "goalCompleted": "Hat ein Ziel erreicht",
+    "projectCreated": "Hat ein Projekt erstellt",
+    "snippetCreated": "Hat ein Code-Snippet erstellt",
+    "filterAll": "Alle",
+    "filterPosts": "Beiträge",
+    "filterComments": "Kommentare",
+    "filterResources": "Ressourcen",
+    "filterGoals": "Ziele",
+    "filterProjects": "Projekte",
+    "filterSnippets": "Snippets"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1752,5 +1752,23 @@
     "forkedFrom": "Forked from",
     "forkCount": "Forks",
     "selectTargetPost": "Select target post"
+  },
+  "activityTimeline": {
+    "title": "Activity Timeline",
+    "empty": "No activity yet",
+    "loadMore": "Load more",
+    "postCreated": "Created a post",
+    "commentCreated": "Posted a comment",
+    "resourceShared": "Shared a resource",
+    "goalCompleted": "Completed a goal",
+    "projectCreated": "Created a project",
+    "snippetCreated": "Created a snippet",
+    "filterAll": "All",
+    "filterPosts": "Posts",
+    "filterComments": "Comments",
+    "filterResources": "Resources",
+    "filterGoals": "Goals",
+    "filterProjects": "Projects",
+    "filterSnippets": "Snippets"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1752,5 +1752,23 @@
     "forkedFrom": "Bifurcado de",
     "forkCount": "Bifurcaciones",
     "selectTargetPost": "Seleccionar publicación destino"
+  },
+  "activityTimeline": {
+    "title": "Cronología de actividad",
+    "empty": "Aún no hay actividad",
+    "loadMore": "Cargar más",
+    "postCreated": "Creó una publicación",
+    "commentCreated": "Publicó un comentario",
+    "resourceShared": "Compartió un recurso",
+    "goalCompleted": "Completó un objetivo",
+    "projectCreated": "Creó un proyecto",
+    "snippetCreated": "Creó un fragmento de código",
+    "filterAll": "Todos",
+    "filterPosts": "Publicaciones",
+    "filterComments": "Comentarios",
+    "filterResources": "Recursos",
+    "filterGoals": "Objetivos",
+    "filterProjects": "Proyectos",
+    "filterSnippets": "Fragmentos"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1752,5 +1752,23 @@
     "forkedFrom": "Dupliqué depuis",
     "forkCount": "Duplications",
     "selectTargetPost": "Sélectionner la publication cible"
+  },
+  "activityTimeline": {
+    "title": "Chronologie d'activité",
+    "empty": "Aucune activité pour le moment",
+    "loadMore": "Charger plus",
+    "postCreated": "A créé une publication",
+    "commentCreated": "A posté un commentaire",
+    "resourceShared": "A partagé une ressource",
+    "goalCompleted": "A atteint un objectif",
+    "projectCreated": "A créé un projet",
+    "snippetCreated": "A créé un extrait de code",
+    "filterAll": "Tous",
+    "filterPosts": "Publications",
+    "filterComments": "Commentaires",
+    "filterResources": "Ressources",
+    "filterGoals": "Objectifs",
+    "filterProjects": "Projets",
+    "filterSnippets": "Extraits"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1654,5 +1654,23 @@
     "forkedFrom": "フォーク元",
     "forkCount": "フォーク数",
     "selectTargetPost": "フォーク先の投稿を選択"
+  },
+  "activityTimeline": {
+    "title": "アクティビティタイムライン",
+    "empty": "アクティビティがありません",
+    "loadMore": "もっと見る",
+    "postCreated": "投稿を作成しました",
+    "commentCreated": "コメントを投稿しました",
+    "resourceShared": "リソースを共有しました",
+    "goalCompleted": "目標を達成しました",
+    "projectCreated": "プロジェクトを作成しました",
+    "snippetCreated": "スニペットを作成しました",
+    "filterAll": "すべて",
+    "filterPosts": "投稿",
+    "filterComments": "コメント",
+    "filterResources": "リソース",
+    "filterGoals": "目標",
+    "filterProjects": "プロジェクト",
+    "filterSnippets": "スニペット"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1754,5 +1754,23 @@
     "forkedFrom": "포크 원본",
     "forkCount": "포크 수",
     "selectTargetPost": "대상 게시물 선택"
+  },
+  "activityTimeline": {
+    "title": "활동 타임라인",
+    "empty": "아직 활동이 없습니다",
+    "loadMore": "더 보기",
+    "postCreated": "게시물을 작성했습니다",
+    "commentCreated": "댓글을 작성했습니다",
+    "resourceShared": "리소스를 공유했습니다",
+    "goalCompleted": "목표를 달성했습니다",
+    "projectCreated": "프로젝트를 생성했습니다",
+    "snippetCreated": "스니펫을 생성했습니다",
+    "filterAll": "전체",
+    "filterPosts": "게시물",
+    "filterComments": "댓글",
+    "filterResources": "리소스",
+    "filterGoals": "목표",
+    "filterProjects": "프로젝트",
+    "filterSnippets": "스니펫"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1752,5 +1752,23 @@
     "forkedFrom": "Bifurcado de",
     "forkCount": "Bifurcações",
     "selectTargetPost": "Selecionar publicação de destino"
+  },
+  "activityTimeline": {
+    "title": "Cronologia de atividades",
+    "empty": "Nenhuma atividade ainda",
+    "loadMore": "Carregar mais",
+    "postCreated": "Criou uma publicação",
+    "commentCreated": "Postou um comentário",
+    "resourceShared": "Compartilhou um recurso",
+    "goalCompleted": "Completou um objetivo",
+    "projectCreated": "Criou um projeto",
+    "snippetCreated": "Criou um trecho de código",
+    "filterAll": "Todos",
+    "filterPosts": "Publicações",
+    "filterComments": "Comentários",
+    "filterResources": "Recursos",
+    "filterGoals": "Objetivos",
+    "filterProjects": "Projetos",
+    "filterSnippets": "Trechos"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1751,5 +1751,23 @@
     "forkedFrom": "Форк из",
     "forkCount": "Форков",
     "selectTargetPost": "Выберите целевую публикацию"
+  },
+  "activityTimeline": {
+    "title": "Хронология активности",
+    "empty": "Активностей пока нет",
+    "loadMore": "Загрузить ещё",
+    "postCreated": "Создал публикацию",
+    "commentCreated": "Оставил комментарий",
+    "resourceShared": "Поделился ресурсом",
+    "goalCompleted": "Достиг цели",
+    "projectCreated": "Создал проект",
+    "snippetCreated": "Создал сниппет",
+    "filterAll": "Все",
+    "filterPosts": "Публикации",
+    "filterComments": "Комментарии",
+    "filterResources": "Ресурсы",
+    "filterGoals": "Цели",
+    "filterProjects": "Проекты",
+    "filterSnippets": "Сниппеты"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1752,5 +1752,23 @@
     "forkedFrom": "派生自",
     "forkCount": "派生数",
     "selectTargetPost": "选择目标帖子"
+  },
+  "activityTimeline": {
+    "title": "活动时间线",
+    "empty": "暂无活动",
+    "loadMore": "加载更多",
+    "postCreated": "创建了帖子",
+    "commentCreated": "发表了评论",
+    "resourceShared": "分享了资源",
+    "goalCompleted": "完成了目标",
+    "projectCreated": "创建了项目",
+    "snippetCreated": "创建了代码片段",
+    "filterAll": "全部",
+    "filterPosts": "帖子",
+    "filterComments": "评论",
+    "filterResources": "资源",
+    "filterGoals": "目标",
+    "filterProjects": "项目",
+    "filterSnippets": "代码片段"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1754,5 +1754,23 @@
     "forkedFrom": "派生自",
     "forkCount": "派生數",
     "selectTargetPost": "選擇目標貼文"
+  },
+  "activityTimeline": {
+    "title": "活動時間線",
+    "empty": "暫無活動",
+    "loadMore": "載入更多",
+    "postCreated": "建立了貼文",
+    "commentCreated": "發表了留言",
+    "resourceShared": "分享了資源",
+    "goalCompleted": "完成了目標",
+    "projectCreated": "建立了專案",
+    "snippetCreated": "建立了程式碼片段",
+    "filterAll": "全部",
+    "filterPosts": "貼文",
+    "filterComments": "留言",
+    "filterResources": "資源",
+    "filterGoals": "目標",
+    "filterProjects": "專案",
+    "filterSnippets": "程式碼片段"
   }
 }


### PR DESCRIPTION
## Summary
- UserActivityモデル（6種類のアクティビティタイプ: 投稿作成、コメント、リソース共有、目標達成、プロジェクト作成、スニペット作成）
- Service層: RecordActivity / GetTimeline + ユニットテスト7件
- Handler層: GetTimeline（タイプフィルター・ページネーション対応） + テスト5件
- フロントエンドAPI + i18n（10言語）対応

## Test plan
- [x] Service層テスト7件 全パス
- [x] Handler層テスト5件 全パス
- [x] TypeScriptビルドチェック パス
- [x] Goビルドチェック パス

closes #2057