### PR TITLE
fix: 外部サービス連携のユーザー名・パラメータ入力バリデーション強化

### DIFF
--- a/backend/internal/domain/validators.go
+++ b/backend/internal/domain/validators.go
@@ -277,6 +277,53 @@ func ValidateStringLength(s string, min, max int, fieldName string) error {
 	return nil
 }
 
+// External username validation constants
+const (
+	MinExternalUsernameLength = 1
+	MaxExternalUsernameLength = 50
+)
+
+// externalUsernameRegex は外部サービスのユーザー名の形式をチェックする正規表現。
+// 英数字・アンダースコア・ハイフン・ドットのみ許可（URLパスやクエリに安全に埋め込める文字のみ）。
+var externalUsernameRegex = regexp.MustCompile(`^[a-zA-Z0-9_\-\.]+$`)
+
+// ValidateExternalUsername は外部サービス（Zenn/Qiita/AtCoder等）のユーザー名をバリデーションする。
+// URLインジェクション防止のため、安全な文字のみ許可する。
+func ValidateExternalUsername(username string) error {
+	username = strings.TrimSpace(username)
+
+	if len(username) < MinExternalUsernameLength {
+		return NewError(ErrCodeValidation, "ユーザー名を入力してください", nil)
+	}
+
+	if len(username) > MaxExternalUsernameLength {
+		return NewError(ErrCodeValidation, fmt.Sprintf("ユーザー名は%d文字以下である必要があります", MaxExternalUsernameLength), nil)
+	}
+
+	if !externalUsernameRegex.MatchString(username) {
+		return NewError(ErrCodeValidation, "ユーザー名は英数字、アンダースコア、ハイフン、ドットのみ使用できます", nil)
+	}
+
+	return nil
+}
+
+// validLanguageCodes はYouTube検索で許可するISO 639-1言語コード。
+var validLanguageCodes = map[string]bool{
+	"ja": true, "en": true, "ko": true, "zh": true,
+	"es": true, "fr": true, "de": true, "pt": true,
+	"ru": true, "it": true, "ar": true, "hi": true,
+	"th": true, "vi": true, "id": true, "tr": true,
+	"pl": true, "nl": true, "sv": true, "da": true,
+}
+
+// ValidateLanguageCode は言語コードがホワイトリストに含まれるかを検証する。
+func ValidateLanguageCode(lang string) error {
+	if !validLanguageCodes[lang] {
+		return NewError(ErrCodeValidation, "サポートされていない言語コードです", nil)
+	}
+	return nil
+}
+
 // ValidateEnum は値が許可されたリストに含まれるかチェックする
 func ValidateEnum(value string, allowedValues []string, fieldName string) error {
 	if value == "" {

--- a/backend/internal/domain/validators_test.go
+++ b/backend/internal/domain/validators_test.go
@@ -338,6 +338,75 @@ func TestValidateStringLength(t *testing.T) {
 	}
 }
 
+func TestValidateExternalUsername(t *testing.T) {
+	tests := []struct {
+		name     string
+		username string
+		wantErr  bool
+	}{
+		{"有効（英数字）", "testuser123", false},
+		{"有効（ハイフン）", "test-user", false},
+		{"有効（アンダースコア）", "test_user", false},
+		{"有効（ドット）", "test.user", false},
+		{"有効（1文字）", "a", false},
+		{"有効（最大長）", strings.Repeat("a", 50), false},
+		{"無効（空）", "", true},
+		{"無効（スペースのみ）", "   ", true},
+		{"無効（長すぎる）", strings.Repeat("a", 51), true},
+		{"無効（スラッシュ）", "user/path", true},
+		{"無効（アンパサンド）", "user&param=1", true},
+		{"無効（イコール）", "user=value", true},
+		{"無効（クエスチョン）", "user?q=1", true},
+		{"無効（スペース）", "user name", true},
+		{"無効（日本語）", "ユーザー", true},
+		{"無効（パーセントエンコード）", "user%2F", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateExternalUsername(tt.username)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.True(t, IsDomainError(err))
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidateLanguageCode(t *testing.T) {
+	tests := []struct {
+		name    string
+		lang    string
+		wantErr bool
+	}{
+		{"有効（日本語）", "ja", false},
+		{"有効（英語）", "en", false},
+		{"有効（韓国語）", "ko", false},
+		{"有効（中国語）", "zh", false},
+		{"有効（スペイン語）", "es", false},
+		{"有効（フランス語）", "fr", false},
+		{"無効（空文字）", "", true},
+		{"無効（不正なコード）", "xx", true},
+		{"無効（長い文字列）", "japanese", true},
+		{"無効（インジェクション試行）", "ja&key=val", true},
+		{"無効（SQLインジェクション試行）", "ja' OR '1'='1", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateLanguageCode(tt.lang)
+			if tt.wantErr {
+				assert.Error(t, err)
+				assert.True(t, IsDomainError(err))
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestValidateEnum(t *testing.T) {
 	allowedValues := []string{"option1", "option2", "option3"}
 

--- a/backend/internal/service/atcoder.go
+++ b/backend/internal/service/atcoder.go
@@ -47,6 +47,10 @@ func NewAtCoderService(userRepo repository.UserRepositoryInterface) *AtCoderServ
 
 // GetRating は指定ユーザーのAtCoderレーティング情報を取得する。
 func (s *AtCoderService) GetRating(username string) (*AtCoderRatingInfo, error) {
+	if err := domain.ValidateExternalUsername(username); err != nil {
+		return nil, err
+	}
+
 	url := fmt.Sprintf("https://atcoder.jp/users/%s/history/json", username)
 	resp, err := s.client.Get(url)
 	if err != nil {
@@ -84,6 +88,10 @@ func (s *AtCoderService) GetRating(username string) (*AtCoderRatingInfo, error) 
 
 // ValidateUsername はAtCoderユーザー名が有効かどうか検証する。
 func (s *AtCoderService) ValidateUsername(username string) bool {
+	if err := domain.ValidateExternalUsername(username); err != nil {
+		return false
+	}
+
 	url := fmt.Sprintf("https://atcoder.jp/users/%s/history/json", username)
 	resp, err := s.client.Get(url)
 	if err != nil {

--- a/backend/internal/service/qiita.go
+++ b/backend/internal/service/qiita.go
@@ -49,6 +49,10 @@ type QiitaAPITag struct {
 // FetchArticles は指定ユーザーのQiita記事を全件取得する。
 // ページネーションにより100件ずつ取得し、全ページを結合して返す。
 func (s *QiitaService) FetchArticles(username string) ([]model.QiitaArticle, error) {
+	if err := domain.ValidateExternalUsername(username); err != nil {
+		return nil, err
+	}
+
 	var allArticles []model.QiitaArticle
 	page := 1
 	perPage := 100
@@ -105,6 +109,10 @@ func (s *QiitaService) FetchArticles(username string) ([]model.QiitaArticle, err
 
 // ValidateUsername はQiitaユーザー名が存在するかを検証する。
 func (s *QiitaService) ValidateUsername(username string) (bool, error) {
+	if err := domain.ValidateExternalUsername(username); err != nil {
+		return false, err
+	}
+
 	url := fmt.Sprintf("https://qiita.com/api/v2/users/%s", username)
 
 	resp, err := s.httpClient.Get(url)

--- a/backend/internal/service/youtube.go
+++ b/backend/internal/service/youtube.go
@@ -46,6 +46,9 @@ func (s *YouTubeService) Search(query, language string) ([]model.YouTubeVideo, b
 	if language == "" {
 		language = "ja"
 	}
+	if err := domain.ValidateLanguageCode(language); err != nil {
+		return nil, false, err
+	}
 
 	// 1. DBキャッシュを検索
 	cache, err := s.repo.FindCachedSearch(normalizedQuery, language)

--- a/backend/internal/service/youtube_test.go
+++ b/backend/internal/service/youtube_test.go
@@ -133,6 +133,29 @@ func TestYouTubeSearch_APIError(t *testing.T) {
 	assert.Error(t, err)
 }
 
+func TestYouTubeSearch_InvalidLanguage(t *testing.T) {
+	mockClient := new(MockYouTubeClient)
+	svc, _, _ := newTestYouTubeService(mockClient)
+
+	tests := []struct {
+		name string
+		lang string
+	}{
+		{"不正な言語コード", "xx"},
+		{"インジェクション試行", "ja&key=val"},
+		{"長い文字列", "japanese"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := svc.Search("Go tutorial", tt.lang)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), "サポートされていない言語コード")
+			mockClient.AssertNotCalled(t, "SearchVideos")
+		})
+	}
+}
+
 // ============================================================
 // GetRecommendations テスト
 // ============================================================

--- a/backend/internal/service/zenn.go
+++ b/backend/internal/service/zenn.go
@@ -48,6 +48,10 @@ type ZennAPIArticle struct {
 
 // FetchArticles はZenn APIから指定ユーザーの全記事を取得する（ページネーション対応）。
 func (s *ZennService) FetchArticles(username string) ([]model.ZennArticle, error) {
+	if err := domain.ValidateExternalUsername(username); err != nil {
+		return nil, err
+	}
+
 	var allArticles []model.ZennArticle
 	page := 1
 
@@ -94,6 +98,10 @@ func (s *ZennService) FetchArticles(username string) ([]model.ZennArticle, error
 
 // ValidateUsername はZennユーザー名が存在するかを検証する。
 func (s *ZennService) ValidateUsername(username string) (bool, error) {
+	if err := domain.ValidateExternalUsername(username); err != nil {
+		return false, err
+	}
+
 	url := fmt.Sprintf("https://zenn.dev/api/articles?username=%s&page=1", username)
 
 	resp, err := s.httpClient.Get(url)

--- a/backend/internal/service/zenn_test.go
+++ b/backend/internal/service/zenn_test.go
@@ -269,6 +269,42 @@ func TestZennFetchArticles_PaginationURL(t *testing.T) {
 	assert.Equal(t, 2, callCount)
 }
 
+func TestZennFetchArticles_InvalidUsername(t *testing.T) {
+	svc := newTestZennService(func(req *http.Request) (*http.Response, error) {
+		t.Fatal("HTTPリクエストが送信されるべきではない")
+		return nil, nil
+	})
+
+	tests := []struct {
+		name     string
+		username string
+	}{
+		{"スラッシュ含む", "user/path"},
+		{"アンパサンド含む", "user&param=1"},
+		{"スペース含む", "user name"},
+		{"空文字", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			articles, err := svc.FetchArticles(tt.username)
+			assert.Nil(t, articles)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestZennValidateUsername_InvalidFormat(t *testing.T) {
+	svc := newTestZennService(func(req *http.Request) (*http.Response, error) {
+		t.Fatal("HTTPリクエストが送信されるべきではない")
+		return nil, nil
+	})
+
+	valid, err := svc.ValidateUsername("user/injection")
+	assert.Error(t, err)
+	assert.False(t, valid)
+}
+
 func TestZennValidateUsername_RequestURL(t *testing.T) {
 	svc := newTestZennService(func(req *http.Request) (*http.Response, error) {
 		assert.Equal(t, "zenn.dev", req.URL.Host)


### PR DESCRIPTION
## 概要
- Zenn/Qiita/AtCoderのユーザー名にURLインジェクション防止バリデーションを追加
- YouTube検索の言語パラメータにホワイトリスト検証を追加
- domain層に`ValidateExternalUsername`・`ValidateLanguageCode`を新設

## 変更ファイル
- `domain/validators.go`: `ValidateExternalUsername`（英数字・`_`・`-`・`.`のみ許可）と`ValidateLanguageCode`（20言語コードのホワイトリスト）追加
- `service/zenn.go`: `FetchArticles`・`ValidateUsername`にバリデーション追加
- `service/qiita.go`: `FetchArticles`・`ValidateUsername`にバリデーション追加
- `service/atcoder.go`: `GetRating`・`ValidateUsername`にバリデーション追加
- `service/youtube.go`: `Search`メソッドに言語コードバリデーション追加

## テスト
- domain層: `TestValidateExternalUsername`（16ケース）、`TestValidateLanguageCode`（11ケース）
- service層: `TestZennFetchArticles_InvalidUsername`（4ケース）、`TestZennValidateUsername_InvalidFormat`、`TestYouTubeSearch_InvalidLanguage`（3ケース）

Closes #2143