### PR TITLE
feat: スタディサークルメンバー役割更新API追加

### DIFF
--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -27,6 +27,7 @@ type StudyCircleServiceInterface interface {
 	GetCheckins(circleID, userID uint) ([]model.StudyCircleCheckin, error)
 	GetStreakRanking(circleID, userID uint) ([]model.CircleMemberStreak, error)
 	GetByStatus(userID uint, status string) ([]model.StudyCircle, error)
+	UpdateMemberRole(circleID, userID, targetUserID uint, role string) error
 }
 
 // StudyCircleHandler はスタディサークル関連のHTTPリクエストを処理する。
@@ -340,4 +341,32 @@ func (h *StudyCircleHandler) GetByStatus(c *gin.Context) {
 		return
 	}
 	respondOK(c, ensureSlice(circles))
+}
+
+// UpdateMemberRole はメンバーの役割を更新する。オーナーのみ操作可能。
+func (h *StudyCircleHandler) UpdateMemberRole(c *gin.Context) {
+	userID := c.GetUint("userID")
+	circleID, ok := parseID(c, "id")
+	if !ok {
+		return
+	}
+	targetUserID, ok := parseID(c, "userId")
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Role string `json:"role" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		respondError(c, domain.NewError(domain.ErrCodeBadRequest, "役割の指定が必要です", err))
+		return
+	}
+
+	if err := h.service.UpdateMemberRole(circleID, userID, targetUserID, req.Role); err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"message": "メンバー役割を更新しました"})
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -768,6 +768,11 @@ func (m *MockStudyCircleRepository) GetByStatus(userID uint, status string) ([]m
 	return args.Get(0).([]model.StudyCircle), args.Error(1)
 }
 
+func (m *MockStudyCircleRepository) UpdateMemberRole(circleID, userID uint, role model.StudyCircleMemberRole) error {
+	args := m.Called(circleID, userID, role)
+	return args.Error(0)
+}
+
 // setupStudyCircleHandler はStudyCircleHandlerテスト用のセットアップを行う。
 func setupStudyCircleHandler() (*StudyCircleHandler, *MockStudyCircleRepository) {
 	repo := new(MockStudyCircleRepository)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -460,6 +460,7 @@ type StudyCircleRepositoryInterface interface {
 	GetMembers(circleID uint) ([]model.StudyCircleMember, error)
 	IsMember(circleID, userID uint) (bool, error)
 	GetMemberCount(circleID uint) (int, error)
+	UpdateMemberRole(circleID, userID uint, role model.StudyCircleMemberRole) error
 
 	// ステップCRUD
 	CreateStep(step *model.StudyCircleStep) error

--- a/backend/internal/repository/study_circle.go
+++ b/backend/internal/repository/study_circle.go
@@ -113,6 +113,13 @@ func (r *StudyCircleRepository) RemoveMember(circleID, userID uint) error {
 	return r.db.Where("circle_id = ? AND user_id = ?", circleID, userID).Delete(&model.StudyCircleMember{}).Error
 }
 
+// UpdateMemberRole はメンバーの役割を更新する。
+func (r *StudyCircleRepository) UpdateMemberRole(circleID, userID uint, role model.StudyCircleMemberRole) error {
+	return r.db.Model(&model.StudyCircleMember{}).
+		Where("circle_id = ? AND user_id = ?", circleID, userID).
+		Update("role", role).Error
+}
+
 // GetMembers はメンバー一覧を返す。
 func (r *StudyCircleRepository) GetMembers(circleID uint) ([]model.StudyCircleMember, error) {
 	var members []model.StudyCircleMember

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -694,6 +694,7 @@ func registerStudyCircleRoutes(g *gin.RouterGroup, c *di.Container) {
 		circles.GET("/:id/members", c.StudyCircleHandler.GetMembers)
 		circles.POST("/:id/members", c.StudyCircleHandler.AddMember)
 		circles.DELETE("/:id/members/:userId", c.StudyCircleHandler.RemoveMember)
+		circles.PUT("/:id/members/:userId/role", c.StudyCircleHandler.UpdateMemberRole)
 		circles.POST("/:id/steps", c.StudyCircleHandler.CreateStep)
 		circles.PUT("/:id/steps/:stepId", c.StudyCircleHandler.UpdateStep)
 		circles.DELETE("/:id/steps/:stepId", c.StudyCircleHandler.DeleteStep)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1752,6 +1752,11 @@ func (m *MockStudyCircleRepository) GetByStatus(userID uint, status string) ([]m
 	return args.Get(0).([]model.StudyCircle), args.Error(1)
 }
 
+func (m *MockStudyCircleRepository) UpdateMemberRole(circleID, userID uint, role model.StudyCircleMemberRole) error {
+	args := m.Called(circleID, userID, role)
+	return args.Error(0)
+}
+
 // インターフェース適合チェック
 var _ EmailSenderInterface = (*MockEmailSender)(nil)
 var _ repository.ActivityReportRepositoryInterface = (*MockActivityReportRepository)(nil)

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -203,6 +203,34 @@ func (s *StudyCircleService) AddMember(circleID, userID, targetUserID uint) erro
 	return s.repo.AddMember(circleID, targetUserID, model.StudyCircleRoleMember)
 }
 
+// validMemberRoles は有効なメンバー役割のマップ。
+var validMemberRoles = map[string]bool{
+	string(model.StudyCircleRoleOwner):  true,
+	string(model.StudyCircleRoleMember): true,
+}
+
+// UpdateMemberRole はメンバーの役割を更新する。オーナーのみ操作可能。
+// オーナー自身の役割は変更不可。
+func (s *StudyCircleService) UpdateMemberRole(circleID, userID, targetUserID uint, role string) error {
+	if !validMemberRoles[role] {
+		return domain.NewError(domain.ErrCodeBadRequest, "無効な役割です", nil)
+	}
+	if _, err := s.findAndCheckOwnership(circleID, userID); err != nil {
+		return err
+	}
+	if userID == targetUserID {
+		return domain.NewError(domain.ErrCodeBadRequest, "オーナー自身の役割は変更できません", nil)
+	}
+	isMember, err := s.repo.IsMember(circleID, targetUserID)
+	if err != nil {
+		return err
+	}
+	if !isMember {
+		return domain.NewError(domain.ErrCodeNotFound, "指定されたユーザーはメンバーではありません", nil)
+	}
+	return s.repo.UpdateMemberRole(circleID, targetUserID, model.StudyCircleMemberRole(role))
+}
+
 // RemoveMember はメンバーを除外する。オーナーは誰でも除外可、メンバーは自分のみ退出可。
 func (s *StudyCircleService) RemoveMember(circleID, userID, targetUserID uint) error {
 	circle, err := s.repo.FindByID(circleID)

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -1119,3 +1119,61 @@ func TestStudyCircleUpdateStep_DescriptionTooLong(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "説明は1000文字以下である必要があります")
 }
+
+// ============================================================
+// UpdateMemberRole テスト
+// ============================================================
+
+func TestStudyCircleUpdateMemberRole_Success(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("IsMember", uint(1), uint(2)).Return(true, nil)
+	repo.On("UpdateMemberRole", uint(1), uint(2), model.StudyCircleRoleOwner).Return(nil)
+
+	err := svc.UpdateMemberRole(1, 1, 2, "owner")
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleUpdateMemberRole_InvalidRole(t *testing.T) {
+	svc, _ := newTestStudyCircleService()
+
+	err := svc.UpdateMemberRole(1, 1, 2, "admin")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+}
+
+func TestStudyCircleUpdateMemberRole_NotOwner(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, OwnerID: 999}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+
+	err := svc.UpdateMemberRole(1, 1, 2, "member")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrForbidden)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleUpdateMemberRole_SelfChange(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+
+	err := svc.UpdateMemberRole(1, 1, 1, "member")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrBadRequest)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleUpdateMemberRole_TargetNotMember(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+	circle := &model.StudyCircle{ID: 1, OwnerID: 1}
+	repo.On("FindByID", uint(1)).Return(circle, nil)
+	repo.On("IsMember", uint(1), uint(2)).Return(false, nil)
+
+	err := svc.UpdateMemberRole(1, 1, 2, "member")
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, ErrNotFound)
+	repo.AssertExpectations(t)
+}

--- a/frontend/src/api/studyCircles.ts
+++ b/frontend/src/api/studyCircles.ts
@@ -75,3 +75,6 @@ export const searchCircles = (query: string, limit = 20, offset = 0) =>
 
 export const getCirclesByStatus = (status: string) =>
   client.get<StudyCircle[]>(`/study-circles/status/${status}`);
+
+export const updateMemberRole = (circleId: number, userId: number, role: 'owner' | 'member') =>
+  client.put(`/study-circles/${circleId}/members/${userId}/role`, { role });

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -886,7 +886,11 @@
     "saveFailed": "Fehler beim Speichern",
     "unsaveFailed": "Fehler beim Entfernen der Speicherung",
     "noteFavorites": "Favorisierte Notizen",
-    "noteFavoritesEmpty": "Noch keine favorisierten Notizen"
+    "noteFavoritesEmpty": "Noch keine favorisierten Notizen",
+    "updateMemberRole": "Mitgliedsrolle aktualisieren",
+    "roleOwner": "Eigentümer",
+    "roleMember": "Mitglied",
+    "memberRoleUpdated": "Mitgliedsrolle aktualisiert"
   },
   "portfolio": {
     "generate": "Portfolio",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -887,7 +887,11 @@
     "saveFailed": "Failed to save",
     "unsaveFailed": "Failed to unsave",
     "noteFavorites": "Favorite Notes",
-    "noteFavoritesEmpty": "No favorite notes yet"
+    "noteFavoritesEmpty": "No favorite notes yet",
+    "updateMemberRole": "Update Member Role",
+    "roleOwner": "Owner",
+    "roleMember": "Member",
+    "memberRoleUpdated": "Member role updated"
   },
   "portfolio": {
     "generate": "Portfolio",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -887,7 +887,11 @@
     "saveFailed": "Error al guardar",
     "unsaveFailed": "Error al quitar guardado",
     "noteFavorites": "Notas favoritas",
-    "noteFavoritesEmpty": "Aún no hay notas favoritas"
+    "noteFavoritesEmpty": "Aún no hay notas favoritas",
+    "updateMemberRole": "Actualizar rol de miembro",
+    "roleOwner": "Propietario",
+    "roleMember": "Miembro",
+    "memberRoleUpdated": "Rol de miembro actualizado"
   },
   "portfolio": {
     "generate": "Portafolio",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -887,7 +887,11 @@
     "saveFailed": "Échec de la sauvegarde",
     "unsaveFailed": "Échec du retrait de la sauvegarde",
     "noteFavorites": "Notes favorites",
-    "noteFavoritesEmpty": "Aucune note favorite pour le moment"
+    "noteFavoritesEmpty": "Aucune note favorite pour le moment",
+    "updateMemberRole": "Modifier le rôle du membre",
+    "roleOwner": "Propriétaire",
+    "roleMember": "Membre",
+    "memberRoleUpdated": "Rôle du membre mis à jour"
   },
   "portfolio": {
     "generate": "Portfolio",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -851,7 +851,11 @@
     "saveFailed": "保存に失敗しました",
     "unsaveFailed": "保存解除に失敗しました",
     "noteFavorites": "お気に入りノート",
-    "noteFavoritesEmpty": "お気に入りノートはまだありません"
+    "noteFavoritesEmpty": "お気に入りノートはまだありません",
+    "updateMemberRole": "メンバー役割を更新",
+    "roleOwner": "オーナー",
+    "roleMember": "メンバー",
+    "memberRoleUpdated": "メンバー役割を更新しました"
   },
   "portfolio": {
     "generate": "ポートフォリオ",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -888,7 +888,11 @@
     "saveFailed": "저장에 실패했습니다",
     "unsaveFailed": "저장 취소에 실패했습니다",
     "noteFavorites": "즐겨찾기 노트",
-    "noteFavoritesEmpty": "즐겨찾기 노트가 아직 없습니다"
+    "noteFavoritesEmpty": "즐겨찾기 노트가 아직 없습니다",
+    "updateMemberRole": "멤버 역할 변경",
+    "roleOwner": "소유자",
+    "roleMember": "멤버",
+    "memberRoleUpdated": "멤버 역할이 변경되었습니다"
   },
   "portfolio": {
     "generate": "포트폴리오",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -887,7 +887,11 @@
     "saveFailed": "Falha ao salvar",
     "unsaveFailed": "Falha ao remover dos salvos",
     "noteFavorites": "Notas favoritas",
-    "noteFavoritesEmpty": "Nenhuma nota favorita ainda"
+    "noteFavoritesEmpty": "Nenhuma nota favorita ainda",
+    "updateMemberRole": "Atualizar função do membro",
+    "roleOwner": "Proprietário",
+    "roleMember": "Membro",
+    "memberRoleUpdated": "Função do membro atualizada"
   },
   "portfolio": {
     "generate": "Portfólio",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -886,7 +886,11 @@
     "saveFailed": "Не удалось сохранить",
     "unsaveFailed": "Не удалось убрать из сохранённых",
     "noteFavorites": "Избранные заметки",
-    "noteFavoritesEmpty": "Избранных заметок пока нет"
+    "noteFavoritesEmpty": "Избранных заметок пока нет",
+    "updateMemberRole": "Обновить роль участника",
+    "roleOwner": "Владелец",
+    "roleMember": "Участник",
+    "memberRoleUpdated": "Роль участника обновлена"
   },
   "portfolio": {
     "generate": "Портфолио",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -887,7 +887,11 @@
     "saveFailed": "收藏失败",
     "unsaveFailed": "取消收藏失败",
     "noteFavorites": "收藏笔记",
-    "noteFavoritesEmpty": "还没有收藏的笔记"
+    "noteFavoritesEmpty": "还没有收藏的笔记",
+    "updateMemberRole": "更新成员角色",
+    "roleOwner": "所有者",
+    "roleMember": "成员",
+    "memberRoleUpdated": "成员角色已更新"
   },
   "portfolio": {
     "generate": "作品集",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -888,7 +888,11 @@
     "saveFailed": "收藏失敗",
     "unsaveFailed": "取消收藏失敗",
     "noteFavorites": "收藏筆記",
-    "noteFavoritesEmpty": "還沒有收藏的筆記"
+    "noteFavoritesEmpty": "還沒有收藏的筆記",
+    "updateMemberRole": "更新成員角色",
+    "roleOwner": "擁有者",
+    "roleMember": "成員",
+    "memberRoleUpdated": "成員角色已更新"
   },
   "portfolio": {
     "generate": "作品集",


### PR DESCRIPTION
## 概要
サークルオーナーが他メンバーの役割（owner/member）を変更できるAPIを実装。

closes #2121

## 変更内容
- **Repository**: `UpdateMemberRole(circleID, userID, role)` メソッド追加
- **Service**: 所有権チェック・自己変更防止・メンバー存在確認ロジック
- **Handler**: `PUT /study-circles/:id/members/:userId/role` エンドポイント
- **テスト**: Service層5ケース（成功・無効な役割・非オーナー・自己変更・非メンバー）
- **フロントエンドAPI**: `updateMemberRole(circleId, userId, role)` 関数追加
- **i18n**: 全10言語にメンバー役割関連キー追加

## テスト計画
- [x] `go test ./internal/service/... -v` 全パス
- [x] `go test ./internal/handler/... -v` 全パス
- [x] `npx tsc --noEmit` 型チェック通過