### PR TITLE
test: 純粋関数・ダッシュボードサービスのテスト品質改善

### DIFF
--- a/backend/internal/service/learning_analytics_test.go
+++ b/backend/internal/service/learning_analytics_test.go
@@ -258,6 +258,64 @@ func TestCalculateProductivityScore_PerfectScore(t *testing.T) {
 	assert.Equal(t, 100.0, score.OverallScore)
 }
 
+func TestCalculateProductivityScore_OnlyPomodoroSessions(t *testing.T) {
+	stats := &model.ProductivityStats{
+		PomodoroSessions: 50,
+		ManualSessions:   0,
+	}
+
+	score := CalculateProductivityScore(stats)
+
+	assert.Equal(t, 100.0, score.PomodoroRate)
+	assert.Equal(t, 0.0, score.GoalRate)
+	assert.Equal(t, 0.0, score.StreakConsistency)
+	// 総合: 100*0.3 + 0*0.4 + 0*0.3 = 30.0
+	assert.Equal(t, 30.0, score.OverallScore)
+}
+
+func TestCalculateProductivityScore_OnlyManualSessions(t *testing.T) {
+	stats := &model.ProductivityStats{
+		PomodoroSessions: 0,
+		ManualSessions:   30,
+	}
+
+	score := CalculateProductivityScore(stats)
+
+	assert.Equal(t, 0.0, score.PomodoroRate)
+}
+
+func TestCalculateProductivityScore_SingleDayStreak(t *testing.T) {
+	stats := &model.ProductivityStats{
+		TotalLogDays:     1,
+		TotalDaysInRange: 30,
+	}
+
+	score := CalculateProductivityScore(stats)
+
+	// 1/30 * 100 = 3.33
+	assert.InDelta(t, 3.33, score.StreakConsistency, 0.01)
+}
+
+func TestCalculateProductivityScore_WeightingVerification(t *testing.T) {
+	// ポモドーロ率=50, 目標率=80, ストリーク率=60
+	stats := &model.ProductivityStats{
+		PomodoroSessions: 5,
+		ManualSessions:   5,
+		CompletedGoals:   4,
+		TotalGoals:       5,
+		TotalLogDays:     30,
+		TotalDaysInRange: 50,
+	}
+
+	score := CalculateProductivityScore(stats)
+
+	assert.Equal(t, 50.0, score.PomodoroRate)
+	assert.Equal(t, 80.0, score.GoalRate)
+	assert.Equal(t, 60.0, score.StreakConsistency)
+	// 重み検証: 50*0.3 + 80*0.4 + 60*0.3 = 15 + 32 + 18 = 65.0
+	assert.Equal(t, 65.0, score.OverallScore)
+}
+
 func TestGetProductivityScore_Success(t *testing.T) {
 	svc, repo := newTestAnalyticsService()
 

--- a/backend/internal/service/learning_dashboard_test.go
+++ b/backend/internal/service/learning_dashboard_test.go
@@ -1,0 +1,137 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
+)
+
+// newTestDashboardService はLearningDashboardServiceのテスト用インスタンスを生成するヘルパー。
+func newTestDashboardService() (*LearningDashboardService, *MockLearningLogRepository, *MockLearningGoalRepository, *MockLearningAnalyticsRepository) {
+	logRepo := new(MockLearningLogRepository)
+	goalRepo := new(MockLearningGoalRepository)
+	analyticsRepo := new(MockLearningAnalyticsRepository)
+	svc := NewLearningDashboardService(logRepo, goalRepo, analyticsRepo)
+	return svc, logRepo, goalRepo, analyticsRepo
+}
+
+// ============================================================
+// GetSummary 正常系テスト
+// ============================================================
+
+func TestGetSummary_Success(t *testing.T) {
+	svc, logRepo, goalRepo, analyticsRepo := newTestDashboardService()
+
+	streakInfo := &model.StreakInfo{CurrentStreak: 5, LongestStreak: 10}
+	logRepo.On("GetStreakInfo", uint(1)).Return(streakInfo, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 7).Return(420, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 1).Return(60, nil)
+	goalRepo.On("GetActiveByUserID", uint(1)).Return([]model.LearningGoal{
+		{Title: "Go学習"},
+		{Title: "React学習"},
+	}, nil)
+	analyticsRepo.On("GetProductivityStats", uint(1)).Return(&model.ProductivityStats{
+		PomodoroSessions: 10,
+		ManualSessions:   5,
+		CompletedGoals:   3,
+		TotalGoals:       5,
+		TotalLogDays:     20,
+		TotalDaysInRange: 30,
+	}, nil)
+
+	summary, err := svc.GetSummary(1)
+	assert.NoError(t, err)
+	assert.NotNil(t, summary)
+	assert.Equal(t, streakInfo, summary.StreakInfo)
+	assert.Equal(t, 420, summary.WeeklyMinutes)
+	assert.Equal(t, 60, summary.TodayMinutes)
+	assert.Equal(t, 2, summary.ActiveGoalCount)
+	assert.NotNil(t, summary.ProductivityScore)
+	logRepo.AssertExpectations(t)
+	goalRepo.AssertExpectations(t)
+	analyticsRepo.AssertExpectations(t)
+}
+
+func TestGetSummary_EmptyData(t *testing.T) {
+	svc, logRepo, goalRepo, analyticsRepo := newTestDashboardService()
+
+	logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 7).Return(0, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 1).Return(0, nil)
+	goalRepo.On("GetActiveByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	analyticsRepo.On("GetProductivityStats", uint(1)).Return(&model.ProductivityStats{}, nil)
+
+	summary, err := svc.GetSummary(1)
+	assert.NoError(t, err)
+	assert.NotNil(t, summary)
+	assert.Equal(t, 0, summary.WeeklyMinutes)
+	assert.Equal(t, 0, summary.TodayMinutes)
+	assert.Equal(t, 0, summary.ActiveGoalCount)
+	assert.Equal(t, 0.0, summary.ProductivityScore.OverallScore)
+	logRepo.AssertExpectations(t)
+}
+
+// ============================================================
+// GetSummary エラー系テスト
+// ============================================================
+
+func TestGetSummary_StreakInfoError(t *testing.T) {
+	svc, logRepo, _, _ := newTestDashboardService()
+
+	logRepo.On("GetStreakInfo", uint(1)).Return((*model.StreakInfo)(nil), assert.AnError)
+
+	summary, err := svc.GetSummary(1)
+	assert.Error(t, err)
+	assert.Nil(t, summary)
+}
+
+func TestGetSummary_WeeklyMinutesError(t *testing.T) {
+	svc, logRepo, _, _ := newTestDashboardService()
+
+	logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 7).Return(0, assert.AnError)
+
+	summary, err := svc.GetSummary(1)
+	assert.Error(t, err)
+	assert.Nil(t, summary)
+}
+
+func TestGetSummary_TodayMinutesError(t *testing.T) {
+	svc, logRepo, _, _ := newTestDashboardService()
+
+	logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 7).Return(100, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 1).Return(0, assert.AnError)
+
+	summary, err := svc.GetSummary(1)
+	assert.Error(t, err)
+	assert.Nil(t, summary)
+}
+
+func TestGetSummary_ActiveGoalsError(t *testing.T) {
+	svc, logRepo, goalRepo, _ := newTestDashboardService()
+
+	logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 7).Return(100, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 1).Return(30, nil)
+	goalRepo.On("GetActiveByUserID", uint(1)).Return([]model.LearningGoal(nil), assert.AnError)
+
+	summary, err := svc.GetSummary(1)
+	assert.Error(t, err)
+	assert.Nil(t, summary)
+}
+
+func TestGetSummary_ProductivityStatsError(t *testing.T) {
+	svc, logRepo, goalRepo, analyticsRepo := newTestDashboardService()
+
+	logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 7).Return(100, nil)
+	logRepo.On("SumDurationByPeriod", uint(1), 1).Return(30, nil)
+	goalRepo.On("GetActiveByUserID", uint(1)).Return([]model.LearningGoal{}, nil)
+	analyticsRepo.On("GetProductivityStats", uint(1)).Return((*model.ProductivityStats)(nil), assert.AnError)
+
+	summary, err := svc.GetSummary(1)
+	assert.Error(t, err)
+	assert.Nil(t, summary)
+}

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -1447,3 +1447,34 @@ func TestLearningLogGetMonthlySummary_RepoError(t *testing.T) {
 	assert.Nil(t, result)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// CalculateGoalProgressPercentage 純粋関数テスト
+// ============================================================
+
+func TestCalculateGoalProgressPercentage(t *testing.T) {
+	tests := []struct {
+		name         string
+		totalMinutes int
+		targetHours  int
+		expected     int
+	}{
+		{"100%達成", 300, 5, 100},
+		{"50%進捗", 150, 5, 50},
+		{"目標超過は100キャップ", 400, 5, 100},
+		{"目標時間0は0%", 0, 0, 0},
+		{"目標時間マイナスは0%", 100, -1, 0},
+		{"実績0は0%", 0, 10, 0},
+		{"微量の進捗（整数切り捨て）", 1, 100, 0},
+		{"1分/1時間=1%", 1, 1, 1},
+		{"59分/1時間=98%", 59, 1, 98},
+		{"60分/1時間=100%", 60, 1, 100},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CalculateGoalProgressPercentage(tt.totalMinutes, tt.targetHours)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## 概要
テストカバレッジが不足していた純粋関数とサービスにテストを追加

## 変更内容
- **learning_log_test.go**: `CalculateGoalProgressPercentage`テーブル駆動テスト追加（10ケース）
  - 境界値（0%, 50%, 100%, 超過キャップ）、ゼロ除算回避、マイナス値、整数丸め込み
- **learning_dashboard_test.go**: `LearningDashboardService.GetSummary`テスト新規作成（7ケース）
  - 正常系（データあり/空データ）、エラー系（5つのリポジトリそれぞれのエラーパス）
- **learning_analytics_test.go**: `CalculateProductivityScore`エッジケーステスト追加（4ケース）
  - ポモドーロのみ/手動のみ、1日ストリーク、重み付け比率（30/40/30）の明示的検証

## テスト計画
- [x] 新規21テストケース全通過
- [x] 既存テスト全通過

closes #2149