### PR TITLE
refactor: ハンドラー層のレスポンス一貫性を改善

### DIFF
--- a/backend/internal/handler/answer.go
+++ b/backend/internal/handler/answer.go
@@ -130,7 +130,7 @@ func (h *AnswerHandler) SetBestAnswer(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("Best answer set successfully"))
+	respondOK(c, domain.NewMessageResponse("ベストアンサーを設定しました"))
 }
 
 // Vote は回答に投票する。
@@ -151,7 +151,7 @@ func (h *AnswerHandler) Vote(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("Voted successfully"))
+	respondOK(c, domain.NewMessageResponse("投票しました"))
 }
 
 // GetByVoteRange は指定質問の回答を投票スコア範囲でフィルタリングして取得する。
@@ -192,5 +192,5 @@ func (h *AnswerHandler) RemoveVote(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("Vote removed successfully"))
+	respondOK(c, domain.NewMessageResponse("投票を取り消しました"))
 }

--- a/backend/internal/handler/atcoder.go
+++ b/backend/internal/handler/atcoder.go
@@ -30,7 +30,7 @@ func NewAtCoderHandler(atcoderService AtCoderServiceInterface) *AtCoderHandler {
 func (h *AtCoderHandler) GetRating(c *gin.Context) {
 	username := c.Param("username")
 	if username == "" {
-		respondBadRequest(c, "username is required")
+		respondBadRequest(c, "ユーザー名は必須です")
 		return
 	}
 

--- a/backend/internal/handler/auth.go
+++ b/backend/internal/handler/auth.go
@@ -203,7 +203,7 @@ func (h *AuthHandler) RequestPasswordReset(c *gin.Context) {
 	// 本番ではここでメール送信を行う
 	// token変数はメール送信時に使用する（レスポンスには含めない）
 	_ = token
-	respondOK(c, dto.MessageResponse{Message: "If the email exists, a reset link has been sent"})
+	respondOK(c, dto.MessageResponse{Message: "メールアドレスが登録されている場合、リセットリンクを送信しました"})
 }
 
 // ResetPassword はトークンを使ってパスワードをリセットする。
@@ -218,13 +218,13 @@ func (h *AuthHandler) ResetPassword(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, dto.MessageResponse{Message: "Password has been reset successfully"})
+	respondOK(c, dto.MessageResponse{Message: "パスワードをリセットしました"})
 }
 
 // Logout はユーザーのログアウトを処理し、認証Cookieをクリアする。
 func (h *AuthHandler) Logout(c *gin.Context) {
 	clearAuthCookie(c)
-	respondOK(c, dto.MessageResponse{Message: "logged out successfully"})
+	respondOK(c, dto.MessageResponse{Message: "ログアウトしました"})
 }
 
 // DeleteAccount はユーザーアカウントを完全に削除する。
@@ -242,5 +242,5 @@ func (h *AuthHandler) DeleteAccount(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, dto.MessageResponse{Message: "Account deleted successfully"})
+	respondOK(c, dto.MessageResponse{Message: "アカウントを削除しました"})
 }

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -221,7 +221,7 @@ func (h *CodeSnippetHandler) Favorite(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("Favorited successfully"))
+	respondOK(c, domain.NewMessageResponse("お気に入りに追加しました"))
 }
 
 // Unfavorite はスニペットのお気に入りを解除する。
@@ -237,7 +237,7 @@ func (h *CodeSnippetHandler) Unfavorite(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("Favorite removed successfully"))
+	respondOK(c, domain.NewMessageResponse("お気に入りを解除しました"))
 }
 
 // GetFavorites はお気に入りスニペット一覧を取得する。

--- a/backend/internal/handler/github.go
+++ b/backend/internal/handler/github.go
@@ -60,13 +60,13 @@ func (h *GitHubHandler) Callback(c *gin.Context) {
 	state := c.Query("state")
 
 	if code == "" || state == "" || len(code) > oauthCodeMaxLen || len(state) > oauthCodeMaxLen {
-		respondBadRequest(c, "missing or invalid code/state")
+		respondBadRequest(c, "codeまたはstateが不正です")
 		return
 	}
 
 	userID, err := h.authService.ValidateOAuthState(state)
 	if err != nil {
-		respondBadRequest(c, "invalid state")
+		respondBadRequest(c, "stateが無効です")
 		return
 	}
 
@@ -75,7 +75,7 @@ func (h *GitHubHandler) Callback(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("github connected"))
+	respondOK(c, domain.NewMessageResponse("GitHub連携が完了しました"))
 }
 
 // GetContributions は指定ユーザーのGitHubコントリビューション情報を取得する。
@@ -132,7 +132,7 @@ func (h *GitHubHandler) Sync(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("sync complete"))
+	respondOK(c, domain.NewMessageResponse("同期が完了しました"))
 }
 
 // Disconnect は現在のユーザーのGitHub連携を解除する。
@@ -144,5 +144,5 @@ func (h *GitHubHandler) Disconnect(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("github disconnected"))
+	respondOK(c, domain.NewMessageResponse("GitHub連携を解除しました"))
 }

--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -16,7 +16,7 @@ func parseID(c *gin.Context, param string) (uint, bool) {
 	raw := c.Param(param)
 	id, err := strconv.ParseUint(raw, 10, 64)
 	if err != nil {
-		respondBadRequest(c, "invalid "+param)
+		respondBadRequest(c, param+"が不正です")
 		return 0, false
 	}
 	return uint(id), true
@@ -69,7 +69,7 @@ const maxUsernameLen = 50
 func parseSearchQuery(c *gin.Context) (string, bool) {
 	query := c.Query("q")
 	if query == "" {
-		respondBadRequest(c, "query parameter 'q' is required")
+		respondBadRequest(c, "検索クエリパラメータ'q'は必須です")
 		return "", false
 	}
 	if len([]rune(query)) > maxSearchQueryLen {

--- a/backend/internal/handler/helpers_test.go
+++ b/backend/internal/handler/helpers_test.go
@@ -52,7 +52,7 @@ func TestParseID_Invalid(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 	var resp map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &resp)
-	assert.Contains(t, resp["error"], "invalid id")
+	assert.Contains(t, resp["error"], "idが不正です")
 }
 
 func TestParseID_Zero(t *testing.T) {

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -222,22 +222,22 @@ func (h *LearningResourceHandler) Delete(c *gin.Context) {
 
 // Like は学習リソースにいいねする。
 func (h *LearningResourceHandler) Like(c *gin.Context) {
-	handleToggleAction(c, h.service.Like, "Resource liked")
+	handleToggleAction(c, h.service.Like, "リソースにいいねしました")
 }
 
 // Unlike は学習リソースのいいねを取り消す。
 func (h *LearningResourceHandler) Unlike(c *gin.Context) {
-	handleToggleAction(c, h.service.Unlike, "Resource unliked")
+	handleToggleAction(c, h.service.Unlike, "いいねを取り消しました")
 }
 
 // SaveResource は学習リソースを保存する。
 func (h *LearningResourceHandler) SaveResource(c *gin.Context) {
-	handleToggleAction(c, h.service.Save, "Resource saved")
+	handleToggleAction(c, h.service.Save, "リソースを保存しました")
 }
 
 // UnsaveResource は学習リソースの保存を取り消す。
 func (h *LearningResourceHandler) UnsaveResource(c *gin.Context) {
-	handleToggleAction(c, h.service.Unsave, "Resource unsaved")
+	handleToggleAction(c, h.service.Unsave, "保存を解除しました")
 }
 
 // GetByDifficulty は難易度別の公開学習リソースを取得する。

--- a/backend/internal/handler/note_version.go
+++ b/backend/internal/handler/note_version.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"net/http"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -40,7 +38,7 @@ func (h *NoteVersionHandler) GetVersions(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gin.H{
+	respondOK(c, gin.H{
 		"versions": ensureSlice(versions),
 		"total":    total,
 		"limit":    limit,
@@ -66,7 +64,7 @@ func (h *NoteVersionHandler) GetVersion(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, version)
+	respondOK(c, version)
 }
 
 // RestoreVersion はバージョンの内容でノートを復元する。
@@ -87,5 +85,5 @@ func (h *NoteVersionHandler) RestoreVersion(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, note)
+	respondOK(c, note)
 }

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -86,7 +86,7 @@ func (h *QuestionHandler) GetAll(c *gin.Context) {
 func (h *QuestionHandler) Search(c *gin.Context) {
 	q := c.Query("q")
 	if q == "" {
-		respondBadRequest(c, "search query is required")
+		respondBadRequest(c, "検索クエリは必須です")
 		return
 	}
 
@@ -196,7 +196,7 @@ func (h *QuestionHandler) Vote(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("Voted successfully"))
+	respondOK(c, domain.NewMessageResponse("投票しました"))
 }
 
 // GetSolved は解決済みの質問一覧を取得する。
@@ -248,7 +248,7 @@ func (h *QuestionHandler) RemoveVote(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("Vote removed successfully"))
+	respondOK(c, domain.NewMessageResponse("投票を取り消しました"))
 }
 
 // Bookmark は質問をブックマークする。
@@ -264,7 +264,7 @@ func (h *QuestionHandler) Bookmark(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("Bookmarked successfully"))
+	respondOK(c, domain.NewMessageResponse("ブックマークしました"))
 }
 
 // Unbookmark は質問のブックマークを解除する。
@@ -280,7 +280,7 @@ func (h *QuestionHandler) Unbookmark(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("Bookmark removed successfully"))
+	respondOK(c, domain.NewMessageResponse("ブックマークを解除しました"))
 }
 
 // GetBookmarks はブックマーク済み質問一覧を取得する。

--- a/backend/internal/handler/spotify.go
+++ b/backend/internal/handler/spotify.go
@@ -57,13 +57,13 @@ func (h *SpotifyHandler) Callback(c *gin.Context) {
 	state := c.Query("state")
 
 	if code == "" || state == "" || len(code) > oauthCodeMaxLen || len(state) > oauthCodeMaxLen {
-		respondBadRequest(c, "missing or invalid code/state")
+		respondBadRequest(c, "codeまたはstateが不正です")
 		return
 	}
 
 	userID, err := h.authService.ValidateOAuthState(state)
 	if err != nil {
-		respondBadRequest(c, "invalid state")
+		respondBadRequest(c, "stateが無効です")
 		return
 	}
 
@@ -72,7 +72,7 @@ func (h *SpotifyHandler) Callback(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("spotify connected"))
+	respondOK(c, domain.NewMessageResponse("Spotify連携が完了しました"))
 }
 
 // GetCurrentlyPlaying は指定ユーザーの現在再生中の曲を返す。
@@ -114,5 +114,5 @@ func (h *SpotifyHandler) Disconnect(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, domain.NewMessageResponse("spotify disconnected"))
+	respondOK(c, domain.NewMessageResponse("Spotify連携を解除しました"))
 }

--- a/backend/internal/handler/upload.go
+++ b/backend/internal/handler/upload.go
@@ -69,13 +69,13 @@ func NewUploadHandler() (*UploadHandler, error) {
 func (h *UploadHandler) UploadImage(c *gin.Context) {
 	file, err := c.FormFile("image")
 	if err != nil {
-		respondBadRequest(c, "No image file provided")
+		respondBadRequest(c, "画像ファイルが必要です")
 		return
 	}
 
 	// ファイルサイズのバリデーション（最大5MB）
 	if file.Size > 5*1024*1024 {
-		respondBadRequest(c, "File size exceeds 5MB limit")
+		respondBadRequest(c, "ファイルサイズは5MB以下にしてください")
 		return
 	}
 
@@ -89,25 +89,25 @@ func (h *UploadHandler) UploadImage(c *gin.Context) {
 		".webp": true,
 	}
 	if !allowedExts[ext] {
-		respondBadRequest(c, "Invalid file type. Allowed: jpg, jpeg, png, gif, webp")
+		respondBadRequest(c, "無効なファイル形式です。許可: jpg, jpeg, png, gif, webp")
 		return
 	}
 
 	// マジックバイトによるMIMEタイプ検証（拡張子偽装防止）
 	src, err := file.Open()
 	if err != nil {
-		respondInternalError(c, "Failed to read file")
+		respondInternalError(c, "ファイルの読み込みに失敗しました")
 		return
 	}
 	defer src.Close()
 
 	mimeType, err := detectMIMEType(src)
 	if err != nil {
-		respondInternalError(c, "Failed to detect file type")
+		respondInternalError(c, "ファイルタイプの検出に失敗しました")
 		return
 	}
 	if !allowedMIMETypes[mimeType] {
-		respondBadRequest(c, fmt.Sprintf("Invalid file content type: %s. Only image files are allowed", mimeType))
+		respondBadRequest(c, fmt.Sprintf("無効なファイルコンテンツタイプ: %s。画像ファイルのみ許可されています", mimeType))
 		return
 	}
 
@@ -118,20 +118,20 @@ func (h *UploadHandler) UploadImage(c *gin.Context) {
 	dateDir := time.Now().Format("2006/01")
 	fullDir := filepath.Join(h.uploadDir, dateDir)
 	if err := os.MkdirAll(fullDir, uploadDirPerm); err != nil {
-		respondInternalError(c, "Failed to create directory")
+		respondInternalError(c, "ディレクトリの作成に失敗しました")
 		return
 	}
 
 	// ファイルを保存する
 	filePath := filepath.Join(fullDir, filename)
 	if err := c.SaveUploadedFile(file, filePath); err != nil {
-		respondInternalError(c, "Failed to save file")
+		respondInternalError(c, "ファイルの保存に失敗しました")
 		return
 	}
 
 	// ファイルパーミッションを制限する
 	if err := os.Chmod(filePath, uploadFilePerm); err != nil {
-		respondInternalError(c, "Failed to set file permissions")
+		respondInternalError(c, "ファイル権限の設定に失敗しました")
 		return
 	}
 
@@ -148,18 +148,18 @@ func (h *UploadHandler) UploadImage(c *gin.Context) {
 func (h *UploadHandler) UploadMultipleImages(c *gin.Context) {
 	form, err := c.MultipartForm()
 	if err != nil {
-		respondBadRequest(c, "Failed to parse form")
+		respondBadRequest(c, "フォームの解析に失敗しました")
 		return
 	}
 
 	files := form.File["images"]
 	if len(files) == 0 {
-		respondBadRequest(c, "No image files provided")
+		respondBadRequest(c, "画像ファイルが必要です")
 		return
 	}
 
 	if len(files) > 10 {
-		respondBadRequest(c, "Maximum 10 images allowed")
+		respondBadRequest(c, "画像は最大10枚までです")
 		return
 	}
 
@@ -175,38 +175,38 @@ func (h *UploadHandler) UploadMultipleImages(c *gin.Context) {
 	dateDir := time.Now().Format("2006/01")
 	fullDir := filepath.Join(h.uploadDir, dateDir)
 	if err := os.MkdirAll(fullDir, uploadDirPerm); err != nil {
-		respondInternalError(c, "Failed to create directory")
+		respondInternalError(c, "ディレクトリの作成に失敗しました")
 		return
 	}
 
 	for _, file := range files {
 		// ファイルサイズのバリデーション
 		if file.Size > 5*1024*1024 {
-			respondBadRequest(c, fmt.Sprintf("File %s exceeds 5MB limit", file.Filename))
+			respondBadRequest(c, fmt.Sprintf("ファイル %s は5MB以下にしてください", file.Filename))
 			return
 		}
 
 		// ファイル拡張子のバリデーション
 		ext := strings.ToLower(filepath.Ext(file.Filename))
 		if !allowedExts[ext] {
-			respondBadRequest(c, fmt.Sprintf("Invalid file type for %s", file.Filename))
+			respondBadRequest(c, fmt.Sprintf("ファイル %s の形式が無効です", file.Filename))
 			return
 		}
 
 		// マジックバイトによるMIMEタイプ検証（拡張子偽装防止）
 		src, err := file.Open()
 		if err != nil {
-			respondInternalError(c, "Failed to read file")
+			respondInternalError(c, "ファイルの読み込みに失敗しました")
 			return
 		}
 		mimeType, err := detectMIMEType(src)
 		src.Close()
 		if err != nil {
-			respondInternalError(c, "Failed to detect file type")
+			respondInternalError(c, "ファイルタイプの検出に失敗しました")
 			return
 		}
 		if !allowedMIMETypes[mimeType] {
-			respondBadRequest(c, fmt.Sprintf("Invalid content type for %s: %s", file.Filename, mimeType))
+			respondBadRequest(c, fmt.Sprintf("ファイル %s のコンテンツタイプが無効です: %s", file.Filename, mimeType))
 			return
 		}
 
@@ -215,13 +215,13 @@ func (h *UploadHandler) UploadMultipleImages(c *gin.Context) {
 		filePath := filepath.Join(fullDir, filename)
 
 		if err := c.SaveUploadedFile(file, filePath); err != nil {
-			respondInternalError(c, "Failed to save file")
+			respondInternalError(c, "ファイルの保存に失敗しました")
 			return
 		}
 
 		// ファイルパーミッションを制限する
 		if err := os.Chmod(filePath, uploadFilePerm); err != nil {
-			respondInternalError(c, "Failed to set file permissions")
+			respondInternalError(c, "ファイル権限の設定に失敗しました")
 			return
 		}
 

--- a/backend/internal/handler/upload_test.go
+++ b/backend/internal/handler/upload_test.go
@@ -71,7 +71,7 @@ func TestUploadImage_NoFile(t *testing.T) {
 	h.UploadImage(c)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "No image file provided")
+	assert.Contains(t, w.Body.String(), "画像ファイルが必要です")
 }
 
 func TestUploadImage_InvalidExtension(t *testing.T) {
@@ -91,7 +91,7 @@ func TestUploadImage_InvalidExtension(t *testing.T) {
 	h.UploadImage(c)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Invalid file type")
+	assert.Contains(t, w.Body.String(), "無効なファイル形式です")
 }
 
 func TestUploadImage_InvalidMIMEType(t *testing.T) {
@@ -112,7 +112,7 @@ func TestUploadImage_InvalidMIMEType(t *testing.T) {
 	h.UploadImage(c)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Invalid file content type")
+	assert.Contains(t, w.Body.String(), "無効なファイルコンテンツタイプ")
 }
 
 // ---------- UploadMultipleImages テスト ----------
@@ -175,7 +175,7 @@ func TestUploadMultipleImages_TooManyFiles(t *testing.T) {
 	h.UploadMultipleImages(c)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Maximum 10 images allowed")
+	assert.Contains(t, w.Body.String(), "画像は最大10枚までです")
 }
 
 func TestUploadMultipleImages_InvalidExtension(t *testing.T) {
@@ -197,7 +197,7 @@ func TestUploadMultipleImages_InvalidExtension(t *testing.T) {
 	h.UploadMultipleImages(c)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Invalid file type")
+	assert.Contains(t, w.Body.String(), "の形式が無効です")
 }
 
 func TestUploadMultipleImages_InvalidMIMEType(t *testing.T) {
@@ -217,7 +217,7 @@ func TestUploadMultipleImages_InvalidMIMEType(t *testing.T) {
 	h.UploadMultipleImages(c)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
-	assert.Contains(t, w.Body.String(), "Invalid content type")
+	assert.Contains(t, w.Body.String(), "のコンテンツタイプが無効です")
 }
 
 // ---------- detectMIMEType テスト ----------

--- a/backend/internal/handler/user.go
+++ b/backend/internal/handler/user.go
@@ -60,7 +60,7 @@ func (h *UserHandler) GetByID(c *gin.Context) {
 func (h *UserHandler) GetByUsername(c *gin.Context) {
 	username := c.Param("username")
 	if username == "" {
-		respondBadRequest(c, "username required")
+		respondBadRequest(c, "ユーザー名は必須です")
 		return
 	}
 	if len([]rune(username)) > maxUsernameLen {

--- a/backend/internal/model/learning_goal.go
+++ b/backend/internal/model/learning_goal.go
@@ -49,6 +49,14 @@ type GoalDeadlineAlert struct {
 	DaysLeft int          `json:"days_left"` // 残り日数（超過時は負数）
 }
 
+// GoalProgress は学習ゴールの実績時間 vs 目標時間の進捗情報を表す。
+type GoalProgress struct {
+	GoalID       uint `json:"goal_id"`
+	TargetHours  int  `json:"target_hours"`  // 目標時間（時間単位）
+	ActualMinutes int `json:"actual_minutes"` // 実績時間（分単位）
+	Percentage   int  `json:"percentage"`     // 進捗率（0-100）
+}
+
 // LearningGoalStats はユーザーの学習目標統計情報を表す。
 type LearningGoalStats struct {
 	TotalGoals      int `json:"total_goals"`


### PR DESCRIPTION
## 概要
- `note_version.go` の `c.JSON()` を `respondOK()` ヘルパーに統一し、不要な `net/http` インポートを削除
- 14個のハンドラーファイルの英語エラーメッセージを日本語に統一
- テストファイルのアサーションを日本語メッセージに合わせて更新
- `GoalProgress` モデルの追加（前回PRでの漏れ分）

## 対象ファイル
| ファイル | 変更内容 |
|----------|----------|
| note_version.go | `c.JSON()` → `respondOK()` |
| helpers.go | `"invalid ..."` → 日本語 |
| upload.go | 14件の英語メッセージを日本語化 |
| github.go | OAuth関連メッセージ日本語化 |
| spotify.go | OAuth関連メッセージ日本語化 |
| question.go | 検索・投票・ブックマークメッセージ日本語化 |
| answer.go | 投票・ベストアンサーメッセージ日本語化 |
| auth.go | 認証関連メッセージ日本語化 |
| learning_resource.go | いいね・保存メッセージ日本語化 |
| code_snippet.go | お気に入りメッセージ日本語化 |
| atcoder.go, user.go | ユーザー名バリデーション日本語化 |
| upload_test.go, helpers_test.go | テストアサーション更新 |

## テスト
- `go test ./internal/handler/...` 全テストPASS
- `go test ./internal/service/...` 全テストPASS

Closes #2123