### PR TITLE
feat: ノートお気に入り一覧フロントエンドAPI追加

### DIFF
--- a/frontend/src/api/notes.ts
+++ b/frontend/src/api/notes.ts
@@ -80,3 +80,6 @@ export const duplicateNote = (id: number) =>
 
 export const exportNoteMarkdown = (id: number) =>
   client.get<Blob>(`/notes/${id}/export`, { responseType: 'blob' });
+
+export const getFavoriteNotes = (page = 1, limit = 20) =>
+  client.get<NotePaginatedResponse>(`/notes/favorites?page=${page}&limit=${limit}`);

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -884,7 +884,9 @@
     "likeFailed": "Fehler beim Liken",
     "unlikeFailed": "Fehler beim Entfernen des Likes",
     "saveFailed": "Fehler beim Speichern",
-    "unsaveFailed": "Fehler beim Entfernen der Speicherung"
+    "unsaveFailed": "Fehler beim Entfernen der Speicherung",
+    "noteFavorites": "Favorisierte Notizen",
+    "noteFavoritesEmpty": "Noch keine favorisierten Notizen"
   },
   "portfolio": {
     "generate": "Portfolio",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -885,7 +885,9 @@
     "likeFailed": "Failed to like",
     "unlikeFailed": "Failed to unlike",
     "saveFailed": "Failed to save",
-    "unsaveFailed": "Failed to unsave"
+    "unsaveFailed": "Failed to unsave",
+    "noteFavorites": "Favorite Notes",
+    "noteFavoritesEmpty": "No favorite notes yet"
   },
   "portfolio": {
     "generate": "Portfolio",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -885,7 +885,9 @@
     "likeFailed": "Error al dar me gusta",
     "unlikeFailed": "Error al quitar me gusta",
     "saveFailed": "Error al guardar",
-    "unsaveFailed": "Error al quitar guardado"
+    "unsaveFailed": "Error al quitar guardado",
+    "noteFavorites": "Notas favoritas",
+    "noteFavoritesEmpty": "Aún no hay notas favoritas"
   },
   "portfolio": {
     "generate": "Portafolio",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -885,7 +885,9 @@
     "likeFailed": "Échec de l'ajout du j'aime",
     "unlikeFailed": "Échec du retrait du j'aime",
     "saveFailed": "Échec de la sauvegarde",
-    "unsaveFailed": "Échec du retrait de la sauvegarde"
+    "unsaveFailed": "Échec du retrait de la sauvegarde",
+    "noteFavorites": "Notes favorites",
+    "noteFavoritesEmpty": "Aucune note favorite pour le moment"
   },
   "portfolio": {
     "generate": "Portfolio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -849,7 +849,9 @@
     "likeFailed": "いいねに失敗しました",
     "unlikeFailed": "いいね解除に失敗しました",
     "saveFailed": "保存に失敗しました",
-    "unsaveFailed": "保存解除に失敗しました"
+    "unsaveFailed": "保存解除に失敗しました",
+    "noteFavorites": "お気に入りノート",
+    "noteFavoritesEmpty": "お気に入りノートはまだありません"
   },
   "portfolio": {
     "generate": "ポートフォリオ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -886,7 +886,9 @@
     "likeFailed": "좋아요에 실패했습니다",
     "unlikeFailed": "좋아요 취소에 실패했습니다",
     "saveFailed": "저장에 실패했습니다",
-    "unsaveFailed": "저장 취소에 실패했습니다"
+    "unsaveFailed": "저장 취소에 실패했습니다",
+    "noteFavorites": "즐겨찾기 노트",
+    "noteFavoritesEmpty": "즐겨찾기 노트가 아직 없습니다"
   },
   "portfolio": {
     "generate": "포트폴리오",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -885,7 +885,9 @@
     "likeFailed": "Falha ao curtir",
     "unlikeFailed": "Falha ao descurtir",
     "saveFailed": "Falha ao salvar",
-    "unsaveFailed": "Falha ao remover dos salvos"
+    "unsaveFailed": "Falha ao remover dos salvos",
+    "noteFavorites": "Notas favoritas",
+    "noteFavoritesEmpty": "Nenhuma nota favorita ainda"
   },
   "portfolio": {
     "generate": "Portfólio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -884,7 +884,9 @@
     "likeFailed": "Не удалось поставить лайк",
     "unlikeFailed": "Не удалось убрать лайк",
     "saveFailed": "Не удалось сохранить",
-    "unsaveFailed": "Не удалось убрать из сохранённых"
+    "unsaveFailed": "Не удалось убрать из сохранённых",
+    "noteFavorites": "Избранные заметки",
+    "noteFavoritesEmpty": "Избранных заметок пока нет"
   },
   "portfolio": {
     "generate": "Портфолио",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -885,7 +885,9 @@
     "likeFailed": "点赞失败",
     "unlikeFailed": "取消点赞失败",
     "saveFailed": "收藏失败",
-    "unsaveFailed": "取消收藏失败"
+    "unsaveFailed": "取消收藏失败",
+    "noteFavorites": "收藏笔记",
+    "noteFavoritesEmpty": "还没有收藏的笔记"
   },
   "portfolio": {
     "generate": "作品集",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -886,7 +886,9 @@
     "likeFailed": "按讚失敗",
     "unlikeFailed": "取消按讚失敗",
     "saveFailed": "收藏失敗",
-    "unsaveFailed": "取消收藏失敗"
+    "unsaveFailed": "取消收藏失敗",
+    "noteFavorites": "收藏筆記",
+    "noteFavoritesEmpty": "還沒有收藏的筆記"
   },
   "portfolio": {
     "generate": "作品集",


### PR DESCRIPTION
## 概要
バックエンド `GET /notes/favorites` に対応するフロントエンドAPI関数を追加。

closes #2119

## 変更内容
- `getFavoriteNotes(page, limit)` 関数追加（notes.ts）
- i18nキー `noteFavorites`, `noteFavoritesEmpty` を全10言語に追加

## テスト計画
- [x] `npx tsc --noEmit` 型チェック通過