### PR TITLE
feat: 学習ログのCSVインポート機能

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -13,6 +14,7 @@ import (
 type LearningLogServiceInterface interface {
 	Create(log *model.LearningLog) error
 	BatchCreate(userID uint, logs []model.LearningLog) ([]model.LearningLog, error)
+	ImportCSV(userID uint, data []byte) ([]model.LearningLog, error)
 	GetByID(id, userID uint) (*model.LearningLog, error)
 	GetByUserID(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	Update(id, userID uint, updates *model.LearningLog) (*model.LearningLog, error)
@@ -354,6 +356,47 @@ func (h *LearningLogHandler) Unfavorite(c *gin.Context) {
 	}
 
 	respondOK(c, gin.H{"message": "学習ログのお気に入りを解除しました"})
+}
+
+// ImportCSV はCSVファイルから学習ログを一括インポートする。
+func (h *LearningLogHandler) ImportCSV(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	file, err := c.FormFile("file")
+	if err != nil {
+		respondBadRequest(c, "CSVファイルが必要です")
+		return
+	}
+
+	// ファイルサイズ制限（1MB）
+	if file.Size > 1*1024*1024 {
+		respondBadRequest(c, "ファイルサイズは1MB以下にしてください")
+		return
+	}
+
+	src, err := file.Open()
+	if err != nil {
+		respondInternalError(c, "ファイルの読み取りに失敗しました")
+		return
+	}
+	defer src.Close()
+
+	data, err := io.ReadAll(src)
+	if err != nil {
+		respondInternalError(c, "ファイルの読み取りに失敗しました")
+		return
+	}
+
+	logs, err := h.service.ImportCSV(userID, data)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, gin.H{
+		"imported": len(logs),
+		"logs":     logs,
+	})
 }
 
 // GetLinkedLogs は指定ゴールに紐付いた学習ログ一覧を取得する。

--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -1,7 +1,9 @@
 package handler
 
 import (
+	"bytes"
 	"errors"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -658,6 +660,73 @@ func TestLearningLogGetLinkedLogs_Handler_ServiceError(t *testing.T) {
 	r := newRouter(1)
 	r.GET("/goals/:id/linked-logs", h.GetLinkedLogs)
 	w := doRequest(r, http.MethodGet, "/goals/5/linked-logs", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// ImportCSV テスト
+// ============================================================
+
+func createCSVMultipartRequest(csvContent string) (*http.Request, error) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", "import.csv")
+	if err != nil {
+		return nil, err
+	}
+	part.Write([]byte(csvContent))
+	writer.Close()
+
+	req, err := http.NewRequest("POST", "/logs/import", &buf)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	return req, nil
+}
+
+func TestLearningLog_ImportCSV_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+
+	logs := []model.LearningLog{{Title: "Go学習", Duration: 60}}
+	svc.On("ImportCSV", uint(1), mock.AnythingOfType("[]uint8")).Return(logs, nil)
+
+	r := newRouter(1)
+	r.POST("/logs/import", h.ImportCSV)
+
+	req, _ := createCSVMultipartRequest("日付,カテゴリ,タイトル,学習時間(分),メモ\n2025-01-15,coding,Go学習,60,テスト\n")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	assertStatus(t, w, http.StatusCreated)
+	body := parseJSON(t, w)
+	assert.Equal(t, float64(1), body["imported"])
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLog_ImportCSV_NoFile(t *testing.T) {
+	h, _ := setupLearningLogHandler()
+
+	r := newRouter(1)
+	r.POST("/logs/import", h.ImportCSV)
+
+	w := doRequest(r, http.MethodPost, "/logs/import", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestLearningLog_ImportCSV_ServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+
+	svc.On("ImportCSV", uint(1), mock.AnythingOfType("[]uint8")).Return(nil, errors.New("parse error"))
+
+	r := newRouter(1)
+	r.POST("/logs/import", h.ImportCSV)
+
+	req, _ := createCSVMultipartRequest("日付,カテゴリ,タイトル,学習時間(分),メモ\ninvalid\n")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1294,6 +1294,13 @@ func (m *MockLearningLogService) BatchCreate(userID uint, logs []model.LearningL
 	}
 	return nil, args.Error(1)
 }
+func (m *MockLearningLogService) ImportCSV(userID uint, data []byte) ([]model.LearningLog, error) {
+	args := m.Called(userID, data)
+	if l := args.Get(0); l != nil {
+		return l.([]model.LearningLog), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
 func (m *MockLearningLogService) GetByID(id, userID uint) (*model.LearningLog, error) {
 	args := m.Called(id, userID)
 	if l := args.Get(0); l != nil {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -454,6 +454,7 @@ func registerLearningLogRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		learningLogs.POST("", c.LearningLogHandler.Create)
 		learningLogs.POST("/batch", c.LearningLogHandler.BatchCreate)
+		learningLogs.POST("/import", c.LearningLogHandler.ImportCSV)
 		learningLogs.GET("", c.LearningLogHandler.GetMyLogs)
 		learningLogs.GET("/export", c.LearningLogHandler.ExportLogs)
 		learningLogs.GET("/recent-categories", c.LearningLogHandler.GetRecentCategories)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -5,6 +5,8 @@ import (
 	"encoding/csv"
 	"encoding/json"
 	"fmt"
+	"io"
+	"strconv"
 	"strings"
 	"time"
 
@@ -321,4 +323,102 @@ func (s *LearningLogService) ExportJSON(userID uint, days int) ([]byte, error) {
 	}
 
 	return json.Marshal(entries)
+}
+
+// ImportCSV はCSVデータから学習ログを一括インポートする。
+// エクスポート形式（BOM付きUTF-8、ヘッダー: 日付,カテゴリ,タイトル,学習時間(分),メモ）に対応する。
+// 最大50件まで。各行のバリデーションを行い、全てパスした場合のみ保存する。
+func (s *LearningLogService) ImportCSV(userID uint, data []byte) ([]model.LearningLog, error) {
+	// BOMを除去
+	data = bytes.TrimPrefix(data, []byte("\xef\xbb\xbf"))
+
+	reader := csv.NewReader(io.NopCloser(bytes.NewReader(data)))
+	reader.TrimLeadingSpace = true
+
+	// ヘッダー行を読み飛ばす
+	header, err := reader.Read()
+	if err != nil {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "CSVファイルの読み取りに失敗しました", err)
+	}
+	if len(header) < 5 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "CSVのカラム数が不足しています（5列必要）", nil)
+	}
+
+	var logs []model.LearningLog
+	lineNum := 1
+	for {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, fmt.Sprintf("CSV %d行目の読み取りに失敗しました", lineNum+1), err)
+		}
+		lineNum++
+
+		if len(record) < 5 {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, fmt.Sprintf("CSV %d行目のカラム数が不足しています", lineNum), nil)
+		}
+
+		// 日付パース
+		dateStr := strings.TrimSpace(record[0])
+		parsedDate, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, fmt.Sprintf("CSV %d行目の日付形式が不正です: %s", lineNum, dateStr), err)
+		}
+
+		// カテゴリ
+		category := model.LogCategory(strings.TrimSpace(record[1]))
+		if category != "" && !model.ValidCategories[category] {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, fmt.Sprintf("CSV %d行目の無効なカテゴリです: %s", lineNum, category), nil)
+		}
+		if category == "" {
+			category = model.LogCategoryOther
+		}
+
+		// タイトル
+		title := strings.TrimSpace(record[2])
+		if title == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, fmt.Sprintf("CSV %d行目のタイトルが空です", lineNum), nil)
+		}
+
+		// 学習時間
+		durationStr := strings.TrimSpace(record[3])
+		duration, err := strconv.Atoi(durationStr)
+		if err != nil {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, fmt.Sprintf("CSV %d行目の学習時間が不正です: %s", lineNum, durationStr), err)
+		}
+		if err := validateDuration(duration); err != nil {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, fmt.Sprintf("CSV %d行目: 学習時間は0〜1440分の範囲で指定してください", lineNum), nil)
+		}
+
+		// メモ
+		content := strings.TrimSpace(record[4])
+		if content == "" {
+			content = title // メモが空の場合はタイトルをデフォルトに
+		}
+
+		logs = append(logs, model.LearningLog{
+			UserID:    userID,
+			Title:     title,
+			Content:   content,
+			Category:  category,
+			Duration:  duration,
+			Source:    model.LogSourceManual,
+			CreatedAt: parsedDate,
+		})
+	}
+
+	if len(logs) == 0 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "インポートするデータがありません", nil)
+	}
+	if len(logs) > 50 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "一度にインポートできるのは50件までです", nil)
+	}
+
+	if err := s.repo.CreateBatch(logs); err != nil {
+		return nil, domain.NewError(domain.ErrCodeInternal, "学習ログのインポートに失敗しました", err)
+	}
+
+	return logs, nil
 }

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -1114,3 +1114,154 @@ func TestLearningLogGetLinkedLogs_NoGoalRepo(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrBadRequest)
 }
+
+// ============================================================
+// ImportCSV テスト
+// ============================================================
+
+func TestLearningLogImportCSV_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	csv := "\xef\xbb\xbf日付,カテゴリ,タイトル,学習時間(分),メモ\n2025-01-15,coding,Go学習,60,インターフェースを学んだ\n2025-01-16,reading,書籍読了,30,Clean Architecture\n"
+
+	repo.On("CreateBatch", mock.MatchedBy(func(logs []model.LearningLog) bool {
+		return len(logs) == 2 &&
+			logs[0].Title == "Go学習" &&
+			logs[0].Duration == 60 &&
+			logs[0].Category == model.LogCategoryCoding &&
+			logs[1].Title == "書籍読了" &&
+			logs[1].Duration == 30
+	})).Return(nil)
+
+	result, err := svc.ImportCSV(1, []byte(csv))
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogImportCSV_NoBOM(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル,学習時間(分),メモ\n2025-01-15,coding,Go学習,60,テスト\n"
+
+	repo.On("CreateBatch", mock.Anything).Return(nil)
+
+	result, err := svc.ImportCSV(1, []byte(csv))
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+}
+
+func TestLearningLogImportCSV_EmptyData(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル,学習時間(分),メモ\n"
+
+	_, err := svc.ImportCSV(1, []byte(csv))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+}
+
+func TestLearningLogImportCSV_InvalidDate(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル,学習時間(分),メモ\nnot-a-date,coding,Test,60,Memo\n"
+
+	_, err := svc.ImportCSV(1, []byte(csv))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Contains(t, err.Error(), "日付形式")
+}
+
+func TestLearningLogImportCSV_InvalidCategory(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル,学習時間(分),メモ\n2025-01-15,invalid_cat,Test,60,Memo\n"
+
+	_, err := svc.ImportCSV(1, []byte(csv))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Contains(t, err.Error(), "カテゴリ")
+}
+
+func TestLearningLogImportCSV_InvalidDuration(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル,学習時間(分),メモ\n2025-01-15,coding,Test,abc,Memo\n"
+
+	_, err := svc.ImportCSV(1, []byte(csv))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Contains(t, err.Error(), "学習時間")
+}
+
+func TestLearningLogImportCSV_DurationOutOfRange(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル,学習時間(分),メモ\n2025-01-15,coding,Test,1500,Memo\n"
+
+	_, err := svc.ImportCSV(1, []byte(csv))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+}
+
+func TestLearningLogImportCSV_EmptyTitle(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル,学習時間(分),メモ\n2025-01-15,coding,,60,Memo\n"
+
+	_, err := svc.ImportCSV(1, []byte(csv))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Contains(t, err.Error(), "タイトル")
+}
+
+func TestLearningLogImportCSV_TooManyRows(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	var b strings.Builder
+	b.WriteString("日付,カテゴリ,タイトル,学習時間(分),メモ\n")
+	for i := 0; i < 51; i++ {
+		b.WriteString("2025-01-15,coding,Test,60,Memo\n")
+	}
+
+	_, err := svc.ImportCSV(1, []byte(b.String()))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	assert.Contains(t, err.Error(), "50件")
+}
+
+func TestLearningLogImportCSV_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル,学習時間(分),メモ\n2025-01-15,coding,Test,60,Memo\n"
+
+	repo.On("CreateBatch", mock.Anything).Return(errors.New("db error"))
+
+	_, err := svc.ImportCSV(1, []byte(csv))
+	assert.Error(t, err)
+}
+
+func TestLearningLogImportCSV_InsufficientColumns(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル\n2025-01-15,coding,Test\n"
+
+	_, err := svc.ImportCSV(1, []byte(csv))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+}
+
+func TestLearningLogImportCSV_DefaultCategory(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	csv := "日付,カテゴリ,タイトル,学習時間(分),メモ\n2025-01-15,,Go学習,60,テスト\n"
+
+	repo.On("CreateBatch", mock.MatchedBy(func(logs []model.LearningLog) bool {
+		return len(logs) == 1 && logs[0].Category == model.LogCategoryOther
+	})).Return(nil)
+
+	result, err := svc.ImportCSV(1, []byte(csv))
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	repo.AssertExpectations(t)
+}

--- a/frontend/src/api/learningLogs.ts
+++ b/frontend/src/api/learningLogs.ts
@@ -57,3 +57,16 @@ export const exportLogsJSON = (period: ExportPeriod = '30') =>
 
 export const exportLogs = (period: ExportPeriod = '30', format: ExportFormat = 'csv') =>
   client.get<Blob>(`/learning-logs/export?format=${format}&period=${period}`, { responseType: 'blob' });
+
+export interface ImportCSVResponse {
+  imported: number;
+  logs: LearningLog[];
+}
+
+export const importLogsCSV = (file: File) => {
+  const formData = new FormData();
+  formData.append('file', file);
+  return client.post<ImportCSVResponse>('/learning-logs/import', formData, {
+    headers: { 'Content-Type': 'multipart/form-data' },
+  });
+};

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -721,7 +721,12 @@
     "exportJSON": "Als JSON exportieren",
     "exportFormat": "Exportformat",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "CSV importieren",
+    "importCSVDesc": "Importieren Sie exportierte CSV-Dateien, um Lernprotokolle im Stapel zu registrieren",
+    "importSuccess": "{{count}} Lernprotokolle importiert",
+    "importError": "CSV-Datei konnte nicht importiert werden",
+    "selectCSVFile": "CSV-Datei auswählen"
   },
   "reports": {
     "title": "Aktivitätsberichte",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -722,7 +722,12 @@
     "exportJSON": "Export as JSON",
     "exportFormat": "Export format",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "Import CSV",
+    "importCSVDesc": "Import exported CSV files to batch register learning logs",
+    "importSuccess": "Successfully imported {{count}} learning logs",
+    "importError": "Failed to import CSV file",
+    "selectCSVFile": "Select CSV file"
   },
   "reports": {
     "title": "Activity Reports",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -722,7 +722,12 @@
     "exportJSON": "Exportar como JSON",
     "exportFormat": "Formato de exportación",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "Importar CSV",
+    "importCSVDesc": "Importa archivos CSV exportados para registrar registros de aprendizaje en lote",
+    "importSuccess": "Se importaron {{count}} registros de aprendizaje",
+    "importError": "Error al importar el archivo CSV",
+    "selectCSVFile": "Seleccionar archivo CSV"
   },
   "reports": {
     "title": "Informes de Actividad",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -722,7 +722,12 @@
     "exportJSON": "Exporter en JSON",
     "exportFormat": "Format d'exportation",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "Importer CSV",
+    "importCSVDesc": "Importez des fichiers CSV exportés pour enregistrer des journaux d apprentissage en lot",
+    "importSuccess": "{{count}} journaux d apprentissage importés",
+    "importError": "Échec de l importation du fichier CSV",
+    "selectCSVFile": "Sélectionner un fichier CSV"
   },
   "reports": {
     "title": "Rapports d'Activité",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -706,7 +706,12 @@
     "exportJSON": "JSON形式でエクスポート",
     "exportFormat": "エクスポート形式",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "CSVインポート",
+    "importCSVDesc": "エクスポートしたCSVファイルをインポートして学習ログを一括登録します",
+    "importSuccess": "{{count}}件の学習ログをインポートしました",
+    "importError": "CSVファイルのインポートに失敗しました",
+    "selectCSVFile": "CSVファイルを選択"
   },
   "reports": {
     "title": "アクティビティレポート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -724,7 +724,12 @@
     "exportJSON": "JSON으로 내보내기",
     "exportFormat": "내보내기 형식",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "CSV 가져오기",
+    "importCSVDesc": "내보낸 CSV 파일을 가져와 학습 로그를 일괄 등록합니다",
+    "importSuccess": "{{count}}개의 학습 로그를 가져왔습니다",
+    "importError": "CSV 파일 가져오기에 실패했습니다",
+    "selectCSVFile": "CSV 파일 선택"
   },
   "reports": {
     "title": "활동 리포트",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -722,7 +722,12 @@
     "exportJSON": "Exportar como JSON",
     "exportFormat": "Formato de exportação",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "Importar CSV",
+    "importCSVDesc": "Importe arquivos CSV exportados para registrar logs de aprendizado em lote",
+    "importSuccess": "{{count}} logs de aprendizado importados",
+    "importError": "Falha ao importar arquivo CSV",
+    "selectCSVFile": "Selecionar arquivo CSV"
   },
   "reports": {
     "title": "Relatórios de Atividade",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -721,7 +721,12 @@
     "exportJSON": "Экспорт в JSON",
     "exportFormat": "Формат экспорта",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "Импорт CSV",
+    "importCSVDesc": "Импортируйте экспортированные CSV-файлы для массовой регистрации журналов обучения",
+    "importSuccess": "Импортировано {{count}} записей обучения",
+    "importError": "Не удалось импортировать CSV-файл",
+    "selectCSVFile": "Выберите CSV-файл"
   },
   "reports": {
     "title": "Отчёты об Активности",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -722,7 +722,12 @@
     "exportJSON": "导出为JSON",
     "exportFormat": "导出格式",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "导入CSV",
+    "importCSVDesc": "导入导出的CSV文件以批量注册学习日志",
+    "importSuccess": "成功导入{{count}}条学习日志",
+    "importError": "CSV文件导入失败",
+    "selectCSVFile": "选择CSV文件"
   },
   "reports": {
     "title": "活动报告",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -724,7 +724,12 @@
     "exportJSON": "匯出為JSON",
     "exportFormat": "匯出格式",
     "formatCSV": "CSV",
-    "formatJSON": "JSON"
+    "formatJSON": "JSON",
+    "importCSV": "匯入CSV",
+    "importCSVDesc": "匯入匯出的CSV檔案以批次註冊學習日誌",
+    "importSuccess": "成功匯入{{count}}筆學習日誌",
+    "importError": "CSV檔案匯入失敗",
+    "selectCSVFile": "選擇CSV檔案"
   },
   "reports": {
     "title": "活動報告",


### PR DESCRIPTION
## 概要
エクスポートしたCSVファイルを再インポートして学習ログを一括登録できる機能を追加。

## 変更内容
- **Service層**: `ImportCSV` メソッド（BOM対応、行ごとバリデーション、50件制限）
- **Handler層**: `ImportCSV` ハンドラー（multipart/form-data、1MBファイルサイズ制限）
- **ルート**: `POST /learning-logs/import`
- **フロントエンドAPI**: `importLogsCSV` 関数
- **i18n**: 全10言語にCSVインポート関連キー追加
- **テスト**: Service 12件、Handler 3件追加

## CSV形式
エクスポート形式と完全互換:
```
日付,カテゴリ,タイトル,学習時間(分),メモ
2025-01-15,coding,Go学習,60,インターフェースを学んだ
```

## テスト計画
- [x] Service テスト12件パス（正常系、バリデーション、エッジケース）
- [x] Handler テスト3件パス（成功、ファイルなし、サービスエラー）
- [x] 全テスト通過

Closes #2065