### PR TITLE
feat: フロントエンドAPIギャップ13件修正

### DIFF
--- a/frontend/src/api/advice.ts
+++ b/frontend/src/api/advice.ts
@@ -60,3 +60,6 @@ export const getConversation = (id: number) =>
 
 export const deleteConversation = (id: number) =>
   client.delete(`/advice/conversations/${id}`);
+
+export const getUnreadAdvice = () =>
+  client.get<AdviceResponse>('/advice/unread');

--- a/frontend/src/api/goals.ts
+++ b/frontend/src/api/goals.ts
@@ -96,3 +96,9 @@ export const getPublicGoalsByUser = (userId: number, limit = 20, offset = 0) =>
 
 export const getGoalProgress = (goalId: number) =>
   client.get<GoalProgress>(`/goals/${goalId}/progress`);
+
+export const getGoalsByCategory = (category: GoalCategory) =>
+  client.get<LearningGoal[]>(`/goals/category/${category}`);
+
+export const getGoalsByStatus = (status: GoalStatus) =>
+  client.get<LearningGoal[]>(`/goals/status/${status}`);

--- a/frontend/src/api/noteLinks.ts
+++ b/frontend/src/api/noteLinks.ts
@@ -25,3 +25,6 @@ export const getNoteBacklinks = (noteId: number) =>
 
 export const deleteNoteLink = (sourceNoteId: number, targetNoteId: number) =>
   client.delete(`/notes/${sourceNoteId}/links/${targetNoteId}`);
+
+export const getNoteLinkStats = (noteId: number) =>
+  client.get(`/notes/${noteId}/link-stats`);

--- a/frontend/src/api/posts.ts
+++ b/frontend/src/api/posts.ts
@@ -152,3 +152,12 @@ export const unlikeComment = (commentId: number) =>
 
 export const getCommentLikeStatus = (commentId: number) =>
   client.get<{ liked: boolean; like_count: number }>(`/comments/${commentId}/likes`);
+
+export const unpublishPost = (id: number) =>
+  client.put<Post>(`/posts/${id}/unpublish`);
+
+export const hideComment = (postId: number, commentId: number) =>
+  client.post(`/posts/${postId}/comments/${commentId}/hide`);
+
+export const unhideComment = (postId: number, commentId: number) =>
+  client.post(`/posts/${postId}/comments/${commentId}/unhide`);

--- a/frontend/src/api/qa.ts
+++ b/frontend/src/api/qa.ts
@@ -101,3 +101,19 @@ export const getUnansweredQuestions = async (
   const res = await client.get('/questions/unanswered', { params: { limit, offset } });
   return res.data;
 };
+
+export const getSolvedQuestions = async (
+  limit = 20, offset = 0
+): Promise<{ questions: Question[]; total: number }> => {
+  const res = await client.get('/questions/solved', { params: { limit, offset } });
+  return res.data;
+};
+
+export const getAnswersByVoteRange = async (
+  questionId: number, minVotes: number, maxVotes: number
+): Promise<Answer[]> => {
+  const res = await client.get(`/questions/${questionId}/answers/vote-range`, {
+    params: { min_votes: minVotes, max_votes: maxVotes },
+  });
+  return res.data;
+};

--- a/frontend/src/api/resources.ts
+++ b/frontend/src/api/resources.ts
@@ -159,3 +159,10 @@ export const updateResourceReview = async (reviewId: number, data: UpdateResourc
 export const deleteResourceReview = async (reviewId: number): Promise<void> => {
   await client.delete(`/resources/reviews/${reviewId}`);
 };
+
+export const getResourcesByDifficulty = async (
+  difficulty: string, limit = 20, offset = 0
+): Promise<{ resources: LearningResource[]; total: number }> => {
+  const res = await client.get(`/resources/difficulty/${difficulty}`, { params: { limit, offset } });
+  return res.data;
+};

--- a/frontend/src/api/roadmaps.ts
+++ b/frontend/src/api/roadmaps.ts
@@ -129,3 +129,6 @@ export const getTemplates = () =>
 
 export const createFromTemplate = (templateId: number) =>
   client.post<Roadmap>(`/roadmaps/templates/${templateId}/use`);
+
+export const getRoadmapsByStatus = (status: RoadmapStatus) =>
+  client.get<Roadmap[]>(`/roadmaps/status/${status}`);

--- a/frontend/src/api/snippets.ts
+++ b/frontend/src/api/snippets.ts
@@ -34,3 +34,6 @@ export const unfavoriteSnippet = (id: number) =>
 
 export const getFavoritedSnippets = (limit = 20, offset = 0) =>
   client.get<{ snippets: CodeSnippet[]; total: number }>('/snippets/favorites', { params: { limit, offset } });
+
+export const getSnippetsByLanguage = (language: string, limit = 20, offset = 0) =>
+  client.get<CodeSnippet[]>(`/snippets/language/${language}`, { params: { limit, offset } });

--- a/frontend/src/api/studyCircles.ts
+++ b/frontend/src/api/studyCircles.ts
@@ -72,3 +72,6 @@ export const getStreakRanking = (circleId: number) =>
 // 検索
 export const searchCircles = (query: string, limit = 20, offset = 0) =>
   client.get<StudyCircle[]>('/search/circles', { params: { q: query, limit, offset } });
+
+export const getCirclesByStatus = (status: string) =>
+  client.get<StudyCircle[]>(`/study-circles/status/${status}`);


### PR DESCRIPTION
## 概要
バックエンドに存在するがフロントエンドAPI層に不足していた13個のエンドポイント関数を追加。

closes #2117

## 変更内容
| ファイル | 追加関数 |
|---------|--------|
| posts.ts | `unpublishPost`, `hideComment`, `unhideComment` |
| advice.ts | `getUnreadAdvice` |
| qa.ts | `getSolvedQuestions`, `getAnswersByVoteRange` |
| goals.ts | `getGoalsByCategory`, `getGoalsByStatus` |
| resources.ts | `getResourcesByDifficulty` |
| snippets.ts | `getSnippetsByLanguage` |
| noteLinks.ts | `getNoteLinkStats` |
| studyCircles.ts | `getCirclesByStatus` |
| roadmaps.ts | `getRoadmapsByStatus` |

## テスト計画
- [x] `npx tsc --noEmit` 型チェック通過