### PR TITLE
feat: サイクル8 UX改善5機能

### DIFF
--- a/frontend/src/components/projects/ProjectCard.tsx
+++ b/frontend/src/components/projects/ProjectCard.tsx
@@ -1,5 +1,5 @@
 import { useTranslation } from 'react-i18next';
-import { Pencil, Trash2, CircleDot, CheckCircle2, ExternalLink, Calendar, Github } from 'lucide-react';
+import { Pencil, Trash2, CircleDot, CheckCircle2, ExternalLink, Calendar, Github, Archive, ArchiveRestore } from 'lucide-react';
 import type { Project } from '../../types/project';
 import { cardClass, iconButtonClass, deleteIconButtonClass, badgeBaseClass } from '../../constants/styles';
 import { parseJsonArray } from '../../utils/json';
@@ -10,10 +10,12 @@ interface ProjectCardProps {
   project: Project;
   onEdit?: () => void;
   onDelete?: () => void;
+  onArchive?: () => void;
+  onUnarchive?: () => void;
   isOwner?: boolean;
 }
 
-export default function ProjectCard({ project, onEdit, onDelete, isOwner }: ProjectCardProps) {
+export default function ProjectCard({ project, onEdit, onDelete, onArchive, onUnarchive, isOwner }: ProjectCardProps) {
   const { t } = useTranslation();
 
   const techStack = parseJsonArray(project.tech_stack);
@@ -67,13 +69,34 @@ export default function ProjectCard({ project, onEdit, onDelete, isOwner }: Proj
 
           {isOwner && (
             <div className="flex gap-1">
-              <button
-                onClick={onEdit}
-                className={iconButtonClass}
-                aria-label={t('common.edit')}
-              >
-                <Pencil className="w-4 h-4" />
-              </button>
+              {project.is_archived ? (
+                <button
+                  onClick={onUnarchive}
+                  className={iconButtonClass}
+                  aria-label={t('projects.unarchive')}
+                  title={t('projects.unarchive')}
+                >
+                  <ArchiveRestore className="w-4 h-4" />
+                </button>
+              ) : (
+                <>
+                  <button
+                    onClick={onArchive}
+                    className={iconButtonClass}
+                    aria-label={t('projects.archive')}
+                    title={t('projects.archive')}
+                  >
+                    <Archive className="w-4 h-4" />
+                  </button>
+                  <button
+                    onClick={onEdit}
+                    className={iconButtonClass}
+                    aria-label={t('common.edit')}
+                  >
+                    <Pencil className="w-4 h-4" />
+                  </button>
+                </>
+              )}
               <button
                 onClick={onDelete}
                 className={deleteIconButtonClass}

--- a/frontend/src/hooks/useNoteForm.ts
+++ b/frontend/src/hooks/useNoteForm.ts
@@ -10,6 +10,7 @@ export function useNoteForm() {
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<'latest' | 'oldest' | 'updated' | 'favorites_first'>('latest');
   const [filterTag, setFilterTag] = useState('');
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(false);
   const [viewMode, setViewMode] = useState<'list' | 'grid'>('list');
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
@@ -64,6 +65,9 @@ export function useNoteForm() {
           note.content.toLowerCase().includes(searchQuery.toLowerCase())
         )
       : notes;
+    if (showFavoritesOnly) {
+      filtered = filtered.filter(note => note.is_favorite);
+    }
     if (filterTag) {
       filtered = filtered.filter(note =>
         note.tags?.split(',').some(t => t.trim() === filterTag)
@@ -82,13 +86,13 @@ export function useNoteForm() {
           return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
       }
     });
-  }, [notes, searchQuery, sortBy, filterTag]);
+  }, [notes, searchQuery, sortBy, filterTag, showFavoritesOnly]);
 
   return {
     // Data
     notes, favoriteNotes, filteredNotes, loading, saving,
     // Form state
-    showForm, setShowForm, editingNote, searchQuery, setSearchQuery, sortBy, setSortBy, filterTag, setFilterTag, allTags, viewMode, setViewMode,
+    showForm, setShowForm, editingNote, searchQuery, setSearchQuery, sortBy, setSortBy, filterTag, setFilterTag, showFavoritesOnly, setShowFavoritesOnly, allTags, viewMode, setViewMode,
     title, setTitle, content, setContent, tags, setTags,
     // Actions
     resetForm, handleSubmit, handleEdit, deleteNote, toggleFavorite,

--- a/frontend/src/hooks/useProjects.ts
+++ b/frontend/src/hooks/useProjects.ts
@@ -1,27 +1,36 @@
-import { useCallback } from 'react';
+import { useState, useCallback, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import toast from 'react-hot-toast';
 import { useAuthStore } from '../store/authStore';
 import type { Project, CreateProjectRequest } from '../types/project';
 import type { GitHubRepository } from '../types/github';
-import { getProjectsByUserId, createProject, updateProject, deleteProject } from '../api/projects';
+import { getProjectsByUserId, createProject, updateProject, deleteProject, archiveProject, unarchiveProject, getArchivedProjects } from '../api/projects';
 import { getRepos } from '../api/github';
 import { useAsyncData } from './useAsyncData';
 import { useLocalList } from './useCRUDList';
+
+export type ProjectSortBy = 'newest' | 'oldest' | 'title';
+export type ProjectTab = 'active' | 'archived';
 
 export function useProjects() {
   const { t } = useTranslation();
   const user = useAuthStore((s) => s.user);
 
+  const [searchQuery, setSearchQuery] = useState('');
+  const [sortBy, setSortBy] = useState<ProjectSortBy>('newest');
+  const [tab, setTab] = useState<ProjectTab>('active');
+
   const { data, loading, refetch } = useAsyncData(
     async () => {
-      if (!user) return { projects: [] as Project[], repos: [] as GitHubRepository[] };
-      const [projectsData, reposResponse] = await Promise.all([
+      if (!user) return { projects: [] as Project[], archivedProjects: [] as Project[], repos: [] as GitHubRepository[] };
+      const [projectsData, archivedData, reposResponse] = await Promise.all([
         getProjectsByUserId(user.id),
+        getArchivedProjects().then(r => r.projects ?? []),
         user.github_connected ? getRepos(user.id) : Promise.resolve({ data: [] as GitHubRepository[] }),
       ]);
       return {
         projects: projectsData,
+        archivedProjects: archivedData,
         repos: reposResponse.data,
       };
     },
@@ -29,9 +38,34 @@ export function useProjects() {
   );
 
   const projects = data?.projects ?? [];
+  const archivedProjects = data?.archivedProjects ?? [];
   const repos = data?.repos ?? [];
 
   const { items: currentProjects, setItems: setLocalProjects } = useLocalList(projects);
+  const { items: currentArchived, setItems: setLocalArchived } = useLocalList(archivedProjects);
+
+  const filteredProjects = useMemo(() => {
+    const source = tab === 'active' ? currentProjects : currentArchived;
+    let filtered = source;
+    if (searchQuery.trim()) {
+      const q = searchQuery.toLowerCase();
+      filtered = filtered.filter(p =>
+        p.title.toLowerCase().includes(q) ||
+        p.description?.toLowerCase().includes(q) ||
+        p.tech_stack?.toLowerCase().includes(q)
+      );
+    }
+    return [...filtered].sort((a, b) => {
+      switch (sortBy) {
+        case 'oldest':
+          return new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
+        case 'title':
+          return a.title.localeCompare(b.title);
+        default:
+          return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+      }
+    });
+  }, [currentProjects, currentArchived, tab, searchQuery, sortBy]);
 
   const handleCreate = useCallback(async (reqData: CreateProjectRequest) => {
     try {
@@ -69,14 +103,47 @@ export function useProjects() {
     }
   }, [t, setLocalProjects]);
 
+  const handleArchive = useCallback(async (project: Project) => {
+    try {
+      await archiveProject(project.id);
+      setLocalProjects(prev => prev.filter(p => p.id !== project.id));
+      setLocalArchived(prev => [{ ...project, is_archived: true }, ...prev]);
+      toast.success(t('projects.archiveSuccess'));
+      return true;
+    } catch {
+      toast.error(t('projects.archiveFailed'));
+      return false;
+    }
+  }, [t, setLocalProjects, setLocalArchived]);
+
+  const handleUnarchive = useCallback(async (project: Project) => {
+    try {
+      await unarchiveProject(project.id);
+      setLocalArchived(prev => prev.filter(p => p.id !== project.id));
+      setLocalProjects(prev => [{ ...project, is_archived: false }, ...prev]);
+      toast.success(t('projects.unarchiveSuccess'));
+      return true;
+    } catch {
+      toast.error(t('projects.unarchiveFailed'));
+      return false;
+    }
+  }, [t, setLocalProjects, setLocalArchived]);
+
   return {
-    projects: currentProjects,
+    projects: filteredProjects,
+    allProjects: currentProjects,
+    archivedProjects: currentArchived,
     repos,
     loading,
     saving: false,
+    searchQuery, setSearchQuery,
+    sortBy, setSortBy,
+    tab, setTab,
     createProject: handleCreate,
     updateProject: handleUpdate,
     deleteProject: handleDelete,
+    archiveProject: handleArchive,
+    unarchiveProject: handleUnarchive,
     refetch,
   };
 }

--- a/frontend/src/i18n/locales/de.json
+++ b/frontend/src/i18n/locales/de.json
@@ -52,7 +52,8 @@
     ],
     "contributionsInLastYear": "{{count}} Beiträge im letzten Jahr",
     "dateContributions": "{{date}}: {{count}} Beiträge",
-    "dateLogs": "{{date}}: {{count}} Einträge"
+    "dateLogs": "{{date}}: {{count}} Einträge",
+    "createFromTemplate": "Aus Vorlage erstellen"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -817,6 +818,18 @@
     "updateFailed": "Projekt konnte nicht aktualisiert werden",
     "deleteFailed": "Projekt konnte nicht gelöscht werden",
     "confirmDelete": "Bist du sicher, dass du dieses Projekt löschen möchtest?",
+    "searchPlaceholder": "Projekte suchen...",
+    "sortNewest": "Neueste",
+    "sortOldest": "Älteste",
+    "sortTitle": "Titel",
+    "noSearchResults": "Keine Projekte gefunden",
+    "archivedTab": "Archiviert",
+    "archive": "Archivieren",
+    "unarchive": "Dearchivieren",
+    "archiveSuccess": "Projekt archiviert",
+    "unarchiveSuccess": "Projekt dearchiviert",
+    "archiveFailed": "Archivierung fehlgeschlagen",
+    "unarchiveFailed": "Dearchivierung fehlgeschlagen",
     "statusInProgress": "In Arbeit",
     "statusCompleted": "Abgeschlossen"
   },
@@ -1493,7 +1506,8 @@
     "volumeDetailed": "Ausführlich",
     "exportMarkdown": "Als Markdown exportieren",
     "exportSuccess": "Notiz erfolgreich exportiert",
-    "exportError": "Export fehlgeschlagen"
+    "exportError": "Export fehlgeschlagen",
+    "favoritesOnly": "Nur Favoriten"
   },
   "githubCallback": {
     "missingOAuthParams": "Fehlende OAuth-Parameter",

--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -52,7 +52,8 @@
     ],
     "contributionsInLastYear": "{{count}} contributions in the last year",
     "dateContributions": "{{date}}: {{count}} contributions",
-    "dateLogs": "{{date}}: {{count}} logs"
+    "dateLogs": "{{date}}: {{count}} logs",
+    "createFromTemplate": "Create from Template"
   },
   "nav": {
     "dashboard": "Dashboard",
@@ -818,6 +819,18 @@
     "updateFailed": "Failed to update project",
     "deleteFailed": "Failed to delete project",
     "confirmDelete": "Are you sure you want to delete this project?",
+    "searchPlaceholder": "Search projects...",
+    "sortNewest": "Newest",
+    "sortOldest": "Oldest",
+    "sortTitle": "Title",
+    "noSearchResults": "No projects found",
+    "archivedTab": "Archived",
+    "archive": "Archive",
+    "unarchive": "Unarchive",
+    "archiveSuccess": "Project archived",
+    "unarchiveSuccess": "Project unarchived",
+    "archiveFailed": "Failed to archive",
+    "unarchiveFailed": "Failed to unarchive",
     "statusInProgress": "In Progress",
     "statusCompleted": "Completed"
   },
@@ -1494,7 +1507,8 @@
     "volumeDetailed": "Detailed",
     "exportMarkdown": "Export as Markdown",
     "exportSuccess": "Note exported successfully",
-    "exportError": "Failed to export note"
+    "exportError": "Failed to export note",
+    "favoritesOnly": "Favorites only"
   },
   "githubCallback": {
     "missingOAuthParams": "Missing OAuth parameters",

--- a/frontend/src/i18n/locales/es.json
+++ b/frontend/src/i18n/locales/es.json
@@ -52,7 +52,8 @@
     ],
     "contributionsInLastYear": "{{count}} contribuciones en el último año",
     "dateContributions": "{{date}}: {{count}} contribuciones",
-    "dateLogs": "{{date}}: {{count}} registros"
+    "dateLogs": "{{date}}: {{count}} registros",
+    "createFromTemplate": "Crear desde plantilla"
   },
   "nav": {
     "dashboard": "Panel",
@@ -818,6 +819,18 @@
     "updateFailed": "Error al actualizar proyecto",
     "deleteFailed": "Error al eliminar proyecto",
     "confirmDelete": "¿Estás seguro de que deseas eliminar este proyecto?",
+    "searchPlaceholder": "Buscar proyectos...",
+    "sortNewest": "Más reciente",
+    "sortOldest": "Más antiguo",
+    "sortTitle": "Título",
+    "noSearchResults": "No se encontraron proyectos",
+    "archivedTab": "Archivados",
+    "archive": "Archivar",
+    "unarchive": "Desarchivar",
+    "archiveSuccess": "Proyecto archivado",
+    "unarchiveSuccess": "Proyecto desarchivado",
+    "archiveFailed": "Error al archivar",
+    "unarchiveFailed": "Error al desarchivar",
     "statusInProgress": "En curso",
     "statusCompleted": "Completado"
   },
@@ -1494,7 +1507,8 @@
     "volumeDetailed": "Detallado",
     "exportMarkdown": "Exportar como Markdown",
     "exportSuccess": "Nota exportada con éxito",
-    "exportError": "Error al exportar la nota"
+    "exportError": "Error al exportar la nota",
+    "favoritesOnly": "Solo favoritos"
   },
   "githubCallback": {
     "missingOAuthParams": "Faltan parámetros OAuth",

--- a/frontend/src/i18n/locales/fr.json
+++ b/frontend/src/i18n/locales/fr.json
@@ -52,7 +52,8 @@
     ],
     "contributionsInLastYear": "{{count}} contributions au cours de l'année écoulée",
     "dateContributions": "{{date}} : {{count}} contributions",
-    "dateLogs": "{{date}} : {{count}} entrées"
+    "dateLogs": "{{date}} : {{count}} entrées",
+    "createFromTemplate": "Créer depuis un modèle"
   },
   "nav": {
     "dashboard": "Tableau de bord",
@@ -818,6 +819,18 @@
     "updateFailed": "Échec de la mise à jour du projet",
     "deleteFailed": "Échec de la suppression du projet",
     "confirmDelete": "Êtes-vous sûr de vouloir supprimer ce projet ?",
+    "searchPlaceholder": "Rechercher des projets...",
+    "sortNewest": "Plus récent",
+    "sortOldest": "Plus ancien",
+    "sortTitle": "Titre",
+    "noSearchResults": "Aucun projet trouvé",
+    "archivedTab": "Archivés",
+    "archive": "Archiver",
+    "unarchive": "Désarchiver",
+    "archiveSuccess": "Projet archivé",
+    "unarchiveSuccess": "Projet désarchivé",
+    "archiveFailed": "Échec de l'archivage",
+    "unarchiveFailed": "Échec du désarchivage",
     "statusInProgress": "En cours",
     "statusCompleted": "Terminé"
   },
@@ -1494,7 +1507,8 @@
     "volumeDetailed": "Détaillé",
     "exportMarkdown": "Exporter en Markdown",
     "exportSuccess": "Note exportée avec succès",
-    "exportError": "Échec de l exportation"
+    "exportError": "Échec de l exportation",
+    "favoritesOnly": "Favoris uniquement"
   },
   "githubCallback": {
     "missingOAuthParams": "Paramètres OAuth manquants",

--- a/frontend/src/i18n/locales/ja.json
+++ b/frontend/src/i18n/locales/ja.json
@@ -53,7 +53,8 @@
     ],
     "contributionsInLastYear": "過去1年間に{{count}}コントリビューション",
     "dateContributions": "{{date}}: {{count}}コントリビューション",
-    "dateLogs": "{{date}}: {{count}}件のログ"
+    "dateLogs": "{{date}}: {{count}}件のログ",
+    "createFromTemplate": "テンプレートから作成"
   },
   "nav": {
     "dashboard": "ダッシュボード",
@@ -787,6 +788,18 @@
     "updateFailed": "プロジェクトの更新に失敗しました",
     "deleteFailed": "プロジェクトの削除に失敗しました",
     "confirmDelete": "このプロジェクトを削除してもよろしいですか？",
+    "searchPlaceholder": "プロジェクトを検索...",
+    "sortNewest": "新しい順",
+    "sortOldest": "古い順",
+    "sortTitle": "タイトル順",
+    "noSearchResults": "検索結果がありません",
+    "archivedTab": "アーカイブ済み",
+    "archive": "アーカイブ",
+    "unarchive": "アーカイブ解除",
+    "archiveSuccess": "プロジェクトをアーカイブしました",
+    "unarchiveSuccess": "プロジェクトのアーカイブを解除しました",
+    "archiveFailed": "アーカイブに失敗しました",
+    "unarchiveFailed": "アーカイブ解除に失敗しました",
     "statusInProgress": "進行中",
     "statusCompleted": "完了"
   },
@@ -1396,7 +1409,8 @@
     "volumeDetailed": "充実",
     "exportMarkdown": "Markdownエクスポート",
     "exportSuccess": "ノートをエクスポートしました",
-    "exportError": "エクスポートに失敗しました"
+    "exportError": "エクスポートに失敗しました",
+    "favoritesOnly": "お気に入りのみ"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuthパラメータが不足しています",

--- a/frontend/src/i18n/locales/ko.json
+++ b/frontend/src/i18n/locales/ko.json
@@ -52,7 +52,8 @@
     ],
     "contributionsInLastYear": "지난 1년간 {{count}}개의 기여",
     "dateContributions": "{{date}}: {{count}}개의 기여",
-    "dateLogs": "{{date}}: {{count}}개의 로그"
+    "dateLogs": "{{date}}: {{count}}개의 로그",
+    "createFromTemplate": "템플릿에서 생성"
   },
   "nav": {
     "dashboard": "대시보드",
@@ -819,6 +820,18 @@
     "updateFailed": "프로젝트 업데이트에 실패했습니다",
     "deleteFailed": "프로젝트 삭제에 실패했습니다",
     "confirmDelete": "이 프로젝트를 삭제하시겠습니까?",
+    "searchPlaceholder": "프로젝트 검색...",
+    "sortNewest": "최신순",
+    "sortOldest": "오래된순",
+    "sortTitle": "제목순",
+    "noSearchResults": "검색 결과가 없습니다",
+    "archivedTab": "보관됨",
+    "archive": "보관",
+    "unarchive": "보관 해제",
+    "archiveSuccess": "프로젝트를 보관했습니다",
+    "unarchiveSuccess": "프로젝트 보관을 해제했습니다",
+    "archiveFailed": "보관에 실패했습니다",
+    "unarchiveFailed": "보관 해제에 실패했습니다",
     "statusInProgress": "진행 중",
     "statusCompleted": "완료"
   },
@@ -1495,7 +1508,8 @@
     "volumeDetailed": "상세",
     "exportMarkdown": "Markdown으로 내보내기",
     "exportSuccess": "노트를 내보냈습니다",
-    "exportError": "내보내기에 실패했습니다"
+    "exportError": "내보내기에 실패했습니다",
+    "favoritesOnly": "즐겨찾기만"
   },
   "githubCallback": {
     "missingOAuthParams": "OAuth 매개변수가 없습니다",

--- a/frontend/src/i18n/locales/pt.json
+++ b/frontend/src/i18n/locales/pt.json
@@ -52,7 +52,8 @@
     ],
     "contributionsInLastYear": "{{count}} contribuições no último ano",
     "dateContributions": "{{date}}: {{count}} contribuições",
-    "dateLogs": "{{date}}: {{count}} registros"
+    "dateLogs": "{{date}}: {{count}} registros",
+    "createFromTemplate": "Criar a partir de modelo"
   },
   "nav": {
     "dashboard": "Painel",
@@ -818,6 +819,18 @@
     "updateFailed": "Falha ao atualizar projeto",
     "deleteFailed": "Falha ao excluir projeto",
     "confirmDelete": "Tem certeza de que deseja excluir este projeto?",
+    "searchPlaceholder": "Pesquisar projetos...",
+    "sortNewest": "Mais recente",
+    "sortOldest": "Mais antigo",
+    "sortTitle": "Título",
+    "noSearchResults": "Nenhum projeto encontrado",
+    "archivedTab": "Arquivados",
+    "archive": "Arquivar",
+    "unarchive": "Desarquivar",
+    "archiveSuccess": "Projeto arquivado",
+    "unarchiveSuccess": "Projeto desarquivado",
+    "archiveFailed": "Falha ao arquivar",
+    "unarchiveFailed": "Falha ao desarquivar",
     "statusInProgress": "Em andamento",
     "statusCompleted": "Concluído"
   },
@@ -1494,7 +1507,8 @@
     "volumeDetailed": "Detalhado",
     "exportMarkdown": "Exportar como Markdown",
     "exportSuccess": "Nota exportada com sucesso",
-    "exportError": "Falha ao exportar nota"
+    "exportError": "Falha ao exportar nota",
+    "favoritesOnly": "Apenas favoritos"
   },
   "githubCallback": {
     "missingOAuthParams": "Parâmetros OAuth ausentes",

--- a/frontend/src/i18n/locales/ru.json
+++ b/frontend/src/i18n/locales/ru.json
@@ -52,7 +52,8 @@
     ],
     "contributionsInLastYear": "{{count}} вкладов за последний год",
     "dateContributions": "{{date}}: {{count}} вкладов",
-    "dateLogs": "{{date}}: {{count}} записей"
+    "dateLogs": "{{date}}: {{count}} записей",
+    "createFromTemplate": "Создать из шаблона"
   },
   "nav": {
     "dashboard": "Панель",
@@ -817,6 +818,18 @@
     "updateFailed": "Не удалось обновить проект",
     "deleteFailed": "Не удалось удалить проект",
     "confirmDelete": "Вы уверены, что хотите удалить этот проект?",
+    "searchPlaceholder": "Поиск проектов...",
+    "sortNewest": "Новые",
+    "sortOldest": "Старые",
+    "sortTitle": "По названию",
+    "noSearchResults": "Проекты не найдены",
+    "archivedTab": "В архиве",
+    "archive": "В архив",
+    "unarchive": "Из архива",
+    "archiveSuccess": "Проект архивирован",
+    "unarchiveSuccess": "Проект разархивирован",
+    "archiveFailed": "Ошибка архивации",
+    "unarchiveFailed": "Ошибка разархивации",
     "statusInProgress": "В процессе",
     "statusCompleted": "Завершён"
   },
@@ -1493,7 +1506,8 @@
     "volumeDetailed": "Подробная",
     "exportMarkdown": "Экспорт в Markdown",
     "exportSuccess": "Заметка экспортирована",
-    "exportError": "Не удалось экспортировать"
+    "exportError": "Не удалось экспортировать",
+    "favoritesOnly": "Только избранные"
   },
   "githubCallback": {
     "missingOAuthParams": "Отсутствуют параметры OAuth",

--- a/frontend/src/i18n/locales/zh-CN.json
+++ b/frontend/src/i18n/locales/zh-CN.json
@@ -52,7 +52,8 @@
     ],
     "contributionsInLastYear": "过去一年 {{count}} 次贡献",
     "dateContributions": "{{date}}: {{count}} 次贡献",
-    "dateLogs": "{{date}}: {{count}} 条日志"
+    "dateLogs": "{{date}}: {{count}} 条日志",
+    "createFromTemplate": "从模板创建"
   },
   "nav": {
     "dashboard": "仪表板",
@@ -818,6 +819,18 @@
     "updateFailed": "更新项目失败",
     "deleteFailed": "删除项目失败",
     "confirmDelete": "确定要删除这个项目吗？",
+    "searchPlaceholder": "搜索项目...",
+    "sortNewest": "最新",
+    "sortOldest": "最早",
+    "sortTitle": "标题",
+    "noSearchResults": "未找到项目",
+    "archivedTab": "已归档",
+    "archive": "归档",
+    "unarchive": "取消归档",
+    "archiveSuccess": "项目已归档",
+    "unarchiveSuccess": "项目已取消归档",
+    "archiveFailed": "归档失败",
+    "unarchiveFailed": "取消归档失败",
     "statusInProgress": "进行中",
     "statusCompleted": "已完成"
   },
@@ -1494,7 +1507,8 @@
     "volumeDetailed": "详细",
     "exportMarkdown": "导出为Markdown",
     "exportSuccess": "笔记导出成功",
-    "exportError": "导出失败"
+    "exportError": "导出失败",
+    "favoritesOnly": "仅收藏"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth参数",

--- a/frontend/src/i18n/locales/zh-TW.json
+++ b/frontend/src/i18n/locales/zh-TW.json
@@ -52,7 +52,8 @@
     ],
     "contributionsInLastYear": "過去一年 {{count}} 次貢獻",
     "dateContributions": "{{date}}: {{count}} 次貢獻",
-    "dateLogs": "{{date}}: {{count}} 條日誌"
+    "dateLogs": "{{date}}: {{count}} 條日誌",
+    "createFromTemplate": "從範本建立"
   },
   "nav": {
     "dashboard": "儀表板",
@@ -819,6 +820,18 @@
     "updateFailed": "更新專案失敗",
     "deleteFailed": "刪除專案失敗",
     "confirmDelete": "確定要刪除這個專案嗎？",
+    "searchPlaceholder": "搜尋專案...",
+    "sortNewest": "最新",
+    "sortOldest": "最早",
+    "sortTitle": "標題",
+    "noSearchResults": "未找到專案",
+    "archivedTab": "已封存",
+    "archive": "封存",
+    "unarchive": "取消封存",
+    "archiveSuccess": "專案已封存",
+    "unarchiveSuccess": "專案已取消封存",
+    "archiveFailed": "封存失敗",
+    "unarchiveFailed": "取消封存失敗",
     "statusInProgress": "進行中",
     "statusCompleted": "已完成"
   },
@@ -1495,7 +1508,8 @@
     "volumeDetailed": "詳細",
     "exportMarkdown": "匯出為Markdown",
     "exportSuccess": "筆記匯出成功",
-    "exportError": "匯出失敗"
+    "exportError": "匯出失敗",
+    "favoritesOnly": "僅收藏"
   },
   "githubCallback": {
     "missingOAuthParams": "缺少OAuth參數",

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -61,7 +61,7 @@ export default function GoalsPage() {
             className={`${buttonSecondaryClass} font-medium text-sm flex items-center gap-1.5`}
           >
             <Sparkles className="w-4 h-4" />
-            テンプレートから作成
+            {t('common.createFromTemplate')}
           </button>
           <button
             onClick={() => setShowForm(true)}

--- a/frontend/src/pages/NotesPage.tsx
+++ b/frontend/src/pages/NotesPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { BookOpen, Plus, ArrowDownWideNarrow, Tag, List, LayoutGrid, Sparkles } from 'lucide-react';
+import { BookOpen, Plus, ArrowDownWideNarrow, Tag, List, LayoutGrid, Sparkles, Star } from 'lucide-react';
 import { useNoteForm } from '../hooks';
 import { PageLoader, SearchInput } from '../components/common';
 import EmptyState from '../components/common/EmptyState';
@@ -17,7 +17,7 @@ export default function NotesPage() {
   const {
     filteredNotes, loading, saving,
     showForm, setShowForm, editingNote, searchQuery, setSearchQuery, sortBy, setSortBy,
-    filterTag, setFilterTag, allTags, viewMode, setViewMode,
+    filterTag, setFilterTag, showFavoritesOnly, setShowFavoritesOnly, allTags, viewMode, setViewMode,
     title, setTitle, content, setContent, tags, setTags,
     resetForm, handleSubmit, handleEdit, deleteNote, toggleFavorite,
   } = useNoteForm();
@@ -50,7 +50,7 @@ export default function NotesPage() {
             className={`${buttonSecondaryClass} flex items-center gap-2`}
           >
             <Sparkles className="w-5 h-5" />
-            テンプレートから作成
+            {t('common.createFromTemplate')}
           </button>
           <button
             onClick={handleToggleForm}
@@ -71,9 +71,18 @@ export default function NotesPage() {
         />
       </div>
 
-      {/* Sort & View Toggle */}
+      {/* Favorites Filter & Sort & View Toggle */}
       <div className="flex items-center justify-between mb-6">
         <div className="flex items-center gap-3">
+          <button
+            onClick={() => setShowFavoritesOnly(prev => !prev)}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
+              showFavoritesOnly ? 'bg-yellow-500/20 text-yellow-400' : 'bg-gray-800/50 text-gray-400 hover:text-white'
+            }`}
+          >
+            <Star className={`w-4 h-4 ${showFavoritesOnly ? 'fill-yellow-400' : ''}`} />
+            {t('notes.favoritesOnly')}
+          </button>
           <ArrowDownWideNarrow className="w-4 h-4 text-gray-400" />
           <div className="flex flex-wrap gap-2">
             {NOTES_SORT_OPTIONS.map((opt) => (

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,19 +1,23 @@
 import { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { FolderOpen } from 'lucide-react';
+import { FolderOpen, Search, ArrowUpDown, Archive } from 'lucide-react';
 import type { Project } from '../types/project';
 import { useProjects, useConfirm } from '../hooks';
+import type { ProjectSortBy, ProjectTab } from '../hooks/useProjects';
 import ProjectCard from '../components/projects/ProjectCard';
 import ProjectForm from '../components/projects/ProjectForm';
 import EmptyState from '../components/common/EmptyState';
 import ConfirmDialog from '../components/common/ConfirmDialog';
 import { Modal, PageHeader, PageLoader } from '../components/common';
+import { inputClass } from '../constants/styles';
 
 export default function ProjectsPage() {
   const { t } = useTranslation();
   const {
-    projects, repos, loading, saving,
+    projects, allProjects, archivedProjects, repos, loading, saving,
+    searchQuery, setSearchQuery, sortBy, setSortBy, tab, setTab,
     createProject, updateProject, deleteProject,
+    archiveProject, unarchiveProject,
   } = useProjects();
 
   const { confirm, dialogProps } = useConfirm();
@@ -45,6 +49,12 @@ export default function ProjectsPage() {
     return <PageLoader />;
   }
 
+  const SORT_OPTIONS: { value: ProjectSortBy; label: string }[] = [
+    { value: 'newest', label: t('projects.sortNewest') },
+    { value: 'oldest', label: t('projects.sortOldest') },
+    { value: 'title', label: t('projects.sortTitle') },
+  ];
+
   return (
     <div className="max-w-6xl mx-auto px-4 py-8">
       <PageHeader
@@ -53,6 +63,58 @@ export default function ProjectsPage() {
         actionLabel={t('projects.addProject')}
         onAction={() => setShowForm(true)}
       />
+
+      {/* Search */}
+      <div className="relative mb-4">
+        <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-500" />
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder={t('projects.searchPlaceholder')}
+          className={`${inputClass} pl-9`}
+        />
+      </div>
+
+      {/* Tabs & Sort */}
+      <div className="flex items-center justify-between mb-6">
+        <div className="flex gap-2">
+          {(['active', 'archived'] as ProjectTab[]).map((tabValue) => (
+            <button
+              key={tabValue}
+              onClick={() => setTab(tabValue)}
+              className={`flex items-center gap-1.5 px-4 py-2 text-sm rounded-lg transition-colors ${
+                tab === tabValue
+                  ? tabValue === 'archived'
+                    ? 'bg-yellow-500/10 text-yellow-400 border border-yellow-500/50'
+                    : 'bg-blue-500/10 text-blue-400 border border-blue-500/50'
+                  : 'text-gray-400 border border-gray-700 hover:border-gray-600'
+              }`}
+            >
+              {tabValue === 'archived' && <Archive className="w-4 h-4" />}
+              {tabValue === 'active'
+                ? `${t('projects.title')} (${allProjects.length})`
+                : `${t('projects.archivedTab')} (${archivedProjects.length})`}
+            </button>
+          ))}
+        </div>
+        <div className="flex items-center gap-2">
+          <ArrowUpDown className="w-4 h-4 text-gray-500" />
+          {SORT_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => setSortBy(opt.value)}
+              className={`px-3 py-1 text-xs rounded-full border transition-colors ${
+                sortBy === opt.value
+                  ? 'border-blue-500 bg-blue-500/10 text-blue-400'
+                  : 'border-gray-700 text-gray-400 hover:border-gray-600'
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Form Modal */}
       <Modal
@@ -71,12 +133,24 @@ export default function ProjectsPage() {
 
       {/* Projects Grid */}
       {projects.length === 0 ? (
-        <EmptyState
-          icon={FolderOpen}
-          message={t('projects.noProjects')}
-          actionLabel={t('projects.addFirstProject')}
-          onAction={() => setShowForm(true)}
-        />
+        searchQuery ? (
+          <EmptyState
+            icon={FolderOpen}
+            message={t('projects.noSearchResults')}
+          />
+        ) : tab === 'archived' ? (
+          <EmptyState
+            icon={Archive}
+            message={t('projects.noSearchResults')}
+          />
+        ) : (
+          <EmptyState
+            icon={FolderOpen}
+            message={t('projects.noProjects')}
+            actionLabel={t('projects.addFirstProject')}
+            onAction={() => setShowForm(true)}
+          />
+        )
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {projects.map(project => (
@@ -86,6 +160,8 @@ export default function ProjectsPage() {
               isOwner
               onEdit={() => setEditingProject(project)}
               onDelete={() => handleDeleteProject(project)}
+              onArchive={() => archiveProject(project)}
+              onUnarchive={() => unarchiveProject(project)}
             />
           ))}
         </div>


### PR DESCRIPTION
## 概要
Closes #2129

サイクル8のフェーズ1として5つのUX改善機能を実装。

## 変更内容
1. **プロジェクトページ検索・ソート** - 検索バー、新しい順/古い順/タイトル順ソートを追加
2. **i18n化** - GoalsPage/NotesPageの「テンプレートから作成」を`common.createFromTemplate`キーに変更、全10言語に翻訳追加
3. **ノートお気に入りフィルター** - Starトグルボタンでお気に入りノートのみ表示可能に
4. **プロジェクトアーカイブタブ** - アクティブ/アーカイブ済みタブ切替、既存API(`/projects/archived`)を活用
5. **プロジェクトカードアーカイブボタン** - Archive/ArchiveRestoreアイコンでアーカイブ/復元操作

## 対象ファイル
- `frontend/src/hooks/useProjects.ts` - 検索/ソート/アーカイブ状態管理追加
- `frontend/src/hooks/useNoteForm.ts` - お気に入りフィルター状態追加
- `frontend/src/pages/ProjectsPage.tsx` - 検索バー、タブ、ソートUI追加
- `frontend/src/pages/NotesPage.tsx` - Starフィルター追加、i18n修正
- `frontend/src/pages/GoalsPage.tsx` - i18n修正
- `frontend/src/components/projects/ProjectCard.tsx` - アーカイブボタン追加
- `frontend/src/i18n/locales/*.json` - 全10言語にキー追加

## テスト
- `npx tsc --noEmit` PASS