### PR TITLE
refactor: レスポンス一貫性とエラーメッセージ日本語化

### DIFF
--- a/backend/internal/handler/article_platform.go
+++ b/backend/internal/handler/article_platform.go
@@ -89,7 +89,7 @@ func (h *ArticlePlatformHandler[A, S]) GetArticles(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, articles)
+	respondOK(c, ensureSlice(articles))
 }
 
 // GetStats は指定ユーザーの統計情報を返す。

--- a/backend/internal/handler/github.go
+++ b/backend/internal/handler/github.go
@@ -90,7 +90,7 @@ func (h *GitHubHandler) GetContributions(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, contributions)
+	respondOK(c, ensureSlice(contributions))
 }
 
 // GetLanguages は指定ユーザーのGitHubリポジトリの使用言語統計を取得する。
@@ -105,7 +105,7 @@ func (h *GitHubHandler) GetLanguages(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, stats)
+	respondOK(c, ensureSlice(stats))
 }
 
 // GetRepos は指定ユーザーのGitHubリポジトリ一覧を取得する。
@@ -120,7 +120,7 @@ func (h *GitHubHandler) GetRepos(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, repos)
+	respondOK(c, ensureSlice(repos))
 }
 
 // Sync は現在のユーザーのGitHubデータを手動で同期する。

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -123,7 +123,7 @@ func (h *ProjectHandler) GetFeatured(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, projects)
+	respondOK(c, ensureSlice(projects))
 }
 
 // Update は指定IDのプロジェクトを更新する。

--- a/backend/internal/handler/search.go
+++ b/backend/internal/handler/search.go
@@ -103,5 +103,5 @@ func (h *SearchHandler) SearchCircles(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, results)
+	respondOK(c, ensureSlice(results))
 }

--- a/backend/internal/handler/spotify.go
+++ b/backend/internal/handler/spotify.go
@@ -102,7 +102,7 @@ func (h *SpotifyHandler) GetRecentlyPlayed(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, tracks)
+	respondOK(c, ensureSlice(tracks))
 }
 
 // Disconnect はSpotify連携を解除する。

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -38,7 +38,7 @@ func (h *UserHandler) GetAll(c *gin.Context) {
 		respondError(c, err)
 		return
 	}
-	respondOK(c, users)
+	respondOK(c, ensureSlice(users))
 }
 
 // GetByID は指定IDのユーザー情報を返す。

--- a/backend/internal/service/auth.go
+++ b/backend/internal/service/auth.go
@@ -134,7 +134,7 @@ func (s *AuthService) Login(input LoginInput) (*AuthResponse, error) {
 func (s *AuthService) ValidateToken(tokenString string) (uint, error) {
 	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, domain.NewError(domain.ErrCodeUnauthorized, "unexpected signing method", nil)
+			return nil, domain.NewError(domain.ErrCodeUnauthorized, "予期しない署名方式です", nil)
 		}
 		return s.jwtSecret, nil
 	})
@@ -169,7 +169,7 @@ func (s *AuthService) GenerateLoginState() (string, error) {
 func (s *AuthService) ValidateLoginState(state string) error {
 	token, err := jwt.Parse(state, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, domain.NewError(domain.ErrCodeUnauthorized, "unexpected signing method", nil)
+			return nil, domain.NewError(domain.ErrCodeUnauthorized, "予期しない署名方式です", nil)
 		}
 		return s.jwtSecret, nil
 	})
@@ -280,7 +280,7 @@ func (s *AuthService) GenerateOAuthState(userID uint) (string, error) {
 func (s *AuthService) ValidateOAuthState(state string) (uint, error) {
 	token, err := jwt.Parse(state, func(token *jwt.Token) (interface{}, error) {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, domain.NewError(domain.ErrCodeUnauthorized, "unexpected signing method", nil)
+			return nil, domain.NewError(domain.ErrCodeUnauthorized, "予期しない署名方式です", nil)
 		}
 		return s.jwtSecret, nil
 	})

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -146,7 +146,7 @@ func (s *UserService) UpdateEmailPreferences(userID uint, weeklyReport *bool, la
 	}
 	if language != nil {
 		if !validEmailLanguages[*language] {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "invalid email language", nil)
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なメール言語設定です", nil)
 		}
 		user.EmailLanguage = *language
 	}


### PR DESCRIPTION
## 概要
Closes #2107

- **ensureSlice()追加（8箇所）**: スライスレスポンスが`null`ではなく`[]`を返すよう修正
  - user.go, search.go, project.go, github.go(3箇所), article_platform.go, spotify.go
- **エラーメッセージ日本語化（4箇所）**: Service層の英語エラーメッセージを日本語化
  - auth.go: "unexpected signing method" → "予期しない署名方式です"（3箇所）
  - user.go: "invalid email language" → "無効なメール言語設定です"

## テスト計画
- [x] `go test ./internal/service/... -v` — 全テスト合格