### PR TITLE
feat: ノートのMarkdownエクスポート機能を追加

### DIFF
--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -1,6 +1,8 @@
 package handler
 
 import (
+	"fmt"
+
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
@@ -26,6 +28,7 @@ type NoteServiceInterface interface {
 	GetArchived(userID uint, page, limit int) ([]model.Note, error)
 	CountArchivedByUserID(userID uint) (int64, error)
 	Duplicate(id uint, userID uint) (*model.Note, error)
+	ExportMarkdown(id, userID uint) ([]byte, string, error)
 }
 
 // NoteHandler は学習ノート関連のHTTPハンドラ。
@@ -255,4 +258,23 @@ func (h *NoteHandler) Duplicate(c *gin.Context) {
 	}
 
 	respondCreated(c, duplicate)
+}
+
+// Export はノートをMarkdownファイルとしてエクスポートする。
+func (h *NoteHandler) Export(c *gin.Context) {
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	userID := c.GetUint("userID")
+
+	data, title, err := h.service.ExportMarkdown(id, userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	filename := fmt.Sprintf("%s.md", title)
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=\"%s\"", filename))
+	c.Data(200, "text/markdown; charset=utf-8", data)
 }

--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -96,6 +97,14 @@ func (m *MockNoteService) Duplicate(id uint, userID uint) (*model.Note, error) {
 		return note.(*model.Note), args.Error(1)
 	}
 	return nil, args.Error(1)
+}
+
+func (m *MockNoteService) ExportMarkdown(id, userID uint) ([]byte, string, error) {
+	args := m.Called(id, userID)
+	if data := args.Get(0); data != nil {
+		return data.([]byte), args.String(1), args.Error(2)
+	}
+	return nil, "", args.Error(2)
 }
 
 // newTestNoteHandler はテスト用のNoteHandlerを生成する。
@@ -702,6 +711,47 @@ func TestNoteHandler_ToggleFavorite_ServiceError(t *testing.T) {
 	svc.On("ToggleFavorite", uint(1), uint(1)).Return(errors.New("error"))
 
 	w := doRequest(r, "PUT", "/notes/1/favorite", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}
+
+// ============================================================
+// Export テスト
+// ============================================================
+
+func TestNoteHandler_Export_Success(t *testing.T) {
+	h, svc := newTestNoteHandler()
+	r := newRouter(1)
+	r.GET("/notes/:id/export", h.Export)
+
+	mdContent := []byte("# テストノート\n\nコンテンツ")
+	svc.On("ExportMarkdown", uint(1), uint(1)).Return(mdContent, "テストノート", nil)
+
+	w := doRequest(r, "GET", "/notes/1/export", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Header().Get("Content-Disposition"), "テストノート.md")
+	assert.Contains(t, w.Header().Get("Content-Type"), "text/markdown")
+	assert.Contains(t, w.Body.String(), "# テストノート")
+	svc.AssertExpectations(t)
+}
+
+func TestNoteHandler_Export_InvalidID(t *testing.T) {
+	h, _ := newTestNoteHandler()
+	r := newRouter(1)
+	r.GET("/notes/:id/export", h.Export)
+
+	w := doRequest(r, "GET", "/notes/abc/export", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestNoteHandler_Export_ServiceError(t *testing.T) {
+	h, svc := newTestNoteHandler()
+	r := newRouter(1)
+	r.GET("/notes/:id/export", h.Export)
+
+	svc.On("ExportMarkdown", uint(999), uint(1)).Return(nil, "", errors.New("not found"))
+
+	w := doRequest(r, "GET", "/notes/999/export", nil)
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -488,6 +488,7 @@ func registerNoteRoutes(g *gin.RouterGroup, c *di.Container) {
 		notes.PUT("/:id/archive", c.NoteHandler.Archive)
 		notes.PUT("/:id/unarchive", c.NoteHandler.Unarchive)
 		notes.POST("/:id/duplicate", c.NoteHandler.Duplicate)
+		notes.GET("/:id/export", c.NoteHandler.Export)
 		notes.POST("/:id/links", c.NoteLinkHandler.CreateLink)
 		notes.GET("/:id/links", c.NoteLinkHandler.GetLinks)
 		notes.GET("/:id/backlinks", c.NoteLinkHandler.GetBacklinks)

--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -149,6 +150,29 @@ func (s *NoteService) GetArchived(userID uint, page, limit int) ([]model.Note, e
 // CountArchivedByUserID は指定ユーザーのアーカイブ済みノート総数を取得する。
 func (s *NoteService) CountArchivedByUserID(userID uint) (int64, error) {
 	return s.repo.CountArchivedByUserID(userID)
+}
+
+// ExportMarkdown はノートをMarkdown形式でエクスポートする。
+// メタデータ（タグ、作成日、更新日）をヘッダーに含む。
+func (s *NoteService) ExportMarkdown(id, userID uint) ([]byte, string, error) {
+	note, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, "", err
+	}
+
+	var b strings.Builder
+	b.WriteString(fmt.Sprintf("# %s\n\n", note.Title))
+
+	if note.Tags != "" {
+		b.WriteString(fmt.Sprintf("**Tags:** %s\n", note.Tags))
+	}
+	b.WriteString(fmt.Sprintf("**Created:** %s\n", note.CreatedAt.Format("2006-01-02 15:04")))
+	b.WriteString(fmt.Sprintf("**Updated:** %s\n", note.UpdatedAt.Format("2006-01-02 15:04")))
+	b.WriteString("\n---\n\n")
+	b.WriteString(note.Content)
+	b.WriteString("\n")
+
+	return []byte(b.String()), note.Title, nil
 }
 
 // Duplicate は既存のノートを複製する。

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
@@ -721,4 +722,70 @@ func TestNoteService_CountFavoritesByUserID_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Equal(t, int64(0), count)
 	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// ExportMarkdown テスト
+// ============================================================
+
+func TestNoteService_ExportMarkdown_Success(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	now := time.Date(2025, 6, 15, 10, 30, 0, 0, time.UTC)
+	note := &model.Note{
+		ID:        1,
+		UserID:    1,
+		Title:     "Go学習メモ",
+		Content:   "## インターフェース\n\nGoのインターフェースは暗黙的に実装される。",
+		Tags:      "Go,学習",
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	repo.On("FindByID", uint(1)).Return(note, nil)
+
+	data, title, err := svc.ExportMarkdown(1, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, "Go学習メモ", title)
+	content := string(data)
+	assert.Contains(t, content, "# Go学習メモ")
+	assert.Contains(t, content, "**Tags:** Go,学習")
+	assert.Contains(t, content, "**Created:** 2025-06-15 10:30")
+	assert.Contains(t, content, "---")
+	assert.Contains(t, content, "## インターフェース")
+	repo.AssertExpectations(t)
+}
+
+func TestNoteService_ExportMarkdown_NoTags(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	now := time.Now()
+	note := &model.Note{
+		ID: 1, UserID: 1, Title: "タグなしノート", Content: "内容", Tags: "",
+		CreatedAt: now, UpdatedAt: now,
+	}
+	repo.On("FindByID", uint(1)).Return(note, nil)
+
+	data, _, err := svc.ExportMarkdown(1, 1)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(data), "**Tags:**")
+}
+
+func TestNoteService_ExportMarkdown_NotFound(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	repo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	_, _, err := svc.ExportMarkdown(999, 1)
+	assert.Error(t, err)
+}
+
+func TestNoteService_ExportMarkdown_Forbidden(t *testing.T) {
+	svc, repo := newTestNoteService()
+
+	note := &model.Note{ID: 1, UserID: 99, Title: "他人のノート"}
+	repo.On("FindByID", uint(1)).Return(note, nil)
+
+	_, _, err := svc.ExportMarkdown(1, 1)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrForbidden)
 }

--- a/frontend/src/api/notes.ts
+++ b/frontend/src/api/notes.ts
@@ -77,3 +77,6 @@ export const getArchivedNotes = (page = 1, limit = 20) =>
 
 export const duplicateNote = (id: number) =>
   client.post<Note>(`/notes/${id}/duplicate`);
+
+export const exportNoteMarkdown = (id: number) =>
+  client.get<Blob>(`/notes/${id}/export`, { responseType: 'blob' });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1476,7 +1476,10 @@
     "tagsPlaceholder": "z.B. React, TypeScript, Go",
     "allTags": "Alle Tags",
     "volumeRegular": "Standard",
-    "volumeDetailed": "Ausführlich"
+    "volumeDetailed": "Ausführlich",
+    "exportMarkdown": "Als Markdown exportieren",
+    "exportSuccess": "Notiz erfolgreich exportiert",
+    "exportError": "Export fehlgeschlagen"
   },
   "githubCallback": {
     "missingOAuthParams": "Fehlende OAuth-Parameter",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1477,7 +1477,10 @@
     "tagsPlaceholder": "e.g., React, TypeScript, Go",
     "allTags": "All Tags",
     "volumeRegular": "Regular",
-    "volumeDetailed": "Detailed"
+    "volumeDetailed": "Detailed",
+    "exportMarkdown": "Export as Markdown",
+    "exportSuccess": "Note exported successfully",
+    "exportError": "Failed to export note"
   },
   "githubCallback": {
     "missingOAuthParams": "Missing OAuth parameters",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1477,7 +1477,10 @@
     "tagsPlaceholder": "Ej: React, TypeScript, Go",
     "allTags": "Todas las etiquetas",
     "volumeRegular": "Normal",
-    "volumeDetailed": "Detallado"
+    "volumeDetailed": "Detallado",
+    "exportMarkdown": "Exportar como Markdown",
+    "exportSuccess": "Nota exportada con éxito",
+    "exportError": "Error al exportar la nota"
   },
   "githubCallback": {
     "missingOAuthParams": "Faltan parámetros OAuth",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1477,7 +1477,10 @@
     "tagsPlaceholder": "Ex : React, TypeScript, Go",
     "allTags": "Tous les tags",
     "volumeRegular": "Standard",
-    "volumeDetailed": "Détaillé"
+    "volumeDetailed": "Détaillé",
+    "exportMarkdown": "Exporter en Markdown",
+    "exportSuccess": "Note exportée avec succès",
+    "exportError": "Échec de l exportation"
   },
   "githubCallback": {
     "missingOAuthParams": "Paramètres OAuth manquants",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1379,7 +1379,10 @@
     "tagsPlaceholder": "例: React, TypeScript, Go",
     "allTags": "すべてのタグ",
     "volumeRegular": "標準",
-    "volumeDetailed": "充実"
+    "volumeDetailed": "充実",
+    "exportMarkdown": "Markdownエクスポート",
+    "exportSuccess": "ノートをエクスポートしました",
+    "exportError": "エクスポートに失敗しました"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuthパラメータが不足しています",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1479,7 +1479,10 @@
     "tagsPlaceholder": "예: React, TypeScript, Go",
     "allTags": "모든 태그",
     "volumeRegular": "보통",
-    "volumeDetailed": "상세"
+    "volumeDetailed": "상세",
+    "exportMarkdown": "Markdown으로 내보내기",
+    "exportSuccess": "노트를 내보냈습니다",
+    "exportError": "내보내기에 실패했습니다"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuth 매개변수가 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1477,7 +1477,10 @@
     "tagsPlaceholder": "Ex: React, TypeScript, Go",
     "allTags": "Todas as tags",
     "volumeRegular": "Regular",
-    "volumeDetailed": "Detalhado"
+    "volumeDetailed": "Detalhado",
+    "exportMarkdown": "Exportar como Markdown",
+    "exportSuccess": "Nota exportada com sucesso",
+    "exportError": "Falha ao exportar nota"
   },
   "githubCallback": {
     "missingOAuthParams": "Parâmetros OAuth ausentes",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1476,7 +1476,10 @@
     "tagsPlaceholder": "Напр.: React, TypeScript, Go",
     "allTags": "Все теги",
     "volumeRegular": "Обычная",
-    "volumeDetailed": "Подробная"
+    "volumeDetailed": "Подробная",
+    "exportMarkdown": "Экспорт в Markdown",
+    "exportSuccess": "Заметка экспортирована",
+    "exportError": "Не удалось экспортировать"
   },
   "githubCallback": {
     "missingOAuthParams": "Отсутствуют параметры OAuth",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1477,7 +1477,10 @@
     "tagsPlaceholder": "例如：React, TypeScript, Go",
     "allTags": "所有标签",
     "volumeRegular": "标准",
-    "volumeDetailed": "详细"
+    "volumeDetailed": "详细",
+    "exportMarkdown": "导出为Markdown",
+    "exportSuccess": "笔记导出成功",
+    "exportError": "导出失败"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth参数",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1479,7 +1479,10 @@
     "tagsPlaceholder": "例如：React, TypeScript, Go",
     "allTags": "所有標籤",
     "volumeRegular": "標準",
-    "volumeDetailed": "詳細"
+    "volumeDetailed": "詳細",
+    "exportMarkdown": "匯出為Markdown",
+    "exportSuccess": "筆記匯出成功",
+    "exportError": "匯出失敗"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth參數",


### PR DESCRIPTION
## 概要
ノートをMarkdownファイルとしてエクスポートする機能を追加。

## 変更内容
- Service層に`ExportMarkdown`メソッドを追加（所有権チェック付き）
- Handler層に`Export`エンドポイントを追加（`GET /notes/:id/export`）
- フロントエンドAPIに`exportNoteMarkdown`関数を追加
- 10言語のi18nキーを追加

## テスト
- Service層テスト4件（成功/タグなし/NotFound/Forbidden）
- Handler層テスト3件（成功/無効ID/サービスエラー）

Closes #2067