### PR TITLE
refactor: ハンドラー層のgin.H/匿名構造体をDTO化・重複ログ削除・定数抽出

### DIFF
--- a/backend/internal/dto/bookmark_collection_dto.go
+++ b/backend/internal/dto/bookmark_collection_dto.go
@@ -1,0 +1,16 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// BookmarkCollectionRequest はブックマークコレクション作成・更新リクエスト。
+type BookmarkCollectionRequest struct {
+	Name        string `json:"name" binding:"required,max=200"`
+	Description string `json:"description" binding:"omitempty,max=2000"`
+	Color       string `json:"color" binding:"omitempty,max=50"`
+}
+
+// BookmarkCollectionPostsResponse はコレクション内投稿一覧レスポンス。
+type BookmarkCollectionPostsResponse struct {
+	Posts []model.Post `json:"posts"`
+	Total int64        `json:"total"`
+}

--- a/backend/internal/dto/code_snippet_dto.go
+++ b/backend/internal/dto/code_snippet_dto.go
@@ -1,5 +1,13 @@
 package dto
 
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// CodeSnippetFavoritesResponse はお気に入りスニペット一覧レスポンス。
+type CodeSnippetFavoritesResponse struct {
+	Snippets []model.CodeSnippet `json:"snippets"`
+	Total    int64               `json:"total"`
+}
+
 // CreateCodeSnippetRequest はコードスニペット作成リクエスト。
 type CreateCodeSnippetRequest struct {
 	Language string `json:"language" binding:"required,max=100" validate:"required,max=100"`

--- a/backend/internal/dto/learning_log_dto.go
+++ b/backend/internal/dto/learning_log_dto.go
@@ -25,6 +25,17 @@ type BatchCreateLearningLogRequest struct {
 	Logs []CreateLearningLogRequest `json:"logs" binding:"required,min=1,max=50,dive"`
 }
 
+// WeeklyDurationResponse は週間学習時間レスポンス。
+type WeeklyDurationResponse struct {
+	Duration int `json:"duration"`
+}
+
+// ImportCSVResponse はCSVインポートレスポンス。
+type ImportCSVResponse struct {
+	Imported int                 `json:"imported"`
+	Logs     []model.LearningLog `json:"logs"`
+}
+
 // UpdateLearningLogRequest は学習ログ更新リクエスト。
 type UpdateLearningLogRequest struct {
 	Title    *string `json:"title" binding:"omitempty,max=200"`

--- a/backend/internal/dto/note_version_dto.go
+++ b/backend/internal/dto/note_version_dto.go
@@ -1,0 +1,11 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// NoteVersionListResponse はノートバージョン一覧レスポンス（ページネーション付き）。
+type NoteVersionListResponse struct {
+	Versions []model.NoteVersion `json:"versions"`
+	Total    int64               `json:"total"`
+	Limit    int                 `json:"limit"`
+	Offset   int                 `json:"offset"`
+}

--- a/backend/internal/dto/post_dto.go
+++ b/backend/internal/dto/post_dto.go
@@ -67,6 +67,11 @@ type AutoSaveDraftResponse struct {
 	UpdatedAt string `json:"updated_at"`
 }
 
+// SchedulePublishRequest はスケジュール公開リクエスト。
+type SchedulePublishRequest struct {
+	ScheduledAt string `json:"scheduled_at" binding:"required"`
+}
+
 // ReactionRequest はリアクション追加/削除リクエスト。
 type ReactionRequest struct {
 	Emoji string `json:"emoji" binding:"required,max=10"`

--- a/backend/internal/dto/resource_review_dto.go
+++ b/backend/internal/dto/resource_review_dto.go
@@ -1,0 +1,9 @@
+package dto
+
+import "github.com/norman6464/devsync/backend/internal/model"
+
+// ResourceReviewListResponse はリソースレビュー一覧レスポンス。
+type ResourceReviewListResponse struct {
+	Reviews []model.ResourceReview `json:"reviews"`
+	Total   int64                  `json:"total"`
+}

--- a/backend/internal/handler/ai_advice.go
+++ b/backend/internal/handler/ai_advice.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"log"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
@@ -103,7 +101,6 @@ func (h *AIAdviceHandler) DeleteConversation(c *gin.Context) {
 	userID := c.GetUint("userID")
 
 	if err := h.service.DeleteConversation(id, userID); err != nil {
-		log.Printf("会話削除エラー: %v", err)
 		respondError(c, err)
 		return
 	}

--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -187,7 +188,7 @@ func (h *BookReviewHandler) Archive(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "書籍レビューをアーカイブしました"})
+	respondOK(c, domain.NewMessageResponse("書籍レビューをアーカイブしました"))
 }
 
 // Unarchive は指定IDの書籍レビューのアーカイブを解除する。
@@ -203,7 +204,7 @@ func (h *BookReviewHandler) Unarchive(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "書籍レビューのアーカイブを解除しました"})
+	respondOK(c, domain.NewMessageResponse("書籍レビューのアーカイブを解除しました"))
 }
 
 // UpdateStatus は書籍レビューの読書状態を更新する。
@@ -224,7 +225,7 @@ func (h *BookReviewHandler) UpdateStatus(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "読書状態を更新しました"})
+	respondOK(c, domain.NewMessageResponse("読書状態を更新しました"))
 }
 
 // UpdateProgress は書籍レビューの読書進捗を更新する。

--- a/backend/internal/handler/bookmark_collection.go
+++ b/backend/internal/handler/bookmark_collection.go
@@ -2,6 +2,8 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -30,11 +32,7 @@ func NewBookmarkCollectionHandler(s BookmarkCollectionServiceInterface) *Bookmar
 func (h *BookmarkCollectionHandler) Create(c *gin.Context) {
 	userID := c.GetUint("userID")
 
-	input := bindJSON[struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-		Color       string `json:"color"`
-	}](c)
+	input := bindJSON[dto.BookmarkCollectionRequest](c)
 	if input == nil {
 		return
 	}
@@ -75,11 +73,7 @@ func (h *BookmarkCollectionHandler) Update(c *gin.Context) {
 		return
 	}
 
-	input := bindJSON[struct {
-		Name        string `json:"name"`
-		Description string `json:"description"`
-		Color       string `json:"color"`
-	}](c)
+	input := bindJSON[dto.BookmarkCollectionRequest](c)
 	if input == nil {
 		return
 	}
@@ -130,7 +124,7 @@ func (h *BookmarkCollectionHandler) AddPost(c *gin.Context) {
 		return
 	}
 
-	respondCreated(c, gin.H{"message": "コレクションに追加しました"})
+	respondCreated(c, domain.NewMessageResponse("コレクションに追加しました"))
 }
 
 // RemovePost はコレクションからブックマークを削除する。
@@ -167,8 +161,8 @@ func (h *BookmarkCollectionHandler) GetPosts(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"posts": ensureSlice(posts),
-		"total": total,
+	respondOK(c, dto.BookmarkCollectionPostsResponse{
+		Posts: ensureSlice(posts),
+		Total: total,
 	})
 }

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -251,8 +251,8 @@ func (h *CodeSnippetHandler) GetFavorites(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"snippets": ensureSlice(snippets),
-		"total":    total,
+	respondOK(c, dto.CodeSnippetFavoritesResponse{
+		Snippets: ensureSlice(snippets),
+		Total:    total,
 	})
 }

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -305,7 +306,7 @@ func (h *LearningLogHandler) GetWeeklyDuration(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"duration": duration})
+	respondOK(c, dto.WeeklyDurationResponse{Duration: duration})
 }
 
 // GetMonthlySummary は指定ユーザーの月別学習サマリーを返す。
@@ -339,7 +340,7 @@ func (h *LearningLogHandler) Favorite(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "学習ログをお気に入りに追加しました"})
+	respondOK(c, domain.NewMessageResponse("学習ログをお気に入りに追加しました"))
 }
 
 // GetRecentCategories はユーザーの最近よく使うカテゴリを返す。
@@ -387,7 +388,7 @@ func (h *LearningLogHandler) Unfavorite(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "学習ログのお気に入りを解除しました"})
+	respondOK(c, domain.NewMessageResponse("学習ログのお気に入りを解除しました"))
 }
 
 // ImportCSV はCSVファイルから学習ログを一括インポートする。
@@ -425,9 +426,9 @@ func (h *LearningLogHandler) ImportCSV(c *gin.Context) {
 		return
 	}
 
-	respondCreated(c, gin.H{
-		"imported": len(logs),
-		"logs":     logs,
+	respondCreated(c, dto.ImportCSVResponse{
+		Imported: len(logs),
+		Logs:     logs,
 	})
 }
 

--- a/backend/internal/handler/note_version.go
+++ b/backend/internal/handler/note_version.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -38,11 +39,11 @@ func (h *NoteVersionHandler) GetVersions(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"versions": ensureSlice(versions),
-		"total":    total,
-		"limit":    limit,
-		"offset":   offset,
+	respondOK(c, dto.NoteVersionListResponse{
+		Versions: ensureSlice(versions),
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
 	})
 }
 

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -501,9 +501,7 @@ func (h *PostHandler) SchedulePublish(c *gin.Context) {
 		return
 	}
 
-	input := bindJSON[struct {
-		ScheduledAt string `json:"scheduled_at"`
-	}](c)
+	input := bindJSON[dto.SchedulePublishRequest](c)
 	if input == nil {
 		return
 	}

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -213,7 +214,7 @@ func (h *ProjectHandler) Archive(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "archived"})
+	respondOK(c, domain.NewMessageResponse("archived"))
 }
 
 // Unarchive はプロジェクトのアーカイブを解除する。
@@ -229,7 +230,7 @@ func (h *ProjectHandler) Unarchive(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "unarchived"})
+	respondOK(c, domain.NewMessageResponse("unarchived"))
 }
 
 // GetArchived はアーカイブ済みプロジェクト一覧を取得する。

--- a/backend/internal/handler/project_milestone.go
+++ b/backend/internal/handler/project_milestone.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -54,7 +55,7 @@ func (h *ProjectMilestoneHandler) Create(c *gin.Context) {
 		return
 	}
 
-	respondCreated(c, gin.H{"message": "マイルストーンを作成しました"})
+	respondCreated(c, domain.NewMessageResponse("マイルストーンを作成しました"))
 }
 
 // GetByProjectID はプロジェクトのマイルストーン一覧を取得する。
@@ -120,5 +121,5 @@ func (h *ProjectMilestoneHandler) Delete(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "マイルストーンを削除しました"})
+	respondOK(c, domain.NewMessageResponse("マイルストーンを削除しました"))
 }

--- a/backend/internal/handler/resource_review.go
+++ b/backend/internal/handler/resource_review.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -70,9 +71,9 @@ func (h *ResourceReviewHandler) GetByResourceID(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{
-		"reviews": ensureSlice(reviews),
-		"total":   total,
+	respondOK(c, dto.ResourceReviewListResponse{
+		Reviews: ensureSlice(reviews),
+		Total:   total,
 	})
 }
 

--- a/backend/internal/handler/streak_freeze.go
+++ b/backend/internal/handler/streak_freeze.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
 
@@ -31,7 +32,7 @@ func (h *StreakFreezeHandler) UseFreeze(c *gin.Context) {
 		return
 	}
 
-	respondCreated(c, gin.H{"message": "ストリークフリーズを使用しました"})
+	respondCreated(c, domain.NewMessageResponse("ストリークフリーズを使用しました"))
 }
 
 // GetStatus は今月のフリーズ使用状況を返す。

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -368,5 +368,5 @@ func (h *StudyCircleHandler) UpdateMemberRole(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "メンバー役割を更新しました"})
+	respondOK(c, domain.NewMessageResponse("メンバー役割を更新しました"))
 }

--- a/backend/internal/handler/widget_settings.go
+++ b/backend/internal/handler/widget_settings.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"github.com/gin-gonic/gin"
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
@@ -49,5 +50,5 @@ func (h *WidgetSettingsHandler) UpdateSettings(c *gin.Context) {
 		return
 	}
 
-	respondOK(c, gin.H{"message": "設定を更新しました"})
+	respondOK(c, domain.NewMessageResponse("設定を更新しました"))
 }

--- a/backend/internal/service/learning_analytics.go
+++ b/backend/internal/service/learning_analytics.go
@@ -7,6 +7,9 @@ import (
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
 
+// defaultWeeklyTrendsWeeks は週間トレンド取得時のデフォルト週数。
+const defaultWeeklyTrendsWeeks = 12
+
 // LearningAnalyticsService は学習分析のビジネスロジックを提供する。
 // ヒートマップ、カテゴリ別集計、生産性スコア計算、AIインサイト生成を担当する。
 type LearningAnalyticsService struct {
@@ -52,7 +55,7 @@ func (s *LearningAnalyticsService) GetCategoryBreakdown(userID uint) ([]model.Ca
 // weeksが0以下の場合はデフォルトの12週に設定される。
 func (s *LearningAnalyticsService) GetWeeklyTrends(userID uint, weeks int) ([]model.WeeklyTrend, error) {
 	if weeks <= 0 {
-		weeks = 12
+		weeks = defaultWeeklyTrendsWeeks
 	}
 	return s.repo.GetWeeklyTrends(userID, weeks)
 }
@@ -106,7 +109,7 @@ func (s *LearningAnalyticsService) GetInsights(userID uint) ([]model.AIInsight, 
 		return nil, err
 	}
 
-	trends, err := s.repo.GetWeeklyTrends(userID, 12)
+	trends, err := s.repo.GetWeeklyTrends(userID, defaultWeeklyTrendsWeeks)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## 概要
ハンドラー層のコード品質を改善するリファクタリング。型安全性の向上とレスポンスパターンの統一を実施。

## 変更内容

### 1. 匿名インライン構造体のDTO化
- `bookmark_collection.go` の Create/Update で使用していた匿名構造体を `BookmarkCollectionRequest` DTOに抽出
- `post.go` の SchedulePublish で使用していた匿名構造体を `SchedulePublishRequest` DTOに抽出

### 2. `gin.H{"message": ...}` → `domain.NewMessageResponse(...)` に統一（13箇所）
- bookmark_collection, book_review, streak_freeze, study_circle, learning_log, project, project_milestone, widget_settings

### 3. `gin.H{...}` 構造化レスポンス → 型付きDTOに置換（6箇所）
- `BookmarkCollectionPostsResponse`, `WeeklyDurationResponse`, `ImportCSVResponse`, `NoteVersionListResponse`, `CodeSnippetFavoritesResponse`, `ResourceReviewListResponse`

### 4. 重複 `log.Printf` 削除
- `ai_advice.go` の `DeleteConversation` で `respondError` 呼び出し前の冗長なログを削除

### 5. マジックナンバー定数化
- `learning_analytics.go` の `weeks = 12` → `defaultWeeklyTrendsWeeks` 定数に抽出

## テスト結果
- `go build ./...` ✅
- `go test ./internal/service/...` ✅
- `go test ./internal/handler/...` ✅
- `go test ./internal/domain/...` ✅

Closes #2131