### PR TITLE
feat: Q&A質問のブックマーク機能を追加 (#2085)

### DIFF
--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -21,6 +21,9 @@ type QuestionServiceInterface interface {
 	Vote(userID, questionID uint, value int) error
 	RemoveVote(userID, questionID uint) error
 	GetSolved(limit, offset int) ([]model.Question, int64, error)
+	Bookmark(userID, questionID uint) error
+	Unbookmark(userID, questionID uint) error
+	GetBookmarkedByUserID(userID uint, limit, offset int) ([]model.Question, int64, error)
 }
 
 // QuestionHandler は質問関連のHTTPハンドラ。
@@ -227,4 +230,55 @@ func (h *QuestionHandler) RemoveVote(c *gin.Context) {
 	}
 
 	respondOK(c, domain.NewMessageResponse("Vote removed successfully"))
+}
+
+// Bookmark は質問をブックマークする。
+func (h *QuestionHandler) Bookmark(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.Bookmark(userID, id); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, domain.NewMessageResponse("Bookmarked successfully"))
+}
+
+// Unbookmark は質問のブックマークを解除する。
+func (h *QuestionHandler) Unbookmark(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.Unbookmark(userID, id); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, domain.NewMessageResponse("Bookmark removed successfully"))
+}
+
+// GetBookmarks はブックマーク済み質問一覧を取得する。
+func (h *QuestionHandler) GetBookmarks(c *gin.Context) {
+	userID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
+
+	questions, total, err := h.service.GetBookmarkedByUserID(userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.QuestionListResponse{
+		Questions: questions,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
 }

--- a/backend/internal/model/question.go
+++ b/backend/internal/model/question.go
@@ -23,6 +23,16 @@ type Question struct {
 	DeletedAt   gorm.DeletedAt `json:"-" gorm:"index"` // 論理削除用
 }
 
+// QuestionBookmark は質問のブックマークを記録する。
+// ユーザーと質問の組み合わせでユニークインデックスを持つ。
+type QuestionBookmark struct {
+	ID         uint      `json:"id" gorm:"primaryKey"`
+	UserID     uint      `json:"user_id" gorm:"not null;uniqueIndex:idx_question_bookmark"`
+	QuestionID uint      `json:"question_id" gorm:"not null;uniqueIndex:idx_question_bookmark"`
+	Question   Question  `json:"question,omitempty" gorm:"foreignKey:QuestionID"`
+	CreatedAt  time.Time `json:"created_at"`
+}
+
 // QuestionVote は質問への投票（賛成/反対）を記録する。
 // Value は +1（賛成）または -1（反対）の値を取る。
 // ユーザーと質問の組み合わせでユニークインデックスを持つ。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -131,6 +131,10 @@ type QuestionRepositoryInterface interface {
 	RemoveVote(userID, questionID uint) error
 	GetUserVote(userID, questionID uint) (int, error)
 	FindSolved(limit, offset int) ([]model.Question, int64, error)
+	Bookmark(userID, questionID uint) error
+	Unbookmark(userID, questionID uint) error
+	HasBookmarked(userID, questionID uint) (bool, error)
+	FindBookmarkedByUserID(userID uint, limit, offset int) ([]model.Question, int64, error)
 }
 
 // AnswerRepositoryInterface はQ&A回答データ操作の契約を定義する。

--- a/backend/internal/repository/question.go
+++ b/backend/internal/repository/question.go
@@ -178,3 +178,47 @@ func (r *QuestionRepository) GetUserVote(userID, questionID uint) (int, error) {
 	}
 	return vote.Value, nil
 }
+
+// Bookmark は質問をブックマークする。
+func (r *QuestionRepository) Bookmark(userID, questionID uint) error {
+	bookmark := &model.QuestionBookmark{
+		UserID:     userID,
+		QuestionID: questionID,
+	}
+	return r.db.Create(bookmark).Error
+}
+
+// Unbookmark は質問のブックマークを解除する。
+func (r *QuestionRepository) Unbookmark(userID, questionID uint) error {
+	return r.db.Where("user_id = ? AND question_id = ?", userID, questionID).
+		Delete(&model.QuestionBookmark{}).Error
+}
+
+// HasBookmarked は指定ユーザーが指定質問をブックマークしているかを返す。
+func (r *QuestionRepository) HasBookmarked(userID, questionID uint) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.QuestionBookmark{}).
+		Where("user_id = ? AND question_id = ?", userID, questionID).
+		Count(&count).Error
+	return count > 0, err
+}
+
+// FindBookmarkedByUserID は指定ユーザーのブックマーク済み質問をページネーション付きで取得する。
+func (r *QuestionRepository) FindBookmarkedByUserID(userID uint, limit, offset int) ([]model.Question, int64, error) {
+	var questions []model.Question
+	var total int64
+
+	subQuery := r.db.Model(&model.QuestionBookmark{}).
+		Select("question_id").
+		Where("user_id = ?", userID)
+
+	query := r.db.Model(&model.Question{}).Where("id IN (?)", subQuery)
+	query.Count(&total)
+
+	err := query.Preload("User").
+		Order("created_at DESC").
+		Limit(limit).Offset(offset).
+		Find(&questions).Error
+
+	return questions, total, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -561,6 +561,9 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		questions.DELETE("/:id", c.QuestionHandler.Delete)
 		questions.POST("/:id/vote", c.QuestionHandler.Vote)
 		questions.DELETE("/:id/vote", c.QuestionHandler.RemoveVote)
+		questions.POST("/:id/bookmark", c.QuestionHandler.Bookmark)
+		questions.DELETE("/:id/bookmark", c.QuestionHandler.Unbookmark)
+		questions.GET("/bookmarks", c.QuestionHandler.GetBookmarks)
 		questions.GET("/user/:userId", c.QuestionHandler.GetByUserID)
 
 		questions.GET("/:id/answers", c.AnswerHandler.GetByQuestionID)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -421,6 +421,26 @@ func (m *MockQuestionRepository) FindSolved(limit, offset int) ([]model.Question
 	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockQuestionRepository) Bookmark(userID, questionID uint) error {
+	args := m.Called(userID, questionID)
+	return args.Error(0)
+}
+
+func (m *MockQuestionRepository) Unbookmark(userID, questionID uint) error {
+	args := m.Called(userID, questionID)
+	return args.Error(0)
+}
+
+func (m *MockQuestionRepository) HasBookmarked(userID, questionID uint) (bool, error) {
+	args := m.Called(userID, questionID)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockQuestionRepository) FindBookmarkedByUserID(userID uint, limit, offset int) ([]model.Question, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
+}
+
 // ============================================================
 // MockAnswerRepository は repository.AnswerRepositoryInterface のテスト用モック実装。
 // ============================================================

--- a/backend/internal/service/question.go
+++ b/backend/internal/service/question.go
@@ -137,3 +137,29 @@ func (s *QuestionService) RemoveVote(userID, questionID uint) error {
 	}
 	return s.repo.RemoveVote(userID, questionID)
 }
+
+// Bookmark は質問をブックマークする。
+// 既にブックマーク済みの場合はErrConflictを返す。
+func (s *QuestionService) Bookmark(userID, questionID uint) error {
+	if _, err := s.repo.FindByID(questionID); err != nil {
+		return ErrNotFound
+	}
+	has, err := s.repo.HasBookmarked(userID, questionID)
+	if err != nil {
+		return err
+	}
+	if has {
+		return ErrConflict
+	}
+	return s.repo.Bookmark(userID, questionID)
+}
+
+// Unbookmark は質問のブックマークを解除する。
+func (s *QuestionService) Unbookmark(userID, questionID uint) error {
+	return s.repo.Unbookmark(userID, questionID)
+}
+
+// GetBookmarkedByUserID はブックマーク済み質問一覧を取得する。
+func (s *QuestionService) GetBookmarkedByUserID(userID uint, limit, offset int) ([]model.Question, int64, error) {
+	return s.repo.FindBookmarkedByUserID(userID, limit, offset)
+}

--- a/backend/internal/service/question_test.go
+++ b/backend/internal/service/question_test.go
@@ -572,3 +572,100 @@ func TestQuestionGetSolved_RepoError(t *testing.T) {
 	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// ブックマークテスト
+// ============================================================
+
+func TestQuestionBookmark_Success(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	question := &model.Question{UserID: 2}
+	question.ID = 10
+
+	repo.On("FindByID", uint(10)).Return(question, nil)
+	repo.On("HasBookmarked", uint(1), uint(10)).Return(false, nil)
+	repo.On("Bookmark", uint(1), uint(10)).Return(nil)
+
+	err := svc.Bookmark(1, 10)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionBookmark_AlreadyBookmarked(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	question := &model.Question{UserID: 2}
+	question.ID = 10
+
+	repo.On("FindByID", uint(10)).Return(question, nil)
+	repo.On("HasBookmarked", uint(1), uint(10)).Return(true, nil)
+
+	err := svc.Bookmark(1, 10)
+	assert.ErrorIs(t, err, ErrConflict)
+	repo.AssertNotCalled(t, "Bookmark")
+}
+
+func TestQuestionBookmark_QuestionNotFound(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.Bookmark(1, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertNotCalled(t, "Bookmark")
+}
+
+func TestQuestionBookmark_OwnQuestion(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	// 自分の質問もブックマーク可能（投票とは異なる）
+	question := &model.Question{UserID: 1}
+	question.ID = 10
+
+	repo.On("FindByID", uint(10)).Return(question, nil)
+	repo.On("HasBookmarked", uint(1), uint(10)).Return(false, nil)
+	repo.On("Bookmark", uint(1), uint(10)).Return(nil)
+
+	err := svc.Bookmark(1, 10)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionUnbookmark_Success(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("Unbookmark", uint(1), uint(10)).Return(nil)
+
+	err := svc.Unbookmark(1, 10)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionGetBookmarkedByUserID_Success(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	questions := []model.Question{
+		{Title: "ブックマーク質問1"},
+		{Title: "ブックマーク質問2"},
+	}
+	repo.On("FindBookmarkedByUserID", uint(1), 20, 0).Return(questions, int64(2), nil)
+
+	result, total, err := svc.GetBookmarkedByUserID(1, 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionGetBookmarkedByUserID_Empty(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindBookmarkedByUserID", uint(1), 20, 0).Return([]model.Question{}, int64(0), nil)
+
+	result, total, err := svc.GetBookmarkedByUserID(1, 20, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}

--- a/frontend/src/api/qa.ts
+++ b/frontend/src/api/qa.ts
@@ -78,3 +78,19 @@ export const voteAnswer = async (questionId: number, answerId: number, data: Vot
 export const removeAnswerVote = async (questionId: number, answerId: number): Promise<void> => {
   await client.delete(`/questions/${questionId}/answers/${answerId}/vote`);
 };
+
+// Bookmarks
+export const bookmarkQuestion = async (id: number): Promise<void> => {
+  await client.post(`/questions/${id}/bookmark`);
+};
+
+export const unbookmarkQuestion = async (id: number): Promise<void> => {
+  await client.delete(`/questions/${id}/bookmark`);
+};
+
+export const getBookmarkedQuestions = async (
+  limit = 20, offset = 0
+): Promise<{ questions: Question[]; total: number }> => {
+  const res = await client.get('/questions/bookmarks', { params: { limit, offset } });
+  return res.data;
+};

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1835,5 +1835,14 @@
     "unarchiveSuccess": "Archivierung erfolgreich aufgehoben",
     "noArchived": "Keine archivierten Projekte",
     "confirmArchive": "Möchten Sie dieses Projekt wirklich archivieren?"
+  },
+  "questionBookmark": {
+    "bookmark": "Lesezeichen",
+    "unbookmark": "Lesezeichen entfernen",
+    "bookmarked": "Mit Lesezeichen",
+    "bookmarkAdded": "Lesezeichen hinzugefügt",
+    "bookmarkRemoved": "Lesezeichen entfernt",
+    "bookmarkedQuestions": "Gemerkte Fragen",
+    "noBookmarks": "Keine gemerkten Fragen"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1836,5 +1836,14 @@
     "unarchiveSuccess": "Project unarchived successfully",
     "noArchived": "No archived projects",
     "confirmArchive": "Are you sure you want to archive this project?"
+  },
+  "questionBookmark": {
+    "bookmark": "Bookmark",
+    "unbookmark": "Remove Bookmark",
+    "bookmarked": "Bookmarked",
+    "bookmarkAdded": "Bookmark added",
+    "bookmarkRemoved": "Bookmark removed",
+    "bookmarkedQuestions": "Bookmarked Questions",
+    "noBookmarks": "No bookmarked questions"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1836,5 +1836,14 @@
     "unarchiveSuccess": "Proyecto desarchivado correctamente",
     "noArchived": "No hay proyectos archivados",
     "confirmArchive": "¿Estás seguro de que quieres archivar este proyecto?"
+  },
+  "questionBookmark": {
+    "bookmark": "Marcador",
+    "unbookmark": "Quitar marcador",
+    "bookmarked": "Marcado",
+    "bookmarkAdded": "Marcador añadido",
+    "bookmarkRemoved": "Marcador eliminado",
+    "bookmarkedQuestions": "Preguntas marcadas",
+    "noBookmarks": "No hay preguntas marcadas"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1836,5 +1836,14 @@
     "unarchiveSuccess": "Projet désarchivé avec succès",
     "noArchived": "Aucun projet archivé",
     "confirmArchive": "Voulez-vous vraiment archiver ce projet ?"
+  },
+  "questionBookmark": {
+    "bookmark": "Signet",
+    "unbookmark": "Retirer le signet",
+    "bookmarked": "Ajouté aux signets",
+    "bookmarkAdded": "Signet ajouté",
+    "bookmarkRemoved": "Signet retiré",
+    "bookmarkedQuestions": "Questions en signet",
+    "noBookmarks": "Aucune question en signet"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1738,5 +1738,14 @@
     "unarchiveSuccess": "アーカイブを解除しました",
     "noArchived": "アーカイブ済みプロジェクトはありません",
     "confirmArchive": "このプロジェクトをアーカイブしますか？"
+  },
+  "questionBookmark": {
+    "bookmark": "ブックマーク",
+    "unbookmark": "ブックマーク解除",
+    "bookmarked": "ブックマーク済み",
+    "bookmarkAdded": "ブックマークに追加しました",
+    "bookmarkRemoved": "ブックマークを解除しました",
+    "bookmarkedQuestions": "ブックマークした質問",
+    "noBookmarks": "ブックマークした質問はありません"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1838,5 +1838,14 @@
     "unarchiveSuccess": "아카이브를 해제했습니다",
     "noArchived": "아카이브된 프로젝트가 없습니다",
     "confirmArchive": "이 프로젝트를 아카이브하시겠습니까?"
+  },
+  "questionBookmark": {
+    "bookmark": "북마크",
+    "unbookmark": "북마크 해제",
+    "bookmarked": "북마크됨",
+    "bookmarkAdded": "북마크에 추가되었습니다",
+    "bookmarkRemoved": "북마크가 해제되었습니다",
+    "bookmarkedQuestions": "북마크한 질문",
+    "noBookmarks": "북마크한 질문이 없습니다"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1836,5 +1836,14 @@
     "unarchiveSuccess": "Projeto desarquivado com sucesso",
     "noArchived": "Nenhum projeto arquivado",
     "confirmArchive": "Tem certeza de que deseja arquivar este projeto?"
+  },
+  "questionBookmark": {
+    "bookmark": "Favoritar",
+    "unbookmark": "Remover favorito",
+    "bookmarked": "Favoritado",
+    "bookmarkAdded": "Adicionado aos favoritos",
+    "bookmarkRemoved": "Removido dos favoritos",
+    "bookmarkedQuestions": "Perguntas favoritadas",
+    "noBookmarks": "Nenhuma pergunta favoritada"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1835,5 +1835,14 @@
     "unarchiveSuccess": "Проект успешно разархивирован",
     "noArchived": "Нет архивированных проектов",
     "confirmArchive": "Вы уверены, что хотите архивировать этот проект?"
+  },
+  "questionBookmark": {
+    "bookmark": "Закладка",
+    "unbookmark": "Удалить закладку",
+    "bookmarked": "В закладках",
+    "bookmarkAdded": "Добавлено в закладки",
+    "bookmarkRemoved": "Удалено из закладок",
+    "bookmarkedQuestions": "Вопросы в закладках",
+    "noBookmarks": "Нет вопросов в закладках"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1836,5 +1836,14 @@
     "unarchiveSuccess": "已取消归档",
     "noArchived": "没有已归档的项目",
     "confirmArchive": "确定要归档此项目吗？"
+  },
+  "questionBookmark": {
+    "bookmark": "收藏",
+    "unbookmark": "取消收藏",
+    "bookmarked": "已收藏",
+    "bookmarkAdded": "已添加到收藏",
+    "bookmarkRemoved": "已取消收藏",
+    "bookmarkedQuestions": "收藏的问题",
+    "noBookmarks": "没有收藏的问题"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1838,5 +1838,14 @@
     "unarchiveSuccess": "已取消封存",
     "noArchived": "沒有已封存的專案",
     "confirmArchive": "確定要封存此專案嗎？"
+  },
+  "questionBookmark": {
+    "bookmark": "收藏",
+    "unbookmark": "取消收藏",
+    "bookmarked": "已收藏",
+    "bookmarkAdded": "已新增至收藏",
+    "bookmarkRemoved": "已取消收藏",
+    "bookmarkedQuestions": "收藏的問題",
+    "noBookmarks": "沒有收藏的問題"
   }
 }


### PR DESCRIPTION
## 概要
Q&A質問をブックマークして後から参照できる機能を実装しました。

## 変更内容
- **Model**: `QuestionBookmark`構造体を追加（ユニークインデックス付き）
- **Repository**: `Bookmark`, `Unbookmark`, `HasBookmarked`, `FindBookmarkedByUserID`メソッド追加
- **Service**: ブックマーク追加（重複チェック付き）/解除/一覧取得ロジック
- **Handler**: 3つのエンドポイント（POST/DELETE bookmark, GET bookmarks）
- **テスト**: 7つのService層ユニットテスト追加（全パス）
- **フロントエンド**: APIクライアント・i18n（10言語）対応

## テスト
- `go test ./internal/service/... -v` 全テストパス
- `npx tsc --noEmit` 型チェックパス

Closes #2085