### PR TITLE
feat: コードスニペットのお気に入り機能を追加 (#2087)

### DIFF
--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -17,6 +18,9 @@ type CodeSnippetHandlerServiceInterface interface {
 	CreateComment(comment *model.SnippetComment) error
 	DeleteComment(id, userID uint) error
 	Fork(userID, snippetID, targetPostID uint) (*model.CodeSnippet, error)
+	Favorite(userID, snippetID uint) error
+	Unfavorite(userID, snippetID uint) error
+	GetFavoritedByUserID(userID uint, limit, offset int) ([]model.CodeSnippet, int64, error)
 }
 
 // CodeSnippetHandler はコードスニペット関連のHTTPハンドラ。
@@ -202,4 +206,53 @@ func (h *CodeSnippetHandler) GetByUserLanguage(c *gin.Context) {
 		return
 	}
 	respondOK(c, ensureSlice(snippets))
+}
+
+// Favorite はスニペットをお気に入りに追加する。
+func (h *CodeSnippetHandler) Favorite(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.Favorite(userID, id); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, domain.NewMessageResponse("Favorited successfully"))
+}
+
+// Unfavorite はスニペットのお気に入りを解除する。
+func (h *CodeSnippetHandler) Unfavorite(c *gin.Context) {
+	userID := c.GetUint("userID")
+	id, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	if err := h.service.Unfavorite(userID, id); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, domain.NewMessageResponse("Favorite removed successfully"))
+}
+
+// GetFavorites はお気に入りスニペット一覧を取得する。
+func (h *CodeSnippetHandler) GetFavorites(c *gin.Context) {
+	userID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
+
+	snippets, total, err := h.service.GetFavoritedByUserID(userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{
+		"snippets": ensureSlice(snippets),
+		"total":    total,
+	})
 }

--- a/backend/internal/model/code_snippet.go
+++ b/backend/internal/model/code_snippet.go
@@ -19,6 +19,15 @@ type CodeSnippet struct {
 	UpdatedAt    time.Time `json:"updated_at"`
 }
 
+// CodeSnippetFavorite はコードスニペットのお気に入りを記録する。
+// ユーザーとスニペットの組み合わせでユニークインデックスを持つ。
+type CodeSnippetFavorite struct {
+	ID        uint      `json:"id" gorm:"primaryKey"`
+	UserID    uint      `json:"user_id" gorm:"not null;uniqueIndex:idx_snippet_favorite"`
+	SnippetID uint      `json:"snippet_id" gorm:"not null;uniqueIndex:idx_snippet_favorite"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
 // SnippetComment はコードスニペットの特定行へのインラインコメントを表す。
 // GitHub PRレビュー風の行単位フィードバックを提供する。
 type SnippetComment struct {

--- a/backend/internal/repository/code_snippet.go
+++ b/backend/internal/repository/code_snippet.go
@@ -91,3 +91,46 @@ func (r *CodeSnippetRepository) IncrementForkCount(id uint) error {
 	return r.db.Model(&model.CodeSnippet{}).Where("id = ?", id).
 		UpdateColumn("fork_count", gorm.Expr("fork_count + 1")).Error
 }
+
+// Favorite はスニペットをお気に入りに追加する。
+func (r *CodeSnippetRepository) Favorite(userID, snippetID uint) error {
+	fav := &model.CodeSnippetFavorite{
+		UserID:    userID,
+		SnippetID: snippetID,
+	}
+	return r.db.Create(fav).Error
+}
+
+// Unfavorite はスニペットのお気に入りを解除する。
+func (r *CodeSnippetRepository) Unfavorite(userID, snippetID uint) error {
+	return r.db.Where("user_id = ? AND snippet_id = ?", userID, snippetID).
+		Delete(&model.CodeSnippetFavorite{}).Error
+}
+
+// HasFavorited は指定ユーザーが指定スニペットをお気に入りしているかを返す。
+func (r *CodeSnippetRepository) HasFavorited(userID, snippetID uint) (bool, error) {
+	var count int64
+	err := r.db.Model(&model.CodeSnippetFavorite{}).
+		Where("user_id = ? AND snippet_id = ?", userID, snippetID).
+		Count(&count).Error
+	return count > 0, err
+}
+
+// FindFavoritedByUserID は指定ユーザーのお気に入りスニペットをページネーション付きで取得する。
+func (r *CodeSnippetRepository) FindFavoritedByUserID(userID uint, limit, offset int) ([]model.CodeSnippet, int64, error) {
+	var snippets []model.CodeSnippet
+	var total int64
+
+	subQuery := r.db.Model(&model.CodeSnippetFavorite{}).
+		Select("snippet_id").
+		Where("user_id = ?", userID)
+
+	query := r.db.Model(&model.CodeSnippet{}).Where("id IN (?)", subQuery)
+	query.Count(&total)
+
+	err := query.Order("created_at DESC").
+		Limit(limit).Offset(offset).
+		Find(&snippets).Error
+
+	return snippets, total, err
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -320,6 +320,10 @@ type CodeSnippetRepositoryInterface interface {
 	GetComments(snippetID uint) ([]model.SnippetComment, error)
 	DeleteComment(id, userID uint) error
 	IncrementForkCount(id uint) error
+	Favorite(userID, snippetID uint) error
+	Unfavorite(userID, snippetID uint) error
+	HasFavorited(userID, snippetID uint) (bool, error)
+	FindFavoritedByUserID(userID uint, limit, offset int) ([]model.CodeSnippet, int64, error)
 }
 
 // GitHubRepositoryInterface はGitHub連携データ操作の契約を定義する。

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -284,6 +284,9 @@ func registerSnippetRoutes(g *gin.RouterGroup, c *di.Container) {
 		snippets.DELETE("/:id/comments/:commentId", c.CodeSnippetHandler.DeleteComment)
 		snippets.GET("/language/:language", c.CodeSnippetHandler.GetByUserLanguage)
 		snippets.POST("/:id/fork", c.CodeSnippetHandler.Fork)
+		snippets.POST("/:id/favorite", c.CodeSnippetHandler.Favorite)
+		snippets.DELETE("/:id/favorite", c.CodeSnippetHandler.Unfavorite)
+		snippets.GET("/favorites", c.CodeSnippetHandler.GetFavorites)
 	}
 }
 

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -166,3 +166,29 @@ func (s *CodeSnippetService) Fork(userID, snippetID, targetPostID uint) (*model.
 
 	return forked, nil
 }
+
+// Favorite はスニペットをお気に入りに追加する。
+// 既にお気に入り済みの場合はErrConflictを返す。
+func (s *CodeSnippetService) Favorite(userID, snippetID uint) error {
+	if _, err := s.repo.FindByID(snippetID); err != nil {
+		return ErrNotFound
+	}
+	has, err := s.repo.HasFavorited(userID, snippetID)
+	if err != nil {
+		return err
+	}
+	if has {
+		return ErrConflict
+	}
+	return s.repo.Favorite(userID, snippetID)
+}
+
+// Unfavorite はスニペットのお気に入りを解除する。
+func (s *CodeSnippetService) Unfavorite(userID, snippetID uint) error {
+	return s.repo.Unfavorite(userID, snippetID)
+}
+
+// GetFavoritedByUserID はお気に入りスニペット一覧を取得する。
+func (s *CodeSnippetService) GetFavoritedByUserID(userID uint, limit, offset int) ([]model.CodeSnippet, int64, error) {
+	return s.repo.FindFavoritedByUserID(userID, limit, offset)
+}

--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -617,3 +617,98 @@ func TestSnippetFork_CreateError(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "フォークに失敗")
 }
+
+// ---------- お気に入りテスト ----------
+
+func TestSnippetFavorite_Success(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippet := &model.CodeSnippet{UserID: 2}
+	snippet.ID = 10
+
+	snippetRepo.On("FindByID", uint(10)).Return(snippet, nil)
+	snippetRepo.On("HasFavorited", uint(1), uint(10)).Return(false, nil)
+	snippetRepo.On("Favorite", uint(1), uint(10)).Return(nil)
+
+	err := svc.Favorite(1, 10)
+	assert.NoError(t, err)
+	snippetRepo.AssertExpectations(t)
+}
+
+func TestSnippetFavorite_AlreadyFavorited(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippet := &model.CodeSnippet{UserID: 2}
+	snippet.ID = 10
+
+	snippetRepo.On("FindByID", uint(10)).Return(snippet, nil)
+	snippetRepo.On("HasFavorited", uint(1), uint(10)).Return(true, nil)
+
+	err := svc.Favorite(1, 10)
+	assert.ErrorIs(t, err, ErrConflict)
+	snippetRepo.AssertNotCalled(t, "Favorite")
+}
+
+func TestSnippetFavorite_SnippetNotFound(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippetRepo.On("FindByID", uint(99)).Return(nil, gorm.ErrRecordNotFound)
+
+	err := svc.Favorite(1, 99)
+	assert.ErrorIs(t, err, ErrNotFound)
+	snippetRepo.AssertNotCalled(t, "Favorite")
+}
+
+func TestSnippetFavorite_OwnSnippet(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	// 自分のスニペットもお気に入り可能
+	snippet := &model.CodeSnippet{UserID: 1}
+	snippet.ID = 10
+
+	snippetRepo.On("FindByID", uint(10)).Return(snippet, nil)
+	snippetRepo.On("HasFavorited", uint(1), uint(10)).Return(false, nil)
+	snippetRepo.On("Favorite", uint(1), uint(10)).Return(nil)
+
+	err := svc.Favorite(1, 10)
+	assert.NoError(t, err)
+	snippetRepo.AssertExpectations(t)
+}
+
+func TestSnippetUnfavorite_Success(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippetRepo.On("Unfavorite", uint(1), uint(10)).Return(nil)
+
+	err := svc.Unfavorite(1, 10)
+	assert.NoError(t, err)
+	snippetRepo.AssertExpectations(t)
+}
+
+func TestSnippetGetFavoritedByUserID_Success(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippets := []model.CodeSnippet{
+		{Language: "Go", Code: "package main"},
+		{Language: "Python", Code: "print('hello')"},
+	}
+	snippetRepo.On("FindFavoritedByUserID", uint(1), 20, 0).Return(snippets, int64(2), nil)
+
+	result, total, err := svc.GetFavoritedByUserID(1, 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	snippetRepo.AssertExpectations(t)
+}
+
+func TestSnippetGetFavoritedByUserID_Empty(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippetRepo.On("FindFavoritedByUserID", uint(1), 20, 0).Return([]model.CodeSnippet{}, int64(0), nil)
+
+	result, total, err := svc.GetFavoritedByUserID(1, 20, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	snippetRepo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1130,6 +1130,26 @@ func (m *MockCodeSnippetRepository) IncrementForkCount(id uint) error {
 	return m.Called(id).Error(0)
 }
 
+func (m *MockCodeSnippetRepository) Favorite(userID, snippetID uint) error {
+	args := m.Called(userID, snippetID)
+	return args.Error(0)
+}
+
+func (m *MockCodeSnippetRepository) Unfavorite(userID, snippetID uint) error {
+	args := m.Called(userID, snippetID)
+	return args.Error(0)
+}
+
+func (m *MockCodeSnippetRepository) HasFavorited(userID, snippetID uint) (bool, error) {
+	args := m.Called(userID, snippetID)
+	return args.Bool(0), args.Error(1)
+}
+
+func (m *MockCodeSnippetRepository) FindFavoritedByUserID(userID uint, limit, offset int) ([]model.CodeSnippet, int64, error) {
+	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.CodeSnippet), args.Get(1).(int64), args.Error(2)
+}
+
 // ============================================================
 // インターフェース適合チェック（コンパイル時検証）
 // ============================================================

--- a/frontend/src/api/snippets.ts
+++ b/frontend/src/api/snippets.ts
@@ -24,3 +24,13 @@ export const deleteSnippetComment = (snippetId: number, commentId: number) =>
 
 export const forkSnippet = (snippetId: number, targetPostId: number) =>
   client.post<CodeSnippet>(`/snippets/${snippetId}/fork`, { target_post_id: targetPostId });
+
+// Favorites
+export const favoriteSnippet = (id: number) =>
+  client.post(`/snippets/${id}/favorite`);
+
+export const unfavoriteSnippet = (id: number) =>
+  client.delete(`/snippets/${id}/favorite`);
+
+export const getFavoritedSnippets = (limit = 20, offset = 0) =>
+  client.get<{ snippets: CodeSnippet[]; total: number }>('/snippets/favorites', { params: { limit, offset } });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1844,5 +1844,14 @@
     "bookmarkRemoved": "Lesezeichen entfernt",
     "bookmarkedQuestions": "Gemerkte Fragen",
     "noBookmarks": "Keine gemerkten Fragen"
+  },
+  "snippetFavorite": {
+    "favorite": "Favorit",
+    "unfavorite": "Favorit entfernen",
+    "favorited": "Favorisiert",
+    "favoriteAdded": "Zu Favoriten hinzugefügt",
+    "favoriteRemoved": "Aus Favoriten entfernt",
+    "favoritedSnippets": "Favorisierte Snippets",
+    "noFavorites": "Keine favorisierten Snippets"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1845,5 +1845,14 @@
     "bookmarkRemoved": "Bookmark removed",
     "bookmarkedQuestions": "Bookmarked Questions",
     "noBookmarks": "No bookmarked questions"
+  },
+  "snippetFavorite": {
+    "favorite": "Favorite",
+    "unfavorite": "Remove Favorite",
+    "favorited": "Favorited",
+    "favoriteAdded": "Added to favorites",
+    "favoriteRemoved": "Removed from favorites",
+    "favoritedSnippets": "Favorite Snippets",
+    "noFavorites": "No favorite snippets"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1845,5 +1845,14 @@
     "bookmarkRemoved": "Marcador eliminado",
     "bookmarkedQuestions": "Preguntas marcadas",
     "noBookmarks": "No hay preguntas marcadas"
+  },
+  "snippetFavorite": {
+    "favorite": "Favorito",
+    "unfavorite": "Quitar favorito",
+    "favorited": "Favorito",
+    "favoriteAdded": "Añadido a favoritos",
+    "favoriteRemoved": "Eliminado de favoritos",
+    "favoritedSnippets": "Fragmentos favoritos",
+    "noFavorites": "No hay fragmentos favoritos"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1845,5 +1845,14 @@
     "bookmarkRemoved": "Signet retiré",
     "bookmarkedQuestions": "Questions en signet",
     "noBookmarks": "Aucune question en signet"
+  },
+  "snippetFavorite": {
+    "favorite": "Favori",
+    "unfavorite": "Retirer des favoris",
+    "favorited": "En favoris",
+    "favoriteAdded": "Ajouté aux favoris",
+    "favoriteRemoved": "Retiré des favoris",
+    "favoritedSnippets": "Extraits favoris",
+    "noFavorites": "Aucun extrait favori"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1747,5 +1747,14 @@
     "bookmarkRemoved": "ブックマークを解除しました",
     "bookmarkedQuestions": "ブックマークした質問",
     "noBookmarks": "ブックマークした質問はありません"
+  },
+  "snippetFavorite": {
+    "favorite": "お気に入り",
+    "unfavorite": "お気に入り解除",
+    "favorited": "お気に入り済み",
+    "favoriteAdded": "お気に入りに追加しました",
+    "favoriteRemoved": "お気に入りを解除しました",
+    "favoritedSnippets": "お気に入りスニペット",
+    "noFavorites": "お気に入りスニペットはありません"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1847,5 +1847,14 @@
     "bookmarkRemoved": "북마크가 해제되었습니다",
     "bookmarkedQuestions": "북마크한 질문",
     "noBookmarks": "북마크한 질문이 없습니다"
+  },
+  "snippetFavorite": {
+    "favorite": "즐겨찾기",
+    "unfavorite": "즐겨찾기 해제",
+    "favorited": "즐겨찾기됨",
+    "favoriteAdded": "즐겨찾기에 추가되었습니다",
+    "favoriteRemoved": "즐겨찾기가 해제되었습니다",
+    "favoritedSnippets": "즐겨찾기 스니펫",
+    "noFavorites": "즐겨찾기 스니펫이 없습니다"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1845,5 +1845,14 @@
     "bookmarkRemoved": "Removido dos favoritos",
     "bookmarkedQuestions": "Perguntas favoritadas",
     "noBookmarks": "Nenhuma pergunta favoritada"
+  },
+  "snippetFavorite": {
+    "favorite": "Favorito",
+    "unfavorite": "Remover favorito",
+    "favorited": "Favoritado",
+    "favoriteAdded": "Adicionado aos favoritos",
+    "favoriteRemoved": "Removido dos favoritos",
+    "favoritedSnippets": "Snippets favoritos",
+    "noFavorites": "Nenhum snippet favorito"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1844,5 +1844,14 @@
     "bookmarkRemoved": "Удалено из закладок",
     "bookmarkedQuestions": "Вопросы в закладках",
     "noBookmarks": "Нет вопросов в закладках"
+  },
+  "snippetFavorite": {
+    "favorite": "Избранное",
+    "unfavorite": "Удалить из избранного",
+    "favorited": "В избранном",
+    "favoriteAdded": "Добавлено в избранное",
+    "favoriteRemoved": "Удалено из избранного",
+    "favoritedSnippets": "Избранные сниппеты",
+    "noFavorites": "Нет избранных сниппетов"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1845,5 +1845,14 @@
     "bookmarkRemoved": "已取消收藏",
     "bookmarkedQuestions": "收藏的问题",
     "noBookmarks": "没有收藏的问题"
+  },
+  "snippetFavorite": {
+    "favorite": "收藏",
+    "unfavorite": "取消收藏",
+    "favorited": "已收藏",
+    "favoriteAdded": "已添加到收藏",
+    "favoriteRemoved": "已取消收藏",
+    "favoritedSnippets": "收藏的代码片段",
+    "noFavorites": "没有收藏的代码片段"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1847,5 +1847,14 @@
     "bookmarkRemoved": "已取消收藏",
     "bookmarkedQuestions": "收藏的問題",
     "noBookmarks": "沒有收藏的問題"
+  },
+  "snippetFavorite": {
+    "favorite": "收藏",
+    "unfavorite": "取消收藏",
+    "favorited": "已收藏",
+    "favoriteAdded": "已新增至收藏",
+    "favoriteRemoved": "已取消收藏",
+    "favoritedSnippets": "收藏的程式碼片段",
+    "noFavorites": "沒有收藏的程式碼片段"
   }
 }


### PR DESCRIPTION
## 概要
コードスニペットにお気に入り（スター）機能を実装しました。

## 変更内容
- **Model**: `CodeSnippetFavorite`構造体を追加（ユニークインデックス付き）
- **Repository**: `Favorite`, `Unfavorite`, `HasFavorited`, `FindFavoritedByUserID`メソッド追加
- **Service**: お気に入り追加（重複チェック付き）/解除/一覧取得ロジック
- **Handler**: 3つのエンドポイント（POST/DELETE favorite, GET favorites）
- **テスト**: 7つのService層ユニットテスト追加（全パス）
- **フロントエンド**: APIクライアント・i18n（10言語）対応

## テスト
- `go test ./internal/service/... -v` 全テストパス
- `npx tsc --noEmit` 型チェックパス

Closes #2087