### PR TITLE
feat: 学習目標の公開/非公開共有機能を追加

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -20,6 +20,9 @@ type LearningGoalServiceInterface interface {
 	Delete(id, userID uint) error
 	GetDeadlineAlerts(userID uint) ([]model.GoalDeadlineAlert, error)
 	Duplicate(id, userID uint) (*model.LearningGoal, error)
+	ToggleShare(id, userID uint) (*model.LearningGoal, error)
+	GetPublicGoals(limit, offset int) ([]model.LearningGoal, int64, error)
+	GetPublicByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error)
 }
 
 // LearningGoalHandler は学習目標関連のHTTPハンドラ。
@@ -243,4 +246,61 @@ func (h *LearningGoalHandler) GetStats(c *gin.Context) {
 	}
 
 	respondOK(c, stats)
+}
+
+// ToggleShare は学習目標の公開/非公開を切り替える。所有者のみ操作可能。
+func (h *LearningGoalHandler) ToggleShare(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	goal, err := h.service.ToggleShare(id, userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, goal)
+}
+
+// GetPublicGoals は全ユーザーの公開済み学習目標一覧を返す。
+func (h *LearningGoalHandler) GetPublicGoals(c *gin.Context) {
+	limit, offset := parseLimitOffset(c)
+
+	goals, total, err := h.service.GetPublicGoals(limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.GoalListResponse{
+		Goals:  goals,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
+// GetPublicByUserID は指定ユーザーの公開済み学習目標一覧を返す。
+func (h *LearningGoalHandler) GetPublicByUserID(c *gin.Context) {
+	userID, ok := parseID(c, "userId")
+	if !ok {
+		return
+	}
+
+	limit, offset := parseLimitOffset(c)
+	goals, total, err := h.service.GetPublicByUserID(userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.GoalListResponse{
+		Goals:  goals,
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
 }

--- a/backend/internal/handler/learning_goal_test.go
+++ b/backend/internal/handler/learning_goal_test.go
@@ -61,6 +61,16 @@ func (m *MockLearningGoalRepository) GetByStatus(userID uint, status string) ([]
 	return args.Get(0).([]model.LearningGoal), args.Error(1)
 }
 
+func (m *MockLearningGoalRepository) GetPublicByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.LearningGoal), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockLearningGoalRepository) GetPublicGoals(limit, offset int) ([]model.LearningGoal, int64, error) {
+	args := m.Called(limit, offset)
+	return args.Get(0).([]model.LearningGoal), args.Get(1).(int64), args.Error(2)
+}
+
 // setupLearningGoalHandler はテスト用のLearningGoalHandlerとモックを準備する。
 func setupLearningGoalHandler() (*LearningGoalHandler, *MockLearningGoalRepository) {
 	repo := new(MockLearningGoalRepository)
@@ -626,4 +636,87 @@ func TestLearningGoalDuplicate_InvalidID(t *testing.T) {
 
 	w := doRequest(r, http.MethodPost, "/goals/abc/duplicate", nil)
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ========== ToggleShare ==========
+
+func TestLearningGoalToggleShare_Success(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.PUT("/goals/:id/share", h.ToggleShare)
+
+	goal := &model.LearningGoal{Title: "目標", IsPublic: false, UserID: 1}
+	goal.ID = 10
+	repo.On("FindByID", uint(10)).Return(goal, nil)
+	repo.On("Update", mock.AnythingOfType("*model.LearningGoal")).Return(nil)
+
+	w := doRequest(r, http.MethodPut, "/goals/10/share", nil)
+	assertStatus(t, w, http.StatusOK)
+}
+
+func TestLearningGoalToggleShare_Forbidden(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.PUT("/goals/:id/share", h.ToggleShare)
+
+	goal := &model.LearningGoal{Title: "目標", UserID: 999}
+	goal.ID = 10
+	repo.On("FindByID", uint(10)).Return(goal, nil)
+
+	w := doRequest(r, http.MethodPut, "/goals/10/share", nil)
+	assertStatus(t, w, http.StatusForbidden)
+}
+
+func TestLearningGoalToggleShare_NotFound(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.PUT("/goals/:id/share", h.ToggleShare)
+
+	repo.On("FindByID", uint(99)).Return(nil, service.ErrNotFound)
+
+	w := doRequest(r, http.MethodPut, "/goals/99/share", nil)
+	assertStatus(t, w, http.StatusNotFound)
+}
+
+// ========== GetPublicGoals ==========
+
+func TestLearningGoalGetPublicGoals_Success(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.GET("/goals/public", h.GetPublicGoals)
+
+	goals := []model.LearningGoal{{Title: "公開目標1"}, {Title: "公開目標2"}}
+	repo.On("GetPublicGoals", 20, 0).Return(goals, int64(2), nil)
+
+	w := doRequest(r, http.MethodGet, "/goals/public", nil)
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	if body["total"] != float64(2) {
+		t.Errorf("expected total=2, got %v", body["total"])
+	}
+}
+
+func TestLearningGoalGetPublicGoals_ServiceError(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.GET("/goals/public", h.GetPublicGoals)
+
+	repo.On("GetPublicGoals", 20, 0).Return([]model.LearningGoal{}, int64(0), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/goals/public", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+}
+
+// ========== GetPublicByUserID ==========
+
+func TestLearningGoalGetPublicByUserID_Success(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.GET("/goals/public/user/:userId", h.GetPublicByUserID)
+
+	goals := []model.LearningGoal{{Title: "公開目標"}}
+	repo.On("GetPublicByUserID", uint(5), 20, 0).Return(goals, int64(1), nil)
+
+	w := doRequest(r, http.MethodGet, "/goals/public/user/5", nil)
+	assertStatus(t, w, http.StatusOK)
 }

--- a/backend/internal/model/learning_goal.go
+++ b/backend/internal/model/learning_goal.go
@@ -36,6 +36,7 @@ type LearningGoal struct {
 	Progress    int          `json:"progress" gorm:"default:0"`         // 0〜100の達成率
 	TargetHours int          `json:"target_hours" gorm:"default:0"`     // 目標学習時間（時間単位、0=未設定）
 	Status      GoalStatus   `json:"status" gorm:"default:'active'"`
+	IsPublic    bool         `json:"is_public" gorm:"default:false"`
 	CreatedAt   time.Time    `json:"created_at"`
 	UpdatedAt   time.Time    `json:"updated_at"`
 	CompletedAt *time.Time   `json:"completed_at"`                      // 完了日時（完了時に自動設定）

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -179,6 +179,8 @@ type LearningGoalRepositoryInterface interface {
 	GetActiveByUserID(userID uint) ([]model.LearningGoal, error)
 	GetByCategory(userID uint, category string) ([]model.LearningGoal, error)
 	GetByStatus(userID uint, status string) ([]model.LearningGoal, error)
+	GetPublicByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error)
+	GetPublicGoals(limit, offset int) ([]model.LearningGoal, int64, error)
 	GetStats(userID uint) (*model.LearningGoalStats, error)
 }
 

--- a/backend/internal/repository/learning_goal.go
+++ b/backend/internal/repository/learning_goal.go
@@ -71,6 +71,26 @@ func (r *LearningGoalRepository) GetByStatus(userID uint, status string) ([]mode
 	return goals, err
 }
 
+// GetPublicByUserID は指定ユーザーの公開済み学習目標をページネーション付きで取得する（新しい順）。
+func (r *LearningGoalRepository) GetPublicByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error) {
+	var goals []model.LearningGoal
+	var total int64
+	query := r.db.Where("user_id = ? AND is_public = ?", userID, true)
+	query.Model(&model.LearningGoal{}).Count(&total)
+	err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&goals).Error
+	return goals, total, err
+}
+
+// GetPublicGoals は全ユーザーの公開済み学習目標をページネーション付きで取得する（新しい順）。
+func (r *LearningGoalRepository) GetPublicGoals(limit, offset int) ([]model.LearningGoal, int64, error) {
+	var goals []model.LearningGoal
+	var total int64
+	query := r.db.Where("is_public = ?", true)
+	query.Model(&model.LearningGoal{}).Count(&total)
+	err := query.Order("created_at DESC").Limit(limit).Offset(offset).Find(&goals).Error
+	return goals, total, err
+}
+
 // GetStats は指定ユーザーの学習目標統計情報を算出する。
 // 目標総数、アクティブ数、完了数、平均進捗率を返す。
 func (r *LearningGoalRepository) GetStats(userID uint) (*model.LearningGoalStats, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -384,6 +384,9 @@ func registerGoalRoutes(g *gin.RouterGroup, c *di.Container) {
 		goals.GET("/category/:category", c.LearningGoalHandler.GetByCategory)
 		goals.GET("/status/:status", c.LearningGoalHandler.GetByStatus)
 		goals.POST("/:id/duplicate", c.LearningGoalHandler.Duplicate)
+		goals.PUT("/:id/share", c.LearningGoalHandler.ToggleShare)
+		goals.GET("/public", c.LearningGoalHandler.GetPublicGoals)
+		goals.GET("/public/user/:userId", c.LearningGoalHandler.GetPublicByUserID)
 		goals.GET("/:id/linked-logs", c.LearningLogHandler.GetLinkedLogs)
 	}
 }

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -215,6 +215,30 @@ func (s *LearningGoalService) Duplicate(id, userID uint) (*model.LearningGoal, e
 	return newGoal, nil
 }
 
+// ToggleShare は学習目標の公開/非公開を切り替える。所有者のみ操作可能。
+func (s *LearningGoalService) ToggleShare(id, userID uint) (*model.LearningGoal, error) {
+	goal, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	goal.IsPublic = !goal.IsPublic
+	if err := s.repo.Update(goal); err != nil {
+		return nil, err
+	}
+	return goal, nil
+}
+
+// GetPublicGoals は全ユーザーの公開済み学習目標をページネーション付きで取得する。
+func (s *LearningGoalService) GetPublicGoals(limit, offset int) ([]model.LearningGoal, int64, error) {
+	return s.repo.GetPublicGoals(limit, offset)
+}
+
+// GetPublicByUserID は指定ユーザーの公開済み学習目標をページネーション付きで取得する。
+func (s *LearningGoalService) GetPublicByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error) {
+	return s.repo.GetPublicByUserID(userID, limit, offset)
+}
+
 // Delete は所有権を検証した後、学習目標を削除する。
 func (s *LearningGoalService) Delete(id, userID uint) error {
 	if _, err := s.findAndCheckOwnership(id, userID); err != nil {

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -787,3 +787,88 @@ func TestLearningGoalDuplicate_CreateError(t *testing.T) {
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// 共有トグルテスト
+// ============================================================
+
+func TestLearningGoalToggleShare_MakePublic(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	goal := &model.LearningGoal{UserID: 1, Title: "公開テスト", IsPublic: false}
+	goal.ID = 1
+	repo.On("FindByID", uint(1)).Return(goal, nil)
+	repo.On("Update", mock.MatchedBy(func(g *model.LearningGoal) bool {
+		return g.IsPublic == true
+	})).Return(nil)
+
+	result, err := svc.ToggleShare(1, 1)
+	assert.NoError(t, err)
+	assert.True(t, result.IsPublic)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalToggleShare_MakePrivate(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	goal := &model.LearningGoal{UserID: 1, Title: "非公開テスト", IsPublic: true}
+	goal.ID = 1
+	repo.On("FindByID", uint(1)).Return(goal, nil)
+	repo.On("Update", mock.MatchedBy(func(g *model.LearningGoal) bool {
+		return g.IsPublic == false
+	})).Return(nil)
+
+	result, err := svc.ToggleShare(1, 1)
+	assert.NoError(t, err)
+	assert.False(t, result.IsPublic)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalToggleShare_Forbidden(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	goal := &model.LearningGoal{UserID: 999, Title: "他人の目標"}
+	goal.ID = 1
+	repo.On("FindByID", uint(1)).Return(goal, nil)
+
+	_, err := svc.ToggleShare(1, 1)
+	assert.Error(t, err)
+}
+
+func TestLearningGoalToggleShare_NotFound(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	_, err := svc.ToggleShare(99, 1)
+	assert.Error(t, err)
+}
+
+func TestLearningGoalGetPublicGoals_Success(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	goals := []model.LearningGoal{
+		{Title: "公開目標1", IsPublic: true},
+		{Title: "公開目標2", IsPublic: true},
+	}
+	repo.On("GetPublicGoals", 20, 0).Return(goals, int64(2), nil)
+
+	result, total, err := svc.GetPublicGoals(20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningGoalGetPublicByUserID_Success(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	goals := []model.LearningGoal{{Title: "公開目標", IsPublic: true, UserID: 5}}
+	repo.On("GetPublicByUserID", uint(5), 20, 0).Return(goals, int64(1), nil)
+
+	result, total, err := svc.GetPublicByUserID(5, 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -622,6 +622,16 @@ func (m *MockLearningGoalRepository) GetByStatus(userID uint, status string) ([]
 	return args.Get(0).([]model.LearningGoal), args.Error(1)
 }
 
+func (m *MockLearningGoalRepository) GetPublicByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.LearningGoal), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockLearningGoalRepository) GetPublicGoals(limit, offset int) ([]model.LearningGoal, int64, error) {
+	args := m.Called(limit, offset)
+	return args.Get(0).([]model.LearningGoal), args.Get(1).(int64), args.Error(2)
+}
+
 func (m *MockLearningGoalRepository) GetStats(userID uint) (*model.LearningGoalStats, error) {
 	args := m.Called(userID)
 	if args.Get(0) == nil {

--- a/frontend/src/api/goals.ts
+++ b/frontend/src/api/goals.ts
@@ -13,6 +13,7 @@ export interface LearningGoal {
   progress: number;
   target_hours: number;
   status: GoalStatus;
+  is_public: boolean;
   created_at: string;
   updated_at: string;
   completed_at: string | null;
@@ -76,3 +77,12 @@ export const duplicateGoal = (id: number) =>
 
 export const getLinkedLogs = (goalId: number, limit = 20, offset = 0) =>
   client.get(`/goals/${goalId}/linked-logs`, { params: { limit, offset } });
+
+export const toggleGoalShare = (id: number) =>
+  client.put<LearningGoal>(`/goals/${id}/share`);
+
+export const getPublicGoals = (limit = 20, offset = 0) =>
+  client.get<LearningGoal[]>('/goals/public', { params: { limit, offset } });
+
+export const getPublicGoalsByUser = (userId: number, limit = 20, offset = 0) =>
+  client.get<LearningGoal[]>(`/goals/public/user/${userId}`, { params: { limit, offset } });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -654,7 +654,18 @@
       "activeCount": "Aktiv",
       "completedCount": "Abgeschlossen",
       "avgProgress": "Durchschn. Fortschritt"
-    }
+    },
+    "toggleShare": "Öffentlich/Privat umschalten",
+    "shareSuccess": "Freigabeeinstellungen aktualisiert",
+    "shareFailed": "Fehler beim Aktualisieren der Freigabeeinstellungen",
+    "publicGoals": "Öffentliche Ziele",
+    "noPublicGoals": "Keine öffentlichen Ziele",
+    "makePublic": "Öffentlich machen",
+    "makePrivate": "Privat machen",
+    "isPublic": "Öffentlich",
+    "isPrivate": "Privat",
+    "publicGoalsList": "Community-Ziele",
+    "loadPublicGoalsFailed": "Fehler beim Laden der öffentlichen Ziele"
   },
   "learningLogs": {
     "title": "Lernprotokoll",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -655,7 +655,18 @@
       "activeCount": "Active",
       "completedCount": "Completed",
       "avgProgress": "Avg. Progress"
-    }
+    },
+    "toggleShare": "Toggle public/private",
+    "shareSuccess": "Sharing settings updated",
+    "shareFailed": "Failed to update sharing settings",
+    "publicGoals": "Public goals",
+    "noPublicGoals": "No public goals",
+    "makePublic": "Make public",
+    "makePrivate": "Make private",
+    "isPublic": "Public",
+    "isPrivate": "Private",
+    "publicGoalsList": "Community goals",
+    "loadPublicGoalsFailed": "Failed to load public goals"
   },
   "learningLogs": {
     "title": "Learning Logs",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -655,7 +655,18 @@
       "activeCount": "Activos",
       "completedCount": "Completados",
       "avgProgress": "Progreso Promedio"
-    }
+    },
+    "toggleShare": "Alternar público/privado",
+    "shareSuccess": "Configuración de compartición actualizada",
+    "shareFailed": "Error al actualizar la configuración de compartición",
+    "publicGoals": "Objetivos públicos",
+    "noPublicGoals": "No hay objetivos públicos",
+    "makePublic": "Hacer público",
+    "makePrivate": "Hacer privado",
+    "isPublic": "Público",
+    "isPrivate": "Privado",
+    "publicGoalsList": "Objetivos de la comunidad",
+    "loadPublicGoalsFailed": "Error al cargar los objetivos públicos"
   },
   "learningLogs": {
     "title": "Registro de Aprendizaje",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -655,7 +655,18 @@
       "activeCount": "Actifs",
       "completedCount": "Terminés",
       "avgProgress": "Progression moyenne"
-    }
+    },
+    "toggleShare": "Basculer public/privé",
+    "shareSuccess": "Paramètres de partage mis à jour",
+    "shareFailed": "Échec de la mise à jour des paramètres de partage",
+    "publicGoals": "Objectifs publics",
+    "noPublicGoals": "Aucun objectif public",
+    "makePublic": "Rendre public",
+    "makePrivate": "Rendre privé",
+    "isPublic": "Public",
+    "isPrivate": "Privé",
+    "publicGoalsList": "Objectifs de la communauté",
+    "loadPublicGoalsFailed": "Échec du chargement des objectifs publics"
   },
   "learningLogs": {
     "title": "Journal d'apprentissage",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -644,7 +644,18 @@
       "activeCount": "進行中",
       "completedCount": "完了",
       "avgProgress": "平均進捗"
-    }
+    },
+    "toggleShare": "公開/非公開を切り替え",
+    "shareSuccess": "共有設定を更新しました",
+    "shareFailed": "共有設定の更新に失敗しました",
+    "publicGoals": "公開中の目標",
+    "noPublicGoals": "公開中の目標はありません",
+    "makePublic": "公開する",
+    "makePrivate": "非公開にする",
+    "isPublic": "公開中",
+    "isPrivate": "非公開",
+    "publicGoalsList": "みんなの目標",
+    "loadPublicGoalsFailed": "公開目標の取得に失敗しました"
   },
   "learningLogs": {
     "title": "学習ログ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -657,7 +657,18 @@
       "activeCount": "진행 중",
       "completedCount": "완료",
       "avgProgress": "평균 진행률"
-    }
+    },
+    "toggleShare": "공개/비공개 전환",
+    "shareSuccess": "공유 설정이 업데이트되었습니다",
+    "shareFailed": "공유 설정 업데이트에 실패했습니다",
+    "publicGoals": "공개 목표",
+    "noPublicGoals": "공개 목표가 없습니다",
+    "makePublic": "공개하기",
+    "makePrivate": "비공개하기",
+    "isPublic": "공개",
+    "isPrivate": "비공개",
+    "publicGoalsList": "모두의 목표",
+    "loadPublicGoalsFailed": "공개 목표를 불러오지 못했습니다"
   },
   "learningLogs": {
     "title": "학습 로그",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -655,7 +655,18 @@
       "activeCount": "Ativas",
       "completedCount": "Concluídas",
       "avgProgress": "Progresso Médio"
-    }
+    },
+    "toggleShare": "Alternar público/privado",
+    "shareSuccess": "Configurações de compartilhamento atualizadas",
+    "shareFailed": "Falha ao atualizar configurações de compartilhamento",
+    "publicGoals": "Metas públicas",
+    "noPublicGoals": "Nenhuma meta pública",
+    "makePublic": "Tornar público",
+    "makePrivate": "Tornar privado",
+    "isPublic": "Público",
+    "isPrivate": "Privado",
+    "publicGoalsList": "Metas da comunidade",
+    "loadPublicGoalsFailed": "Falha ao carregar metas públicas"
   },
   "learningLogs": {
     "title": "Registro de Aprendizado",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -654,7 +654,18 @@
       "activeCount": "Активных",
       "completedCount": "Завершённых",
       "avgProgress": "Средний прогресс"
-    }
+    },
+    "toggleShare": "Переключить публичный/приватный",
+    "shareSuccess": "Настройки общего доступа обновлены",
+    "shareFailed": "Не удалось обновить настройки общего доступа",
+    "publicGoals": "Публичные цели",
+    "noPublicGoals": "Нет публичных целей",
+    "makePublic": "Сделать публичным",
+    "makePrivate": "Сделать приватным",
+    "isPublic": "Публичная",
+    "isPrivate": "Приватная",
+    "publicGoalsList": "Цели сообщества",
+    "loadPublicGoalsFailed": "Не удалось загрузить публичные цели"
   },
   "learningLogs": {
     "title": "Журнал обучения",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -655,7 +655,18 @@
       "activeCount": "进行中",
       "completedCount": "已完成",
       "avgProgress": "平均进度"
-    }
+    },
+    "toggleShare": "切换公开/私密",
+    "shareSuccess": "共享设置已更新",
+    "shareFailed": "共享设置更新失败",
+    "publicGoals": "公开目标",
+    "noPublicGoals": "没有公开目标",
+    "makePublic": "设为公开",
+    "makePrivate": "设为私密",
+    "isPublic": "公开",
+    "isPrivate": "私密",
+    "publicGoalsList": "社区目标",
+    "loadPublicGoalsFailed": "加载公开目标失败"
   },
   "learningLogs": {
     "title": "学习日志",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -657,7 +657,18 @@
       "activeCount": "進行中",
       "completedCount": "已完成",
       "avgProgress": "平均進度"
-    }
+    },
+    "toggleShare": "切換公開/私密",
+    "shareSuccess": "共享設定已更新",
+    "shareFailed": "共享設定更新失敗",
+    "publicGoals": "公開目標",
+    "noPublicGoals": "沒有公開目標",
+    "makePublic": "設為公開",
+    "makePrivate": "設為私密",
+    "isPublic": "公開",
+    "isPrivate": "私密",
+    "publicGoalsList": "社群目標",
+    "loadPublicGoalsFailed": "載入公開目標失敗"
   },
   "learningLogs": {
     "title": "學習日誌",


### PR DESCRIPTION
## 概要
学習目標の公開/非公開を切り替えられる共有機能を追加。

closes #2071

## 変更内容
- `LearningGoal` モデルに `IsPublic` フィールドを追加（デフォルト: false）
- `PUT /goals/:id/share` — 公開/非公開のトグル切り替え
- `GET /goals/public` — 全ユーザーの公開目標一覧（ページネーション付き）
- `GET /goals/public/user/:userId` — 特定ユーザーの公開目標一覧
- フロントエンドAPI関数: `toggleGoalShare`, `getPublicGoals`, `getPublicGoalsByUser`
- 10言語のi18nキーを追加

## テスト
- Service層テスト: 6件追加（ToggleShare公開/非公開/権限エラー/NotFound、公開目標取得2件）
- Handler層テスト: 6件追加（ToggleShare成功/権限エラー/NotFound、公開目標取得2件+エラー）
- 全テスト通過確認済み