### PR TITLE
fix: パスワードリセットトークンのSHA-256ハッシュ化

### DIFF
--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"time"
@@ -12,6 +13,13 @@ import (
 	"github.com/norman6464/devsync/backend/internal/repository"
 	"golang.org/x/crypto/bcrypt"
 )
+
+// hashToken はトークンをSHA-256でハッシュ化する。
+// DB保存前にハッシュ化し、検証時も同じハッシュを使って比較する。
+func hashToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}
 
 // AuthService は認証・認可に関するビジネスロジックを提供する。
 // JWT生成・検証、パスワードハッシュ化、GitHub OAuthログインを担当する。
@@ -347,9 +355,10 @@ func (s *AuthService) RequestPasswordReset(email string) (string, error) {
 	token := hex.EncodeToString(tokenBytes)
 
 	// リセットトークンを作成（有効期限1時間）
+	// トークンはSHA-256ハッシュ化してDB保存（平文はメール送信のみ）
 	resetToken := &model.PasswordResetToken{
 		UserID:    user.ID,
-		Token:     token,
+		Token:     hashToken(token),
 		ExpiresAt: time.Now().Add(1 * time.Hour),
 	}
 	if err := s.passwordResetRepo.Create(resetToken); err != nil {
@@ -361,7 +370,7 @@ func (s *AuthService) RequestPasswordReset(email string) (string, error) {
 
 // ResetPassword は有効なリセットトークンを使ってパスワードを再設定する。
 func (s *AuthService) ResetPassword(token string, newPassword string) error {
-	resetToken, err := s.passwordResetRepo.FindByToken(token)
+	resetToken, err := s.passwordResetRepo.FindByToken(hashToken(token))
 	if err != nil {
 		return domain.NewError(domain.ErrCodeBadRequest, "無効なリセットトークンです", err)
 	}

--- a/backend/internal/service/auth_test.go
+++ b/backend/internal/service/auth_test.go
@@ -392,7 +392,7 @@ func TestResetPassword_Success(t *testing.T) {
 	}
 	resetToken.ID = 1
 
-	passwordResetRepo.On("FindByToken", "valid-token").Return(resetToken, nil)
+	passwordResetRepo.On("FindByToken", hashToken("valid-token")).Return(resetToken, nil)
 	userRepo.On("UpdatePassword", uint(1), mock.AnythingOfType("string")).Return(nil)
 	passwordResetRepo.On("MarkAsUsed", uint(1)).Return(nil)
 
@@ -405,7 +405,7 @@ func TestResetPassword_Success(t *testing.T) {
 func TestResetPassword_InvalidToken(t *testing.T) {
 	svc, _, passwordResetRepo := newTestAuthService()
 
-	passwordResetRepo.On("FindByToken", "invalid-token").Return(nil, errors.New("not found"))
+	passwordResetRepo.On("FindByToken", hashToken("invalid-token")).Return(nil, errors.New("not found"))
 
 	err := svc.ResetPassword("invalid-token", "newpassword123")
 	assert.ErrorIs(t, err, ErrBadRequest)
@@ -423,7 +423,7 @@ func TestResetPassword_ExpiredToken(t *testing.T) {
 	}
 	resetToken.ID = 1
 
-	passwordResetRepo.On("FindByToken", "expired-token").Return(resetToken, nil)
+	passwordResetRepo.On("FindByToken", hashToken("expired-token")).Return(resetToken, nil)
 
 	err := svc.ResetPassword("expired-token", "newpassword123")
 	assert.ErrorIs(t, err, ErrBadRequest)
@@ -779,7 +779,7 @@ func TestResetPassword_WeakPassword(t *testing.T) {
 	}
 	validToken.ID = 1
 
-	passwordResetRepo.On("FindByToken", "valid-token-for-weak-pw").Return(validToken, nil)
+	passwordResetRepo.On("FindByToken", hashToken("valid-token-for-weak-pw")).Return(validToken, nil)
 
 	// 弱いパスワード（短すぎる）
 	err := svc.ResetPassword("valid-token-for-weak-pw", "weak")
@@ -861,7 +861,7 @@ func TestResetPassword_UpdatePasswordError(t *testing.T) {
 	}
 	validToken.ID = 1
 
-	passwordResetRepo.On("FindByToken", "valid-token-update-err").Return(validToken, nil)
+	passwordResetRepo.On("FindByToken", hashToken("valid-token-update-err")).Return(validToken, nil)
 	userRepo.On("UpdatePassword", uint(1), mock.AnythingOfType("string")).Return(errors.New("db error"))
 
 	err := svc.ResetPassword("valid-token-update-err", "ValidPassword123!")


### PR DESCRIPTION
## 概要
- パスワードリセットトークンを平文ではなくSHA-256ハッシュ化してDB保存するように変更
- リセット実行時もトークンをハッシュ化してからDB検索するように変更
- テストのモック期待値をハッシュ化後の値に更新

## 変更内容
- `hashToken()` 関数を追加（SHA-256ハッシュ化）
- `RequestPasswordReset`: トークン生成後、ハッシュ化してDB保存（平文はメール送信用に返却）
- `ResetPassword`: 受け取ったトークンをハッシュ化してからDB検索
- テスト5件のモック期待値を `hashToken()` 経由に更新

## テスト計画
- [x] パスワードリセット関連テスト全5件がパス
- [x] Service層全テストがパス

closes #2079