### PR TITLE
feat: 学習ログ月別サマリーAPIを追加

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -31,6 +31,7 @@ type LearningLogServiceInterface interface {
 	GetRecentCategories(userID uint) ([]string, error)
 	GetLinkedLogs(goalID, userID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	GetFavorites(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
+	GetMonthlySummary(userID uint, months int) ([]model.MonthlySummary, error)
 }
 
 // LearningLogHandler は学習ログ関連のHTTPハンドラ。
@@ -304,6 +305,24 @@ func (h *LearningLogHandler) GetWeeklyDuration(c *gin.Context) {
 	}
 
 	respondOK(c, gin.H{"duration": duration})
+}
+
+// GetMonthlySummary は指定ユーザーの月別学習サマリーを返す。
+func (h *LearningLogHandler) GetMonthlySummary(c *gin.Context) {
+	userID, ok := parseID(c, "userId")
+	if !ok {
+		return
+	}
+
+	months := parseQueryIntSilent(c, "months", 12)
+
+	summaries, err := h.service.GetMonthlySummary(userID, months)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, ensureSlice(summaries))
 }
 
 // Favorite は学習ログをお気に入りに設定する。

--- a/backend/internal/model/learning_log.go
+++ b/backend/internal/model/learning_log.go
@@ -53,6 +53,13 @@ type LearningLog struct {
 	UpdatedAt  time.Time `json:"updated_at"`
 }
 
+// MonthlySummary は月別学習サマリーを表す。
+type MonthlySummary struct {
+	Month        string `json:"month"`         // "YYYY-MM-01" 形式
+	TotalMinutes int    `json:"total_minutes"` // その月の合計学習時間（分）
+	LogCount     int    `json:"log_count"`     // その月のログ件数
+}
+
 // CalendarEntry はカレンダービュー用の日別ログ件数を表す。
 type CalendarEntry struct {
 	Date  string `json:"date"`  // "YYYY-MM-DD" 形式

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -172,6 +172,7 @@ type LearningLogRepositoryInterface interface {
 	GetByGoalID(goalID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	SumDurationByGoalID(goalID uint) (int, error)
 	GetFavorites(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
+	GetMonthlySummary(userID uint, months int) ([]model.MonthlySummary, error)
 }
 
 // LearningGoalRepositoryInterface は学習目標データ操作の契約を定義する。

--- a/backend/internal/repository/learning_log.go
+++ b/backend/internal/repository/learning_log.go
@@ -212,6 +212,24 @@ func (r *LearningLogRepository) GetFavorites(userID uint, limit, offset int) ([]
 	return logs, total, err
 }
 
+// GetMonthlySummary は直近N ヶ月の月別サマリー（合計時間・ログ件数）を取得する。
+func (r *LearningLogRepository) GetMonthlySummary(userID uint, months int) ([]model.MonthlySummary, error) {
+	startDate := time.Now().AddDate(0, -months, 0).Format("2006-01-02")
+
+	var summaries []model.MonthlySummary
+	err := r.db.Raw(`
+		SELECT
+			TO_CHAR(DATE_TRUNC('month', created_at), 'YYYY-MM-DD') AS month,
+			COALESCE(SUM(duration), 0) AS total_minutes,
+			COUNT(*) AS log_count
+		FROM learning_logs
+		WHERE user_id = ? AND created_at >= ?
+		GROUP BY month
+		ORDER BY month
+	`, userID, startDate).Scan(&summaries).Error
+	return summaries, err
+}
+
 // GetCalendarData はカレンダー表示用の日別ログ件数を取得する。
 func (r *LearningLogRepository) GetCalendarData(userID uint) ([]model.CalendarEntry, error) {
 	var entries []model.CalendarEntry

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -496,6 +496,7 @@ func registerLearningLogRoutes(g *gin.RouterGroup, c *di.Container) {
 		learningLogs.GET("/calendar/:userId", c.LearningLogHandler.GetCalendarData)
 		learningLogs.GET("/streak/:userId", c.LearningLogHandler.GetStreakInfo)
 		learningLogs.GET("/weekly-duration/:userId", c.LearningLogHandler.GetWeeklyDuration)
+		learningLogs.GET("/monthly-summary/:userId", c.LearningLogHandler.GetMonthlySummary)
 		learningLogs.GET("/:id", c.LearningLogHandler.GetByID)
 		learningLogs.PUT("/:id", c.LearningLogHandler.Update)
 		learningLogs.PUT("/:id/favorite", c.LearningLogHandler.Favorite)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -257,6 +257,14 @@ func (s *LearningLogService) GetFavorites(userID uint, limit, offset int) ([]mod
 	return s.repo.GetFavorites(userID, limit, offset)
 }
 
+// GetMonthlySummary はユーザーの月別学習サマリー（直近Nヶ月）を取得する。
+func (s *LearningLogService) GetMonthlySummary(userID uint, months int) ([]model.MonthlySummary, error) {
+	if months < 1 || months > 24 {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "monthsは1〜24の範囲で指定してください", nil)
+	}
+	return s.repo.GetMonthlySummary(userID, months)
+}
+
 // ExportCSV は指定ユーザーの学習ログをCSV形式でエクスポートする。
 // days: 取得する過去の日数（0は全期間）。負の値はバリデーションエラー。
 func (s *LearningLogService) ExportCSV(userID uint, days int) ([]byte, error) {

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -1308,3 +1308,58 @@ func TestLearningLogGetFavorites_RepoError(t *testing.T) {
 	assert.Empty(t, logs)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// 月別サマリーテスト
+// ============================================================
+
+func TestLearningLogGetMonthlySummary_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	expected := []model.MonthlySummary{
+		{Month: "2026-01-01", TotalMinutes: 300, LogCount: 10},
+		{Month: "2026-02-01", TotalMinutes: 450, LogCount: 15},
+	}
+	repo.On("GetMonthlySummary", uint(1), 12).Return(expected, nil)
+
+	result, err := svc.GetMonthlySummary(1, 12)
+	assert.NoError(t, err)
+	assert.Len(t, result, 2)
+	assert.Equal(t, "2026-01-01", result[0].Month)
+	assert.Equal(t, 300, result[0].TotalMinutes)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogGetMonthlySummary_Empty(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetMonthlySummary", uint(1), 6).Return([]model.MonthlySummary{}, nil)
+
+	result, err := svc.GetMonthlySummary(1, 6)
+	assert.NoError(t, err)
+	assert.Empty(t, result)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogGetMonthlySummary_InvalidMonths(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	result, err := svc.GetMonthlySummary(1, 0)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+
+	result, err = svc.GetMonthlySummary(1, 25)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+}
+
+func TestLearningLogGetMonthlySummary_RepoError(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("GetMonthlySummary", uint(1), 12).Return([]model.MonthlySummary(nil), errors.New("db error"))
+
+	result, err := svc.GetMonthlySummary(1, 12)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -601,6 +601,11 @@ func (m *MockLearningLogRepository) GetFavorites(userID uint, limit, offset int)
 	return args.Get(0).([]model.LearningLog), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockLearningLogRepository) GetMonthlySummary(userID uint, months int) ([]model.MonthlySummary, error) {
+	args := m.Called(userID, months)
+	return args.Get(0).([]model.MonthlySummary), args.Error(1)
+}
+
 // ============================================================
 // MockLearningGoalRepository は repository.LearningGoalRepositoryInterface のテスト用モック実装。
 // ============================================================

--- a/frontend/src/api/learningLogs.ts
+++ b/frontend/src/api/learningLogs.ts
@@ -31,6 +31,9 @@ export const getStreakInfo = (userId: number) =>
 export const getWeeklyDuration = (userId: number) =>
   client.get<{ duration: number }>(`/learning-logs/weekly-duration/${userId}`);
 
+export const getMonthlySummary = (userId: number, months = 12) =>
+  client.get<{ month: string; total_minutes: number; log_count: number }[]>(`/learning-logs/monthly-summary/${userId}?months=${months}`);
+
 export const getLogsByCategory = (category: string) =>
   client.get<LearningLog[]>(`/learning-logs/category/${category}`);
 

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -743,7 +743,9 @@
     "importError": "CSV-Datei konnte nicht importiert werden",
     "selectCSVFile": "CSV-Datei auswählen",
     "favorites": "Favoriten",
-    "noFavorites": "Keine Lieblings-Lernprotokolle"
+    "noFavorites": "Keine Lieblings-Lernprotokolle",
+    "monthlySummary": "Monatszusammenfassung",
+    "noMonthlySummary": "Keine Monatsdaten vorhanden"
   },
   "reports": {
     "title": "Aktivitätsberichte",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -744,7 +744,9 @@
     "importError": "Failed to import CSV file",
     "selectCSVFile": "Select CSV file",
     "favorites": "Favorites",
-    "noFavorites": "No favorite learning logs"
+    "noFavorites": "No favorite learning logs",
+    "monthlySummary": "Monthly summary",
+    "noMonthlySummary": "No monthly data available"
   },
   "reports": {
     "title": "Activity Reports",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -744,7 +744,9 @@
     "importError": "Error al importar el archivo CSV",
     "selectCSVFile": "Seleccionar archivo CSV",
     "favorites": "Favoritos",
-    "noFavorites": "No hay registros de aprendizaje favoritos"
+    "noFavorites": "No hay registros de aprendizaje favoritos",
+    "monthlySummary": "Resumen mensual",
+    "noMonthlySummary": "Sin datos mensuales"
   },
   "reports": {
     "title": "Informes de Actividad",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -744,7 +744,9 @@
     "importError": "Échec de l importation du fichier CSV",
     "selectCSVFile": "Sélectionner un fichier CSV",
     "favorites": "Favoris",
-    "noFavorites": "Aucun journal d'apprentissage favori"
+    "noFavorites": "Aucun journal d'apprentissage favori",
+    "monthlySummary": "Résumé mensuel",
+    "noMonthlySummary": "Aucune donnée mensuelle"
   },
   "reports": {
     "title": "Rapports d'Activité",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -728,7 +728,9 @@
     "importError": "CSVファイルのインポートに失敗しました",
     "selectCSVFile": "CSVファイルを選択",
     "favorites": "お気に入り",
-    "noFavorites": "お気に入りの学習ログはありません"
+    "noFavorites": "お気に入りの学習ログはありません",
+    "monthlySummary": "月別サマリー",
+    "noMonthlySummary": "月別データがありません"
   },
   "reports": {
     "title": "アクティビティレポート",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -746,7 +746,9 @@
     "importError": "CSV 파일 가져오기에 실패했습니다",
     "selectCSVFile": "CSV 파일 선택",
     "favorites": "즐겨찾기",
-    "noFavorites": "즐겨찾기 학습 로그가 없습니다"
+    "noFavorites": "즐겨찾기 학습 로그가 없습니다",
+    "monthlySummary": "월별 요약",
+    "noMonthlySummary": "월별 데이터가 없습니다"
   },
   "reports": {
     "title": "활동 리포트",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -744,7 +744,9 @@
     "importError": "Falha ao importar arquivo CSV",
     "selectCSVFile": "Selecionar arquivo CSV",
     "favorites": "Favoritos",
-    "noFavorites": "Nenhum registro de aprendizado favorito"
+    "noFavorites": "Nenhum registro de aprendizado favorito",
+    "monthlySummary": "Resumo mensal",
+    "noMonthlySummary": "Sem dados mensais"
   },
   "reports": {
     "title": "Relatórios de Atividade",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -743,7 +743,9 @@
     "importError": "Не удалось импортировать CSV-файл",
     "selectCSVFile": "Выберите CSV-файл",
     "favorites": "Избранное",
-    "noFavorites": "Нет избранных записей обучения"
+    "noFavorites": "Нет избранных записей обучения",
+    "monthlySummary": "Ежемесячная сводка",
+    "noMonthlySummary": "Нет месячных данных"
   },
   "reports": {
     "title": "Отчёты об Активности",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -744,7 +744,9 @@
     "importError": "CSV文件导入失败",
     "selectCSVFile": "选择CSV文件",
     "favorites": "收藏",
-    "noFavorites": "没有收藏的学习日志"
+    "noFavorites": "没有收藏的学习日志",
+    "monthlySummary": "月度摘要",
+    "noMonthlySummary": "没有月度数据"
   },
   "reports": {
     "title": "活动报告",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -746,7 +746,9 @@
     "importError": "CSV檔案匯入失敗",
     "selectCSVFile": "選擇CSV檔案",
     "favorites": "收藏",
-    "noFavorites": "沒有收藏的學習日誌"
+    "noFavorites": "沒有收藏的學習日誌",
+    "monthlySummary": "月度摘要",
+    "noMonthlySummary": "沒有月度資料"
   },
   "reports": {
     "title": "活動報告",


### PR DESCRIPTION
## 概要
- 月別学習サマリーAPI（GET /learning-logs/monthly-summary/:userId?months=12）を追加
- 各月の合計学習時間（分）とログ件数を集計
- months パラメータで取得期間を指定可能（1〜24ヶ月、デフォルト12）
- フロントエンドAPI関数 `getMonthlySummary` を追加
- 全10言語にi18nキー（monthlySummary, noMonthlySummary）を追加

## テスト
- [x] 月別サマリー取得成功テスト
- [x] 空結果テスト
- [x] 不正パラメータ（0、25）バリデーションテスト
- [x] DBエラーテスト
- [x] 全サービステスト通過

Closes #2105