### PR TITLE
feat: 認証ユーザー向け便利エンドポイント追加（my系5つ）

### DIFF
--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -92,6 +92,26 @@ func (h *BookReviewHandler) GetByUserID(c *gin.Context) {
 	})
 }
 
+// GetMyReviews は認証ユーザー自身の書籍レビュー一覧を取得する。
+func (h *BookReviewHandler) GetMyReviews(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	limit, offset := parseLimitOffset(c)
+
+	reviews, total, err := h.service.GetByUserID(userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.BookReviewListResponse{
+		Reviews: reviews,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+	})
+}
+
 // GetAll は書籍レビューの一覧をページネーション付きで取得する。
 func (h *BookReviewHandler) GetAll(c *gin.Context) {
 	limit, offset := parseLimitOffset(c)

--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -471,3 +471,42 @@ func (h *LearningLogHandler) GetGoalProgress(c *gin.Context) {
 
 	respondOK(c, progress)
 }
+
+// GetMyStreakInfo は認証ユーザー自身のストリーク情報を取得する。
+func (h *LearningLogHandler) GetMyStreakInfo(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	info, err := h.service.GetStreakInfo(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, info)
+}
+
+// GetMyCalendarData は認証ユーザー自身のカレンダーデータを取得する。
+func (h *LearningLogHandler) GetMyCalendarData(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	entries, err := h.service.GetCalendarData(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, ensureSlice(entries))
+}
+
+// GetMyWeeklyDuration は認証ユーザー自身の過去7日間の学習時間合計を返す。
+func (h *LearningLogHandler) GetMyWeeklyDuration(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	duration, err := h.service.GetWeeklyDuration(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.WeeklyDurationResponse{Duration: duration})
+}

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -97,6 +97,26 @@ func (h *ProjectHandler) GetByUserID(c *gin.Context) {
 	})
 }
 
+// GetMyProjects は認証ユーザー自身のプロジェクト一覧を取得する。
+func (h *ProjectHandler) GetMyProjects(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	limit, offset := parseLimitOffset(c)
+
+	projects, total, err := h.service.GetByUserID(userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.ProjectListResponse{
+		Projects: projects,
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
+	})
+}
+
 // GetFeatured は指定ユーザーの注目プロジェクト一覧を取得する。
 func (h *ProjectHandler) GetFeatured(c *gin.Context) {
 	userID, ok := parseID(c, "userId")

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -419,6 +419,7 @@ func registerProjectRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		projects.POST("", c.ProjectHandler.Create)
 		projects.GET("", c.ProjectHandler.GetAll)
+		projects.GET("/my", c.ProjectHandler.GetMyProjects)
 		projects.GET("/:id", c.ProjectHandler.GetByID)
 		projects.PUT("/:id", c.ProjectHandler.Update)
 		projects.DELETE("/:id", c.ProjectHandler.Delete)
@@ -497,6 +498,9 @@ func registerLearningLogRoutes(g *gin.RouterGroup, c *di.Container) {
 		learningLogs.GET("/export", c.LearningLogHandler.ExportLogs)
 		learningLogs.GET("/favorites", c.LearningLogHandler.GetFavorites)
 		learningLogs.GET("/recent-categories", c.LearningLogHandler.GetRecentCategories)
+		learningLogs.GET("/my-streak", c.LearningLogHandler.GetMyStreakInfo)
+		learningLogs.GET("/my-calendar", c.LearningLogHandler.GetMyCalendarData)
+		learningLogs.GET("/my-weekly-duration", c.LearningLogHandler.GetMyWeeklyDuration)
 		learningLogs.GET("/category/:category", c.LearningLogHandler.GetByCategory)
 		learningLogs.GET("/source/:source", c.LearningLogHandler.GetBySource)
 		learningLogs.GET("/user/:userId", c.LearningLogHandler.GetByUserID)
@@ -637,6 +641,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		bookReviews.POST("", c.BookReviewHandler.Create)
 		bookReviews.GET("", c.BookReviewHandler.GetAll)
+		bookReviews.GET("/my", c.BookReviewHandler.GetMyReviews)
 		bookReviews.GET("/:id", c.BookReviewHandler.GetByID)
 		bookReviews.PUT("/:id", c.BookReviewHandler.Update)
 		bookReviews.DELETE("/:id", c.BookReviewHandler.Delete)


### PR DESCRIPTION
## 概要
フロントエンドが認証ユーザーのデータを取得する際、userIDパスパラメータを不要にする便利エンドポイントを5つ追加

## 変更内容
- **handler/book_review.go**: `GetMyReviews`メソッド追加
- **handler/project.go**: `GetMyProjects`メソッド追加
- **handler/learning_log.go**: `GetMyStreakInfo`, `GetMyCalendarData`, `GetMyWeeklyDuration`メソッド追加
- **router/router.go**: 5つの新規ルート登録

## 新規エンドポイント
| メソッド | パス | 説明 |
|---------|------|------|
| GET | /api/v1/book-reviews/my | 自分の書籍レビュー一覧 |
| GET | /api/v1/projects/my | 自分のプロジェクト一覧 |
| GET | /api/v1/learning-logs/my-streak | 自分のストリーク情報 |
| GET | /api/v1/learning-logs/my-calendar | 自分のカレンダーデータ |
| GET | /api/v1/learning-logs/my-weekly-duration | 自分の週間学習時間 |

## テスト計画
- [x] `go build ./...` ビルド成功
- [x] 全テスト通過

closes #2153