### PR TITLE
refactor: Service層のエラーハンドリング一貫性改善

### DIFF
--- a/backend/internal/domain/errors.go
+++ b/backend/internal/domain/errors.go
@@ -51,6 +51,15 @@ func (e *DomainError) Unwrap() error {
 	return e.Err
 }
 
+// Is は errors.Is で同じエラーコードの DomainError を一致させるために使用する。
+func (e *DomainError) Is(target error) bool {
+	t, ok := target.(*DomainError)
+	if !ok {
+		return false
+	}
+	return e.Code == t.Code
+}
+
 // HTTPStatus returns the appropriate HTTP status code for the error.
 func (e *DomainError) HTTPStatus() int {
 	switch e.Code {

--- a/backend/internal/service/ai_advice.go
+++ b/backend/internal/service/ai_advice.go
@@ -72,7 +72,7 @@ func (s *AIAdviceService) IsLLMAvailable() bool {
 func (s *AIAdviceService) GetDailyChatRemaining(userID uint) (int, error) {
 	count, err := s.convRepo.CountTodayMessages(userID)
 	if err != nil {
-		return 0, err
+		return 0, domain.NewError(domain.ErrCodeDatabase, "チャット回数の取得に失敗しました", err)
 	}
 	remaining := DailyChatLimit - int(count)
 	if remaining < 0 {
@@ -85,10 +85,10 @@ func (s *AIAdviceService) GetDailyChatRemaining(userID uint) (int, error) {
 func (s *AIAdviceService) findAndCheckConversationOwnership(id, userID uint) (*model.AIConversation, error) {
 	conv, err := s.convRepo.FindConversationByID(id)
 	if err != nil {
-		return nil, ErrNotFound
+		return nil, domain.NewError(domain.ErrCodeNotFound, "会話が見つかりません", err)
 	}
 	if conv.UserID != userID {
-		return nil, ErrForbidden
+		return nil, domain.NewError(domain.ErrCodeForbidden, "この会話にアクセスする権限がありません", nil)
 	}
 	return conv, nil
 }

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -76,7 +76,7 @@ func (s *AuthService) Register(input RegisterInput) (*AuthResponse, error) {
 
 	hashed, err := bcrypt.GenerateFromPassword([]byte(input.Password), bcrypt.DefaultCost)
 	if err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "パスワードのハッシュ化に失敗しました", err)
 	}
 
 	user := &model.User{
@@ -87,12 +87,12 @@ func (s *AuthService) Register(input RegisterInput) (*AuthResponse, error) {
 	}
 
 	if err := s.userRepo.Create(user); err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "ユーザーの作成に失敗しました", err)
 	}
 
 	token, err := s.generateToken(user.ID)
 	if err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "トークンの生成に失敗しました", err)
 	}
 
 	return &AuthResponse{Token: token, User: *user}, nil
@@ -116,7 +116,7 @@ func (s *AuthService) Login(input LoginInput) (*AuthResponse, error) {
 
 	token, err := s.generateToken(user.ID)
 	if err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "トークンの生成に失敗しました", err)
 	}
 
 	return &AuthResponse{Token: token, User: *user}, nil
@@ -131,7 +131,7 @@ func (s *AuthService) ValidateToken(tokenString string) (uint, error) {
 		return s.jwtSecret, nil
 	})
 	if err != nil {
-		return 0, err
+		return 0, domain.NewError(domain.ErrCodeUnauthorized, "無効なトークンです", err)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
@@ -166,7 +166,7 @@ func (s *AuthService) ValidateLoginState(state string) error {
 		return s.jwtSecret, nil
 	})
 	if err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeUnauthorized, "無効なログインステートです", err)
 	}
 	claims, ok := token.Claims.(jwt.MapClaims)
 	if !ok || !token.Valid {
@@ -196,7 +196,7 @@ func (s *AuthService) GitHubLogin(ghUser *GitHubUserInfo, accessToken string) (*
 
 		token, err := s.generateToken(user.ID)
 		if err != nil {
-			return nil, err
+			return nil, domain.NewError(domain.ErrCodeInternal, "トークンの生成に失敗しました", err)
 		}
 		return &AuthResponse{Token: token, User: *user}, nil
 	}
@@ -216,7 +216,7 @@ func (s *AuthService) GitHubLogin(ghUser *GitHubUserInfo, accessToken string) (*
 
 			token, err := s.generateToken(user.ID)
 			if err != nil {
-				return nil, err
+				return nil, domain.NewError(domain.ErrCodeInternal, "トークンの生成に失敗しました", err)
 			}
 			return &AuthResponse{Token: token, User: *user}, nil
 		}
@@ -247,12 +247,12 @@ func (s *AuthService) GitHubLogin(ghUser *GitHubUserInfo, accessToken string) (*
 	}
 
 	if err := s.userRepo.Create(newUser); err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "ユーザーの作成に失敗しました", err)
 	}
 
 	token, err := s.generateToken(newUser.ID)
 	if err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "トークンの生成に失敗しました", err)
 	}
 	return &AuthResponse{Token: token, User: *newUser}, nil
 }
@@ -277,7 +277,7 @@ func (s *AuthService) ValidateOAuthState(state string) (uint, error) {
 		return s.jwtSecret, nil
 	})
 	if err != nil {
-		return 0, err
+		return 0, domain.NewError(domain.ErrCodeUnauthorized, "無効なOAuthステートです", err)
 	}
 
 	claims, ok := token.Claims.(jwt.MapClaims)
@@ -308,20 +308,23 @@ func (s *AuthService) GetMe(userID uint) (*model.User, error) {
 func (s *AuthService) DeleteAccount(userID uint, password string) error {
 	user, err := s.userRepo.FindByID(userID)
 	if err != nil {
-		return ErrNotFound
+		return domain.NewError(domain.ErrCodeNotFound, "ユーザーが見つかりません", err)
 	}
 
 	// パスワードが設定されている場合（GitHub専用アカウントでない場合）は検証
 	if user.Password != "" {
 		if password == "" {
-			return ErrBadRequest
+			return domain.NewError(domain.ErrCodeBadRequest, "パスワードの入力が必要です", nil)
 		}
 		if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
-			return ErrForbidden
+			return domain.NewError(domain.ErrCodeForbidden, "パスワードが正しくありません", nil)
 		}
 	}
 
-	return s.userRepo.DeleteWithRelatedData(userID)
+	if err := s.userRepo.DeleteWithRelatedData(userID); err != nil {
+		return domain.NewError(domain.ErrCodeInternal, "アカウント削除に失敗しました", err)
+	}
+	return nil
 }
 
 // RequestPasswordReset はパスワードリセットトークンを生成する。
@@ -339,7 +342,7 @@ func (s *AuthService) RequestPasswordReset(email string) (string, error) {
 	// セキュアなランダムトークンを生成
 	tokenBytes := make([]byte, 32)
 	if _, err := rand.Read(tokenBytes); err != nil {
-		return "", err
+		return "", domain.NewError(domain.ErrCodeInternal, "トークンの生成に失敗しました", err)
 	}
 	token := hex.EncodeToString(tokenBytes)
 
@@ -350,7 +353,7 @@ func (s *AuthService) RequestPasswordReset(email string) (string, error) {
 		ExpiresAt: time.Now().Add(1 * time.Hour),
 	}
 	if err := s.passwordResetRepo.Create(resetToken); err != nil {
-		return "", err
+		return "", domain.NewError(domain.ErrCodeInternal, "リセットトークンの保存に失敗しました", err)
 	}
 
 	return token, nil
@@ -360,11 +363,11 @@ func (s *AuthService) RequestPasswordReset(email string) (string, error) {
 func (s *AuthService) ResetPassword(token string, newPassword string) error {
 	resetToken, err := s.passwordResetRepo.FindByToken(token)
 	if err != nil {
-		return ErrBadRequest
+		return domain.NewError(domain.ErrCodeBadRequest, "無効なリセットトークンです", err)
 	}
 
 	if !resetToken.IsValid() {
-		return ErrBadRequest
+		return domain.NewError(domain.ErrCodeBadRequest, "リセットトークンが期限切れです", nil)
 	}
 
 	if err := domain.ValidatePassword(newPassword); err != nil {
@@ -373,11 +376,11 @@ func (s *AuthService) ResetPassword(token string, newPassword string) error {
 
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(newPassword), bcrypt.DefaultCost)
 	if err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeInternal, "パスワードのハッシュ化に失敗しました", err)
 	}
 
 	if err := s.userRepo.UpdatePassword(resetToken.UserID, string(hashedPassword)); err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeInternal, "パスワードの更新に失敗しました", err)
 	}
 
 	s.passwordResetRepo.MarkAsUsed(resetToken.ID)

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -36,11 +36,11 @@ func (s *CodeSnippetService) Create(snippet *model.CodeSnippet) (*model.CodeSnip
 
 	// 投稿の存在確認
 	if _, err := s.postRepo.FindByID(snippet.PostID); err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeNotFound, "投稿が見つかりません", err)
 	}
 
 	if err := s.repo.Create(snippet); err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "スニペットの作成に失敗しました", err)
 	}
 
 	created, err := s.repo.FindByID(snippet.ID)
@@ -93,7 +93,7 @@ func (s *CodeSnippetService) Update(id, userID uint, language, fileName, code st
 	}
 
 	if err := s.repo.Update(snippet); err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "スニペットの更新に失敗しました", err)
 	}
 	return snippet, nil
 }
@@ -103,7 +103,10 @@ func (s *CodeSnippetService) Delete(id, userID uint) error {
 	if _, err := s.findAndCheckOwnership(id, userID); err != nil {
 		return err
 	}
-	return s.repo.Delete(id)
+	if err := s.repo.Delete(id); err != nil {
+		return domain.NewError(domain.ErrCodeInternal, "スニペットの削除に失敗しました", err)
+	}
+	return nil
 }
 
 // CreateComment はスニペットへのインラインコメントを作成する。
@@ -114,7 +117,7 @@ func (s *CodeSnippetService) CreateComment(comment *model.SnippetComment) error 
 	}
 	comment.Content = strings.TrimSpace(comment.Content)
 	if _, err := s.repo.FindByID(comment.SnippetID); err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeNotFound, "スニペットが見つかりません", err)
 	}
 	return s.repo.CreateComment(comment)
 }
@@ -155,7 +158,7 @@ func (s *CodeSnippetService) Fork(userID, snippetID, targetPostID uint) (*model.
 	}
 
 	if err := s.repo.Create(forked); err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "スニペットのフォークに失敗しました", err)
 	}
 
 	// フォーク元のカウンターをインクリメント

--- a/backend/internal/service/github.go
+++ b/backend/internal/service/github.go
@@ -57,7 +57,7 @@ func (s *GitHubService) ExchangeCode(code string) (string, error) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", err
+		return "", domain.NewError(domain.ErrCodeServiceUnavailable, "GitHub APIへの接続に失敗しました", err)
 	}
 	defer resp.Body.Close()
 
@@ -66,7 +66,7 @@ func (s *GitHubService) ExchangeCode(code string) (string, error) {
 		Error       string `json:"error"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return "", err
+		return "", domain.NewError(domain.ErrCodeServiceUnavailable, "GitHub APIレスポンスの解析に失敗しました", err)
 	}
 	if result.Error != "" {
 		return "", domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("GitHub OAuthエラー: %s", result.Error), nil)
@@ -92,13 +92,13 @@ func (s *GitHubService) GetGitHubUser(token string) (*GitHubUserInfo, error) {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "GitHubユーザー情報の取得に失敗しました", err)
 	}
 	defer resp.Body.Close()
 
 	var user GitHubUserInfo
 	if err := json.NewDecoder(resp.Body).Decode(&user); err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "GitHubユーザー情報の解析に失敗しました", err)
 	}
 
 	// メールアドレスが非公開の場合、/user/emails APIからプライマリメールを取得
@@ -184,7 +184,7 @@ func (s *GitHubService) syncContributions(user *model.User) error {
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeServiceUnavailable, "GitHub GraphQL APIへの接続に失敗しました", err)
 	}
 	defer resp.Body.Close()
 
@@ -206,7 +206,7 @@ func (s *GitHubService) syncContributions(user *model.User) error {
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeServiceUnavailable, "GitHub GraphQLレスポンスの解析に失敗しました", err)
 	}
 
 	var contributions []model.GitHubContribution
@@ -247,7 +247,7 @@ func (s *GitHubService) syncReposAndLanguages(user *model.User) error {
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			return err
+			return domain.NewError(domain.ErrCodeServiceUnavailable, "GitHubリポジトリ一覧の取得に失敗しました", err)
 		}
 
 		data, _ := io.ReadAll(resp.Body)
@@ -264,7 +264,7 @@ func (s *GitHubService) syncReposAndLanguages(user *model.User) error {
 			Private     bool   `json:"private"`
 		}
 		if err := json.Unmarshal(data, &repos); err != nil {
-			return err
+			return domain.NewError(domain.ErrCodeServiceUnavailable, "GitHubリポジトリ一覧の解析に失敗しました", err)
 		}
 		if len(repos) == 0 {
 			break
@@ -308,7 +308,7 @@ func (s *GitHubService) syncReposAndLanguages(user *model.User) error {
 	}
 
 	if err := s.githubRepo.UpsertRepos(modelRepos); err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeDatabase, "リポジトリデータの保存に失敗しました", err)
 	}
 
 	// 上位20リポジトリの言語バイト数を取得（レート制限対策）
@@ -350,7 +350,10 @@ func (s *GitHubService) syncReposAndLanguages(user *model.User) error {
 		langStats = append(langStats, *stat)
 	}
 
-	return s.githubRepo.UpsertLanguageStats(langStats)
+	if err := s.githubRepo.UpsertLanguageStats(langStats); err != nil {
+		return domain.NewError(domain.ErrCodeDatabase, "言語統計の保存に失敗しました", err)
+	}
+	return nil
 }
 
 // ConnectGitHub はOAuthコールバック後にユーザーのGitHubアカウントを連携する。
@@ -368,7 +371,7 @@ func (s *GitHubService) ConnectGitHub(userID uint, code, state string) error {
 
 	user, err := s.userRepo.FindByID(userID)
 	if err != nil {
-		return ErrNotFound
+		return domain.NewError(domain.ErrCodeNotFound, "ユーザーが見つかりません", err)
 	}
 
 	user.GitHubToken = accessToken
@@ -380,7 +383,7 @@ func (s *GitHubService) ConnectGitHub(userID uint, code, state string) error {
 	}
 
 	if err := s.userRepo.Update(user); err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeInternal, "ユーザー情報の更新に失敗しました", err)
 	}
 
 	go s.SyncData(user)
@@ -391,7 +394,7 @@ func (s *GitHubService) ConnectGitHub(userID uint, code, state string) error {
 func (s *GitHubService) DisconnectGitHub(userID uint) error {
 	user, err := s.userRepo.FindByID(userID)
 	if err != nil {
-		return ErrNotFound
+		return domain.NewError(domain.ErrCodeNotFound, "ユーザーが見つかりません", err)
 	}
 
 	user.GitHubToken = ""
@@ -399,7 +402,7 @@ func (s *GitHubService) DisconnectGitHub(userID uint) error {
 	user.GitHubConnected = false
 
 	if err := s.userRepo.Update(user); err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeInternal, "ユーザー情報の更新に失敗しました", err)
 	}
 
 	s.githubRepo.DeleteUserData(userID)
@@ -410,7 +413,7 @@ func (s *GitHubService) DisconnectGitHub(userID uint) error {
 func (s *GitHubService) SyncUserData(userID uint) error {
 	user, err := s.userRepo.FindByID(userID)
 	if err != nil {
-		return ErrNotFound
+		return domain.NewError(domain.ErrCodeNotFound, "ユーザーが見つかりません", err)
 	}
 	return s.SyncData(user)
 }

--- a/backend/internal/service/github_test.go
+++ b/backend/internal/service/github_test.go
@@ -106,7 +106,7 @@ func TestGitHubService_DisconnectGitHub_UpdateError(t *testing.T) {
 
 	err := svc.DisconnectGitHub(1)
 	assert.Error(t, err)
-	assert.Equal(t, "db error", err.Error())
+	assert.Contains(t, err.Error(), "db error")
 	userRepo.AssertExpectations(t)
 }
 

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -37,11 +37,11 @@ func (s *LearningLogService) Create(log *model.LearningLog) error {
 	}
 	// Category: 空文字（デフォルト適用）または有効な値のみ許可
 	if log.Category != "" && !model.ValidCategories[log.Category] {
-		return ErrBadRequest
+		return domain.NewError(domain.ErrCodeBadRequest, "無効なカテゴリです", nil)
 	}
 	// Source: 空文字（デフォルト"manual"）または有効な値のみ許可
 	if log.Source != "" && !model.ValidSources[log.Source] {
-		return ErrBadRequest
+		return domain.NewError(domain.ErrCodeBadRequest, "無効なソースです", nil)
 	}
 
 	// ゴール紐付けバリデーション
@@ -58,7 +58,7 @@ func (s *LearningLogService) Create(log *model.LearningLog) error {
 	}
 
 	if err := s.repo.Create(log); err != nil {
-		return err
+		return domain.NewError(domain.ErrCodeInternal, "学習ログの作成に失敗しました", err)
 	}
 
 	// ゴール進捗自動更新（TargetHoursが設定されている場合のみ）
@@ -116,15 +116,15 @@ func (s *LearningLogService) BatchCreate(userID uint, logs []model.LearningLog) 
 			return nil, err
 		}
 		if logs[i].Category != "" && !model.ValidCategories[logs[i].Category] {
-			return nil, ErrBadRequest
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なカテゴリです", nil)
 		}
 		if logs[i].Source != "" && !model.ValidSources[logs[i].Source] {
-			return nil, ErrBadRequest
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なソースです", nil)
 		}
 	}
 
 	if err := s.repo.CreateBatch(logs); err != nil {
-		return nil, err
+		return nil, domain.NewError(domain.ErrCodeInternal, "学習ログの一括作成に失敗しました", err)
 	}
 
 	return logs, nil
@@ -159,7 +159,7 @@ func (s *LearningLogService) GetBySource(userID uint, source string) ([]model.Le
 // validateDuration は学習時間（分）が有効な範囲（0〜1440）かを検証する。
 func validateDuration(duration int) error {
 	if duration < 0 || duration > 1440 {
-		return ErrBadRequest
+		return domain.NewError(domain.ErrCodeBadRequest, "学習時間は0〜1440分の範囲で指定してください", nil)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Service層で生のエラーをdomain.NewError()でラップし、エラーハンドリングの一貫性を改善
- auth.go, github.go, ai_advice.go, code_snippet.go, learning_log.goの20箇所以上を修正
- DomainError.Is()メソッドを追加し、同一エラーコードでのerrors.Isマッチングを実現

## Test plan
- [x] Service層テスト全件パス
- [x] Handler層テスト全件パス
- [x] Goビルドチェック パス

closes #2059