### PR TITLE
feat: 学習リソースのレビュー機能を追加

### DIFF
--- a/backend/internal/di/container.go
+++ b/backend/internal/di/container.go
@@ -91,6 +91,7 @@ type Container struct {
 	ProjectMilestoneHandler      *handler.ProjectMilestoneHandler
 	UserActivityHandler          *handler.UserActivityHandler
 	LearningLogTemplateHandler   *handler.LearningLogTemplateHandler
+	ResourceReviewHandler        *handler.ResourceReviewHandler
 
 	// ミドルウェア・コールバック用
 	AuthService      *service.AuthService
@@ -423,6 +424,11 @@ func NewContainer(db *gorm.DB, cfg *config.Config, hub *service.Hub) *Container 
 	userActivityRepo := repository.NewUserActivityRepository(db)
 	userActivityService := service.NewUserActivityService(userActivityRepo)
 	c.UserActivityHandler = handler.NewUserActivityHandler(userActivityService)
+
+	// リソースレビューサービス
+	resourceReviewRepo := repository.NewResourceReviewRepository(db)
+	resourceReviewService := service.NewResourceReviewService(resourceReviewRepo, learningResourceRepo)
+	c.ResourceReviewHandler = handler.NewResourceReviewHandler(resourceReviewService)
 
 	// HubのGetRoomMembersコールバックを設定
 	hub.GetRoomMembers = groupMessageRepo.GetMemberUserIDs

--- a/backend/internal/handler/resource_review.go
+++ b/backend/internal/handler/resource_review.go
@@ -1,0 +1,119 @@
+package handler
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/model"
+)
+
+// ResourceReviewServiceInterface はResourceReviewHandlerが依存するサービスのインターフェース。
+type ResourceReviewServiceInterface interface {
+	Create(review *model.ResourceReview) error
+	GetByResourceID(resourceID uint, limit, offset int) ([]model.ResourceReview, int64, error)
+	Update(id, userID uint, rating int, comment string) (*model.ResourceReview, error)
+	Delete(id, userID uint) error
+}
+
+// ResourceReviewHandler は学習リソースレビュー関連のHTTPハンドラ。
+type ResourceReviewHandler struct {
+	service ResourceReviewServiceInterface
+}
+
+// NewResourceReviewHandler は新しいResourceReviewHandlerインスタンスを生成する。
+func NewResourceReviewHandler(s ResourceReviewServiceInterface) *ResourceReviewHandler {
+	return &ResourceReviewHandler{service: s}
+}
+
+// Create は新しいレビューを作成する。
+func (h *ResourceReviewHandler) Create(c *gin.Context) {
+	userID := c.GetUint("userID")
+	resourceID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Rating  int    `json:"rating" binding:"required"`
+		Comment string `json:"comment"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondBadRequest(c, "リクエストが不正です")
+		return
+	}
+
+	review := &model.ResourceReview{
+		UserID:     userID,
+		ResourceID: resourceID,
+		Rating:     req.Rating,
+		Comment:    req.Comment,
+	}
+
+	if err := h.service.Create(review); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondCreated(c, review)
+}
+
+// GetByResourceID は指定リソースのレビュー一覧を取得する。
+func (h *ResourceReviewHandler) GetByResourceID(c *gin.Context) {
+	resourceID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	limit, offset := parseLimitOffset(c)
+
+	reviews, total, err := h.service.GetByResourceID(resourceID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{
+		"reviews": ensureSlice(reviews),
+		"total":   total,
+	})
+}
+
+// Update はレビューを更新する。
+func (h *ResourceReviewHandler) Update(c *gin.Context) {
+	userID := c.GetUint("userID")
+	reviewID, ok := parseID(c, "reviewId")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Rating  int    `json:"rating"`
+		Comment string `json:"comment"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondBadRequest(c, "リクエストが不正です")
+		return
+	}
+
+	review, err := h.service.Update(reviewID, userID, req.Rating, req.Comment)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, review)
+}
+
+// Delete はレビューを削除する。
+func (h *ResourceReviewHandler) Delete(c *gin.Context) {
+	userID := c.GetUint("userID")
+	reviewID, ok := parseID(c, "reviewId")
+	if !ok {
+		return
+	}
+
+	if err := h.service.Delete(reviewID, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondDeleted(c)
+}

--- a/backend/internal/model/learning_resource.go
+++ b/backend/internal/model/learning_resource.go
@@ -67,3 +67,16 @@ type ResourceSave struct {
 	ResourceID uint      `json:"resource_id" gorm:"not null;uniqueIndex:idx_resource_save"`
 	CreatedAt  time.Time `json:"created_at"`
 }
+
+// ResourceReview は学習リソースへのレビュー（評価＋コメント）を記録する。
+// ユーザーとリソースの組み合わせでユニーク（1リソースにつき1レビュー）。
+type ResourceReview struct {
+	ID         uint      `json:"id" gorm:"primaryKey"`
+	UserID     uint      `json:"user_id" gorm:"not null;uniqueIndex:idx_resource_review"`
+	User       User      `json:"user,omitempty" gorm:"foreignKey:UserID"`
+	ResourceID uint      `json:"resource_id" gorm:"not null;uniqueIndex:idx_resource_review;index"`
+	Rating     int       `json:"rating" gorm:"not null"`       // 1-5の評価
+	Comment    string    `json:"comment" gorm:"type:text"`     // レビューコメント
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -243,6 +243,16 @@ type LearningResourceRepositoryInterface interface {
 	FindByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error)
 }
 
+// ResourceReviewRepositoryInterface は学習リソースレビューデータ操作の契約を定義する。
+type ResourceReviewRepositoryInterface interface {
+	Create(review *model.ResourceReview) error
+	FindByID(id uint) (*model.ResourceReview, error)
+	FindByResourceID(resourceID uint, limit, offset int) ([]model.ResourceReview, int64, error)
+	FindByUserAndResource(userID, resourceID uint) (*model.ResourceReview, error)
+	Update(review *model.ResourceReview) error
+	Delete(id uint) error
+}
+
 // ProjectMilestoneRepositoryInterface はプロジェクトマイルストーンデータ操作の契約を定義する。
 type ProjectMilestoneRepositoryInterface interface {
 	Create(milestone *model.ProjectMilestone) error

--- a/backend/internal/repository/resource_review.go
+++ b/backend/internal/repository/resource_review.go
@@ -1,0 +1,67 @@
+package repository
+
+import (
+	"github.com/norman6464/devsync/backend/internal/model"
+	"gorm.io/gorm"
+)
+
+// ResourceReviewRepository は学習リソースレビューのデータアクセス層。
+type ResourceReviewRepository struct {
+	db *gorm.DB
+}
+
+// NewResourceReviewRepository は新しいResourceReviewRepositoryインスタンスを生成する。
+func NewResourceReviewRepository(db *gorm.DB) *ResourceReviewRepository {
+	return &ResourceReviewRepository{db: db}
+}
+
+// Create は新しいレビューを作成する。
+func (r *ResourceReviewRepository) Create(review *model.ResourceReview) error {
+	return r.db.Create(review).Error
+}
+
+// FindByID は指定IDのレビューをユーザー情報付きで取得する。
+func (r *ResourceReviewRepository) FindByID(id uint) (*model.ResourceReview, error) {
+	var review model.ResourceReview
+	err := r.db.Preload("User").First(&review, id).Error
+	if err != nil {
+		return nil, err
+	}
+	return &review, nil
+}
+
+// FindByResourceID は指定リソースのレビュー一覧をページネーション付きで取得する。
+func (r *ResourceReviewRepository) FindByResourceID(resourceID uint, limit, offset int) ([]model.ResourceReview, int64, error) {
+	var reviews []model.ResourceReview
+	var total int64
+
+	query := r.db.Model(&model.ResourceReview{}).Where("resource_id = ?", resourceID)
+	query.Count(&total)
+
+	err := query.Preload("User").
+		Order("created_at DESC").
+		Limit(limit).Offset(offset).
+		Find(&reviews).Error
+
+	return reviews, total, err
+}
+
+// FindByUserAndResource は指定ユーザーの指定リソースへのレビューを取得する。
+func (r *ResourceReviewRepository) FindByUserAndResource(userID, resourceID uint) (*model.ResourceReview, error) {
+	var review model.ResourceReview
+	err := r.db.Where("user_id = ? AND resource_id = ?", userID, resourceID).First(&review).Error
+	if err != nil {
+		return nil, err
+	}
+	return &review, nil
+}
+
+// Update はレビューを更新する。
+func (r *ResourceReviewRepository) Update(review *model.ResourceReview) error {
+	return r.db.Save(review).Error
+}
+
+// Delete はレビューを削除する。
+func (r *ResourceReviewRepository) Delete(id uint) error {
+	return r.db.Delete(&model.ResourceReview{}, id).Error
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -449,6 +449,12 @@ func registerResourceRoutes(g *gin.RouterGroup, c *di.Container) {
 		resources.PUT("/progress", c.ResourceProgressHandler.Upsert)
 		resources.GET("/progress", c.ResourceProgressHandler.GetMyProgress)
 		resources.GET("/:resourceId/progress", c.ResourceProgressHandler.GetByResource)
+
+		// リソースレビュー
+		resources.POST("/:id/reviews", c.ResourceReviewHandler.Create)
+		resources.GET("/:id/reviews", c.ResourceReviewHandler.GetByResourceID)
+		resources.PUT("/reviews/:reviewId", c.ResourceReviewHandler.Update)
+		resources.DELETE("/reviews/:reviewId", c.ResourceReviewHandler.Delete)
 	}
 }
 

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -857,6 +857,50 @@ func (m *MockLearningResourceRepository) FindByDifficulty(difficulty string, lim
 }
 
 // ============================================================
+// MockResourceReviewRepository は repository.ResourceReviewRepositoryInterface のテスト用モック実装。
+// ============================================================
+
+type MockResourceReviewRepository struct {
+	mock.Mock
+}
+
+func (m *MockResourceReviewRepository) Create(review *model.ResourceReview) error {
+	args := m.Called(review)
+	return args.Error(0)
+}
+
+func (m *MockResourceReviewRepository) FindByID(id uint) (*model.ResourceReview, error) {
+	args := m.Called(id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.ResourceReview), args.Error(1)
+}
+
+func (m *MockResourceReviewRepository) FindByResourceID(resourceID uint, limit, offset int) ([]model.ResourceReview, int64, error) {
+	args := m.Called(resourceID, limit, offset)
+	return args.Get(0).([]model.ResourceReview), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockResourceReviewRepository) FindByUserAndResource(userID, resourceID uint) (*model.ResourceReview, error) {
+	args := m.Called(userID, resourceID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.ResourceReview), args.Error(1)
+}
+
+func (m *MockResourceReviewRepository) Update(review *model.ResourceReview) error {
+	args := m.Called(review)
+	return args.Error(0)
+}
+
+func (m *MockResourceReviewRepository) Delete(id uint) error {
+	args := m.Called(id)
+	return args.Error(0)
+}
+
+// ============================================================
 // MockPasswordResetRepository は repository.PasswordResetRepositoryInterface のテスト用モック実装。
 // ============================================================
 
@@ -1176,6 +1220,7 @@ var _ repository.AIAdviceRepositoryInterface = (*MockAIAdviceRepository)(nil)
 var _ repository.WeeklyChallengeRepositoryInterface = (*MockWeeklyChallengeRepository)(nil)
 var _ repository.PostTemplateRepositoryInterface = (*MockPostTemplateRepository)(nil)
 var _ repository.WeeklyGoalRepositoryInterface = (*MockWeeklyGoalRepository)(nil)
+var _ repository.ResourceReviewRepositoryInterface = (*MockResourceReviewRepository)(nil)
 
 // ============================================================
 // MockWeeklyGoalRepository は repository.WeeklyGoalRepositoryInterface のテスト用モック実装。

--- a/backend/internal/service/resource_review.go
+++ b/backend/internal/service/resource_review.go
@@ -1,0 +1,94 @@
+package service
+
+import (
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/norman6464/devsync/backend/internal/repository"
+)
+
+// ResourceReviewService は学習リソースレビューのビジネスロジックを提供する。
+type ResourceReviewService struct {
+	repo         repository.ResourceReviewRepositoryInterface
+	resourceRepo repository.LearningResourceRepositoryInterface
+}
+
+// NewResourceReviewService は新しいResourceReviewServiceインスタンスを生成する。
+func NewResourceReviewService(
+	repo repository.ResourceReviewRepositoryInterface,
+	resourceRepo repository.LearningResourceRepositoryInterface,
+) *ResourceReviewService {
+	return &ResourceReviewService{repo: repo, resourceRepo: resourceRepo}
+}
+
+// Create は新しいレビューを作成する。
+// リソースの存在確認、評価値バリデーション、重複チェックを行う。
+func (s *ResourceReviewService) Create(review *model.ResourceReview) error {
+	// リソースの存在確認
+	if _, err := s.resourceRepo.FindByID(review.ResourceID); err != nil {
+		return ErrNotFound
+	}
+
+	// 評価値バリデーション（1-5）
+	if review.Rating < 1 || review.Rating > 5 {
+		return domain.NewError(domain.ErrCodeValidation, "評価は1〜5の範囲で指定してください", nil)
+	}
+
+	// コメントバリデーション
+	if len(review.Comment) > 5000 {
+		return domain.NewError(domain.ErrCodeValidation, "コメントは5000文字以下で入力してください", nil)
+	}
+
+	// 重複チェック
+	existing, _ := s.repo.FindByUserAndResource(review.UserID, review.ResourceID)
+	if existing != nil {
+		return ErrConflict
+	}
+
+	return s.repo.Create(review)
+}
+
+// GetByResourceID は指定リソースのレビュー一覧を取得する。
+func (s *ResourceReviewService) GetByResourceID(resourceID uint, limit, offset int) ([]model.ResourceReview, int64, error) {
+	return s.repo.FindByResourceID(resourceID, limit, offset)
+}
+
+// Update はレビューを更新する。所有者のみ更新可能。
+func (s *ResourceReviewService) Update(id, userID uint, rating int, comment string) (*model.ResourceReview, error) {
+	review, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, ErrNotFound
+	}
+	if review.UserID != userID {
+		return nil, ErrForbidden
+	}
+
+	if rating != 0 {
+		if rating < 1 || rating > 5 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "評価は1〜5の範囲で指定してください", nil)
+		}
+		review.Rating = rating
+	}
+	if comment != "" {
+		if len(comment) > 5000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "コメントは5000文字以下で入力してください", nil)
+		}
+		review.Comment = comment
+	}
+
+	if err := s.repo.Update(review); err != nil {
+		return nil, err
+	}
+	return review, nil
+}
+
+// Delete はレビューを削除する。所有者のみ削除可能。
+func (s *ResourceReviewService) Delete(id, userID uint) error {
+	review, err := s.repo.FindByID(id)
+	if err != nil {
+		return ErrNotFound
+	}
+	if review.UserID != userID {
+		return ErrForbidden
+	}
+	return s.repo.Delete(id)
+}

--- a/backend/internal/service/resource_review_test.go
+++ b/backend/internal/service/resource_review_test.go
@@ -1,0 +1,240 @@
+package service
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+// newTestResourceReviewService はResourceReviewServiceのテスト用インスタンスを生成するヘルパー。
+func newTestResourceReviewService() (*ResourceReviewService, *MockResourceReviewRepository, *MockLearningResourceRepository) {
+	reviewRepo := new(MockResourceReviewRepository)
+	resourceRepo := new(MockLearningResourceRepository)
+	svc := NewResourceReviewService(reviewRepo, resourceRepo)
+	return svc, reviewRepo, resourceRepo
+}
+
+// ============================================================
+// レビュー作成テスト
+// ============================================================
+
+func TestResourceReviewCreate_Success(t *testing.T) {
+	svc, reviewRepo, resourceRepo := newTestResourceReviewService()
+
+	resource := &model.LearningResource{UserID: 2}
+	resource.ID = 10
+
+	resourceRepo.On("FindByID", uint(10)).Return(resource, nil)
+	reviewRepo.On("FindByUserAndResource", uint(1), uint(10)).Return(nil, errors.New("not found"))
+	reviewRepo.On("Create", mock.AnythingOfType("*model.ResourceReview")).Return(nil)
+
+	review := &model.ResourceReview{
+		UserID:     1,
+		ResourceID: 10,
+		Rating:     4,
+		Comment:    "とても良いリソースです",
+	}
+
+	err := svc.Create(review)
+	assert.NoError(t, err)
+	reviewRepo.AssertExpectations(t)
+}
+
+func TestResourceReviewCreate_ResourceNotFound(t *testing.T) {
+	svc, _, resourceRepo := newTestResourceReviewService()
+
+	resourceRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	review := &model.ResourceReview{
+		UserID:     1,
+		ResourceID: 99,
+		Rating:     4,
+	}
+
+	err := svc.Create(review)
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestResourceReviewCreate_InvalidRating_TooLow(t *testing.T) {
+	svc, _, resourceRepo := newTestResourceReviewService()
+
+	resource := &model.LearningResource{UserID: 2}
+	resource.ID = 10
+	resourceRepo.On("FindByID", uint(10)).Return(resource, nil)
+
+	review := &model.ResourceReview{
+		UserID:     1,
+		ResourceID: 10,
+		Rating:     0,
+	}
+
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "1〜5")
+}
+
+func TestResourceReviewCreate_InvalidRating_TooHigh(t *testing.T) {
+	svc, _, resourceRepo := newTestResourceReviewService()
+
+	resource := &model.LearningResource{UserID: 2}
+	resource.ID = 10
+	resourceRepo.On("FindByID", uint(10)).Return(resource, nil)
+
+	review := &model.ResourceReview{
+		UserID:     1,
+		ResourceID: 10,
+		Rating:     6,
+	}
+
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "1〜5")
+}
+
+func TestResourceReviewCreate_Duplicate(t *testing.T) {
+	svc, reviewRepo, resourceRepo := newTestResourceReviewService()
+
+	resource := &model.LearningResource{UserID: 2}
+	resource.ID = 10
+
+	resourceRepo.On("FindByID", uint(10)).Return(resource, nil)
+	existing := &model.ResourceReview{UserID: 1, ResourceID: 10, Rating: 3}
+	reviewRepo.On("FindByUserAndResource", uint(1), uint(10)).Return(existing, nil)
+
+	review := &model.ResourceReview{
+		UserID:     1,
+		ResourceID: 10,
+		Rating:     4,
+	}
+
+	err := svc.Create(review)
+	assert.ErrorIs(t, err, ErrConflict)
+}
+
+// ============================================================
+// レビュー取得テスト
+// ============================================================
+
+func TestResourceReviewGetByResourceID_Success(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	reviews := []model.ResourceReview{
+		{Rating: 5, Comment: "素晴らしい"},
+		{Rating: 3, Comment: "普通"},
+	}
+	reviewRepo.On("FindByResourceID", uint(10), 20, 0).Return(reviews, int64(2), nil)
+
+	result, total, err := svc.GetByResourceID(10, 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	reviewRepo.AssertExpectations(t)
+}
+
+func TestResourceReviewGetByResourceID_Empty(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	reviewRepo.On("FindByResourceID", uint(10), 20, 0).Return([]model.ResourceReview{}, int64(0), nil)
+
+	result, total, err := svc.GetByResourceID(10, 20, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	reviewRepo.AssertExpectations(t)
+}
+
+// ============================================================
+// レビュー更新テスト
+// ============================================================
+
+func TestResourceReviewUpdate_Success(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	existing := &model.ResourceReview{UserID: 1, ResourceID: 10, Rating: 3, Comment: "普通"}
+	existing.ID = 1
+
+	reviewRepo.On("FindByID", uint(1)).Return(existing, nil)
+	reviewRepo.On("Update", existing).Return(nil)
+
+	result, err := svc.Update(1, 1, 5, "最高でした")
+	assert.NoError(t, err)
+	assert.Equal(t, 5, result.Rating)
+	assert.Equal(t, "最高でした", result.Comment)
+	reviewRepo.AssertExpectations(t)
+}
+
+func TestResourceReviewUpdate_Forbidden(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	existing := &model.ResourceReview{UserID: 1}
+	existing.ID = 1
+
+	reviewRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.Update(1, 999, 5, "")
+	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+func TestResourceReviewUpdate_NotFound(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	reviewRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	_, err := svc.Update(99, 1, 5, "")
+	assert.ErrorIs(t, err, ErrNotFound)
+}
+
+func TestResourceReviewUpdate_InvalidRating(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	existing := &model.ResourceReview{UserID: 1, Rating: 3}
+	existing.ID = 1
+
+	reviewRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.Update(1, 1, 6, "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "1〜5")
+}
+
+// ============================================================
+// レビュー削除テスト
+// ============================================================
+
+func TestResourceReviewDelete_Success(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	existing := &model.ResourceReview{UserID: 1}
+	existing.ID = 1
+
+	reviewRepo.On("FindByID", uint(1)).Return(existing, nil)
+	reviewRepo.On("Delete", uint(1)).Return(nil)
+
+	err := svc.Delete(1, 1)
+	assert.NoError(t, err)
+	reviewRepo.AssertExpectations(t)
+}
+
+func TestResourceReviewDelete_Forbidden(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	existing := &model.ResourceReview{UserID: 1}
+	existing.ID = 1
+
+	reviewRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	err := svc.Delete(1, 999)
+	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+func TestResourceReviewDelete_NotFound(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	reviewRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+
+	err := svc.Delete(99, 1)
+	assert.ErrorIs(t, err, ErrNotFound)
+}

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -113,3 +113,49 @@ export const getResourceProgress = async (resourceId: number): Promise<ResourceP
   const res = await client.get(`/resources/${resourceId}/progress`);
   return res.data.progress;
 };
+
+// --- リソースレビュー ---
+
+export interface ResourceReview {
+  id: number;
+  user_id: number;
+  user?: { id: number; name: string; username: string; avatar_url: string };
+  resource_id: number;
+  rating: number;
+  comment: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateResourceReviewRequest {
+  rating: number;
+  comment?: string;
+}
+
+export interface UpdateResourceReviewRequest {
+  rating?: number;
+  comment?: string;
+}
+
+export const createResourceReview = async (resourceId: number, data: CreateResourceReviewRequest): Promise<ResourceReview> => {
+  const res = await client.post(`/resources/${resourceId}/reviews`, data);
+  return res.data;
+};
+
+export const getResourceReviews = async (
+  resourceId: number,
+  limit = 20,
+  offset = 0
+): Promise<{ reviews: ResourceReview[]; total: number }> => {
+  const res = await client.get(`/resources/${resourceId}/reviews`, { params: { limit, offset } });
+  return res.data;
+};
+
+export const updateResourceReview = async (reviewId: number, data: UpdateResourceReviewRequest): Promise<ResourceReview> => {
+  const res = await client.put(`/resources/reviews/${reviewId}`, data);
+  return res.data;
+};
+
+export const deleteResourceReview = async (reviewId: number): Promise<void> => {
+  await client.delete(`/resources/reviews/${reviewId}`);
+};

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1853,5 +1853,21 @@
     "favoriteRemoved": "Aus Favoriten entfernt",
     "favoritedSnippets": "Favorisierte Snippets",
     "noFavorites": "Keine favorisierten Snippets"
+  },
+  "resourceReview": {
+    "title": "Bewertungen",
+    "addReview": "Bewertung schreiben",
+    "editReview": "Bewertung bearbeiten",
+    "deleteReview": "Bewertung löschen",
+    "deleteConfirm": "Möchten Sie diese Bewertung wirklich löschen?",
+    "rating": "Bewertung",
+    "comment": "Kommentar",
+    "commentPlaceholder": "Schreiben Sie Ihre Bewertung...",
+    "submitSuccess": "Bewertung eingereicht",
+    "updateSuccess": "Bewertung aktualisiert",
+    "deleteSuccess": "Bewertung gelöscht",
+    "noReviews": "Noch keine Bewertungen",
+    "reviewCount": "{{count}} Bewertungen",
+    "averageRating": "Durchschnittsbewertung"
   }
 }

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1854,5 +1854,21 @@
     "favoriteRemoved": "Removed from favorites",
     "favoritedSnippets": "Favorite Snippets",
     "noFavorites": "No favorite snippets"
+  },
+  "resourceReview": {
+    "title": "Reviews",
+    "addReview": "Write a Review",
+    "editReview": "Edit Review",
+    "deleteReview": "Delete Review",
+    "deleteConfirm": "Are you sure you want to delete this review?",
+    "rating": "Rating",
+    "comment": "Comment",
+    "commentPlaceholder": "Write your review...",
+    "submitSuccess": "Review submitted",
+    "updateSuccess": "Review updated",
+    "deleteSuccess": "Review deleted",
+    "noReviews": "No reviews yet",
+    "reviewCount": "{{count}} reviews",
+    "averageRating": "Average Rating"
   }
 }

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1854,5 +1854,21 @@
     "favoriteRemoved": "Eliminado de favoritos",
     "favoritedSnippets": "Fragmentos favoritos",
     "noFavorites": "No hay fragmentos favoritos"
+  },
+  "resourceReview": {
+    "title": "Reseñas",
+    "addReview": "Escribir una reseña",
+    "editReview": "Editar reseña",
+    "deleteReview": "Eliminar reseña",
+    "deleteConfirm": "¿Estás seguro de que deseas eliminar esta reseña?",
+    "rating": "Valoración",
+    "comment": "Comentario",
+    "commentPlaceholder": "Escribe tu reseña...",
+    "submitSuccess": "Reseña enviada",
+    "updateSuccess": "Reseña actualizada",
+    "deleteSuccess": "Reseña eliminada",
+    "noReviews": "Aún no hay reseñas",
+    "reviewCount": "{{count}} reseñas",
+    "averageRating": "Valoración media"
   }
 }

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1854,5 +1854,21 @@
     "favoriteRemoved": "Retiré des favoris",
     "favoritedSnippets": "Extraits favoris",
     "noFavorites": "Aucun extrait favori"
+  },
+  "resourceReview": {
+    "title": "Avis",
+    "addReview": "Écrire un avis",
+    "editReview": "Modifier l'avis",
+    "deleteReview": "Supprimer l'avis",
+    "deleteConfirm": "Êtes-vous sûr de vouloir supprimer cet avis ?",
+    "rating": "Note",
+    "comment": "Commentaire",
+    "commentPlaceholder": "Rédigez votre avis...",
+    "submitSuccess": "Avis soumis",
+    "updateSuccess": "Avis mis à jour",
+    "deleteSuccess": "Avis supprimé",
+    "noReviews": "Aucun avis pour le moment",
+    "reviewCount": "{{count}} avis",
+    "averageRating": "Note moyenne"
   }
 }

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1756,5 +1756,21 @@
     "favoriteRemoved": "お気に入りを解除しました",
     "favoritedSnippets": "お気に入りスニペット",
     "noFavorites": "お気に入りスニペットはありません"
+  },
+  "resourceReview": {
+    "title": "レビュー",
+    "addReview": "レビューを書く",
+    "editReview": "レビューを編集",
+    "deleteReview": "レビューを削除",
+    "deleteConfirm": "このレビューを削除してもよろしいですか？",
+    "rating": "評価",
+    "comment": "コメント",
+    "commentPlaceholder": "レビューコメントを入力...",
+    "submitSuccess": "レビューを投稿しました",
+    "updateSuccess": "レビューを更新しました",
+    "deleteSuccess": "レビューを削除しました",
+    "noReviews": "まだレビューはありません",
+    "reviewCount": "{{count}}件のレビュー",
+    "averageRating": "平均評価"
   }
 }

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1856,5 +1856,21 @@
     "favoriteRemoved": "즐겨찾기가 해제되었습니다",
     "favoritedSnippets": "즐겨찾기 스니펫",
     "noFavorites": "즐겨찾기 스니펫이 없습니다"
+  },
+  "resourceReview": {
+    "title": "리뷰",
+    "addReview": "리뷰 작성",
+    "editReview": "리뷰 수정",
+    "deleteReview": "리뷰 삭제",
+    "deleteConfirm": "이 리뷰를 삭제하시겠습니까?",
+    "rating": "평점",
+    "comment": "댓글",
+    "commentPlaceholder": "리뷰를 작성하세요...",
+    "submitSuccess": "리뷰가 등록되었습니다",
+    "updateSuccess": "리뷰가 수정되었습니다",
+    "deleteSuccess": "리뷰가 삭제되었습니다",
+    "noReviews": "아직 리뷰가 없습니다",
+    "reviewCount": "리뷰 {{count}}개",
+    "averageRating": "평균 평점"
   }
 }

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1854,5 +1854,21 @@
     "favoriteRemoved": "Removido dos favoritos",
     "favoritedSnippets": "Snippets favoritos",
     "noFavorites": "Nenhum snippet favorito"
+  },
+  "resourceReview": {
+    "title": "Avaliações",
+    "addReview": "Escrever avaliação",
+    "editReview": "Editar avaliação",
+    "deleteReview": "Excluir avaliação",
+    "deleteConfirm": "Tem certeza de que deseja excluir esta avaliação?",
+    "rating": "Nota",
+    "comment": "Comentário",
+    "commentPlaceholder": "Escreva sua avaliação...",
+    "submitSuccess": "Avaliação enviada",
+    "updateSuccess": "Avaliação atualizada",
+    "deleteSuccess": "Avaliação excluída",
+    "noReviews": "Nenhuma avaliação ainda",
+    "reviewCount": "{{count}} avaliações",
+    "averageRating": "Nota média"
   }
 }

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1853,5 +1853,21 @@
     "favoriteRemoved": "Удалено из избранного",
     "favoritedSnippets": "Избранные сниппеты",
     "noFavorites": "Нет избранных сниппетов"
+  },
+  "resourceReview": {
+    "title": "Отзывы",
+    "addReview": "Написать отзыв",
+    "editReview": "Редактировать отзыв",
+    "deleteReview": "Удалить отзыв",
+    "deleteConfirm": "Вы уверены, что хотите удалить этот отзыв?",
+    "rating": "Оценка",
+    "comment": "Комментарий",
+    "commentPlaceholder": "Напишите ваш отзыв...",
+    "submitSuccess": "Отзыв отправлен",
+    "updateSuccess": "Отзыв обновлён",
+    "deleteSuccess": "Отзыв удалён",
+    "noReviews": "Отзывов пока нет",
+    "reviewCount": "{{count}} отзывов",
+    "averageRating": "Средняя оценка"
   }
 }

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1854,5 +1854,21 @@
     "favoriteRemoved": "已取消收藏",
     "favoritedSnippets": "收藏的代码片段",
     "noFavorites": "没有收藏的代码片段"
+  },
+  "resourceReview": {
+    "title": "评价",
+    "addReview": "写评价",
+    "editReview": "编辑评价",
+    "deleteReview": "删除评价",
+    "deleteConfirm": "确定要删除此评价吗？",
+    "rating": "评分",
+    "comment": "评论",
+    "commentPlaceholder": "写下你的评价...",
+    "submitSuccess": "评价已提交",
+    "updateSuccess": "评价已更新",
+    "deleteSuccess": "评价已删除",
+    "noReviews": "暂无评价",
+    "reviewCount": "{{count}}条评价",
+    "averageRating": "平均评分"
   }
 }

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1856,5 +1856,21 @@
     "favoriteRemoved": "已取消收藏",
     "favoritedSnippets": "收藏的程式碼片段",
     "noFavorites": "沒有收藏的程式碼片段"
+  },
+  "resourceReview": {
+    "title": "評價",
+    "addReview": "撰寫評價",
+    "editReview": "編輯評價",
+    "deleteReview": "刪除評價",
+    "deleteConfirm": "確定要刪除此評價嗎？",
+    "rating": "評分",
+    "comment": "評論",
+    "commentPlaceholder": "寫下你的評價...",
+    "submitSuccess": "評價已提交",
+    "updateSuccess": "評價已更新",
+    "deleteSuccess": "評價已刪除",
+    "noReviews": "尚無評價",
+    "reviewCount": "{{count}}則評價",
+    "averageRating": "平均評分"
   }
 }


### PR DESCRIPTION
## 概要
学習リソースに対してレビュー（評価+コメント）を投稿・管理できる機能を追加。

## 変更内容
- **バックエンド**: ResourceReviewのModel/Repository/Service/Handler新規作成
  - CRUD APIエンドポイント4つ（POST/GET/PUT/DELETE）
  - 評価（1-5）とコメント（最大5000文字）のバリデーション
  - 所有権チェック・重複レビュー防止
  - サービス層ユニットテスト14件追加（全パス）
- **フロントエンド**: API関数4つ + i18n対応（10言語、14キー）

## テスト
- `go test ./internal/service/... -v` → 全テストパス
- `npx tsc --noEmit` → 型チェックパス

closes #2089