### PR TITLE
test: 新規追加純粋関数のユニットテスト24件追加

### DIFF
--- a/backend/internal/service/learning_analytics_test.go
+++ b/backend/internal/service/learning_analytics_test.go
@@ -702,3 +702,58 @@ func TestGetInsights_PeakTimeAllZeroMinutes(t *testing.T) {
 	}
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// AggregateDayOfWeek テスト
+// ============================================================
+
+func TestAggregateDayOfWeek_Empty(t *testing.T) {
+	result := AggregateDayOfWeek([]model.HeatmapEntry{})
+	assert.Len(t, result, 7)
+	for i := 0; i < 7; i++ {
+		assert.Equal(t, i, result[i].DayOfWeek)
+		assert.Equal(t, 0, result[i].TotalMinutes)
+		assert.Equal(t, 0, result[i].LogCount)
+		assert.Equal(t, 0, result[i].AverageMinutes)
+	}
+}
+
+func TestAggregateDayOfWeek_SingleEntry(t *testing.T) {
+	heatmap := []model.HeatmapEntry{
+		{DayOfWeek: 1, Hour: 10, TotalMinutes: 60},
+	}
+	result := AggregateDayOfWeek(heatmap)
+	assert.Equal(t, 60, result[1].TotalMinutes)
+	assert.Equal(t, 1, result[1].LogCount)
+	assert.Equal(t, 60, result[1].AverageMinutes)
+	assert.Equal(t, 0, result[0].TotalMinutes) // 日曜はデータなし
+}
+
+func TestAggregateDayOfWeek_MultipleEntriesSameDay(t *testing.T) {
+	heatmap := []model.HeatmapEntry{
+		{DayOfWeek: 3, Hour: 9, TotalMinutes: 30},
+		{DayOfWeek: 3, Hour: 14, TotalMinutes: 45},
+		{DayOfWeek: 3, Hour: 20, TotalMinutes: 25},
+	}
+	result := AggregateDayOfWeek(heatmap)
+	assert.Equal(t, 100, result[3].TotalMinutes)
+	assert.Equal(t, 3, result[3].LogCount)
+	assert.Equal(t, 33, result[3].AverageMinutes) // 100/3 = 33
+}
+
+func TestAggregateDayOfWeek_AllDays(t *testing.T) {
+	heatmap := []model.HeatmapEntry{
+		{DayOfWeek: 0, Hour: 8, TotalMinutes: 10},
+		{DayOfWeek: 1, Hour: 8, TotalMinutes: 20},
+		{DayOfWeek: 2, Hour: 8, TotalMinutes: 30},
+		{DayOfWeek: 3, Hour: 8, TotalMinutes: 40},
+		{DayOfWeek: 4, Hour: 8, TotalMinutes: 50},
+		{DayOfWeek: 5, Hour: 8, TotalMinutes: 60},
+		{DayOfWeek: 6, Hour: 8, TotalMinutes: 70},
+	}
+	result := AggregateDayOfWeek(heatmap)
+	for i := 0; i < 7; i++ {
+		assert.Equal(t, (i+1)*10, result[i].TotalMinutes)
+		assert.Equal(t, 1, result[i].LogCount)
+	}
+}

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -884,3 +884,111 @@ func TestLearningGoalGetPublicByUserID_Success(t *testing.T) {
 	assert.Equal(t, int64(1), total)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// CalculateGoalForecast テスト
+// ============================================================
+
+func TestCalculateGoalForecast_NoTargetDate_NoDailyAvg(t *testing.T) {
+	goal := &model.LearningGoal{Title: "Go学習", Progress: 30}
+	goal.ID = 1
+
+	f := CalculateGoalForecast(goal, 0, 0, time.Now())
+	assert.Equal(t, uint(1), f.GoalID)
+	assert.Equal(t, "Go学習", f.Title)
+	assert.Equal(t, 30, f.CurrentProgress)
+	assert.Equal(t, -1, f.EstimatedDaysLeft)
+	assert.Equal(t, -1, f.DaysUntilDeadline)
+	assert.Equal(t, "unknown", f.Difficulty)
+	assert.False(t, f.OnTrack)
+}
+
+func TestCalculateGoalForecast_WithDeadline_OnTrack(t *testing.T) {
+	deadline := time.Now().Add(30 * 24 * time.Hour)
+	goal := &model.LearningGoal{
+		Title:       "React学習",
+		TargetHours: 10,
+		TargetDate:  &deadline,
+	}
+	goal.ID = 2
+
+	// 10時間 = 600分目標、既に300分学習済み、日平均30分 → 残り10日
+	f := CalculateGoalForecast(goal, 300, 30, time.Now())
+	assert.Equal(t, 10, f.EstimatedDaysLeft)
+	assert.Equal(t, 30, f.DaysUntilDeadline)
+	assert.True(t, f.OnTrack)
+	assert.Equal(t, "easy", f.Difficulty) // 10/30 ≈ 0.33 ≤ 0.5
+}
+
+func TestCalculateGoalForecast_WithDeadline_OffTrack(t *testing.T) {
+	deadline := time.Now().Add(5 * 24 * time.Hour)
+	goal := &model.LearningGoal{
+		Title:       "難しい目標",
+		TargetHours: 100,
+		TargetDate:  &deadline,
+	}
+	goal.ID = 3
+
+	// 100時間 = 6000分、0分学習済み、日平均30分 → 200日必要
+	f := CalculateGoalForecast(goal, 0, 30, time.Now())
+	assert.Equal(t, 200, f.EstimatedDaysLeft)
+	assert.Equal(t, 5, f.DaysUntilDeadline)
+	assert.False(t, f.OnTrack)
+	assert.Equal(t, "hard", f.Difficulty) // 200/5 = 40.0 > 1.0
+}
+
+func TestCalculateGoalForecast_AlreadyCompleted(t *testing.T) {
+	deadline := time.Now().Add(10 * 24 * time.Hour)
+	goal := &model.LearningGoal{
+		Title:       "完了済み",
+		TargetHours: 5,
+		TargetDate:  &deadline,
+	}
+	goal.ID = 4
+
+	// 5時間 = 300分目標、既に400分学習済み → 残り0日
+	f := CalculateGoalForecast(goal, 400, 60, time.Now())
+	assert.Equal(t, 0, f.EstimatedDaysLeft)
+	assert.True(t, f.OnTrack)
+	assert.Equal(t, "easy", f.Difficulty)
+}
+
+func TestCalculateGoalForecast_NoDailyAvg_WithTargetHours(t *testing.T) {
+	goal := &model.LearningGoal{
+		Title:       "学習開始前",
+		TargetHours: 10,
+	}
+	goal.ID = 5
+
+	f := CalculateGoalForecast(goal, 0, 0, time.Now())
+	assert.Equal(t, -1, f.EstimatedDaysLeft)
+	assert.Equal(t, "hard", f.Difficulty)
+}
+
+func TestCalculateGoalForecast_MediumDifficulty(t *testing.T) {
+	deadline := time.Now().Add(10 * 24 * time.Hour)
+	goal := &model.LearningGoal{
+		Title:       "中程度",
+		TargetHours: 5,
+		TargetDate:  &deadline,
+	}
+	goal.ID = 6
+
+	// 300分目標、0分学習済み、日平均40分 → 8日必要、10日猶予 → ratio=0.8
+	f := CalculateGoalForecast(goal, 0, 40, time.Now())
+	assert.Equal(t, 8, f.EstimatedDaysLeft)
+	assert.True(t, f.OnTrack)
+	assert.Equal(t, "medium", f.Difficulty) // 8/10 = 0.8, 0.5 < 0.8 ≤ 1.0
+}
+
+func TestCalculateGoalForecast_PastDeadline(t *testing.T) {
+	deadline := time.Now().Add(-2 * 24 * time.Hour)
+	goal := &model.LearningGoal{
+		Title:      "期限切れ",
+		TargetDate: &deadline,
+	}
+	goal.ID = 7
+
+	f := CalculateGoalForecast(goal, 0, 0, time.Now())
+	assert.Equal(t, 0, f.DaysUntilDeadline) // 負の値は0に正規化
+}

--- a/backend/internal/service/note_test.go
+++ b/backend/internal/service/note_test.go
@@ -789,3 +789,63 @@ func TestNoteService_ExportMarkdown_Forbidden(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, ErrForbidden)
 }
+
+// ============================================================
+// ExtractUniqueTags テスト
+// ============================================================
+
+func TestExtractUniqueTags_Empty(t *testing.T) {
+	result := ExtractUniqueTags([]model.Note{})
+	assert.Nil(t, result)
+}
+
+func TestExtractUniqueTags_NoTags(t *testing.T) {
+	notes := []model.Note{
+		{Tags: ""},
+		{Tags: ""},
+	}
+	result := ExtractUniqueTags(notes)
+	assert.Nil(t, result)
+}
+
+func TestExtractUniqueTags_SingleTag(t *testing.T) {
+	notes := []model.Note{
+		{Tags: "Go"},
+	}
+	result := ExtractUniqueTags(notes)
+	assert.Equal(t, []string{"Go"}, result)
+}
+
+func TestExtractUniqueTags_MultipleTags(t *testing.T) {
+	notes := []model.Note{
+		{Tags: "Go,React,TypeScript"},
+	}
+	result := ExtractUniqueTags(notes)
+	assert.Equal(t, []string{"Go", "React", "TypeScript"}, result)
+}
+
+func TestExtractUniqueTags_Deduplication(t *testing.T) {
+	notes := []model.Note{
+		{Tags: "Go,React"},
+		{Tags: "React,TypeScript"},
+		{Tags: "Go"},
+	}
+	result := ExtractUniqueTags(notes)
+	assert.Equal(t, []string{"Go", "React", "TypeScript"}, result)
+}
+
+func TestExtractUniqueTags_WhitespaceHandling(t *testing.T) {
+	notes := []model.Note{
+		{Tags: " Go , React , TypeScript "},
+	}
+	result := ExtractUniqueTags(notes)
+	assert.Equal(t, []string{"Go", "React", "TypeScript"}, result)
+}
+
+func TestExtractUniqueTags_EmptyTagsSkipped(t *testing.T) {
+	notes := []model.Note{
+		{Tags: "Go,,React,, ,TypeScript"},
+	}
+	result := ExtractUniqueTags(notes)
+	assert.Equal(t, []string{"Go", "React", "TypeScript"}, result)
+}

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -1825,3 +1825,84 @@ func TestPostAutoSaveDraft_UpdateWithImageURLs(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "https://example.com/img.png", result.ImageURLs)
 }
+
+// ============================================================
+// NormalizeReactionMaps テスト
+// ============================================================
+
+func TestNormalizeReactionMaps_NilToEmpty(t *testing.T) {
+	reactions := map[uint][]model.ReactionCount{
+		1: {{Emoji: "👍", Count: 3}},
+	}
+	userReactions := map[uint][]string{
+		1: {"👍"},
+	}
+	postIDs := []uint{1, 2, 3}
+
+	NormalizeReactionMaps(reactions, userReactions, postIDs)
+
+	assert.Equal(t, []model.ReactionCount{{Emoji: "👍", Count: 3}}, reactions[1])
+	assert.Equal(t, []model.ReactionCount{}, reactions[2])
+	assert.Equal(t, []model.ReactionCount{}, reactions[3])
+	assert.Equal(t, []string{"👍"}, userReactions[1])
+	assert.Equal(t, []string{}, userReactions[2])
+	assert.Equal(t, []string{}, userReactions[3])
+}
+
+func TestNormalizeReactionMaps_EmptyPostIDs(t *testing.T) {
+	reactions := map[uint][]model.ReactionCount{}
+	userReactions := map[uint][]string{}
+	NormalizeReactionMaps(reactions, userReactions, []uint{})
+	assert.Empty(t, reactions)
+	assert.Empty(t, userReactions)
+}
+
+// ============================================================
+// GetReactionsWithUser テスト
+// ============================================================
+
+func TestGetReactionsWithUser_Success(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("GetReactionsByPostID", uint(1)).Return([]model.ReactionCount{
+		{Emoji: "👍", Count: 5},
+	}, nil)
+	postRepo.On("GetUserReactions", uint(10), uint(1)).Return([]string{"👍"}, nil)
+
+	reactions, userReactions, err := svc.GetReactionsWithUser(10, 1)
+	assert.NoError(t, err)
+	assert.Len(t, reactions, 1)
+	assert.Equal(t, []string{"👍"}, userReactions)
+	postRepo.AssertExpectations(t)
+}
+
+func TestGetReactionsWithUser_NilNormalized(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("GetReactionsByPostID", uint(1)).Return([]model.ReactionCount(nil), nil)
+	postRepo.On("GetUserReactions", uint(10), uint(1)).Return([]string(nil), nil)
+
+	reactions, userReactions, err := svc.GetReactionsWithUser(10, 1)
+	assert.NoError(t, err)
+	assert.Equal(t, []model.ReactionCount{}, reactions)
+	assert.Equal(t, []string{}, userReactions)
+}
+
+func TestGetReactionsWithUser_RepoError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("GetReactionsByPostID", uint(1)).Return([]model.ReactionCount(nil), assert.AnError)
+
+	_, _, err := svc.GetReactionsWithUser(10, 1)
+	assert.Error(t, err)
+}
+
+func TestGetReactionsWithUser_UserReactionsError(t *testing.T) {
+	svc, postRepo, _ := newTestPostService()
+
+	postRepo.On("GetReactionsByPostID", uint(1)).Return([]model.ReactionCount{}, nil)
+	postRepo.On("GetUserReactions", uint(10), uint(1)).Return([]string(nil), assert.AnError)
+
+	_, _, err := svc.GetReactionsWithUser(10, 1)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
## 概要
Issue #2141 に対応。PR #2137, #2139 で追加された純粋関数・サービスメソッドのユニットテスト24件を追加。

## テスト追加内容

### CalculateGoalForecast（7件）
- 目標日未設定・日平均なし → unknown難易度
- デッドライン内でOnTrack → easy難易度
- デッドライン超過でOffTrack → hard難易度
- 既に目標達成済み → easy/OnTrack
- 日平均なし+目標時間あり → hard
- 中程度の達成見込み → medium難易度
- 過去のデッドライン → DaysUntilDeadline=0に正規化

### AggregateDayOfWeek（4件）
- 空ヒートマップ → 7曜日分の空サマリー
- 単一エントリ / 同曜日複数エントリの集計 / 全曜日データ

### ExtractUniqueTags（7件）
- 空スライス / タグなし / 単一・複数タグ / 重複排除 / 空白処理 / 空タグ除去

### NormalizeReactionMaps（2件）+ GetReactionsWithUser（4件）
- nilスライス→空スライス正規化 / 正常取得 / 各repoエラー

## テスト結果
- 24件全テストPASS
- `go test ./...` 全パス