### PR TITLE
test: Service層のエッジケーステストを追加しカバレッジ改善

### DIFF
--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -585,3 +585,35 @@ func TestSnippetFork_SelfFork(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, forked)
 }
+
+func TestSnippetDelete_RepoError(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	existing := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", Code: "package main"}
+	existing.ID = 10
+	snippetRepo.On("FindByID", uint(10)).Return(existing, nil)
+	snippetRepo.On("Delete", uint(10)).Return(assert.AnError)
+
+	err := svc.Delete(10, 1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "削除に失敗")
+}
+
+func TestSnippetFork_CreateError(t *testing.T) {
+	svc, snippetRepo, postRepo := newTestCodeSnippetService()
+
+	original := &model.CodeSnippet{
+		ID: 1, PostID: 5, UserID: 99, Language: "go", FileName: "main.go", Code: "package main",
+	}
+	snippetRepo.On("FindByID", uint(1)).Return(original, nil)
+
+	targetPost := &model.Post{UserID: 10}
+	targetPost.ID = 20
+	postRepo.On("FindByID", uint(20)).Return(targetPost, nil)
+
+	snippetRepo.On("Create", mock.Anything).Return(assert.AnError)
+
+	_, err := svc.Fork(10, 1, 20)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "フォークに失敗")
+}

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -844,6 +844,18 @@ func TestLearningGoalToggleShare_NotFound(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestLearningGoalToggleShare_UpdateError(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+
+	goal := &model.LearningGoal{UserID: 1, Title: "テスト目標", IsPublic: false}
+	goal.ID = 1
+	repo.On("FindByID", uint(1)).Return(goal, nil)
+	repo.On("Update", mock.Anything).Return(errors.New("db error"))
+
+	_, err := svc.ToggleShare(1, 1)
+	assert.Error(t, err)
+}
+
 func TestLearningGoalGetPublicGoals_Success(t *testing.T) {
 	svc, repo := newTestLearningGoalService()
 

--- a/backend/internal/service/post_template_test.go
+++ b/backend/internal/service/post_template_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // newTestPostTemplateService はPostTemplateServiceのテスト用インスタンスを生成するヘルパー。
@@ -225,4 +226,32 @@ func TestPostTemplateDelete_NotFound(t *testing.T) {
 
 	err := svc.Delete(999, 1)
 	assert.Error(t, err)
+}
+
+func TestPostTemplateUpdate_RepoError(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	existing := &model.PostTemplate{UserID: 1, Name: "テスト", ContentTemplate: "内容"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.Anything).Return(errors.New("db error"))
+
+	_, err := svc.Update(1, 1, &model.PostTemplate{Name: "更新名"})
+	assert.Error(t, err)
+}
+
+func TestPostTemplateUpdate_PartialFields(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	existing := &model.PostTemplate{UserID: 1, Name: "元の名前", TitleTemplate: "元のタイトル", ContentTemplate: "元の内容"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.MatchedBy(func(t *model.PostTemplate) bool {
+		return t.Name == "新しい名前" && t.TitleTemplate == "元のタイトル" && t.ContentTemplate == "元の内容"
+	})).Return(nil)
+
+	result, err := svc.Update(1, 1, &model.PostTemplate{Name: "新しい名前"})
+	assert.NoError(t, err)
+	assert.Equal(t, "新しい名前", result.Name)
+	assert.Equal(t, "元のタイトル", result.TitleTemplate)
 }

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -1723,3 +1723,39 @@ func TestPostGetReactionsBatch_UserReactionsRepoError(t *testing.T) {
 	_, _, err := svc.GetReactionsBatch(1, postIDs)
 	assert.Error(t, err)
 }
+
+func TestPostAutoSaveDraft_ContentTooLong(t *testing.T) {
+	svc, _, _ := newTestPostService()
+
+	longContent := strings.Repeat("あ", 50001)
+	_, err := svc.AutoSaveDraft(1, 0, "title", longContent, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "50000文字")
+}
+
+func TestPostAutoSaveDraft_UpdateRepoError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	existing := &model.Post{UserID: 1, Title: "下書き", IsDraft: true}
+	existing.ID = 5
+	postRepo.On("FindByID", uint(5)).Return(existing, nil)
+	postRepo.On("Update", mock.Anything).Return(errors.New("db error"))
+
+	_, err := svc.AutoSaveDraft(1, 5, "更新タイトル", "更新内容", "")
+	assert.Error(t, err)
+}
+
+func TestPostAutoSaveDraft_UpdateWithImageURLs(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	existing := &model.Post{UserID: 1, Title: "下書き", IsDraft: true}
+	existing.ID = 5
+	postRepo.On("FindByID", uint(5)).Return(existing, nil)
+	postRepo.On("Update", mock.MatchedBy(func(p *model.Post) bool {
+		return p.ImageURLs == "https://example.com/img.png"
+	})).Return(nil)
+
+	result, err := svc.AutoSaveDraft(1, 5, "title", "content", "https://example.com/img.png")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://example.com/img.png", result.ImageURLs)
+}

--- a/backend/internal/service/project_milestone_test.go
+++ b/backend/internal/service/project_milestone_test.go
@@ -196,3 +196,45 @@ func TestProjectMilestoneService_Create_WithDueDate(t *testing.T) {
 	err := svc.Create(10, 1, "v1.0", "", &dueDate)
 	assert.NoError(t, err)
 }
+
+func TestProjectMilestoneService_Update_TitleTooLong(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	milestone := &model.ProjectMilestone{ID: 1, ProjectID: 5, Title: "既存"}
+	milestoneRepo.On("FindByID", uint(1)).Return(milestone, nil)
+	projectRepo.On("FindByID", uint(5)).Return(&model.Project{ID: 5, UserID: 10}, nil)
+
+	longTitle := string(make([]rune, 201))
+	_, err := svc.Update(10, 1, longTitle, "", nil, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "200文字")
+}
+
+func TestProjectMilestoneService_Update_StatusResetCompletedAt(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	now := time.Now()
+	milestone := &model.ProjectMilestone{ID: 1, ProjectID: 5, Title: "既存", Status: model.MilestoneCompleted, CompletedAt: &now}
+	milestoneRepo.On("FindByID", uint(1)).Return(milestone, nil)
+	projectRepo.On("FindByID", uint(5)).Return(&model.Project{ID: 5, UserID: 10}, nil)
+	milestoneRepo.On("Update", mock.MatchedBy(func(m *model.ProjectMilestone) bool {
+		return m.Status == model.MilestoneInProgress && m.CompletedAt == nil
+	})).Return(nil)
+
+	result, err := svc.Update(10, 1, "", "", nil, "in_progress")
+	assert.NoError(t, err)
+	assert.Nil(t, result.CompletedAt)
+	assert.Equal(t, model.MilestoneInProgress, result.Status)
+}
+
+func TestProjectMilestoneService_Update_RepoError(t *testing.T) {
+	svc, milestoneRepo, projectRepo := newTestProjectMilestoneService()
+
+	milestone := &model.ProjectMilestone{ID: 1, ProjectID: 5, Title: "既存"}
+	milestoneRepo.On("FindByID", uint(1)).Return(milestone, nil)
+	projectRepo.On("FindByID", uint(5)).Return(&model.Project{ID: 5, UserID: 10}, nil)
+	milestoneRepo.On("Update", mock.Anything).Return(errors.New("db error"))
+
+	_, err := svc.Update(10, 1, "新しいタイトル", "", nil, "")
+	assert.Error(t, err)
+}

--- a/backend/internal/service/user_test.go
+++ b/backend/internal/service/user_test.go
@@ -454,3 +454,45 @@ func TestUserUpdate_AvatarURLTooLong(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "アバターURLは2000文字以下である必要があります")
 }
+
+func TestUserUpdateProfile_UpdateRepoError(t *testing.T) {
+	svc, repo := newTestUserService()
+
+	existing := &model.User{ID: 1, Name: "Alice"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.AnythingOfType("*model.User")).Return(errors.New("db error"))
+
+	input := &UpdateProfileInput{Name: "Bob"}
+	_, err := svc.UpdateProfile(1, 1, input)
+	assert.Error(t, err)
+}
+
+func TestUserUpdateProfile_AllOptionalFields(t *testing.T) {
+	svc, repo := newTestUserService()
+
+	existing := &model.User{ID: 1, Name: "Alice"}
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", mock.AnythingOfType("*model.User")).Return(nil)
+
+	skills := "Go,Rust"
+	frameworks := "Gin,Actix"
+	atcoder := "alice123"
+	paiza := "S"
+	onboarding := true
+	input := &UpdateProfileInput{
+		Name:                "Alice",
+		SkillsLanguages:     &skills,
+		SkillsFrameworks:    &frameworks,
+		AtCoderUsername:     &atcoder,
+		PaizaRank:           &paiza,
+		OnboardingCompleted: &onboarding,
+	}
+
+	result, err := svc.UpdateProfile(1, 1, input)
+	assert.NoError(t, err)
+	assert.Equal(t, "Go,Rust", result.SkillsLanguages)
+	assert.Equal(t, "Gin,Actix", result.SkillsFrameworks)
+	assert.Equal(t, "alice123", result.AtCoderUsername)
+	assert.Equal(t, "S", result.PaizaRank)
+	assert.True(t, result.OnboardingCompleted)
+}


### PR DESCRIPTION
## 概要
Service層のテストカバレッジを改善するエッジケーステストを追加。

closes #2077

## 変更内容
13テスト追加:
- `CodeSnippet`: Delete_RepoError, Fork_CreateError
- `LearningGoal`: ToggleShare_UpdateError
- `PostTemplate`: Update_RepoError, Update_PartialFields
- `User`: UpdateProfile_UpdateRepoError, UpdateProfile_AllOptionalFields
- `Post`: AutoSaveDraft_ContentTooLong, AutoSaveDraft_UpdateRepoError, AutoSaveDraft_UpdateWithImageURLs
- `ProjectMilestone`: Update_TitleTooLong, Update_StatusResetCompletedAt, Update_RepoError

## テスト結果
- 全1793テスト通過
- カバレッジ: 87.0% → 87.4%