### PR TITLE
feat: 未回答Q&A一覧API追加

### DIFF
--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -24,6 +24,7 @@ type QuestionServiceInterface interface {
 	Bookmark(userID, questionID uint) error
 	Unbookmark(userID, questionID uint) error
 	GetBookmarkedByUserID(userID uint, limit, offset int) ([]model.Question, int64, error)
+	GetUnanswered(limit, offset int) ([]model.Question, int64, error)
 }
 
 // QuestionHandler は質問関連のHTTPハンドラ。
@@ -203,6 +204,24 @@ func (h *QuestionHandler) GetSolved(c *gin.Context) {
 	limit, offset := parseLimitOffset(c)
 
 	questions, total, err := h.service.GetSolved(limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.QuestionListResponse{
+		Questions: questions,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
+}
+
+// GetUnanswered は未回答の質問一覧を取得する。
+func (h *QuestionHandler) GetUnanswered(c *gin.Context) {
+	limit, offset := parseLimitOffset(c)
+
+	questions, total, err := h.service.GetUnanswered(limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -135,6 +135,7 @@ type QuestionRepositoryInterface interface {
 	Unbookmark(userID, questionID uint) error
 	HasBookmarked(userID, questionID uint) (bool, error)
 	FindBookmarkedByUserID(userID uint, limit, offset int) ([]model.Question, int64, error)
+	FindUnanswered(limit, offset int) ([]model.Question, int64, error)
 }
 
 // AnswerRepositoryInterface はQ&A回答データ操作の契約を定義する。

--- a/backend/internal/repository/question.go
+++ b/backend/internal/repository/question.go
@@ -169,6 +169,22 @@ func (r *QuestionRepository) FindSolved(limit, offset int) ([]model.Question, in
 	return questions, total, err
 }
 
+// FindUnanswered は回答が0件の質問をページネーション付きで取得する（新しい順）。
+func (r *QuestionRepository) FindUnanswered(limit, offset int) ([]model.Question, int64, error) {
+	var questions []model.Question
+	var total int64
+
+	query := r.db.Model(&model.Question{}).Where("answer_count = 0")
+	query.Count(&total)
+
+	err := query.Preload("User").
+		Order("created_at DESC").
+		Limit(limit).Offset(offset).
+		Find(&questions).Error
+
+	return questions, total, err
+}
+
 // GetUserVote は指定ユーザーの指定質問への投票値を取得する（未投票の場合は0を返す）。
 func (r *QuestionRepository) GetUserVote(userID, questionID uint) (int, error) {
 	var vote model.QuestionVote

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -566,6 +566,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		questions.GET("", c.QuestionHandler.GetAll)
 		questions.GET("/search", c.QuestionHandler.Search)
 		questions.GET("/solved", c.QuestionHandler.GetSolved)
+		questions.GET("/unanswered", c.QuestionHandler.GetUnanswered)
 		questions.GET("/:id", c.QuestionHandler.GetByID)
 		questions.PUT("/:id", c.QuestionHandler.Update)
 		questions.DELETE("/:id", c.QuestionHandler.Delete)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -441,6 +441,11 @@ func (m *MockQuestionRepository) FindBookmarkedByUserID(userID uint, limit, offs
 	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockQuestionRepository) FindUnanswered(limit, offset int) ([]model.Question, int64, error) {
+	args := m.Called(limit, offset)
+	return args.Get(0).([]model.Question), args.Get(1).(int64), args.Error(2)
+}
+
 // ============================================================
 // MockAnswerRepository は repository.AnswerRepositoryInterface のテスト用モック実装。
 // ============================================================

--- a/backend/internal/service/question.go
+++ b/backend/internal/service/question.go
@@ -129,6 +129,11 @@ func (s *QuestionService) GetSolved(limit, offset int) ([]model.Question, int64,
 	return s.repo.FindSolved(limit, offset)
 }
 
+// GetUnanswered は未回答の質問一覧をページネーション付きで取得する。
+func (s *QuestionService) GetUnanswered(limit, offset int) ([]model.Question, int64, error) {
+	return s.repo.FindUnanswered(limit, offset)
+}
+
 // RemoveVote は質問への投票を取り消す。
 // 自分の質問への投票削除は禁止する（そもそも投票できないため）。
 func (s *QuestionService) RemoveVote(userID, questionID uint) error {

--- a/backend/internal/service/question_test.go
+++ b/backend/internal/service/question_test.go
@@ -669,3 +669,48 @@ func TestQuestionGetBookmarkedByUserID_Empty(t *testing.T) {
 	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// 未回答質問一覧テスト
+// ============================================================
+
+func TestQuestionGetUnanswered_Success(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	questions := []model.Question{
+		{Title: "未回答Q1", AnswerCount: 0},
+		{Title: "未回答Q2", AnswerCount: 0},
+	}
+	repo.On("FindUnanswered", 20, 0).Return(questions, int64(2), nil)
+
+	result, total, err := svc.GetUnanswered(20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, int64(2), total)
+	assert.Equal(t, 0, result[0].AnswerCount)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionGetUnanswered_Empty(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindUnanswered", 20, 0).Return([]model.Question{}, int64(0), nil)
+
+	result, total, err := svc.GetUnanswered(20, 0)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionGetUnanswered_RepoError(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("FindUnanswered", 20, 0).Return([]model.Question{}, int64(0), errors.New("db error"))
+
+	result, total, err := svc.GetUnanswered(20, 0)
+	assert.Error(t, err)
+	assert.Empty(t, result)
+	assert.Equal(t, int64(0), total)
+	repo.AssertExpectations(t)
+}

--- a/frontend/src/api/qa.ts
+++ b/frontend/src/api/qa.ts
@@ -94,3 +94,10 @@ export const getBookmarkedQuestions = async (
   const res = await client.get('/questions/bookmarks', { params: { limit, offset } });
   return res.data;
 };
+
+export const getUnansweredQuestions = async (
+  limit = 20, offset = 0
+): Promise<{ questions: Question[]; total: number }> => {
+  const res = await client.get('/questions/unanswered', { params: { limit, offset } });
+  return res.data;
+};

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1037,7 +1037,9 @@
     "bestAnswerSet": "Beste Antwort festgelegt",
     "bestAnswerFailed": "Beste Antwort konnte nicht festgelegt werden",
     "voteFailed": "Abstimmung fehlgeschlagen",
-    "popularBadge": "Beliebt"
+    "popularBadge": "Beliebt",
+    "unanswered": "Unbeantwortet",
+    "noUnanswered": "Keine unbeantworteten Fragen"
   },
   "roadmaps": {
     "title": "Lern-Roadmaps",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1038,7 +1038,9 @@
     "bestAnswerSet": "Best answer set",
     "bestAnswerFailed": "Failed to set best answer",
     "voteFailed": "Failed to vote",
-    "popularBadge": "Popular"
+    "popularBadge": "Popular",
+    "unanswered": "Unanswered",
+    "noUnanswered": "No unanswered questions"
   },
   "roadmaps": {
     "title": "Learning Roadmaps",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1038,7 +1038,9 @@
     "bestAnswerSet": "Mejor respuesta establecida",
     "bestAnswerFailed": "Error al establecer la mejor respuesta",
     "voteFailed": "Error al votar",
-    "popularBadge": "Popular"
+    "popularBadge": "Popular",
+    "unanswered": "Sin respuesta",
+    "noUnanswered": "No hay preguntas sin respuesta"
   },
   "roadmaps": {
     "title": "Hojas de Ruta de Aprendizaje",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1038,7 +1038,9 @@
     "bestAnswerSet": "Meilleure réponse définie",
     "bestAnswerFailed": "Échec de la définition de la meilleure réponse",
     "voteFailed": "Échec du vote",
-    "popularBadge": "Populaire"
+    "popularBadge": "Populaire",
+    "unanswered": "Sans réponse",
+    "noUnanswered": "Aucune question sans réponse"
   },
   "roadmaps": {
     "title": "Feuilles de Route d'Apprentissage",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -993,7 +993,9 @@
     "bestAnswerSet": "ベストアンサーを設定しました",
     "bestAnswerFailed": "ベストアンサーの設定に失敗しました",
     "voteFailed": "投票に失敗しました",
-    "popularBadge": "人気"
+    "popularBadge": "人気",
+    "unanswered": "未回答",
+    "noUnanswered": "未回答の質問はありません"
   },
   "roadmaps": {
     "title": "学習ロードマップ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1040,7 +1040,9 @@
     "bestAnswerSet": "채택 답변이 설정되었습니다",
     "bestAnswerFailed": "채택 답변 설정에 실패했습니다",
     "voteFailed": "투표에 실패했습니다",
-    "popularBadge": "인기"
+    "popularBadge": "인기",
+    "unanswered": "미답변",
+    "noUnanswered": "미답변 질문이 없습니다"
   },
   "roadmaps": {
     "title": "학습 로드맵",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1038,7 +1038,9 @@
     "bestAnswerSet": "Melhor resposta definida",
     "bestAnswerFailed": "Falha ao definir melhor resposta",
     "voteFailed": "Falha ao votar",
-    "popularBadge": "Popular"
+    "popularBadge": "Popular",
+    "unanswered": "Sem resposta",
+    "noUnanswered": "Nenhuma pergunta sem resposta"
   },
   "roadmaps": {
     "title": "Roteiros de Aprendizado",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1037,7 +1037,9 @@
     "bestAnswerSet": "Лучший ответ установлен",
     "bestAnswerFailed": "Не удалось установить лучший ответ",
     "voteFailed": "Не удалось проголосовать",
-    "popularBadge": "Популярное"
+    "popularBadge": "Популярное",
+    "unanswered": "Без ответа",
+    "noUnanswered": "Нет вопросов без ответа"
   },
   "roadmaps": {
     "title": "Дорожные карты обучения",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1038,7 +1038,9 @@
     "bestAnswerSet": "已设置最佳答案",
     "bestAnswerFailed": "设置最佳答案失败",
     "voteFailed": "投票失败",
-    "popularBadge": "热门"
+    "popularBadge": "热门",
+    "unanswered": "未回答",
+    "noUnanswered": "没有未回答的问题"
   },
   "roadmaps": {
     "title": "学习路线图",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1040,7 +1040,9 @@
     "bestAnswerSet": "已設定最佳答案",
     "bestAnswerFailed": "設定最佳答案失敗",
     "voteFailed": "投票失敗",
-    "popularBadge": "熱門"
+    "popularBadge": "熱門",
+    "unanswered": "未回答",
+    "noUnanswered": "沒有未回答的問題"
   },
   "roadmaps": {
     "title": "學習路線圖",


### PR DESCRIPTION
## 概要
Q&Aの未回答質問をフィルタリングするAPIを追加。

## 変更内容
- `GET /questions/unanswered` エンドポイント追加（ページネーション対応）
- `answer_count = 0` でフィルタリング
- Service層テスト3件追加
- フロントエンドAPI関数・10言語i18n追加

## テスト
- `go test ./internal/service/... -run TestQuestionGetUnanswered` 全パス

Close #2099