### PR TITLE
refactor: リポジトリインターフェースをrepository/interfaces.goに集約

### DIFF
--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -715,3 +715,25 @@ type WidgetSettingsRepositoryInterface interface {
 	FindByUserID(userID uint) (*model.WidgetSettings, error)
 	Upsert(settings *model.WidgetSettings) error
 }
+
+// NoteLinkRepositoryInterface はノート間リンクデータ操作の契約を定義する。
+type NoteLinkRepositoryInterface interface {
+	Create(link *model.NoteLink) error
+	FindBySourceNoteID(sourceNoteID uint) ([]model.NoteLink, error)
+	FindByTargetNoteID(targetNoteID uint) ([]model.NoteLink, error)
+	Delete(sourceNoteID, targetNoteID uint) error
+	Exists(sourceNoteID, targetNoteID uint) (bool, error)
+	CountBySourceNoteID(noteID uint) (int64, error)
+	CountByTargetNoteID(noteID uint) (int64, error)
+}
+
+// NoteTemplateRepositoryInterface はノートテンプレートデータ操作の契約を定義する。
+type NoteTemplateRepositoryInterface interface {
+	Create(template *model.NoteTemplate) error
+	FindByID(id uint) (*model.NoteTemplate, error)
+	FindByUserID(userID uint) ([]model.NoteTemplate, error)
+	FindDefaultByUserID(userID uint) (*model.NoteTemplate, error)
+	Update(template *model.NoteTemplate) error
+	Delete(id uint) error
+	ClearDefaultFlag(userID uint) error
+}

--- a/backend/internal/service/note_link.go
+++ b/backend/internal/service/note_link.go
@@ -6,25 +6,14 @@ import (
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
 
-// NoteLinkRepositoryInterface はNoteLinkRepositoryのインターフェース。
-type NoteLinkRepositoryInterface interface {
-	Create(link *model.NoteLink) error
-	FindBySourceNoteID(sourceNoteID uint) ([]model.NoteLink, error)
-	FindByTargetNoteID(targetNoteID uint) ([]model.NoteLink, error)
-	Delete(sourceNoteID, targetNoteID uint) error
-	Exists(sourceNoteID, targetNoteID uint) (bool, error)
-	CountBySourceNoteID(noteID uint) (int64, error)
-	CountByTargetNoteID(noteID uint) (int64, error)
-}
-
 // NoteLinkService はノート間リンクのビジネスロジック。
 type NoteLinkService struct {
-	repo     NoteLinkRepositoryInterface
+	repo     repository.NoteLinkRepositoryInterface
 	noteRepo repository.NoteRepositoryInterface
 }
 
 // NewNoteLinkService は新しいNoteLinkServiceインスタンスを生成する。
-func NewNoteLinkService(repo NoteLinkRepositoryInterface, noteRepo repository.NoteRepositoryInterface) *NoteLinkService {
+func NewNoteLinkService(repo repository.NoteLinkRepositoryInterface, noteRepo repository.NoteRepositoryInterface) *NoteLinkService {
 	return &NoteLinkService{
 		repo:     repo,
 		noteRepo: noteRepo,

--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -5,18 +5,8 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
 )
-
-// NoteTemplateRepositoryInterface はNoteTemplateRepositoryのインターフェース。
-type NoteTemplateRepositoryInterface interface {
-	Create(template *model.NoteTemplate) error
-	FindByID(id uint) (*model.NoteTemplate, error)
-	FindByUserID(userID uint) ([]model.NoteTemplate, error)
-	FindDefaultByUserID(userID uint) (*model.NoteTemplate, error)
-	Update(template *model.NoteTemplate) error
-	Delete(id uint) error
-	ClearDefaultFlag(userID uint) error
-}
 
 // NoteCreatorInterface はノート作成機能のインターフェース。
 type NoteCreatorInterface interface {
@@ -25,12 +15,12 @@ type NoteCreatorInterface interface {
 
 // NoteTemplateService はノートテンプレートのビジネスロジック。
 type NoteTemplateService struct {
-	repo        NoteTemplateRepositoryInterface
+	repo        repository.NoteTemplateRepositoryInterface
 	noteCreator NoteCreatorInterface
 }
 
 // NewNoteTemplateService は新しいNoteTemplateServiceインスタンスを生成する。
-func NewNoteTemplateService(repo NoteTemplateRepositoryInterface, noteCreator NoteCreatorInterface) *NoteTemplateService {
+func NewNoteTemplateService(repo repository.NoteTemplateRepositoryInterface, noteCreator NoteCreatorInterface) *NoteTemplateService {
 	return &NoteTemplateService{repo: repo, noteCreator: noteCreator}
 }
 


### PR DESCRIPTION
## 概要
service層に散在していたリポジトリインターフェースをrepository/interfaces.goに集約。

closes #2075

## 変更内容
- `NoteLinkRepositoryInterface` を `service/note_link.go` → `repository/interfaces.go` に移動
- `NoteTemplateRepositoryInterface` を `service/note_template.go` → `repository/interfaces.go` に移動
- サービス層の参照を `repository.XxxInterface` に統一

## 影響
- アーキテクチャ境界の一貫性が向上（全リポジトリインターフェースが repository 層に集約）
- 依存の方向: handler → service → repository（インターフェースは repository 層で定義）

## テスト
- `go build ./...` 通過
- 全 service/handler テスト通過