### PR TITLE
fix: OAuthパラメータ長さ制限・バックグラウンドエラーログ追加

### DIFF
--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"log"
 	"net/http"
 	"os"
 
@@ -9,6 +10,9 @@ import (
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
 )
+
+// oauthCodeMaxLen はOAuth認可コード・stateパラメータの最大許容長。
+const oauthCodeMaxLen = 2048
 
 // AuthServiceInterface は認証サービスの抽象インターフェース。
 type AuthServiceInterface interface {
@@ -130,7 +134,7 @@ func (h *AuthHandler) GitHubLoginCallback(c *gin.Context) {
 	code := c.Query("code")
 	state := c.Query("state")
 
-	if code == "" || state == "" {
+	if code == "" || state == "" || len(code) > oauthCodeMaxLen || len(state) > oauthCodeMaxLen {
 		respondError(c, service.ErrBadRequest)
 		return
 	}
@@ -159,7 +163,11 @@ func (h *AuthHandler) GitHubLoginCallback(c *gin.Context) {
 	}
 
 	// バックグラウンドでGitHubデータを同期
-	go h.githubService.SyncUserData(resp.User.ID)
+	go func() {
+		if err := h.githubService.SyncUserData(resp.User.ID); err != nil {
+			log.Printf("GitHubデータ同期エラー (userID=%d): %v", resp.User.ID, err)
+		}
+	}()
 
 	setAuthCookie(c, resp.Token)
 	respondOK(c, dto.UserResponse{User: resp.User})

--- a/backend/internal/handler/github.go
+++ b/backend/internal/handler/github.go
@@ -59,8 +59,8 @@ func (h *GitHubHandler) Callback(c *gin.Context) {
 	code := c.Query("code")
 	state := c.Query("state")
 
-	if code == "" || state == "" {
-		respondBadRequest(c, "missing code or state")
+	if code == "" || state == "" || len(code) > oauthCodeMaxLen || len(state) > oauthCodeMaxLen {
+		respondBadRequest(c, "missing or invalid code/state")
 		return
 	}
 

--- a/backend/internal/handler/spotify.go
+++ b/backend/internal/handler/spotify.go
@@ -56,8 +56,8 @@ func (h *SpotifyHandler) Callback(c *gin.Context) {
 	code := c.Query("code")
 	state := c.Query("state")
 
-	if code == "" || state == "" {
-		respondBadRequest(c, "missing code or state")
+	if code == "" || state == "" || len(code) > oauthCodeMaxLen || len(state) > oauthCodeMaxLen {
+		respondBadRequest(c, "missing or invalid code/state")
 		return
 	}
 


### PR DESCRIPTION
## 概要
Closes #2111

セキュリティ監査で発見された軽微な改善点を修正。

## 修正内容
- **OAuthパラメータ長さ制限**: `code`/`state`パラメータに2048文字の上限を追加
  - `auth.go`: GitHubログインコールバック
  - `github.go`: GitHub連携コールバック
  - `spotify.go`: Spotify連携コールバック
- **バックグラウンドgoroutineエラーログ**: GitHub同期の`go`ルーチンにエラーログを追加

## テスト計画
- [x] `go test ./internal/handler/...` — 全テスト合格
- [x] `go test ./internal/service/...` — 全テスト合格