### PR TITLE
feat: 学習ゴール進捗率API追加

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -30,6 +30,7 @@ type LearningLogServiceInterface interface {
 	UnfavoriteLog(id, userID uint) error
 	GetRecentCategories(userID uint) ([]string, error)
 	GetLinkedLogs(goalID, userID uint, limit, offset int) ([]model.LearningLog, int64, error)
+	GetGoalProgress(goalID, userID uint) (*model.GoalProgress, error)
 	GetFavorites(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	GetMonthlySummary(userID uint, months int) ([]model.MonthlySummary, error)
 }
@@ -451,4 +452,21 @@ func (h *LearningLogHandler) GetLinkedLogs(c *gin.Context) {
 		Limit:  limit,
 		Offset: offset,
 	})
+}
+
+// GetGoalProgress は指定ゴールの実績時間 vs 目標時間の進捗情報を返す。
+func (h *LearningLogHandler) GetGoalProgress(c *gin.Context) {
+	userID := c.GetUint("userID")
+	goalID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+
+	progress, err := h.service.GetGoalProgress(goalID, userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, progress)
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1451,6 +1451,14 @@ func (m *MockLearningLogService) GetMonthlySummary(userID uint, months int) ([]m
 	return args.Get(0).([]model.MonthlySummary), args.Error(1)
 }
 
+func (m *MockLearningLogService) GetGoalProgress(goalID, userID uint) (*model.GoalProgress, error) {
+	args := m.Called(goalID, userID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*model.GoalProgress), args.Error(1)
+}
+
 // setupLearningLogHandler はLearningLogHandlerテスト用のセットアップを行う。
 func setupLearningLogHandler() (*LearningLogHandler, *MockLearningLogService) {
 	svc := new(MockLearningLogService)

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -393,6 +393,7 @@ func registerGoalRoutes(g *gin.RouterGroup, c *di.Container) {
 		goals.GET("/public", c.LearningGoalHandler.GetPublicGoals)
 		goals.GET("/public/user/:userId", c.LearningGoalHandler.GetPublicByUserID)
 		goals.GET("/:id/linked-logs", c.LearningLogHandler.GetLinkedLogs)
+		goals.GET("/:id/progress", c.LearningLogHandler.GetGoalProgress)
 	}
 }
 

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -102,6 +102,40 @@ func (s *LearningLogService) GetLinkedLogs(goalID, userID uint, limit, offset in
 	return s.repo.GetByGoalID(goalID, limit, offset)
 }
 
+// GetGoalProgress は指定ゴールの実績時間 vs 目標時間の進捗情報を返す。所有権を検証する。
+func (s *LearningLogService) GetGoalProgress(goalID, userID uint) (*model.GoalProgress, error) {
+	if s.goalRepo == nil {
+		return nil, domain.NewError(domain.ErrCodeBadRequest, "ゴール連携が有効ではありません", nil)
+	}
+	goal, err := s.goalRepo.FindByID(goalID)
+	if err != nil {
+		return nil, domain.NewError(domain.ErrCodeNotFound, "指定されたゴールが見つかりません", err)
+	}
+	if goal.UserID != userID {
+		return nil, domain.NewError(domain.ErrCodeForbidden, "他のユーザーのゴール進捗は参照できません", nil)
+	}
+
+	actualMinutes, err := s.repo.SumDurationByGoalID(goalID)
+	if err != nil {
+		return nil, err
+	}
+
+	percentage := 0
+	if goal.TargetHours > 0 {
+		percentage = actualMinutes * 100 / (goal.TargetHours * 60)
+		if percentage > 100 {
+			percentage = 100
+		}
+	}
+
+	return &model.GoalProgress{
+		GoalID:        goalID,
+		TargetHours:   goal.TargetHours,
+		ActualMinutes: actualMinutes,
+		Percentage:    percentage,
+	}, nil
+}
+
 // BatchCreate は複数の学習ログを一括作成する。
 // 各ログのバリデーションを行い、全てパスした場合のみ一括保存する。
 // 最大50件まで。

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -1116,6 +1116,90 @@ func TestLearningLogGetLinkedLogs_NoGoalRepo(t *testing.T) {
 }
 
 // ============================================================
+// GetGoalProgress テスト
+// ============================================================
+
+func TestLearningLogGetGoalProgress_Success(t *testing.T) {
+	svc, repo, goalRepo := newTestLearningLogServiceWithGoalRepo()
+
+	goal := &model.LearningGoal{ID: 10, UserID: 1, TargetHours: 10}
+	goalRepo.On("FindByID", uint(10)).Return(goal, nil)
+	// 120分 = 2時間 / 10時間 = 20%
+	repo.On("SumDurationByGoalID", uint(10)).Return(120, nil)
+
+	progress, err := svc.GetGoalProgress(uint(10), uint(1))
+	assert.NoError(t, err)
+	assert.Equal(t, uint(10), progress.GoalID)
+	assert.Equal(t, 10, progress.TargetHours)
+	assert.Equal(t, 120, progress.ActualMinutes)
+	assert.Equal(t, 20, progress.Percentage)
+	repo.AssertExpectations(t)
+	goalRepo.AssertExpectations(t)
+}
+
+func TestLearningLogGetGoalProgress_ZeroTargetHours(t *testing.T) {
+	svc, repo, goalRepo := newTestLearningLogServiceWithGoalRepo()
+
+	goal := &model.LearningGoal{ID: 10, UserID: 1, TargetHours: 0}
+	goalRepo.On("FindByID", uint(10)).Return(goal, nil)
+	repo.On("SumDurationByGoalID", uint(10)).Return(60, nil)
+
+	progress, err := svc.GetGoalProgress(uint(10), uint(1))
+	assert.NoError(t, err)
+	assert.Equal(t, 0, progress.Percentage)
+	assert.Equal(t, 60, progress.ActualMinutes)
+	repo.AssertExpectations(t)
+	goalRepo.AssertExpectations(t)
+}
+
+func TestLearningLogGetGoalProgress_Over100Percent(t *testing.T) {
+	svc, repo, goalRepo := newTestLearningLogServiceWithGoalRepo()
+
+	goal := &model.LearningGoal{ID: 10, UserID: 1, TargetHours: 1}
+	goalRepo.On("FindByID", uint(10)).Return(goal, nil)
+	// 120分 = 2時間 / 1時間 = 200% → キャップ100%
+	repo.On("SumDurationByGoalID", uint(10)).Return(120, nil)
+
+	progress, err := svc.GetGoalProgress(uint(10), uint(1))
+	assert.NoError(t, err)
+	assert.Equal(t, 100, progress.Percentage)
+	repo.AssertExpectations(t)
+	goalRepo.AssertExpectations(t)
+}
+
+func TestLearningLogGetGoalProgress_Forbidden(t *testing.T) {
+	svc, _, goalRepo := newTestLearningLogServiceWithGoalRepo()
+
+	goal := &model.LearningGoal{ID: 10, UserID: 999}
+	goalRepo.On("FindByID", uint(10)).Return(goal, nil)
+
+	_, err := svc.GetGoalProgress(uint(10), uint(1))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrForbidden)
+	goalRepo.AssertExpectations(t)
+}
+
+func TestLearningLogGetGoalProgress_NotFound(t *testing.T) {
+	svc, _, goalRepo := newTestLearningLogServiceWithGoalRepo()
+
+	goalRepo.On("FindByID", uint(999)).Return(nil, errors.New("not found"))
+
+	_, err := svc.GetGoalProgress(uint(999), uint(1))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+	goalRepo.AssertExpectations(t)
+}
+
+func TestLearningLogGetGoalProgress_NoGoalRepo(t *testing.T) {
+	repo := new(MockLearningLogRepository)
+	svc := NewLearningLogService(repo, nil)
+
+	_, err := svc.GetGoalProgress(uint(10), uint(1))
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+}
+
+// ============================================================
 // ImportCSV テスト
 // ============================================================
 

--- a/frontend/src/api/goals.ts
+++ b/frontend/src/api/goals.ts
@@ -32,6 +32,13 @@ export interface GoalDeadlineAlert {
   days_left: number;
 }
 
+export interface GoalProgress {
+  goal_id: number;
+  target_hours: number;
+  actual_minutes: number;
+  percentage: number;
+}
+
 export interface CreateGoalRequest {
   title: string;
   description?: string;
@@ -86,3 +93,6 @@ export const getPublicGoals = (limit = 20, offset = 0) =>
 
 export const getPublicGoalsByUser = (userId: number, limit = 20, offset = 0) =>
   client.get<LearningGoal[]>(`/goals/public/user/${userId}`, { params: { limit, offset } });
+
+export const getGoalProgress = (goalId: number) =>
+  client.get<GoalProgress>(`/goals/${goalId}/progress`);

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -107,7 +107,12 @@
     "viewsReceived": "Aufrufe",
     "followerCount": "Follower",
     "followingCount": "Folge ich",
-    "noStats": "Keine Statistiken verfügbar"
+    "noStats": "Keine Statistiken verfügbar",
+    "goalProgressTitle": "Zielfortschritt",
+    "goalProgressTargetHours": "Zielstunden",
+    "goalProgressActualTime": "Tatsächliche Zeit",
+    "goalProgressPercentage": "Erfolgsquote",
+    "goalProgressNoTarget": "Zielstunden nicht festgelegt"
   },
   "series": {
     "title": "Beitragsserien",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -107,7 +107,12 @@
     "viewsReceived": "Views",
     "followerCount": "Followers",
     "followingCount": "Following",
-    "noStats": "No stats available"
+    "noStats": "No stats available",
+    "goalProgressTitle": "Goal Progress",
+    "goalProgressTargetHours": "Target Hours",
+    "goalProgressActualTime": "Actual Time",
+    "goalProgressPercentage": "Completion Rate",
+    "goalProgressNoTarget": "Target hours not set"
   },
   "series": {
     "title": "Post Series",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -107,7 +107,12 @@
     "viewsReceived": "Vistas",
     "followerCount": "Seguidores",
     "followingCount": "Siguiendo",
-    "noStats": "No hay estadísticas disponibles"
+    "noStats": "No hay estadísticas disponibles",
+    "goalProgressTitle": "Progreso del objetivo",
+    "goalProgressTargetHours": "Horas objetivo",
+    "goalProgressActualTime": "Tiempo real",
+    "goalProgressPercentage": "Tasa de logro",
+    "goalProgressNoTarget": "Horas objetivo no establecidas"
   },
   "series": {
     "title": "Series de publicaciones",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -107,7 +107,12 @@
     "viewsReceived": "Vues",
     "followerCount": "Abonnés",
     "followingCount": "Abonnements",
-    "noStats": "Aucune statistique disponible"
+    "noStats": "Aucune statistique disponible",
+    "goalProgressTitle": "Progression de l'objectif",
+    "goalProgressTargetHours": "Heures cibles",
+    "goalProgressActualTime": "Temps réel",
+    "goalProgressPercentage": "Taux de réalisation",
+    "goalProgressNoTarget": "Heures cibles non définies"
   },
   "series": {
     "title": "Séries de publications",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -108,7 +108,12 @@
     "viewsReceived": "閲覧数",
     "followerCount": "フォロワー数",
     "followingCount": "フォロー中",
-    "noStats": "統計情報がありません"
+    "noStats": "統計情報がありません",
+    "goalProgressTitle": "学習ゴール進捗",
+    "goalProgressTargetHours": "目標時間",
+    "goalProgressActualTime": "実績時間",
+    "goalProgressPercentage": "達成率",
+    "goalProgressNoTarget": "目標時間が未設定です"
   },
   "series": {
     "title": "投稿シリーズ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -107,7 +107,12 @@
     "viewsReceived": "조회수",
     "followerCount": "팔로워",
     "followingCount": "팔로잉",
-    "noStats": "통계 정보가 없습니다"
+    "noStats": "통계 정보가 없습니다",
+    "goalProgressTitle": "학습 목표 진행률",
+    "goalProgressTargetHours": "목표 시간",
+    "goalProgressActualTime": "실적 시간",
+    "goalProgressPercentage": "달성률",
+    "goalProgressNoTarget": "목표 시간이 설정되지 않았습니다"
   },
   "series": {
     "title": "게시물 시리즈",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -107,7 +107,12 @@
     "viewsReceived": "Visualizações",
     "followerCount": "Seguidores",
     "followingCount": "Seguindo",
-    "noStats": "Sem estatísticas disponíveis"
+    "noStats": "Sem estatísticas disponíveis",
+    "goalProgressTitle": "Progresso da meta",
+    "goalProgressTargetHours": "Horas alvo",
+    "goalProgressActualTime": "Tempo real",
+    "goalProgressPercentage": "Taxa de conclusão",
+    "goalProgressNoTarget": "Horas alvo não definidas"
   },
   "series": {
     "title": "Séries de publicações",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -107,7 +107,12 @@
     "viewsReceived": "Просмотры",
     "followerCount": "Подписчики",
     "followingCount": "Подписки",
-    "noStats": "Статистика недоступна"
+    "noStats": "Статистика недоступна",
+    "goalProgressTitle": "Прогресс цели",
+    "goalProgressTargetHours": "Целевые часы",
+    "goalProgressActualTime": "Фактическое время",
+    "goalProgressPercentage": "Процент выполнения",
+    "goalProgressNoTarget": "Целевые часы не установлены"
   },
   "series": {
     "title": "Серии публикаций",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -107,7 +107,12 @@
     "viewsReceived": "浏览量",
     "followerCount": "粉丝数",
     "followingCount": "关注中",
-    "noStats": "暂无统计信息"
+    "noStats": "暂无统计信息",
+    "goalProgressTitle": "学习目标进度",
+    "goalProgressTargetHours": "目标时间",
+    "goalProgressActualTime": "实际时间",
+    "goalProgressPercentage": "完成率",
+    "goalProgressNoTarget": "未设置目标时间"
   },
   "series": {
     "title": "帖子系列",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -107,7 +107,12 @@
     "viewsReceived": "瀏覽量",
     "followerCount": "追蹤者",
     "followingCount": "追蹤中",
-    "noStats": "暫無統計資訊"
+    "noStats": "暫無統計資訊",
+    "goalProgressTitle": "學習目標進度",
+    "goalProgressTargetHours": "目標時間",
+    "goalProgressActualTime": "實際時間",
+    "goalProgressPercentage": "完成率",
+    "goalProgressNoTarget": "未設定目標時間"
   },
   "series": {
     "title": "貼文系列",


### PR DESCRIPTION
## 概要
学習ゴールの実績時間 vs 目標時間の進捗情報を取得するAPIを実装。

closes #2115

## 変更内容
- **Service層**: `GetGoalProgress(goalID, userID)` メソッド追加（所有権チェック・進捗計算ロジック）
- **Handler層**: `GetGoalProgress` ハンドラーメソッド追加
- **Router**: `GET /goals/:id/progress` ルート追加
- **テスト**: Service層6ケース（成功・0時間目標・100%超過キャップ・権限エラー・未検出・連携無効）
- **フロントエンドAPI**: `GoalProgress` 型 + `getGoalProgress` 関数追加
- **i18n**: 全10言語にgoalProgress関連キー追加

## テスト計画
- [x] `go test ./internal/service/... -v` 全パス
- [x] `go test ./internal/handler/... -v` 全パス
- [x] `npx tsc --noEmit` 型チェック通過