### PR TITLE
fix: 入力バリデーション強化（Emoji長制限・ランキングperiod検証）

### DIFF
--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -64,7 +64,7 @@ type AutoSaveDraftResponse struct {
 
 // ReactionRequest はリアクション追加/削除リクエスト。
 type ReactionRequest struct {
-	Emoji string `json:"emoji" binding:"required"`
+	Emoji string `json:"emoji" binding:"required,max=10"`
 }
 
 // ReactionResponse はリアクション一覧レスポンス。

--- a/backend/internal/service/ranking.go
+++ b/backend/internal/service/ranking.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
@@ -16,13 +17,27 @@ func NewRankingService(repo repository.RankingRepositoryInterface) *RankingServi
 	return &RankingService{repo: repo}
 }
 
+// validRankingPeriods はランキングで許可される期間パラメータ。
+var validRankingPeriods = map[string]bool{
+	"weekly": true, "monthly": true,
+}
+
 // ContributionRanking は指定期間のコントリビューションランキングを返す。
 func (s *RankingService) ContributionRanking(period string) ([]model.RankingEntry, error) {
+	if !validRankingPeriods[period] {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "periodはweekly/monthlyのいずれかを指定してください", nil)
+	}
 	return s.repo.ContributionRanking(period)
 }
 
 // LanguageRanking は指定言語・期間の言語別ランキングを返す。
 func (s *RankingService) LanguageRanking(language, period string) ([]model.RankingEntry, error) {
+	if !validRankingPeriods[period] {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "periodはweekly/monthlyのいずれかを指定してください", nil)
+	}
+	if len(language) > 50 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "言語名が長すぎます", nil)
+	}
 	return s.repo.LanguageRanking(language, period)
 }
 

--- a/backend/internal/service/ranking_test.go
+++ b/backend/internal/service/ranking_test.go
@@ -2,8 +2,10 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/stretchr/testify/assert"
 )
@@ -188,4 +190,44 @@ func TestRankingService_ContributionRanking_LargeScores(t *testing.T) {
 	assert.Equal(t, int64(999999), result[0].Score)
 	assert.Equal(t, int64(0), result[1].Score)
 	repo.AssertExpectations(t)
+}
+
+func TestRankingService_ContributionRanking_InvalidPeriod(t *testing.T) {
+	repo := new(MockRankingRepository)
+	svc := NewRankingService(repo)
+
+	result, err := svc.ContributionRanking("daily")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+
+	var domainErr *domain.DomainError
+	assert.True(t, errors.As(err, &domainErr))
+	assert.Equal(t, domain.ErrCodeBadRequest, domainErr.Code)
+}
+
+func TestRankingService_LanguageRanking_InvalidPeriod(t *testing.T) {
+	repo := new(MockRankingRepository)
+	svc := NewRankingService(repo)
+
+	result, err := svc.LanguageRanking("Go", "yearly")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+
+	var domainErr *domain.DomainError
+	assert.True(t, errors.As(err, &domainErr))
+	assert.Equal(t, domain.ErrCodeBadRequest, domainErr.Code)
+}
+
+func TestRankingService_LanguageRanking_TooLongLanguage(t *testing.T) {
+	repo := new(MockRankingRepository)
+	svc := NewRankingService(repo)
+
+	longLang := strings.Repeat("a", 51)
+	result, err := svc.LanguageRanking(longLang, "weekly")
+	assert.Nil(t, result)
+	assert.Error(t, err)
+
+	var domainErr *domain.DomainError
+	assert.True(t, errors.As(err, &domainErr))
+	assert.Equal(t, domain.ErrCodeBadRequest, domainErr.Code)
 }


### PR DESCRIPTION
## 概要
セキュリティ監査で発見された入力バリデーションの改善。

## 変更内容
- **ReactionRequest.Emoji**: DTOレベルで`max=10`制限を追加（防御的バリデーション）
- **RankingService.ContributionRanking/LanguageRanking**: periodパラメータを`weekly`/`monthly`のみに制限
- **RankingService.LanguageRanking**: 言語パラメータを50文字以下に制限

## テスト
- 新規テスト3件追加（不正period、不正period（言語ランキング）、長すぎる言語名）
- 既存テスト全件パス確認済み

Close #2095