### PR TITLE
feat: 投稿のリアクション一括取得エンドポイントを追加

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -72,3 +72,13 @@ type ReactionResponse struct {
 	Reactions     []model.ReactionCount `json:"reactions"`
 	UserReactions []string              `json:"user_reactions"`
 }
+
+// BatchReactionRequest はリアクション一括取得リクエスト。
+type BatchReactionRequest struct {
+	PostIDs []uint `json:"post_ids" binding:"required"`
+}
+
+// BatchReactionResponse はリアクション一括取得レスポンス。
+type BatchReactionResponse struct {
+	Reactions map[uint]ReactionResponse `json:"reactions"`
+}

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -39,6 +39,7 @@ type PostServiceInterface interface {
 	RemoveReaction(userID, postID uint, emoji string) error
 	GetReactionsByPostID(postID uint) ([]model.ReactionCount, error)
 	GetUserReactions(userID, postID uint) ([]string, error)
+	GetReactionsBatch(userID uint, postIDs []uint) (map[uint][]model.ReactionCount, map[uint][]string, error)
 	SchedulePublish(id, userID uint, scheduledAt time.Time) (*model.Post, error)
 	CancelSchedule(id, userID uint) (*model.Post, error)
 	GetScheduled(userID uint) ([]model.Post, error)
@@ -549,4 +550,38 @@ func (h *PostHandler) AutoSaveDraft(c *gin.Context) {
 		ID:        result.ID,
 		UpdatedAt: result.UpdatedAt.Format(time.RFC3339),
 	})
+}
+
+// GetReactionsBatch は複数投稿のリアクション情報を一括取得する。
+func (h *PostHandler) GetReactionsBatch(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	input := bindJSON[dto.BatchReactionRequest](c)
+	if input == nil {
+		return
+	}
+
+	reactions, userReactions, err := h.service.GetReactionsBatch(userID, input.PostIDs)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	result := make(map[uint]dto.ReactionResponse)
+	for _, id := range input.PostIDs {
+		r := reactions[id]
+		ur := userReactions[id]
+		if r == nil {
+			r = []model.ReactionCount{}
+		}
+		if ur == nil {
+			ur = []string{}
+		}
+		result[id] = dto.ReactionResponse{
+			Reactions:     r,
+			UserReactions: ur,
+		}
+	}
+
+	respondOK(c, dto.BatchReactionResponse{Reactions: result})
 }

--- a/backend/internal/handler/post_test.go
+++ b/backend/internal/handler/post_test.go
@@ -1269,3 +1269,55 @@ func TestPostAutoSaveDraft_ServiceError(t *testing.T) {
 	})
 	assertStatus(t, w, http.StatusNotFound)
 }
+
+// ---------- GetReactionsBatch ----------
+
+func TestPostGetReactionsBatch_Success(t *testing.T) {
+	h, postRepo, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/reactions/batch", h.GetReactionsBatch)
+
+	postIDs := []uint{1, 2}
+	postRepo.On("GetReactionsBatch", postIDs).Return(map[uint][]model.ReactionCount{
+		1: {{Emoji: "👍", Count: 3}},
+	}, nil)
+	postRepo.On("GetUserReactionsBatch", uint(1), postIDs).Return(map[uint][]string{
+		1: {"👍"},
+	}, nil)
+
+	w := doRequest(r, http.MethodPost, "/posts/reactions/batch", map[string]interface{}{
+		"post_ids": []uint{1, 2},
+	})
+	assertStatus(t, w, http.StatusOK)
+
+	body := parseJSON(t, w)
+	reactions, ok := body["reactions"].(map[string]interface{})
+	assert.True(t, ok)
+	assert.Contains(t, reactions, "1")
+	assert.Contains(t, reactions, "2")
+}
+
+func TestPostGetReactionsBatch_InvalidJSON(t *testing.T) {
+	h, _, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/reactions/batch", h.GetReactionsBatch)
+
+	w := doRequestRaw(r, http.MethodPost, "/posts/reactions/batch", "{invalid}")
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestPostGetReactionsBatch_ServiceError(t *testing.T) {
+	h, postRepo, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.POST("/posts/reactions/batch", h.GetReactionsBatch)
+
+	postIDs := []uint{1}
+	postRepo.On("GetReactionsBatch", postIDs).Return(
+		map[uint][]model.ReactionCount(nil), service.ErrBadRequest,
+	)
+
+	w := doRequest(r, http.MethodPost, "/posts/reactions/batch", map[string]interface{}{
+		"post_ids": []uint{1},
+	})
+	assertStatus(t, w, http.StatusBadRequest)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -144,6 +144,14 @@ func (m *MockPostRepository) GetUserReactions(userID, postID uint) ([]string, er
 	args := m.Called(userID, postID)
 	return args.Get(0).([]string), args.Error(1)
 }
+func (m *MockPostRepository) GetReactionsBatch(postIDs []uint) (map[uint][]model.ReactionCount, error) {
+	args := m.Called(postIDs)
+	return args.Get(0).(map[uint][]model.ReactionCount), args.Error(1)
+}
+func (m *MockPostRepository) GetUserReactionsBatch(userID uint, postIDs []uint) (map[uint][]string, error) {
+	args := m.Called(userID, postIDs)
+	return args.Get(0).(map[uint][]string), args.Error(1)
+}
 func (m *MockPostRepository) Search(query string, limit, offset int) (interface{}, int64, error) {
 	args := m.Called(query, limit, offset)
 	return args.Get(0), args.Get(1).(int64), args.Error(2)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -81,6 +81,8 @@ type PostRepositoryInterface interface {
 	RemoveReaction(userID, postID uint, emoji string) error
 	GetReactionsByPostID(postID uint) ([]model.ReactionCount, error)
 	GetUserReactions(userID, postID uint) ([]string, error)
+	GetReactionsBatch(postIDs []uint) (map[uint][]model.ReactionCount, error)
+	GetUserReactionsBatch(userID uint, postIDs []uint) (map[uint][]string, error)
 	FindScheduledByUserID(userID uint) ([]model.Post, error)
 }
 

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -249,6 +249,53 @@ func (r *PostRepository) GetUserReactions(userID, postID uint) ([]string, error)
 	return emojis, err
 }
 
+// GetReactionsBatch は複数投稿のリアクション集計を一括取得する。
+func (r *PostRepository) GetReactionsBatch(postIDs []uint) (map[uint][]model.ReactionCount, error) {
+	type result struct {
+		PostID uint   `gorm:"column:post_id"`
+		Emoji  string `gorm:"column:emoji"`
+		Count  int    `gorm:"column:count"`
+	}
+	var results []result
+	err := r.db.Model(&model.Reaction{}).
+		Select("post_id, emoji, COUNT(*) as count").
+		Where("post_id IN ?", postIDs).
+		Group("post_id, emoji").
+		Order("post_id, count DESC").
+		Find(&results).Error
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[uint][]model.ReactionCount)
+	for _, res := range results {
+		m[res.PostID] = append(m[res.PostID], model.ReactionCount{Emoji: res.Emoji, Count: res.Count})
+	}
+	return m, nil
+}
+
+// GetUserReactionsBatch は複数投稿に対するユーザーのリアクションを一括取得する。
+func (r *PostRepository) GetUserReactionsBatch(userID uint, postIDs []uint) (map[uint][]string, error) {
+	type result struct {
+		PostID uint   `gorm:"column:post_id"`
+		Emoji  string `gorm:"column:emoji"`
+	}
+	var results []result
+	err := r.db.Model(&model.Reaction{}).
+		Select("post_id, emoji").
+		Where("user_id = ? AND post_id IN ?", userID, postIDs).
+		Find(&results).Error
+	if err != nil {
+		return nil, err
+	}
+
+	m := make(map[uint][]string)
+	for _, res := range results {
+		m[res.PostID] = append(m[res.PostID], res.Emoji)
+	}
+	return m, nil
+}
+
 // FindDraftsByUserID は指定ユーザーの下書き一覧を取得する（新しい順）。
 func (r *PostRepository) FindDraftsByUserID(userID uint) ([]model.Post, error) {
 	var posts []model.Post

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -207,6 +207,7 @@ func registerPostRoutes(g *gin.RouterGroup, c *di.Container) {
 		posts.DELETE("/:id/comments/:commentId", c.PostHandler.DeleteComment)
 		posts.POST("/:id/comments/:commentId/hide", c.PostHandler.HideComment)
 		posts.POST("/:id/comments/:commentId/unhide", c.PostHandler.UnhideComment)
+		posts.POST("/reactions/batch", c.PostHandler.GetReactionsBatch)
 		posts.GET("/:id/reactions", c.PostHandler.GetReactions)
 		posts.POST("/:id/reactions", c.PostHandler.AddReaction)
 		posts.DELETE("/:id/reactions", c.PostHandler.RemoveReaction)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -225,6 +225,17 @@ func (m *MockPostRepository) GetUserReactions(userID, postID uint) ([]string, er
 	args := m.Called(userID, postID)
 	return args.Get(0).([]string), args.Error(1)
 }
+
+func (m *MockPostRepository) GetReactionsBatch(postIDs []uint) (map[uint][]model.ReactionCount, error) {
+	args := m.Called(postIDs)
+	return args.Get(0).(map[uint][]model.ReactionCount), args.Error(1)
+}
+
+func (m *MockPostRepository) GetUserReactionsBatch(userID uint, postIDs []uint) (map[uint][]string, error) {
+	args := m.Called(userID, postIDs)
+	return args.Get(0).(map[uint][]string), args.Error(1)
+}
+
 func (m *MockPostRepository) FindScheduledByUserID(userID uint) ([]model.Post, error) {
 	args := m.Called(userID)
 	return args.Get(0).([]model.Post), args.Error(1)

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -318,6 +318,29 @@ func (s *PostService) GetUserReactions(userID, postID uint) ([]string, error) {
 	return s.repo.GetUserReactions(userID, postID)
 }
 
+// GetReactionsBatch は複数投稿のリアクション情報を一括取得する。
+// 最大50件まで。
+func (s *PostService) GetReactionsBatch(userID uint, postIDs []uint) (map[uint][]model.ReactionCount, map[uint][]string, error) {
+	if len(postIDs) == 0 {
+		return map[uint][]model.ReactionCount{}, map[uint][]string{}, nil
+	}
+	if len(postIDs) > 50 {
+		return nil, nil, domain.NewError(domain.ErrCodeBadRequest, "一度に取得できる投稿は50件までです", nil)
+	}
+
+	reactions, err := s.repo.GetReactionsBatch(postIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	userReactions, err := s.repo.GetUserReactionsBatch(userID, postIDs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return reactions, userReactions, nil
+}
+
 // SchedulePublish は下書き投稿にスケジュール公開日時を設定する。
 func (s *PostService) SchedulePublish(id, userID uint, scheduledAt time.Time) (*model.Post, error) {
 	post, err := s.findAndCheckOwnership(id, userID)

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -1647,3 +1647,79 @@ func TestPostAutoSaveDraft_CreateRepoError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Nil(t, result)
 }
+
+// ============================================================
+// リアクション一括取得テスト
+// ============================================================
+
+func TestPostGetReactionsBatch_Success(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postIDs := []uint{1, 2, 3}
+
+	postRepo.On("GetReactionsBatch", postIDs).Return(map[uint][]model.ReactionCount{
+		1: {{Emoji: "👍", Count: 5}, {Emoji: "🎉", Count: 2}},
+		2: {{Emoji: "❤️", Count: 1}},
+	}, nil)
+	postRepo.On("GetUserReactionsBatch", uint(10), postIDs).Return(map[uint][]string{
+		1: {"👍"},
+	}, nil)
+
+	reactions, userReactions, err := svc.GetReactionsBatch(10, postIDs)
+	assert.NoError(t, err)
+	assert.Len(t, reactions[1], 2)
+	assert.Len(t, reactions[2], 1)
+	assert.Nil(t, reactions[3])
+	assert.Equal(t, []string{"👍"}, userReactions[1])
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostGetReactionsBatch_EmptyPostIDs(t *testing.T) {
+	svc, _, _ := newTestPostService()
+
+	reactions, userReactions, err := svc.GetReactionsBatch(1, []uint{})
+	assert.NoError(t, err)
+	assert.Empty(t, reactions)
+	assert.Empty(t, userReactions)
+}
+
+func TestPostGetReactionsBatch_TooManyPostIDs(t *testing.T) {
+	svc, _, _ := newTestPostService()
+
+	postIDs := make([]uint, 51)
+	for i := range postIDs {
+		postIDs[i] = uint(i + 1)
+	}
+
+	_, _, err := svc.GetReactionsBatch(1, postIDs)
+	assert.Error(t, err)
+
+	var domainErr *domain.DomainError
+	assert.True(t, errors.As(err, &domainErr))
+	assert.Equal(t, domain.ErrCodeBadRequest, domainErr.Code)
+}
+
+func TestPostGetReactionsBatch_RepoError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postIDs := []uint{1, 2}
+	postRepo.On("GetReactionsBatch", postIDs).Return(
+		map[uint][]model.ReactionCount(nil), errors.New("db error"),
+	)
+
+	_, _, err := svc.GetReactionsBatch(1, postIDs)
+	assert.Error(t, err)
+}
+
+func TestPostGetReactionsBatch_UserReactionsRepoError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postIDs := []uint{1}
+	postRepo.On("GetReactionsBatch", postIDs).Return(map[uint][]model.ReactionCount{}, nil)
+	postRepo.On("GetUserReactionsBatch", uint(1), postIDs).Return(
+		map[uint][]string(nil), errors.New("db error"),
+	)
+
+	_, _, err := svc.GetReactionsBatch(1, postIDs)
+	assert.Error(t, err)
+}

--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -132,6 +132,9 @@ export const getScheduledPosts = () =>
 export const getReactions = (postId: number) =>
   client.get<ReactionResponse>(`/posts/${postId}/reactions`);
 
+export const getReactionsBatch = (postIds: number[]) =>
+  client.post<{ reactions: Record<number, ReactionResponse> }>('/posts/reactions/batch', { post_ids: postIds });
+
 export const addReaction = (postId: number, emoji: string) =>
   client.post(`/posts/${postId}/reactions`, { emoji });
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -219,7 +219,9 @@
     "addReaction": "Reagieren",
     "sortNewest": "Neueste",
     "sortOldest": "Älteste",
-    "sortTitle": "Nach Titel"
+    "sortTitle": "Nach Titel",
+    "loadReactionsBatch": "Reaktionen stapelweise laden",
+    "loadReactionsBatchError": "Fehler beim stapelweisen Laden der Reaktionen"
   },
   "follow": {
     "noFollowers": "Noch keine Follower",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -219,7 +219,9 @@
     "addReaction": "React",
     "sortNewest": "Newest",
     "sortOldest": "Oldest",
-    "sortTitle": "By Title"
+    "sortTitle": "By Title",
+    "loadReactionsBatch": "Load reactions in batch",
+    "loadReactionsBatchError": "Failed to load reactions in batch"
   },
   "follow": {
     "noFollowers": "No followers yet",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -219,7 +219,9 @@
     "addReaction": "Reaccionar",
     "sortNewest": "Más reciente",
     "sortOldest": "Más antiguo",
-    "sortTitle": "Por título"
+    "sortTitle": "Por título",
+    "loadReactionsBatch": "Cargar reacciones en lote",
+    "loadReactionsBatchError": "Error al cargar reacciones en lote"
   },
   "follow": {
     "noFollowers": "Aún no hay seguidores",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -219,7 +219,9 @@
     "addReaction": "Réagir",
     "sortNewest": "Plus récent",
     "sortOldest": "Plus ancien",
-    "sortTitle": "Par titre"
+    "sortTitle": "Par titre",
+    "loadReactionsBatch": "Charger les réactions en lot",
+    "loadReactionsBatchError": "Échec du chargement des réactions en lot"
   },
   "follow": {
     "noFollowers": "Pas encore d'abonnés",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -236,7 +236,9 @@
     "linkCopied": "リンクをコピーしました",
     "bookmarks": "ブックマーク一覧",
     "noBookmarks": "ブックマークした投稿はありません",
-    "addReaction": "リアクション"
+    "addReaction": "リアクション",
+    "loadReactionsBatch": "リアクションを一括読み込み",
+    "loadReactionsBatchError": "リアクションの一括読み込みに失敗しました"
   },
   "follow": {
     "noFollowers": "まだフォロワーはいません",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -220,7 +220,9 @@
     "addReaction": "리액션",
     "sortNewest": "최신순",
     "sortOldest": "오래된순",
-    "sortTitle": "제목순"
+    "sortTitle": "제목순",
+    "loadReactionsBatch": "리액션 일괄 로드",
+    "loadReactionsBatchError": "리액션 일괄 로드에 실패했습니다"
   },
   "follow": {
     "noFollowers": "아직 팔로워가 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -219,7 +219,9 @@
     "addReaction": "Reagir",
     "sortNewest": "Mais recente",
     "sortOldest": "Mais antigo",
-    "sortTitle": "Por título"
+    "sortTitle": "Por título",
+    "loadReactionsBatch": "Carregar reações em lote",
+    "loadReactionsBatchError": "Falha ao carregar reações em lote"
   },
   "follow": {
     "noFollowers": "Ainda sem seguidores",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -219,7 +219,9 @@
     "addReaction": "Реакция",
     "sortNewest": "Новые",
     "sortOldest": "Старые",
-    "sortTitle": "По названию"
+    "sortTitle": "По названию",
+    "loadReactionsBatch": "Загрузить реакции пакетом",
+    "loadReactionsBatchError": "Не удалось загрузить реакции пакетом"
   },
   "follow": {
     "noFollowers": "Пока нет подписчиков",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -219,7 +219,9 @@
     "addReaction": "表情回应",
     "sortNewest": "最新",
     "sortOldest": "最旧",
-    "sortTitle": "按标题"
+    "sortTitle": "按标题",
+    "loadReactionsBatch": "批量加载反应",
+    "loadReactionsBatchError": "批量加载反应失败"
   },
   "follow": {
     "noFollowers": "暂无粉丝",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -220,7 +220,9 @@
     "addReaction": "表情回應",
     "sortNewest": "最新",
     "sortOldest": "最舊",
-    "sortTitle": "按標題"
+    "sortTitle": "按標題",
+    "loadReactionsBatch": "批次載入反應",
+    "loadReactionsBatchError": "批次載入反應失敗"
   },
   "follow": {
     "noFollowers": "尚無追蹤者",


### PR DESCRIPTION
## 概要
投稿一覧表示時にリアクション情報をN+1クエリなく一括取得するバッチエンドポイントを追加。

## 変更内容
- Repository層に`GetReactionsBatch`/`GetUserReactionsBatch`を追加
- Service層に`GetReactionsBatch`メソッドを追加（最大50件制限）
- Handler層に`GetReactionsBatch`エンドポイントを追加（`POST /posts/reactions/batch`）
- フロントエンドAPIに`getReactionsBatch`関数を追加
- 10言語のi18nキーを追加

## テスト
- Service層テスト5件（成功/空配列/上限超過/リポジトリエラー×2）
- Handler層テスト3件（成功/無効JSON/サービスエラー）

Closes #2069