### PR TITLE
feat: ロードマップステップ一括完了APIを追加

### DIFF
--- a/backend/internal/dto/roadmap_dto.go
+++ b/backend/internal/dto/roadmap_dto.go
@@ -42,6 +42,11 @@ type ReorderRoadmapStepsRequest struct {
 	Orders []model.StepOrder `json:"orders" binding:"required"`
 }
 
+// BatchCompleteStepsRequest はステップ一括完了リクエストのDTO。
+type BatchCompleteStepsRequest struct {
+	StepIDs []uint `json:"step_ids" binding:"required,min=1"`
+}
+
 // RoadmapListResponse はロードマップ一覧レスポンス。
 type RoadmapListResponse struct {
 	Roadmaps []model.Roadmap `json:"roadmaps"`

--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -23,6 +23,7 @@ type RoadmapServiceInterface interface {
 	CreateStep(roadmapID, userID uint, step *model.RoadmapStep) error
 	UpdateStep(roadmapID, stepID, userID uint, updates *model.RoadmapStep) (*model.RoadmapStep, error)
 	UpdateStepCompletion(roadmapID, stepID, userID uint, isCompleted bool) (*model.RoadmapStep, error)
+	BatchCompleteSteps(roadmapID, userID uint, stepIDs []uint) (*model.Roadmap, error)
 	DeleteStep(roadmapID, stepID, userID uint) error
 	ReorderSteps(roadmapID, userID uint, orders []model.StepOrder) error
 }
@@ -300,6 +301,28 @@ func (h *RoadmapHandler) UpdateStep(c *gin.Context) {
 	}
 
 	respondOK(c, step)
+}
+
+// BatchCompleteSteps はロードマップの複数ステップを一括で完了にする。
+func (h *RoadmapHandler) BatchCompleteSteps(c *gin.Context) {
+	userID := c.GetUint("userID")
+	roadmapID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	input := bindJSON[dto.BatchCompleteStepsRequest](c)
+	if input == nil {
+		return
+	}
+
+	roadmap, err := h.service.BatchCompleteSteps(roadmapID, userID, input.StepIDs)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, roadmap)
 }
 
 // DeleteStep はロードマップのステップを削除する。

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -604,6 +604,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		roadmaps.POST("/:id/steps", c.RoadmapHandler.CreateStep)
 		roadmaps.PUT("/:id/steps/:stepId", c.RoadmapHandler.UpdateStep)
 		roadmaps.DELETE("/:id/steps/:stepId", c.RoadmapHandler.DeleteStep)
+		roadmaps.POST("/:id/steps/batch-complete", c.RoadmapHandler.BatchCompleteSteps)
 		roadmaps.PUT("/:id/steps/reorder", c.RoadmapHandler.ReorderSteps)
 	}
 

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -229,6 +229,34 @@ func (s *RoadmapService) UpdateStepCompletion(roadmapID, stepID, userID uint, is
 	return step, nil
 }
 
+// BatchCompleteSteps はロードマップの所有権を検証した後、複数ステップを一括で完了にする。
+func (s *RoadmapService) BatchCompleteSteps(roadmapID, userID uint, stepIDs []uint) (*model.Roadmap, error) {
+	if _, err := s.findAndCheckOwnership(roadmapID, userID); err != nil {
+		return nil, err
+	}
+
+	now := time.Now()
+	for _, stepID := range stepIDs {
+		step, err := s.repo.FindStepByID(stepID)
+		if err != nil {
+			return nil, err
+		}
+		if step.RoadmapID != roadmapID {
+			return nil, ErrBadRequest
+		}
+		if step.IsCompleted {
+			continue
+		}
+		step.IsCompleted = true
+		step.CompletedAt = &now
+		if err := s.repo.UpdateStep(step); err != nil {
+			return nil, err
+		}
+	}
+
+	return s.repo.FindByID(roadmapID)
+}
+
 // DeleteStep はロードマップの所有権とステップの所属を検証した後、ステップを削除する。
 func (s *RoadmapService) DeleteStep(roadmapID, stepID, userID uint) error {
 	if _, err := s.findAndCheckStepOwnership(roadmapID, stepID, userID); err != nil {

--- a/backend/internal/service/roadmap_test.go
+++ b/backend/internal/service/roadmap_test.go
@@ -380,6 +380,86 @@ func TestRoadmapUpdateStepCompletion_Uncomplete(t *testing.T) {
 }
 
 // ============================================================
+// ステップ一括完了テスト
+// ============================================================
+
+func TestRoadmapBatchCompleteSteps_Success(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+
+	step1 := &model.RoadmapStep{RoadmapID: 10, IsCompleted: false}
+	step1.ID = 1
+	step2 := &model.RoadmapStep{RoadmapID: 10, IsCompleted: false}
+	step2.ID = 2
+
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(1)).Return(step1, nil)
+	repo.On("UpdateStep", step1).Return(nil)
+	repo.On("FindStepByID", uint(2)).Return(step2, nil)
+	repo.On("UpdateStep", step2).Return(nil)
+
+	result, err := svc.BatchCompleteSteps(10, 1, []uint{1, 2})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+	assert.True(t, step1.IsCompleted)
+	assert.True(t, step2.IsCompleted)
+	assert.NotNil(t, step1.CompletedAt)
+	assert.NotNil(t, step2.CompletedAt)
+}
+
+func TestRoadmapBatchCompleteSteps_Forbidden(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+
+	result, err := svc.BatchCompleteSteps(10, 999, []uint{1})
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrForbidden)
+}
+
+func TestRoadmapBatchCompleteSteps_StepNotBelonging(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+
+	step := &model.RoadmapStep{RoadmapID: 20}
+	step.ID = 5
+
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(5)).Return(step, nil)
+
+	result, err := svc.BatchCompleteSteps(10, 1, []uint{5})
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, ErrBadRequest)
+}
+
+func TestRoadmapBatchCompleteSteps_SkipsAlreadyCompleted(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	roadmap := &model.Roadmap{UserID: 1}
+	roadmap.ID = 10
+
+	step := &model.RoadmapStep{RoadmapID: 10, IsCompleted: true}
+	step.ID = 1
+
+	repo.On("FindByID", uint(10)).Return(roadmap, nil)
+	repo.On("FindStepByID", uint(1)).Return(step, nil)
+
+	updatedRoadmap := &model.Roadmap{UserID: 1, Progress: 50}
+	updatedRoadmap.ID = 10
+	repo.On("FindByID", uint(10)).Return(updatedRoadmap, nil)
+
+	result, err := svc.BatchCompleteSteps(10, 1, []uint{1})
+	assert.NoError(t, err)
+	assert.NotNil(t, result)
+}
+
+// ============================================================
 // 存在しないロードマップテスト
 // ============================================================
 

--- a/frontend/src/api/roadmaps.ts
+++ b/frontend/src/api/roadmaps.ts
@@ -117,6 +117,9 @@ export const updateStep = (roadmapId: number, stepId: number, data: UpdateStepRe
 export const deleteStep = (roadmapId: number, stepId: number) =>
   client.delete(`/roadmaps/${roadmapId}/steps/${stepId}`);
 
+export const batchCompleteSteps = (roadmapId: number, stepIds: number[]) =>
+  client.post<Roadmap>(`/roadmaps/${roadmapId}/steps/batch-complete`, { step_ids: stepIds });
+
 export const reorderSteps = (roadmapId: number, data: ReorderStepsRequest) =>
   client.put(`/roadmaps/${roadmapId}/steps/reorder`, data);
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -1103,6 +1103,8 @@
     "noSteps": "Noch keine Schritte",
     "addFirstStep": "Fügen Sie Ihren ersten Schritt hinzu",
     "stepsReordered": "Schritte neu angeordnet",
+    "batchComplete": "Alle abschließen",
+    "batchCompleteSuccess": "Schritte erfolgreich abgeschlossen",
     "templates": "Empfohlene Vorlagen",
     "templatesDescription": "Starten Sie Ihr Lernen mit einer empfohlenen Roadmap",
     "templatesAvailable": "Vorlagen",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -1104,6 +1104,8 @@
     "noSteps": "No steps yet",
     "addFirstStep": "Add your first step",
     "stepsReordered": "Steps reordered",
+    "batchComplete": "Complete all",
+    "batchCompleteSuccess": "Steps completed successfully",
     "templates": "Recommended Templates",
     "templatesDescription": "Start your learning with a recommended roadmap",
     "templatesAvailable": "templates",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -1104,6 +1104,8 @@
     "noSteps": "No hay pasos aún",
     "addFirstStep": "Agrega tu primer paso",
     "stepsReordered": "Pasos reordenados",
+    "batchComplete": "Completar todos",
+    "batchCompleteSuccess": "Pasos completados correctamente",
     "templates": "Plantillas recomendadas",
     "templatesDescription": "Comienza tu aprendizaje con una hoja de ruta recomendada",
     "templatesAvailable": "plantillas",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -1104,6 +1104,8 @@
     "noSteps": "Pas encore d'étapes",
     "addFirstStep": "Ajoutez la première étape",
     "stepsReordered": "Ordre des étapes modifié",
+    "batchComplete": "Tout terminer",
+    "batchCompleteSuccess": "Étapes complétées avec succès",
     "templates": "Modèles recommandés",
     "templatesDescription": "Commencez votre apprentissage avec une feuille de route recommandée",
     "templatesAvailable": "modèles",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -1055,6 +1055,8 @@
     "noSteps": "ステップがまだありません",
     "addFirstStep": "最初のステップを追加",
     "stepsReordered": "ステップの順序を変更しました",
+    "batchComplete": "一括完了",
+    "batchCompleteSuccess": "ステップを一括完了しました",
     "templates": "おすすめテンプレート",
     "templatesDescription": "おすすめのロードマップで学習を始めよう",
     "templatesAvailable": "件のテンプレート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -1106,6 +1106,8 @@
     "noSteps": "아직 단계가 없습니다",
     "addFirstStep": "첫 번째 단계를 추가하세요",
     "stepsReordered": "단계 순서가 변경되었습니다",
+    "batchComplete": "일괄 완료",
+    "batchCompleteSuccess": "단계를 일괄 완료했습니다",
     "templates": "추천 템플릿",
     "templatesDescription": "추천 로드맵으로 학습을 시작하세요",
     "templatesAvailable": "개 템플릿",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -1104,6 +1104,8 @@
     "noSteps": "Ainda não há etapas",
     "addFirstStep": "Adicione a primeira etapa",
     "stepsReordered": "Ordem das etapas alterada",
+    "batchComplete": "Concluir todos",
+    "batchCompleteSuccess": "Etapas concluídas com sucesso",
     "templates": "Modelos recomendados",
     "templatesDescription": "Comece seu aprendizado com um roteiro recomendado",
     "templatesAvailable": "modelos",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -1103,6 +1103,8 @@
     "noSteps": "Пока нет шагов",
     "addFirstStep": "Добавьте первый шаг",
     "stepsReordered": "Порядок шагов изменён",
+    "batchComplete": "Завершить все",
+    "batchCompleteSuccess": "Шаги успешно завершены",
     "templates": "Рекомендуемые шаблоны",
     "templatesDescription": "Начните обучение с рекомендуемой дорожной карты",
     "templatesAvailable": "шаблонов",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -1104,6 +1104,8 @@
     "noSteps": "还没有步骤",
     "addFirstStep": "添加第一个步骤",
     "stepsReordered": "步骤顺序已更改",
+    "batchComplete": "批量完成",
+    "batchCompleteSuccess": "已批量完成步骤",
     "templates": "推荐模板",
     "templatesDescription": "使用推荐的路线图开始学习",
     "templatesAvailable": "个模板",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -1106,6 +1106,8 @@
     "noSteps": "還沒有步驟",
     "addFirstStep": "新增第一個步驟",
     "stepsReordered": "步驟順序已變更",
+    "batchComplete": "批次完成",
+    "batchCompleteSuccess": "已批次完成步驟",
     "templates": "推薦範本",
     "templatesDescription": "使用推薦的路線圖開始學習",
     "templatesAvailable": "個範本",


### PR DESCRIPTION
## 概要
- ロードマップステップの一括完了API（POST /roadmaps/:id/steps/batch-complete）を追加
- step_ids配列で複数ステップを一度に完了可能
- 所有権チェック・ステップ所属確認・既完了ステップのスキップ対応
- フロントエンドAPI関数 `batchCompleteSteps` を追加
- 全10言語にi18nキー（batchComplete, batchCompleteSuccess）を追加

## テスト
- [x] 一括完了成功テスト
- [x] 権限エラー（他ユーザー）テスト
- [x] 不正ステップ（別ロードマップ所属）テスト
- [x] 既完了ステップスキップテスト
- [x] 全サービステスト通過

Closes #2103