### PR TITLE
fix: 外部APIエラーメッセージの漏洩防止・GraphQLインジェクション対策

### DIFF
--- a/backend/internal/handler/search.go
+++ b/backend/internal/handler/search.go
@@ -53,8 +53,11 @@ func (h *SearchHandler) SearchPosts(c *gin.Context) {
 		}
 	}
 
-	// ソート順
+	// ソート順（Handler層で無効値をデフォルトに正規化）
 	sortBy := model.SearchSortBy(c.DefaultQuery("sort_by", string(model.SearchSortByLatest)))
+	if !model.ValidSearchSortBy[sortBy] {
+		sortBy = model.SearchSortByLatest
+	}
 
 	// 日付範囲フィルター
 	var dateFrom, dateTo *time.Time

--- a/backend/internal/service/github.go
+++ b/backend/internal/service/github.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/norman6464/devsync/backend/internal/config"
@@ -69,7 +71,8 @@ func (s *GitHubService) ExchangeCode(code string) (string, error) {
 		return "", domain.NewError(domain.ErrCodeServiceUnavailable, "GitHub APIレスポンスの解析に失敗しました", err)
 	}
 	if result.Error != "" {
-		return "", domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("GitHub OAuthエラー: %s", result.Error), nil)
+		log.Printf("[WARN] GitHub OAuthエラー: %s", result.Error)
+		return "", domain.NewError(domain.ErrCodeServiceUnavailable, "GitHub認証に失敗しました", nil)
 	}
 	return result.AccessToken, nil
 }
@@ -162,6 +165,10 @@ func (s *GitHubService) syncContributions(user *model.User) error {
 	from := now.AddDate(-1, 0, 0).Format("2006-01-02T15:04:05Z")
 	to := now.Format("2006-01-02T15:04:05Z")
 
+	// GraphQLインジェクション防止: ユーザー名をサニタイズ
+	safeUsername := strings.ReplaceAll(user.GitHubUsername, `"`, "")
+	safeUsername = strings.ReplaceAll(safeUsername, `\`, "")
+
 	query := fmt.Sprintf(`query {
 		user(login: "%s") {
 			contributionsCollection(from: "%s", to: "%s") {
@@ -175,7 +182,7 @@ func (s *GitHubService) syncContributions(user *model.User) error {
 				}
 			}
 		}
-	}`, user.GitHubUsername, from, to)
+	}`, safeUsername, from, to)
 
 	body, _ := json.Marshal(map[string]string{"query": query})
 	req, _ := http.NewRequest("POST", "https://api.github.com/graphql", bytes.NewBuffer(body))

--- a/backend/internal/service/openai_client.go
+++ b/backend/internal/service/openai_client.go
@@ -3,8 +3,8 @@ package service
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"time"
 
@@ -107,7 +107,8 @@ func (c *OpenAIClient) Complete(messages []ChatMessage) (*ChatResponse, error) {
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("OpenAI APIエラー (ステータス %d): %s", resp.StatusCode, string(body)), nil)
+		log.Printf("[WARN] OpenAI APIエラー (ステータス %d): %s", resp.StatusCode, string(body))
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "AI サービスが一時的に利用できません", nil)
 	}
 
 	var apiResp openAIResponse
@@ -116,7 +117,8 @@ func (c *OpenAIClient) Complete(messages []ChatMessage) (*ChatResponse, error) {
 	}
 
 	if apiResp.Error != nil {
-		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, fmt.Sprintf("OpenAI APIエラー: %s", apiResp.Error.Message), nil)
+		log.Printf("[WARN] OpenAI APIエラー: %s", apiResp.Error.Message)
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "AI サービスが一時的に利用できません", nil)
 	}
 
 	if len(apiResp.Choices) == 0 {

--- a/backend/internal/service/openai_client_test.go
+++ b/backend/internal/service/openai_client_test.go
@@ -73,7 +73,7 @@ func TestComplete_ServerError(t *testing.T) {
 	var domainErr *domain.DomainError
 	assert.True(t, errors.As(err, &domainErr))
 	assert.Equal(t, domain.ErrCodeServiceUnavailable, domainErr.Code)
-	assert.Contains(t, domainErr.Message, "500")
+	assert.Contains(t, domainErr.Message, "AI サービスが一時的に利用できません")
 }
 
 func TestComplete_RateLimited(t *testing.T) {
@@ -92,7 +92,7 @@ func TestComplete_RateLimited(t *testing.T) {
 	var domainErr *domain.DomainError
 	assert.True(t, errors.As(err, &domainErr))
 	assert.Equal(t, domain.ErrCodeServiceUnavailable, domainErr.Code)
-	assert.Contains(t, domainErr.Message, "429")
+	assert.Contains(t, domainErr.Message, "AI サービスが一時的に利用できません")
 }
 
 func TestComplete_InvalidJSON(t *testing.T) {
@@ -130,7 +130,7 @@ func TestComplete_APIError(t *testing.T) {
 	var domainErr *domain.DomainError
 	assert.True(t, errors.As(err, &domainErr))
 	assert.Equal(t, domain.ErrCodeServiceUnavailable, domainErr.Code)
-	assert.Contains(t, domainErr.Message, "invalid api key")
+	assert.Contains(t, domainErr.Message, "AI サービスが一時的に利用できません")
 }
 
 func TestComplete_EmptyChoices(t *testing.T) {
@@ -210,7 +210,7 @@ func TestComplete_UnauthorizedError(t *testing.T) {
 	var domainErr *domain.DomainError
 	assert.True(t, errors.As(err, &domainErr))
 	assert.Equal(t, domain.ErrCodeServiceUnavailable, domainErr.Code)
-	assert.Contains(t, domainErr.Message, "401")
+	assert.Contains(t, domainErr.Message, "AI サービスが一時的に利用できません")
 }
 
 func TestComplete_ReadBodyError(t *testing.T) {

--- a/backend/internal/service/youtube_client.go
+++ b/backend/internal/service/youtube_client.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/url"
 	"time"
@@ -101,8 +102,8 @@ func (c *YouTubeClient) SearchVideos(query string, maxResults int, language stri
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, domain.NewError(domain.ErrCodeServiceUnavailable,
-			fmt.Sprintf("YouTube APIエラー (ステータス %d): %s", resp.StatusCode, string(body)), nil)
+		log.Printf("[WARN] YouTube APIエラー (ステータス %d): %s", resp.StatusCode, string(body))
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "YouTube APIが一時的に利用できません", nil)
 	}
 
 	var apiResp youtubeSearchResponse
@@ -111,8 +112,8 @@ func (c *YouTubeClient) SearchVideos(query string, maxResults int, language stri
 	}
 
 	if apiResp.Error != nil {
-		return nil, domain.NewError(domain.ErrCodeServiceUnavailable,
-			fmt.Sprintf("YouTube APIエラー: %s", apiResp.Error.Message), nil)
+		log.Printf("[WARN] YouTube APIエラー: %s", apiResp.Error.Message)
+		return nil, domain.NewError(domain.ErrCodeServiceUnavailable, "YouTube APIが一時的に利用できません", nil)
 	}
 
 	var videos []model.YouTubeVideo


### PR DESCRIPTION
## 概要
- 外部API（OpenAI/YouTube/GitHub）のエラー詳細がクライアントに漏洩していた問題を修正
- GitHub GraphQLクエリにおけるインジェクション脆弱性を修正
- 検索ソート順の防御的バリデーションを追加

## 変更内容
- `openai_client.go`: APIレスポンスボディ・エラーメッセージをログのみに記録し、汎用メッセージを返却
- `youtube_client.go`: 同上
- `github.go`: OAuthエラー文字列の隠蔽、GraphQLクエリのユーザー名サニタイズ
- `search.go`: Handler層でsort_byパラメータの無効値をデフォルトに正規化
- `openai_client_test.go`: セキュリティ修正に合わせたアサーション更新

## テスト結果
全テスト合格（service/handler/domain）

closes #2135