### PR TITLE
fix: SSRF対策を強化（クラウドメタデータブロック・DNS解決チェック）

### DIFF
--- a/backend/internal/domain/validators.go
+++ b/backend/internal/domain/validators.go
@@ -172,18 +172,49 @@ func ValidateURL(rawURL string) error {
 	return nil
 }
 
-// isBlockedHost はSSRF対策として内部ネットワークのホストを検出する
+// cloudMetadataHosts はクラウドメタデータサービスのホスト名一覧。
+var cloudMetadataHosts = map[string]bool{
+	"metadata.google.internal":        true,
+	"metadata.google.internal.":       true,
+	"instance-data":                   true,
+	"169.254.169.254":                 true,
+	"fd00:ec2::254":                   true,
+}
+
+// isBlockedHost はSSRF対策として内部ネットワークのホストを検出する。
+// IPアドレスの直接指定に加え、DNS解決後のIPもチェックする。
 func isBlockedHost(hostname string) bool {
 	lower := strings.ToLower(hostname)
-	if lower == "localhost" || lower == "0.0.0.0" {
+	if lower == "localhost" || lower == "0.0.0.0" || lower == "[::1]" {
 		return true
 	}
 
-	ip := net.ParseIP(hostname)
-	if ip == nil {
-		return false // ドメイン名の場合はDNS解決前なので許可
+	// クラウドメタデータサービスのホスト名をブロック
+	if cloudMetadataHosts[lower] {
+		return true
 	}
 
+	// 直接IPアドレスが指定された場合
+	ip := net.ParseIP(hostname)
+	if ip != nil {
+		return isBlockedIP(ip)
+	}
+
+	// ドメイン名の場合はDNS解決してIPをチェック
+	ips, err := net.LookupIP(hostname)
+	if err != nil {
+		return false
+	}
+	for _, resolvedIP := range ips {
+		if isBlockedIP(resolvedIP) {
+			return true
+		}
+	}
+	return false
+}
+
+// isBlockedIP は指定IPが内部ネットワークに属するかチェックする。
+func isBlockedIP(ip net.IP) bool {
 	return ip.IsLoopback() || ip.IsPrivate() || ip.IsLinkLocalUnicast() || ip.IsLinkLocalMulticast() || ip.IsUnspecified()
 }
 

--- a/backend/internal/domain/validators_test.go
+++ b/backend/internal/domain/validators_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"net"
 	"strings"
 	"testing"
 
@@ -168,6 +169,11 @@ func TestValidateURL(t *testing.T) {
 		{"SSRF: 0.0.0.0", "http://0.0.0.0", true},
 		{"SSRF: IPv6ループバック", "http://[::1]/path", true},
 		{"SSRF: IPv6 unspecified", "http://[::]/path", true},
+		{"SSRF: AWSメタデータIP", "http://169.254.169.254/latest/meta-data/", true},
+		{"SSRF: GCPメタデータ", "http://metadata.google.internal/computeMetadata/v1/", true},
+		{"SSRF: GCPメタデータ（末尾ドット）", "http://metadata.google.internal./computeMetadata/v1/", true},
+		{"SSRF: EC2 IPv6メタデータ", "http://[fd00:ec2::254]/latest/meta-data/", true},
+		{"SSRF: instance-data", "http://instance-data/latest/meta-data/", true},
 	}
 
 	for _, tt := range tests {
@@ -179,6 +185,67 @@ func TestValidateURL(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestIsBlockedHost(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		blocked bool
+	}{
+		{"localhost", "localhost", true},
+		{"0.0.0.0", "0.0.0.0", true},
+		{"[::1]", "[::1]", true},
+		{"127.0.0.1", "127.0.0.1", true},
+		{"プライベートIP(10.x)", "10.0.0.1", true},
+		{"プライベートIP(192.168.x)", "192.168.1.1", true},
+		{"プライベートIP(172.16.x)", "172.16.0.1", true},
+		{"リンクローカル", "169.254.169.254", true},
+		{"AWSメタデータIP", "169.254.169.254", true},
+		{"GCPメタデータホスト", "metadata.google.internal", true},
+		{"GCPメタデータホスト（末尾ドット）", "metadata.google.internal.", true},
+		{"EC2 IPv6メタデータ", "fd00:ec2::254", true},
+		{"instance-data", "instance-data", true},
+		{"大文字小文字混在（LOCALHOST）", "LOCALHOST", true},
+		{"大文字小文字混在（Metadata）", "Metadata.Google.Internal", true},
+		{"外部ホスト", "example.com", false},
+		{"外部IP", "8.8.8.8", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isBlockedHost(tt.host)
+			assert.Equal(t, tt.blocked, result)
+		})
+	}
+}
+
+func TestIsBlockedIP(t *testing.T) {
+	tests := []struct {
+		name    string
+		ip      string
+		blocked bool
+	}{
+		{"ループバック(127.0.0.1)", "127.0.0.1", true},
+		{"ループバック(::1)", "::1", true},
+		{"プライベート(10.x)", "10.0.0.1", true},
+		{"プライベート(192.168.x)", "192.168.1.1", true},
+		{"プライベート(172.16.x)", "172.16.0.1", true},
+		{"リンクローカルユニキャスト", "169.254.1.1", true},
+		{"未指定(0.0.0.0)", "0.0.0.0", true},
+		{"未指定(::)", "::", true},
+		{"外部IP(8.8.8.8)", "8.8.8.8", false},
+		{"外部IP(1.1.1.1)", "1.1.1.1", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ip := net.ParseIP(tt.ip)
+			assert.NotNil(t, ip, "IPのパースに失敗: %s", tt.ip)
+			result := isBlockedIP(ip)
+			assert.Equal(t, tt.blocked, result)
 		})
 	}
 }


### PR DESCRIPTION
## 概要
Closes #2127

- クラウドメタデータサービスのホスト名ブロックリスト追加（AWS 169.254.169.254, GCP metadata.google.internal, EC2 fd00:ec2::254, instance-data）
- ドメイン名指定時のDNS解決後IPチェック追加（プライベートIPへのリダイレクト防止）
- `isBlockedIP` ヘルパー関数を抽出して可読性向上
- IPv6 `[::1]` を直接ブロックリストに追加

## テスト
- `TestIsBlockedHost`: 17ケース（localhost, プライベートIP, メタデータホスト, 大文字小文字混在, 外部ホスト）
- `TestIsBlockedIP`: 10ケース（ループバック, プライベート, リンクローカル, 未指定, 外部IP）
- `TestValidateURL`: 5つのメタデータURL統合テスト追加
- 全テストPASS確認済み