### PR TITLE
fix: セキュリティ脆弱性の修正（入力バリデーション・CORS・レート制限）

### DIFF
--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -57,6 +57,12 @@ const maxSearchQueryLen = 500
 // maxUserSearchQueryLen はユーザー検索クエリの最大文字数（ルーン数）。
 const maxUserSearchQueryLen = 100
 
+// maxTagQueryLen はタグ検索クエリの最大文字数（ルーン数）。
+const maxTagQueryLen = 100
+
+// maxUsernameLen はユーザー名パラメータの最大文字数（ルーン数）。
+const maxUsernameLen = 50
+
 // parseSearchQuery はクエリパラメータ "q" を取得・検証する共通ヘルパー。
 // 未指定・空文字列・500文字超の場合は400を返しfalseを返す。
 // 前後の空白はTrimSpaceで除去して返す。

--- a/backend/internal/handler/post_tag.go
+++ b/backend/internal/handler/post_tag.go
@@ -68,6 +68,10 @@ func (h *PostTagHandler) FindPostsByTag(c *gin.Context) {
 		respondBadRequest(c, "tagパラメータが必要です")
 		return
 	}
+	if len([]rune(tag)) > maxTagQueryLen {
+		respondBadRequest(c, "タグは100文字以下である必要があります")
+		return
+	}
 
 	page, limit := parsePagination(c)
 	offset := (page - 1) * limit

--- a/backend/internal/handler/post_tag_test.go
+++ b/backend/internal/handler/post_tag_test.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -166,6 +167,31 @@ func TestPostTagFindPostsByTag_MissingTag(t *testing.T) {
 
 	w := doRequest(r, http.MethodGet, "/posts/tags/search", nil)
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTagFindPostsByTag_TagTooLong(t *testing.T) {
+	h, _ := setupPostTagHandler()
+
+	r := newRouter(1)
+	r.GET("/posts/tags/search", h.FindPostsByTag)
+
+	longTag := strings.Repeat("あ", 101)
+	w := doRequest(r, http.MethodGet, "/posts/tags/search?tag="+longTag, nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostTagFindPostsByTag_TagExact100Chars(t *testing.T) {
+	h, svc := setupPostTagHandler()
+
+	r := newRouter(1)
+	r.GET("/posts/tags/search", h.FindPostsByTag)
+
+	tag100 := strings.Repeat("あ", 100)
+	svc.On("FindPostsByTag", tag100, 20, 0).Return([]model.Post{}, int64(0), nil)
+
+	w := doRequest(r, http.MethodGet, "/posts/tags/search?tag="+tag100, nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
 }
 
 func TestPostTagFindPostsByTag_ServiceError(t *testing.T) {

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -63,6 +63,10 @@ func (h *UserHandler) GetByUsername(c *gin.Context) {
 		respondBadRequest(c, "username required")
 		return
 	}
+	if len([]rune(username)) > maxUsernameLen {
+		respondBadRequest(c, "ユーザー名は50文字以下である必要があります")
+		return
+	}
 
 	user, err := h.service.GetByUsername(username)
 	if err != nil {

--- a/backend/internal/handler/user_test.go
+++ b/backend/internal/handler/user_test.go
@@ -214,6 +214,16 @@ func TestUserHandler_GetByUsername(t *testing.T) {
 		assertStatus(t, w, http.StatusNotFound)
 		svc.AssertExpectations(t)
 	})
+
+	t.Run("50文字超のユーザー名で400を返す", func(t *testing.T) {
+		h, _ := newTestUserHandler()
+		r := newRouter(1)
+		r.GET("/users/username/:username", h.GetByUsername)
+
+		longUsername := strings.Repeat("a", 51)
+		w := doRequest(r, "GET", "/users/username/"+longUsername, nil)
+		assertStatus(t, w, http.StatusBadRequest)
+	})
 }
 
 // ============================================================

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -3,6 +3,7 @@
 package router
 
 import (
+	"log"
 	"os"
 	"strings"
 
@@ -24,8 +25,28 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 
 	r := gin.Default()
 
-	// CORS設定
+	// 信頼するプロキシを設定（X-Forwarded-For偽装によるレート制限回避を防止）
+	trustedProxies := os.Getenv("TRUSTED_PROXIES")
+	if trustedProxies != "" {
+		proxies := strings.Split(trustedProxies, ",")
+		for i := range proxies {
+			proxies[i] = strings.TrimSpace(proxies[i])
+		}
+		if err := r.SetTrustedProxies(proxies); err != nil {
+			log.Fatalf("信頼するプロキシの設定に失敗: %v", err)
+		}
+	} else {
+		// プロキシ未設定の場合はローカルホストのみ信頼
+		_ = r.SetTrustedProxies([]string{"127.0.0.1", "::1"})
+	}
+
+	// CORS設定（AllowCredentials=true の場合、ワイルドカードオリジンを拒否）
 	origins := strings.Split(cfg.CORSOrigins, ",")
+	for _, origin := range origins {
+		if strings.TrimSpace(origin) == "*" {
+			log.Fatal("CORS: AllowCredentials=true の場合、ワイルドカード '*' オリジンは使用できません")
+		}
+	}
 	r.Use(cors.New(cors.Config{
 		AllowOrigins:     origins,
 		AllowMethods:     []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
@@ -46,6 +67,8 @@ func Setup(db *gorm.DB, cfg *config.Config, hub *service.Hub) *gin.Engine {
 		if strings.HasPrefix(ctx.Request.URL.Path, "/uploads/") {
 			ctx.Header("Cache-Control", "public, max-age=86400")
 			ctx.Header("Content-Security-Policy", "default-src 'none'; img-src 'self'; style-src 'none'; script-src 'none'")
+			ctx.Header("Content-Disposition", "inline")
+			ctx.Header("X-Content-Type-Options", "nosniff")
 		} else {
 			ctx.Header("Cache-Control", "no-store")
 			ctx.Header("Content-Security-Policy", "default-src 'none'")


### PR DESCRIPTION
## 概要
セキュリティ分析で発見された脆弱性を修正。

## 変更内容
- **入力バリデーション強化**: タグ検索（100文字）、ユーザー名（50文字）にパラメータ長制限を追加
- **CORS設定安全性**: `AllowCredentials=true` の場合にワイルドカード `*` オリジンを拒否するバリデーション追加
- **レート制限IP spoofing対策**: `SetTrustedProxies` でX-Forwarded-For偽装を防止
- **アップロードXSS防止**: Content-Disposition/X-Content-Type-Options ヘッダー追加
- **テスト追加**: 新しいバリデーションのテストケース（タグ長さ超過、ユーザー名長さ超過）

## テスト計画
- [x] handler テスト全件パス
- [x] service テスト全件パス
- [x] `go build ./...` 成功

Closes #2063