### PR TITLE
test: ウィークリーチャレンジのエラーハンドリングテスト追加

### DIFF
--- a/backend/internal/service/weekly_challenge_test.go
+++ b/backend/internal/service/weekly_challenge_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -117,5 +118,89 @@ func TestUpdateProgress_NoChallengeFound(t *testing.T) {
 
 	_, err := svc.UpdateProgress(uint(1), 100)
 	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
+// エラーハンドリングテスト
+// ============================================================
+
+func TestGetCurrentChallenge_DBError(t *testing.T) {
+	svc, repo := newTestWeeklyChallengeService()
+
+	year, week := time.Now().ISOWeek()
+	dbErr := errors.New("connection refused")
+	repo.On("FindByUserAndWeek", uint(1), year, week).Return(nil, dbErr)
+
+	result, err := svc.GetCurrentChallenge(uint(1))
+	assert.Nil(t, result)
+	assert.ErrorIs(t, err, dbErr)
+	repo.AssertNotCalled(t, "Create")
+	repo.AssertExpectations(t)
+}
+
+func TestGetCurrentChallenge_CreateError(t *testing.T) {
+	svc, repo := newTestWeeklyChallengeService()
+
+	year, week := time.Now().ISOWeek()
+	repo.On("FindByUserAndWeek", uint(1), year, week).Return(nil, gorm.ErrRecordNotFound)
+	repo.On("Create", mock.AnythingOfType("*model.WeeklyChallenge")).Return(errors.New("db write error"))
+
+	result, err := svc.GetCurrentChallenge(uint(1))
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestUpdateProgress_UpdateError(t *testing.T) {
+	svc, repo := newTestWeeklyChallengeService()
+
+	year, week := time.Now().ISOWeek()
+	challenge := &model.WeeklyChallenge{
+		ID:            1,
+		UserID:        1,
+		Year:          year,
+		Week:          week,
+		ChallengeType: model.ChallengeDurationTotal,
+		TargetValue:   300,
+		CurrentValue:  100,
+	}
+	repo.On("FindByUserAndWeek", uint(1), year, week).Return(challenge, nil)
+	repo.On("Update", mock.AnythingOfType("*model.WeeklyChallenge")).Return(errors.New("db update error"))
+
+	result, err := svc.UpdateProgress(uint(1), 200)
+	assert.Nil(t, result)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}
+
+func TestUpdateProgress_AlreadyCompleted(t *testing.T) {
+	svc, repo := newTestWeeklyChallengeService()
+
+	year, week := time.Now().ISOWeek()
+	completedAt := time.Now().Add(-1 * time.Hour)
+	challenge := &model.WeeklyChallenge{
+		ID:            1,
+		UserID:        1,
+		Year:          year,
+		Week:          week,
+		ChallengeType: model.ChallengeDurationTotal,
+		TargetValue:   300,
+		CurrentValue:  300,
+		IsCompleted:   true,
+		CompletedAt:   &completedAt,
+	}
+	repo.On("FindByUserAndWeek", uint(1), year, week).Return(challenge, nil)
+	repo.On("Update", mock.MatchedBy(func(c *model.WeeklyChallenge) bool {
+		// 既に完了済みの場合、CompletedAtが上書きされないことを検証
+		return c.IsCompleted && c.CompletedAt.Equal(completedAt)
+	})).Return(nil)
+
+	result, err := svc.UpdateProgress(uint(1), 500)
+	assert.NoError(t, err)
+	assert.True(t, result.IsCompleted)
+	assert.Equal(t, 500, result.CurrentValue)
+	// CompletedAtは元の値のままであること
+	assert.Equal(t, completedAt, *result.CompletedAt)
 	repo.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
ウィークリーチャレンジサービスのエラーハンドリングテストを4件追加。

## 追加テスト
- `TestGetCurrentChallenge_DBError` - DB接続エラー時のエラー伝播
- `TestGetCurrentChallenge_CreateError` - チャレンジ生成失敗時のエラー伝播
- `TestUpdateProgress_UpdateError` - 進捗更新DB失敗時のエラー伝播
- `TestUpdateProgress_AlreadyCompleted` - 完了済みチャレンジの再更新時にCompletedAtが保持されることを検証

## テスト結果
- `go test ./internal/service/...` 全テストPASS

Closes #2125