### PR TITLE
refactor: Handler層のビジネスロジックをService層へ移動・日付パース集約

### DIFF
--- a/backend/internal/handler/helpers.go
+++ b/backend/internal/handler/helpers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -273,6 +274,29 @@ func handleGetByIDPublic[T any](c *gin.Context, getter func(id uint) (*T, error)
 		return
 	}
 	respondOK(c, result)
+}
+
+// parseDateParam は "2006-01-02" 形式の日付文字列をパースする。
+// 空文字列の場合はゼロ値とtrueを返す。パース失敗時は400レスポンスを返しfalseを返す。
+func parseDateParam(dateStr string) (time.Time, bool) {
+	if dateStr == "" {
+		return time.Time{}, true
+	}
+	t, err := time.Parse("2006-01-02", dateStr)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
+}
+
+// parseDateTimeRFC3339 は RFC3339 形式の日時文字列をパースする。
+// パース失敗時はゼロ値とfalseを返す。
+func parseDateTimeRFC3339(dateStr string) (time.Time, bool) {
+	t, err := time.Parse(time.RFC3339, dateStr)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return t, true
 }
 
 // handleToggleAction はLike/Unlikeなどのトグル操作を共通化するヘルパー。

--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -1,8 +1,6 @@
 package handler
 
 import (
-	"time"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -61,11 +59,8 @@ func (h *LearningGoalHandler) Create(c *gin.Context) {
 	}
 
 	// 目標日が指定されている場合はパースして設定
-	if req.TargetDate != "" {
-		targetDate, err := time.Parse("2006-01-02", req.TargetDate)
-		if err == nil {
-			goal.TargetDate = &targetDate
-		}
+	if targetDate, ok := parseDateParam(req.TargetDate); ok && !targetDate.IsZero() {
+		goal.TargetDate = &targetDate
 	}
 
 	if err := h.service.Create(goal); err != nil {
@@ -102,11 +97,8 @@ func (h *LearningGoalHandler) Update(c *gin.Context) {
 	if req.TargetDate != nil {
 		if *req.TargetDate == "" {
 			updates.TargetDate = nil
-		} else {
-			targetDate, err := time.Parse("2006-01-02", *req.TargetDate)
-			if err == nil {
-				updates.TargetDate = &targetDate
-			}
+		} else if targetDate, ok := parseDateParam(*req.TargetDate); ok {
+			updates.TargetDate = &targetDate
 		}
 	}
 	if req.Progress != nil {

--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -40,6 +40,7 @@ type PostServiceInterface interface {
 	RemoveReaction(userID, postID uint, emoji string) error
 	GetReactionsByPostID(postID uint) ([]model.ReactionCount, error)
 	GetUserReactions(userID, postID uint) ([]string, error)
+	GetReactionsWithUser(userID, postID uint) ([]model.ReactionCount, []string, error)
 	GetReactionsBatch(userID uint, postIDs []uint) (map[uint][]model.ReactionCount, map[uint][]string, error)
 	SchedulePublish(id, userID uint, scheduledAt time.Time) (*model.Post, error)
 	CancelSchedule(id, userID uint) (*model.Post, error)
@@ -475,13 +476,7 @@ func (h *PostHandler) GetReactions(c *gin.Context) {
 	}
 	userID := c.GetUint("userID")
 
-	reactions, err := h.service.GetReactionsByPostID(id)
-	if err != nil {
-		respondError(c, err)
-		return
-	}
-
-	userReactions, err := h.service.GetUserReactions(userID, id)
+	reactions, userReactions, err := h.service.GetReactionsWithUser(userID, id)
 	if err != nil {
 		respondError(c, err)
 		return
@@ -506,9 +501,9 @@ func (h *PostHandler) SchedulePublish(c *gin.Context) {
 		return
 	}
 
-	scheduledAt, err := time.Parse(time.RFC3339, input.ScheduledAt)
-	if err != nil {
-		respondError(c, domain.NewError(domain.ErrCodeBadRequest, "日時のフォーマットが不正です（RFC3339形式で指定してください）", err))
+	scheduledAt, ok := parseDateTimeRFC3339(input.ScheduledAt)
+	if !ok {
+		respondBadRequest(c, "日時のフォーマットが不正です（RFC3339形式で指定してください）")
 		return
 	}
 
@@ -587,19 +582,11 @@ func (h *PostHandler) GetReactionsBatch(c *gin.Context) {
 		return
 	}
 
-	result := make(map[uint]dto.ReactionResponse)
+	result := make(map[uint]dto.ReactionResponse, len(input.PostIDs))
 	for _, id := range input.PostIDs {
-		r := reactions[id]
-		ur := userReactions[id]
-		if r == nil {
-			r = []model.ReactionCount{}
-		}
-		if ur == nil {
-			ur = []string{}
-		}
 		result[id] = dto.ReactionResponse{
-			Reactions:     r,
-			UserReactions: ur,
+			Reactions:     reactions[id],
+			UserReactions: userReactions[id],
 		}
 	}
 

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -1,18 +1,11 @@
 package handler
 
 import (
-	"time"
-
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/dto"
 	"github.com/norman6464/devsync/backend/internal/model"
 )
-
-// parseDate は日付文字列を "2006-01-02" 形式でパースする。
-func parseDate(dateStr string) (time.Time, error) {
-	return time.Parse("2006-01-02", dateStr)
-}
 
 // ProjectServiceInterface はProjectHandlerが依存するサービスメソッドを定義する。
 type ProjectServiceInterface interface {
@@ -62,17 +55,11 @@ func (h *ProjectHandler) Create(c *gin.Context) {
 		GithubRepoID: req.GithubRepoID,
 	}
 
-	if req.StartDate != "" {
-		startDate, err := parseDate(req.StartDate)
-		if err == nil {
-			project.StartDate = &startDate
-		}
+	if startDate, ok := parseDateParam(req.StartDate); ok && !startDate.IsZero() {
+		project.StartDate = &startDate
 	}
-	if req.EndDate != "" {
-		endDate, err := parseDate(req.EndDate)
-		if err == nil {
-			project.EndDate = &endDate
-		}
+	if endDate, ok := parseDateParam(req.EndDate); ok && !endDate.IsZero() {
+		project.EndDate = &endDate
 	}
 
 	if err := h.service.Create(project); err != nil {
@@ -165,17 +152,11 @@ func (h *ProjectHandler) Update(c *gin.Context) {
 	if req.GithubRepoID != nil {
 		updates.GithubRepoID = req.GithubRepoID
 	}
-	if req.StartDate != "" {
-		startDate, err := parseDate(req.StartDate)
-		if err == nil {
-			updates.StartDate = &startDate
-		}
+	if startDate, ok := parseDateParam(req.StartDate); ok && !startDate.IsZero() {
+		updates.StartDate = &startDate
 	}
-	if req.EndDate != "" {
-		endDate, err := parseDate(req.EndDate)
-		if err == nil {
-			updates.EndDate = &endDate
-		}
+	if endDate, ok := parseDateParam(req.EndDate); ok && !endDate.IsZero() {
+		updates.EndDate = &endDate
 	}
 
 	project, err := h.service.Update(id, userID, updates)

--- a/backend/internal/handler/project_milestone.go
+++ b/backend/internal/handler/project_milestone.go
@@ -42,8 +42,8 @@ func (h *ProjectMilestoneHandler) Create(c *gin.Context) {
 
 	var dueDate *time.Time
 	if req.DueDate != "" {
-		d, err := parseDate(req.DueDate)
-		if err != nil {
+		d, ok := parseDateParam(req.DueDate)
+		if !ok {
 			respondBadRequest(c, "日付の形式が不正です（YYYY-MM-DD）")
 			return
 		}
@@ -91,8 +91,8 @@ func (h *ProjectMilestoneHandler) Update(c *gin.Context) {
 
 	var dueDate *time.Time
 	if req.DueDate != "" {
-		d, err := parseDate(req.DueDate)
-		if err != nil {
+		d, ok := parseDateParam(req.DueDate)
+		if !ok {
 			respondBadRequest(c, "日付の形式が不正です（YYYY-MM-DD）")
 			return
 		}

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -339,7 +339,7 @@ func (s *PostService) GetUserReactions(userID, postID uint) ([]string, error) {
 }
 
 // GetReactionsBatch は複数投稿のリアクション情報を一括取得する。
-// 最大50件まで。
+// 最大50件まで。返却マップはリクエストされた全postIDに対してエントリを持ち、nilスライスは空スライスに正規化される。
 func (s *PostService) GetReactionsBatch(userID uint, postIDs []uint) (map[uint][]model.ReactionCount, map[uint][]string, error) {
 	if len(postIDs) == 0 {
 		return map[uint][]model.ReactionCount{}, map[uint][]string{}, nil
@@ -358,7 +358,45 @@ func (s *PostService) GetReactionsBatch(userID uint, postIDs []uint) (map[uint][
 		return nil, nil, err
 	}
 
+	// リクエストされた全postIDに対してエントリを保証（nilスライス正規化）
+	NormalizeReactionMaps(reactions, userReactions, postIDs)
+
 	return reactions, userReactions, nil
+}
+
+// GetReactionsWithUser は投稿のリアクション一覧とユーザーのリアクションを一括取得する。
+func (s *PostService) GetReactionsWithUser(userID, postID uint) ([]model.ReactionCount, []string, error) {
+	reactions, err := s.repo.GetReactionsByPostID(postID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	userReactions, err := s.repo.GetUserReactions(userID, postID)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if reactions == nil {
+		reactions = []model.ReactionCount{}
+	}
+	if userReactions == nil {
+		userReactions = []string{}
+	}
+
+	return reactions, userReactions, nil
+}
+
+// NormalizeReactionMaps はリアクションマップをpostIDsに対して正規化する純粋関数。
+// nilスライスを空スライスに変換し、全postIDにエントリを保証する。
+func NormalizeReactionMaps(reactions map[uint][]model.ReactionCount, userReactions map[uint][]string, postIDs []uint) {
+	for _, id := range postIDs {
+		if reactions[id] == nil {
+			reactions[id] = []model.ReactionCount{}
+		}
+		if userReactions[id] == nil {
+			userReactions[id] = []string{}
+		}
+	}
 }
 
 // SchedulePublish は下書き投稿にスケジュール公開日時を設定する。

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -1734,8 +1734,9 @@ func TestPostGetReactionsBatch_Success(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, reactions[1], 2)
 	assert.Len(t, reactions[2], 1)
-	assert.Nil(t, reactions[3])
+	assert.Equal(t, []model.ReactionCount{}, reactions[3])
 	assert.Equal(t, []string{"👍"}, userReactions[1])
+	assert.Equal(t, []string{}, userReactions[3])
 	postRepo.AssertExpectations(t)
 }
 


### PR DESCRIPTION
## 概要
Issue #2139 に対応。Handler層に残るビジネスロジック・データ変換をService層に移動し、日付パースロジックを共通ヘルパーに集約。

## 変更内容

### 1. GetReactionsBatch — nilスライス正規化をService層に移動
- `NormalizeReactionMaps` 純粋関数を `service/post.go` に追加
- Service層でマップ正規化を行い、Handler層のnil→空スライス変換ロジックを除去

### 2. GetReactions — 複合サービスメソッド追加
- `GetReactionsWithUser(userID, postID)` を `service/post.go` に追加
- Handler側の2回のService呼び出しを1回に統合

### 3. 日付パース — 共通ヘルパーに集約
- `parseDateParam` (YYYY-MM-DD) / `parseDateTimeRFC3339` を `handler/helpers.go` に追加
- `project.go` のローカル `parseDate` 関数を削除
- `learning_goal.go`, `project.go`, `project_milestone.go`, `post.go` の散在する `time.Parse` を統一

## テスト
- `go test ./...` 全パス（正規化変更に伴うテスト期待値を更新）
- `go build ./...` 成功