### PR TITLE
fix: テンプレート・チャットルームの入力バリデーション強化

### DIFF
--- a/backend/internal/domain/validator/note_template.go
+++ b/backend/internal/domain/validator/note_template.go
@@ -58,6 +58,9 @@ func (v *NoteTemplateValidator) ValidateContentTemplate(content string) error {
 	if content == "" {
 		return domain.NewError(domain.ErrCodeValidation, "本文テンプレートを入力してください", nil)
 	}
+	if len([]rune(content)) > 50000 {
+		return domain.NewError(domain.ErrCodeValidation, "本文テンプレートは50000文字以下である必要があります", nil)
+	}
 	return nil
 }
 

--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -90,18 +90,20 @@ func (s *ChatRoomService) Update(roomID, userID uint, name, description string) 
 		if strings.TrimSpace(name) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "チャットルーム名は空白のみでは入力できません", nil)
 		}
-		if len(strings.TrimSpace(name)) > 100 {
+		if len([]rune(strings.TrimSpace(name))) > 100 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "チャットルーム名は100文字以下である必要があります", nil)
 		}
 		room.Name = strings.TrimSpace(name)
 	}
-	if description != "" && strings.TrimSpace(description) == "" {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "説明は空白のみでは入力できません", nil)
+	if description != "" {
+		if strings.TrimSpace(description) == "" {
+			return nil, domain.NewError(domain.ErrCodeBadRequest, "説明は空白のみでは入力できません", nil)
+		}
+		if len([]rune(strings.TrimSpace(description))) > 500 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "説明は500文字以下である必要があります", nil)
+		}
+		room.Description = strings.TrimSpace(description)
 	}
-	if len(strings.TrimSpace(description)) > 500 {
-		return nil, domain.NewError(domain.ErrCodeValidation, "説明は500文字以下である必要があります", nil)
-	}
-	room.Description = strings.TrimSpace(description)
 
 	if err := s.roomRepo.Update(room); err != nil {
 		return nil, err

--- a/backend/internal/service/learning_log_template.go
+++ b/backend/internal/service/learning_log_template.go
@@ -30,6 +30,12 @@ func (s *LearningLogTemplateService) Create(template *model.LearningLogTemplate)
 	if len([]rune(template.Name)) > 100 {
 		return domain.NewError(domain.ErrCodeValidation, "テンプレート名は100文字以下である必要があります", nil)
 	}
+	if len([]rune(template.DefaultTitle)) > 200 {
+		return domain.NewError(domain.ErrCodeValidation, "デフォルトタイトルは200文字以下である必要があります", nil)
+	}
+	if len([]rune(template.DefaultContent)) > 50000 {
+		return domain.NewError(domain.ErrCodeValidation, "デフォルト本文は50000文字以下である必要があります", nil)
+	}
 	if template.DefaultCategory != "" && !model.ValidCategories[template.DefaultCategory] {
 		return domain.NewError(domain.ErrCodeValidation, "無効なカテゴリです", nil)
 	}
@@ -80,9 +86,15 @@ func (s *LearningLogTemplateService) Update(id, userID uint, name, defaultTitle,
 		template.Name = name
 	}
 	if defaultTitle != "" {
+		if len([]rune(defaultTitle)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "デフォルトタイトルは200文字以下である必要があります", nil)
+		}
 		template.DefaultTitle = defaultTitle
 	}
 	if defaultContent != "" {
+		if len([]rune(defaultContent)) > 50000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "デフォルト本文は50000文字以下である必要があります", nil)
+		}
 		template.DefaultContent = defaultContent
 	}
 	if defaultCategory != "" {


### PR DESCRIPTION
## 概要
テンプレート系の入力長さ制限不足とチャットルームのバリデーション一貫性問題を修正

## 変更内容
- **domain/validator/note_template.go**: `ValidateContentTemplate`に50000文字上限追加（DoS防止）
- **service/learning_log_template.go**: `DefaultTitle`(200文字)・`DefaultContent`(50000文字)の長さ制限をCreate/Update両方に追加
- **service/chat_room.go**: Update時の`description`バリデーション修正
  - `len([]rune(...))`でマルチバイト安全な文字数カウントに統一
  - 空文字時にdescriptionを上書きしないよう修正（`description != ""`のガード追加）

## テスト計画
- [x] `go build ./...` ビルド成功
- [x] 既存テスト全通過（NoteTemplate 25件、LearningLogTemplate、ChatRoom 8件）

closes #2151