### PR TITLE
feat: ダッシュボードウィジェットのカスタム並び替え・表示切替機能

### DIFF
--- a/frontend/src/components/dashboard/WidgetSettingsPanel.tsx
+++ b/frontend/src/components/dashboard/WidgetSettingsPanel.tsx
@@ -1,0 +1,96 @@
+import { useTranslation } from 'react-i18next';
+import type { WidgetConfig } from '../../types/widgetSettings';
+
+interface WidgetSettingsPanelProps {
+  widgets: WidgetConfig[];
+  saving: boolean;
+  onToggleVisibility: (key: string) => void;
+  onMoveUp: (key: string) => void;
+  onMoveDown: (key: string) => void;
+  onSave: () => void;
+  onCancel: () => void;
+}
+
+export default function WidgetSettingsPanel({
+  widgets,
+  saving,
+  onToggleVisibility,
+  onMoveUp,
+  onMoveDown,
+  onSave,
+  onCancel,
+}: WidgetSettingsPanelProps) {
+  const { t } = useTranslation();
+
+  return (
+    <div className="bg-gray-800/50 border border-gray-700 rounded-lg p-4">
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-white">{t('widgetSettings.title')}</h3>
+        <div className="flex gap-2">
+          <button
+            onClick={onCancel}
+            className="px-3 py-1 text-xs text-gray-400 hover:text-white border border-gray-600 rounded transition-colors"
+          >
+            {t('common.cancel')}
+          </button>
+          <button
+            onClick={onSave}
+            disabled={saving}
+            className="px-3 py-1 text-xs bg-blue-600 hover:bg-blue-500 text-white rounded transition-colors disabled:opacity-50"
+          >
+            {saving ? t('common.saving') : t('common.save')}
+          </button>
+        </div>
+      </div>
+      <ul className="space-y-1">
+        {widgets.map((widget, idx) => (
+          <li
+            key={widget.key}
+            className="flex items-center gap-2 px-2 py-1.5 rounded hover:bg-gray-700/50 transition-colors"
+          >
+            <button
+              onClick={() => onToggleVisibility(widget.key)}
+              className={`w-5 h-5 flex items-center justify-center rounded border transition-colors ${
+                widget.visible
+                  ? 'bg-blue-600 border-blue-500 text-white'
+                  : 'border-gray-600 text-gray-500'
+              }`}
+              aria-label={widget.visible ? t('widgetSettings.hide') : t('widgetSettings.show')}
+            >
+              {widget.visible && (
+                <svg className="w-3 h-3" fill="none" stroke="currentColor" strokeWidth="3" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 13l4 4L19 7" />
+                </svg>
+              )}
+            </button>
+            <span className={`flex-1 text-sm ${widget.visible ? 'text-white' : 'text-gray-500'}`}>
+              {t(`widgetSettings.widgets.${widget.key}`)}
+            </span>
+            <div className="flex gap-0.5">
+              <button
+                onClick={() => onMoveUp(widget.key)}
+                disabled={idx === 0}
+                className="p-1 text-gray-400 hover:text-white disabled:text-gray-700 transition-colors"
+                aria-label={t('widgetSettings.moveUp')}
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M5 15l7-7 7 7" />
+                </svg>
+              </button>
+              <button
+                onClick={() => onMoveDown(widget.key)}
+                disabled={idx === widgets.length - 1}
+                className="p-1 text-gray-400 hover:text-white disabled:text-gray-700 transition-colors"
+                aria-label={t('widgetSettings.moveDown')}
+              >
+                <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M19 9l-7 7-7-7" />
+                </svg>
+              </button>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -60,3 +60,4 @@ export { useBookmarkCollections, useCollectionPosts as useBookmarkCollectionPost
 export { useScheduledPosts } from './useScheduledPosts';
 export { useQuickEntry } from './useQuickEntry';
 export { useWeeklyChallenge } from './useWeeklyChallenge';
+export { useWidgetSettings } from './useWidgetSettings';

--- a/frontend/src/hooks/useWidgetSettings.ts
+++ b/frontend/src/hooks/useWidgetSettings.ts
@@ -1,0 +1,119 @@
+import { useState, useCallback } from 'react';
+import { useAsyncData } from './useAsyncData';
+import { getWidgetSettings, updateWidgetSettings } from '../api/widgetSettings';
+import type { WidgetConfig } from '../types/widgetSettings';
+import { useToast } from './useToast';
+import { useTranslation } from 'react-i18next';
+
+const DEFAULT_WIDGETS: WidgetConfig[] = [
+  { key: 'userProfile', visible: true, order: 0 },
+  { key: 'level', visible: true, order: 1 },
+  { key: 'streak', visible: true, order: 2 },
+  { key: 'dailyChallenge', visible: true, order: 3 },
+  { key: 'weeklyChallenge', visible: true, order: 4 },
+  { key: 'studyCircle', visible: true, order: 5 },
+  { key: 'quickEntry', visible: true, order: 6 },
+  { key: 'quickActions', visible: true, order: 7 },
+  { key: 'recommendedUsers', visible: true, order: 8 },
+  { key: 'trending', visible: true, order: 9 },
+  { key: 'aiAdvice', visible: true, order: 10 },
+  { key: 'goalsProgress', visible: true, order: 11 },
+  { key: 'recentNotifications', visible: true, order: 12 },
+  { key: 'quickStats', visible: true, order: 13 },
+];
+
+export function useWidgetSettings() {
+  const { t } = useTranslation();
+  const toast = useToast();
+  const [editing, setEditing] = useState(false);
+  const [localWidgets, setLocalWidgets] = useState<WidgetConfig[]>([]);
+  const [saving, setSaving] = useState(false);
+
+  const { data: widgets, loading, refetch } = useAsyncData(
+    async () => {
+      const res = await getWidgetSettings();
+      if (res.data?.settings) {
+        try {
+          return JSON.parse(res.data.settings) as WidgetConfig[];
+        } catch {
+          return DEFAULT_WIDGETS;
+        }
+      }
+      return DEFAULT_WIDGETS;
+    },
+    { initialData: DEFAULT_WIDGETS }
+  );
+
+  const startEditing = useCallback(() => {
+    setLocalWidgets([...widgets].sort((a, b) => a.order - b.order));
+    setEditing(true);
+  }, [widgets]);
+
+  const cancelEditing = useCallback(() => {
+    setEditing(false);
+    setLocalWidgets([]);
+  }, []);
+
+  const toggleVisibility = useCallback((key: string) => {
+    setLocalWidgets((prev) =>
+      prev.map((w) => (w.key === key ? { ...w, visible: !w.visible } : w))
+    );
+  }, []);
+
+  const moveUp = useCallback((key: string) => {
+    setLocalWidgets((prev) => {
+      const sorted = [...prev].sort((a, b) => a.order - b.order);
+      const idx = sorted.findIndex((w) => w.key === key);
+      if (idx <= 0) return prev;
+      const newOrder = sorted.map((w, i) => ({ ...w, order: i }));
+      const temp = newOrder[idx].order;
+      newOrder[idx].order = newOrder[idx - 1].order;
+      newOrder[idx - 1].order = temp;
+      return newOrder.sort((a, b) => a.order - b.order);
+    });
+  }, []);
+
+  const moveDown = useCallback((key: string) => {
+    setLocalWidgets((prev) => {
+      const sorted = [...prev].sort((a, b) => a.order - b.order);
+      const idx = sorted.findIndex((w) => w.key === key);
+      if (idx < 0 || idx >= sorted.length - 1) return prev;
+      const newOrder = sorted.map((w, i) => ({ ...w, order: i }));
+      const temp = newOrder[idx].order;
+      newOrder[idx].order = newOrder[idx + 1].order;
+      newOrder[idx + 1].order = temp;
+      return newOrder.sort((a, b) => a.order - b.order);
+    });
+  }, []);
+
+  const saveSettings = useCallback(async () => {
+    setSaving(true);
+    try {
+      await updateWidgetSettings(localWidgets);
+      await refetch();
+      setEditing(false);
+      toast.success(t('widgetSettings.saveSuccess'));
+    } catch {
+      toast.error(t('widgetSettings.saveFailed'));
+    } finally {
+      setSaving(false);
+    }
+  }, [localWidgets, refetch, toast, t]);
+
+  const sortedWidgets = [...widgets].sort((a, b) => a.order - b.order);
+  const sortedLocalWidgets = [...localWidgets].sort((a, b) => a.order - b.order);
+
+  return {
+    widgets: sortedWidgets,
+    loading,
+    editing,
+    localWidgets: sortedLocalWidgets,
+    saving,
+    startEditing,
+    cancelEditing,
+    toggleVisibility,
+    moveUp,
+    moveDown,
+    saveSettings,
+  };
+}

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1668,12 +1668,29 @@
   },
   "widgetSettings": {
     "title": "Widget-Einstellungen",
-    "customize": "Widgets anpassen",
+    "customize": "Anpassen",
+    "saveSuccess": "Widget-Einstellungen gespeichert",
+    "saveFailed": "Fehler beim Speichern der Widget-Einstellungen",
     "show": "Anzeigen",
     "hide": "Ausblenden",
-    "resetToDefault": "Auf Standard zurücksetzen",
-    "saveSuccess": "Widget-Einstellungen gespeichert",
-    "resetSuccess": "Widget-Einstellungen zurückgesetzt"
+    "moveUp": "Nach oben",
+    "moveDown": "Nach unten",
+    "widgets": {
+      "userProfile": "Benutzerprofil",
+      "level": "Level",
+      "streak": "Serie",
+      "dailyChallenge": "Tägliche Herausforderung",
+      "weeklyChallenge": "Wöchentliche Herausforderung",
+      "studyCircle": "Lernkreis",
+      "quickEntry": "Schnelleintrag",
+      "quickActions": "Schnellaktionen",
+      "recommendedUsers": "Empfohlene Benutzer",
+      "trending": "Trends",
+      "aiAdvice": "KI-Ratschlag",
+      "goalsProgress": "Zielfortschritt",
+      "recentNotifications": "Letzte Benachrichtigungen",
+      "quickStats": "Schnellstatistiken"
+    }
   },
   "reactionSummary": {
     "title": "Reaktionszusammenfassung",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1669,12 +1669,29 @@
   },
   "widgetSettings": {
     "title": "Widget Settings",
-    "customize": "Customize Widgets",
+    "customize": "Customize",
+    "saveSuccess": "Widget settings saved",
+    "saveFailed": "Failed to save widget settings",
     "show": "Show",
     "hide": "Hide",
-    "resetToDefault": "Reset to Default",
-    "saveSuccess": "Widget settings saved",
-    "resetSuccess": "Widget settings reset"
+    "moveUp": "Move up",
+    "moveDown": "Move down",
+    "widgets": {
+      "userProfile": "User Profile",
+      "level": "Level",
+      "streak": "Streak",
+      "dailyChallenge": "Daily Challenge",
+      "weeklyChallenge": "Weekly Challenge",
+      "studyCircle": "Study Circle",
+      "quickEntry": "Quick Entry",
+      "quickActions": "Quick Actions",
+      "recommendedUsers": "Recommended Users",
+      "trending": "Trending",
+      "aiAdvice": "AI Advice",
+      "goalsProgress": "Goals Progress",
+      "recentNotifications": "Recent Notifications",
+      "quickStats": "Quick Stats"
+    }
   },
   "reactionSummary": {
     "title": "Reaction Summary",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1669,12 +1669,29 @@
   },
   "widgetSettings": {
     "title": "Configuración de widgets",
-    "customize": "Personalizar widgets",
+    "customize": "Personalizar",
+    "saveSuccess": "Configuración de widgets guardada",
+    "saveFailed": "Error al guardar la configuración de widgets",
     "show": "Mostrar",
     "hide": "Ocultar",
-    "resetToDefault": "Restaurar predeterminados",
-    "saveSuccess": "Configuración de widgets guardada",
-    "resetSuccess": "Configuración de widgets restablecida"
+    "moveUp": "Mover arriba",
+    "moveDown": "Mover abajo",
+    "widgets": {
+      "userProfile": "Perfil de usuario",
+      "level": "Nivel",
+      "streak": "Racha",
+      "dailyChallenge": "Desafío diario",
+      "weeklyChallenge": "Desafío semanal",
+      "studyCircle": "Círculo de estudio",
+      "quickEntry": "Entrada rápida",
+      "quickActions": "Acciones rápidas",
+      "recommendedUsers": "Usuarios recomendados",
+      "trending": "Tendencias",
+      "aiAdvice": "Consejo de IA",
+      "goalsProgress": "Progreso de metas",
+      "recentNotifications": "Notificaciones recientes",
+      "quickStats": "Estadísticas rápidas"
+    }
   },
   "reactionSummary": {
     "title": "Resumen de reacciones",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1669,12 +1669,29 @@
   },
   "widgetSettings": {
     "title": "Paramètres des widgets",
-    "customize": "Personnaliser les widgets",
+    "customize": "Personnaliser",
+    "saveSuccess": "Paramètres des widgets enregistrés",
+    "saveFailed": "Échec de l'enregistrement des paramètres des widgets",
     "show": "Afficher",
     "hide": "Masquer",
-    "resetToDefault": "Réinitialiser par défaut",
-    "saveSuccess": "Paramètres des widgets enregistrés",
-    "resetSuccess": "Paramètres des widgets réinitialisés"
+    "moveUp": "Monter",
+    "moveDown": "Descendre",
+    "widgets": {
+      "userProfile": "Profil utilisateur",
+      "level": "Niveau",
+      "streak": "Série",
+      "dailyChallenge": "Défi quotidien",
+      "weeklyChallenge": "Défi hebdomadaire",
+      "studyCircle": "Cercle d'étude",
+      "quickEntry": "Saisie rapide",
+      "quickActions": "Actions rapides",
+      "recommendedUsers": "Utilisateurs recommandés",
+      "trending": "Tendances",
+      "aiAdvice": "Conseil IA",
+      "goalsProgress": "Progression des objectifs",
+      "recentNotifications": "Notifications récentes",
+      "quickStats": "Statistiques rapides"
+    }
   },
   "reactionSummary": {
     "title": "Résumé des réactions",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1571,12 +1571,29 @@
   },
   "widgetSettings": {
     "title": "ウィジェット設定",
-    "customize": "ウィジェットをカスタマイズ",
+    "customize": "カスタマイズ",
+    "saveSuccess": "ウィジェット設定を保存しました",
+    "saveFailed": "ウィジェット設定の保存に失敗しました",
     "show": "表示",
     "hide": "非表示",
-    "resetToDefault": "デフォルトに戻す",
-    "saveSuccess": "ウィジェット設定を保存しました",
-    "resetSuccess": "ウィジェット設定をリセットしました"
+    "moveUp": "上に移動",
+    "moveDown": "下に移動",
+    "widgets": {
+      "userProfile": "ユーザープロフィール",
+      "level": "レベル",
+      "streak": "ストリーク",
+      "dailyChallenge": "デイリーチャレンジ",
+      "weeklyChallenge": "ウィークリーチャレンジ",
+      "studyCircle": "スタディサークル",
+      "quickEntry": "クイックエントリー",
+      "quickActions": "クイックアクション",
+      "recommendedUsers": "おすすめユーザー",
+      "trending": "トレンド",
+      "aiAdvice": "AIアドバイス",
+      "goalsProgress": "目標進捗",
+      "recentNotifications": "最近の通知",
+      "quickStats": "クイック統計"
+    }
   },
   "reactionSummary": {
     "title": "リアクションサマリー",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1671,12 +1671,29 @@
   },
   "widgetSettings": {
     "title": "위젯 설정",
-    "customize": "위젯 커스터마이즈",
+    "customize": "커스터마이즈",
+    "saveSuccess": "위젯 설정이 저장되었습니다",
+    "saveFailed": "위젯 설정 저장에 실패했습니다",
     "show": "표시",
     "hide": "숨기기",
-    "resetToDefault": "기본값으로 복원",
-    "saveSuccess": "위젯 설정이 저장되었습니다",
-    "resetSuccess": "위젯 설정이 초기화되었습니다"
+    "moveUp": "위로 이동",
+    "moveDown": "아래로 이동",
+    "widgets": {
+      "userProfile": "사용자 프로필",
+      "level": "레벨",
+      "streak": "스트릭",
+      "dailyChallenge": "일일 챌린지",
+      "weeklyChallenge": "주간 챌린지",
+      "studyCircle": "스터디 서클",
+      "quickEntry": "빠른 입력",
+      "quickActions": "빠른 작업",
+      "recommendedUsers": "추천 사용자",
+      "trending": "트렌딩",
+      "aiAdvice": "AI 조언",
+      "goalsProgress": "목표 진행",
+      "recentNotifications": "최근 알림",
+      "quickStats": "빠른 통계"
+    }
   },
   "reactionSummary": {
     "title": "리액션 요약",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1669,12 +1669,29 @@
   },
   "widgetSettings": {
     "title": "Configurações de widgets",
-    "customize": "Personalizar widgets",
+    "customize": "Personalizar",
+    "saveSuccess": "Configurações de widgets salvas",
+    "saveFailed": "Falha ao salvar configurações de widgets",
     "show": "Mostrar",
     "hide": "Ocultar",
-    "resetToDefault": "Restaurar padrão",
-    "saveSuccess": "Configurações de widgets salvas",
-    "resetSuccess": "Configurações de widgets redefinidas"
+    "moveUp": "Mover para cima",
+    "moveDown": "Mover para baixo",
+    "widgets": {
+      "userProfile": "Perfil do usuário",
+      "level": "Nível",
+      "streak": "Sequência",
+      "dailyChallenge": "Desafio diário",
+      "weeklyChallenge": "Desafio semanal",
+      "studyCircle": "Círculo de estudo",
+      "quickEntry": "Entrada rápida",
+      "quickActions": "Ações rápidas",
+      "recommendedUsers": "Usuários recomendados",
+      "trending": "Tendências",
+      "aiAdvice": "Conselho de IA",
+      "goalsProgress": "Progresso de metas",
+      "recentNotifications": "Notificações recentes",
+      "quickStats": "Estatísticas rápidas"
+    }
   },
   "reactionSummary": {
     "title": "Resumo de reações",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1668,12 +1668,29 @@
   },
   "widgetSettings": {
     "title": "Настройки виджетов",
-    "customize": "Настроить виджеты",
+    "customize": "Настроить",
+    "saveSuccess": "Настройки виджетов сохранены",
+    "saveFailed": "Не удалось сохранить настройки виджетов",
     "show": "Показать",
     "hide": "Скрыть",
-    "resetToDefault": "Сбросить по умолчанию",
-    "saveSuccess": "Настройки виджетов сохранены",
-    "resetSuccess": "Настройки виджетов сброшены"
+    "moveUp": "Переместить вверх",
+    "moveDown": "Переместить вниз",
+    "widgets": {
+      "userProfile": "Профиль пользователя",
+      "level": "Уровень",
+      "streak": "Серия",
+      "dailyChallenge": "Ежедневный вызов",
+      "weeklyChallenge": "Еженедельный вызов",
+      "studyCircle": "Учебный кружок",
+      "quickEntry": "Быстрая запись",
+      "quickActions": "Быстрые действия",
+      "recommendedUsers": "Рекомендуемые пользователи",
+      "trending": "Тренды",
+      "aiAdvice": "Совет ИИ",
+      "goalsProgress": "Прогресс целей",
+      "recentNotifications": "Последние уведомления",
+      "quickStats": "Быстрая статистика"
+    }
   },
   "reactionSummary": {
     "title": "Сводка реакций",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1669,12 +1669,29 @@
   },
   "widgetSettings": {
     "title": "小部件设置",
-    "customize": "自定义小部件",
+    "customize": "自定义",
+    "saveSuccess": "小部件设置已保存",
+    "saveFailed": "保存小部件设置失败",
     "show": "显示",
     "hide": "隐藏",
-    "resetToDefault": "恢复默认",
-    "saveSuccess": "小部件设置已保存",
-    "resetSuccess": "小部件设置已重置"
+    "moveUp": "上移",
+    "moveDown": "下移",
+    "widgets": {
+      "userProfile": "用户资料",
+      "level": "等级",
+      "streak": "连续天数",
+      "dailyChallenge": "每日挑战",
+      "weeklyChallenge": "每周挑战",
+      "studyCircle": "学习圈",
+      "quickEntry": "快速记录",
+      "quickActions": "快捷操作",
+      "recommendedUsers": "推荐用户",
+      "trending": "热门",
+      "aiAdvice": "AI建议",
+      "goalsProgress": "目标进度",
+      "recentNotifications": "最近通知",
+      "quickStats": "快速统计"
+    }
   },
   "reactionSummary": {
     "title": "反应摘要",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1671,12 +1671,29 @@
   },
   "widgetSettings": {
     "title": "小工具設定",
-    "customize": "自訂小工具",
+    "customize": "自訂",
+    "saveSuccess": "小工具設定已儲存",
+    "saveFailed": "儲存小工具設定失敗",
     "show": "顯示",
     "hide": "隱藏",
-    "resetToDefault": "恢復預設",
-    "saveSuccess": "小工具設定已儲存",
-    "resetSuccess": "小工具設定已重設"
+    "moveUp": "上移",
+    "moveDown": "下移",
+    "widgets": {
+      "userProfile": "使用者資料",
+      "level": "等級",
+      "streak": "連續天數",
+      "dailyChallenge": "每日挑戰",
+      "weeklyChallenge": "每週挑戰",
+      "studyCircle": "讀書圈",
+      "quickEntry": "快速記錄",
+      "quickActions": "快捷操作",
+      "recommendedUsers": "推薦使用者",
+      "trending": "熱門",
+      "aiAdvice": "AI建議",
+      "goalsProgress": "目標進度",
+      "recentNotifications": "最近通知",
+      "quickStats": "快速統計"
+    }
   },
   "reactionSummary": {
     "title": "反應摘要",

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,10 +1,10 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, type ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import QuickStatsWidget from '../components/dashboard/QuickStatsWidget';
 import QuickActionsWidget from '../components/dashboard/QuickActionsWidget';
 import { useAuthStore } from '../store/authStore';
-import { usePosts, useDashboard, useBadgeNotifier, useConfirm } from '../hooks';
+import { usePosts, useDashboard, useBadgeNotifier, useConfirm, useWidgetSettings } from '../hooks';
 import { getUserBadges } from '../api/badges';
 import { useAsyncData } from '../hooks/useAsyncData';
 import type { BadgeResult } from '../types/badge';
@@ -29,6 +29,7 @@ import StudyCircleWidget from '../components/dashboard/StudyCircleWidget';
 import GoalsProgressWidget from '../components/dashboard/GoalsProgressWidget';
 import QuickEntryWidget from '../components/dashboard/QuickEntryWidget';
 import WeeklyChallengeWidget from '../components/dashboard/WeeklyChallengeWidget';
+import WidgetSettingsPanel from '../components/dashboard/WidgetSettingsPanel';
 
 export default function DashboardPage() {
   const { t } = useTranslation();
@@ -49,6 +50,19 @@ export default function DashboardPage() {
     recentNotifications,
     notificationsLoading,
   } = useDashboard();
+
+  const {
+    widgets,
+    editing: widgetEditing,
+    localWidgets,
+    saving: widgetSaving,
+    startEditing: startWidgetEditing,
+    cancelEditing: cancelWidgetEditing,
+    toggleVisibility,
+    moveUp,
+    moveDown,
+    saveSettings: saveWidgetSettings,
+  } = useWidgetSettings();
 
   // Fetch badges for the current user and detect new acquisitions
   const { data: badges } = useAsyncData(
@@ -75,6 +89,43 @@ export default function DashboardPage() {
   ) => {
     await createPost(title, content, imageUrls, codeSnippets, isDraft);
   }, [createPost]);
+
+  // Widget component registry
+  const widgetComponents: Record<string, ReactNode> = {
+    userProfile: <UserProfileWidget />,
+    level: <LevelWidget />,
+    streak: <StreakWidget />,
+    dailyChallenge: <DailyChallengeWidget />,
+    weeklyChallenge: <WeeklyChallengeWidget />,
+    studyCircle: <StudyCircleWidget />,
+    quickEntry: <QuickEntryWidget />,
+    quickActions: <QuickActionsWidget />,
+    recommendedUsers: <RecommendedUsersWidget />,
+    trending: <TrendingWidget />,
+    aiAdvice: <AIAdviceWidget />,
+    goalsProgress: (
+      <GoalsProgressWidget
+        activeGoals={activeGoals}
+        completedGoals={completedGoals}
+        avgProgress={avgProgress}
+        loading={goalsLoading}
+      />
+    ),
+    recentNotifications: (
+      <RecentNotificationsWidget
+        notifications={recentNotifications}
+        loading={notificationsLoading}
+      />
+    ),
+    quickStats: (
+      <QuickStatsWidget
+        activeCount={activeGoals.length}
+        completedCount={completedGoals.length}
+      />
+    ),
+  };
+
+  const visibleWidgets = widgets.filter((w) => w.visible);
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-4 gap-6">
@@ -178,67 +229,41 @@ export default function DashboardPage() {
       </div>
 
       {/* Sidebar */}
-      <div className="space-y-6">
-        {/* User Profile Section */}
-        <div>
-          <h2 className="section-heading">{t('dashboard.profile')}</h2>
-          <UserProfileWidget />
-        </div>
-
-        {/* Progress Section */}
-        <div>
-          <h2 className="section-heading">{t('dashboard.progress')}</h2>
-          <div className="space-y-4">
-            <LevelWidget />
-            <StreakWidget />
+      <div className="space-y-4">
+        {/* Widget Settings Toggle */}
+        {!widgetEditing && (
+          <div className="flex justify-end">
+            <button
+              onClick={startWidgetEditing}
+              className="flex items-center gap-1.5 px-2.5 py-1 text-xs text-gray-400 hover:text-white border border-gray-700 hover:border-gray-500 rounded transition-colors"
+            >
+              <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" d="M10.5 6h9.75M10.5 6a1.5 1.5 0 1 1-3 0m3 0a1.5 1.5 0 1 0-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 0 1-3 0m3 0a1.5 1.5 0 0 0-3 0m-9.75 0h9.75" />
+              </svg>
+              {t('widgetSettings.customize')}
+            </button>
           </div>
-        </div>
+        )}
 
-        {/* Activities Section */}
-        <div>
-          <h2 className="section-heading">{t('dashboard.activities')}</h2>
-          <div className="space-y-4">
-            <DailyChallengeWidget />
-            <WeeklyChallengeWidget />
-            <StudyCircleWidget />
+        {/* Widget Settings Panel */}
+        {widgetEditing && (
+          <WidgetSettingsPanel
+            widgets={localWidgets}
+            saving={widgetSaving}
+            onToggleVisibility={toggleVisibility}
+            onMoveUp={moveUp}
+            onMoveDown={moveDown}
+            onSave={saveWidgetSettings}
+            onCancel={cancelWidgetEditing}
+          />
+        )}
+
+        {/* Dynamic Widgets */}
+        {!widgetEditing && visibleWidgets.map((widget) => (
+          <div key={widget.key}>
+            {widgetComponents[widget.key]}
           </div>
-        </div>
-
-        {/* Quick Entry */}
-        <QuickEntryWidget />
-
-        {/* Quick Actions */}
-        <QuickActionsWidget />
-
-        {/* Recommendations Section */}
-        <div>
-          <h2 className="section-heading">{t('dashboard.recommendations')}</h2>
-          <div className="space-y-4">
-            <RecommendedUsersWidget />
-            <TrendingWidget />
-            <AIAdviceWidget />
-          </div>
-        </div>
-
-        {/* Goals Progress Widget */}
-        <GoalsProgressWidget
-          activeGoals={activeGoals}
-          completedGoals={completedGoals}
-          avgProgress={avgProgress}
-          loading={goalsLoading}
-        />
-
-        {/* Recent Notifications Widget */}
-        <RecentNotificationsWidget
-          notifications={recentNotifications}
-          loading={notificationsLoading}
-        />
-
-        {/* Quick Stats */}
-        <QuickStatsWidget
-          activeCount={activeGoals.length}
-          completedCount={completedGoals.length}
-        />
+        ))}
       </div>
       <ConfirmDialog {...dialogProps} />
     </div>


### PR DESCRIPTION
## 概要
ダッシュボードのサイドバーウィジェットをユーザーがカスタマイズできるようにする。

closes #2073

## 変更内容
- `useWidgetSettings` フック: 既存の `GET/PUT /api/widget-settings` APIを活用した設定管理
- `WidgetSettingsPanel` コンポーネント: チェックボックスで表示/非表示切替、上下ボタンで並び替え
- `DashboardPage` をハードコードから動的レンダリングに変更
- 14ウィジェット全てに対応（userProfile, level, streak, etc.）
- 10言語のi18nキーを追加

## テスト
- TypeScript型チェック通過（`npx tsc --noEmit`）
- 既存のバックエンドWidget Settingsテスト全件通過