### PR TITLE
refactor: PostCollectionインターフェース未使用メソッド削除

### DIFF
--- a/backend/internal/handler/post_collection.go
+++ b/backend/internal/handler/post_collection.go
@@ -10,8 +10,6 @@ import (
 type PostCollectionServiceInterface interface {
 	Create(collection *model.PostCollection) (*model.PostCollection, error)
 	GetByID(id uint) (*model.PostCollection, error)
-	GetByUserID(userID uint, limit, offset int) ([]model.PostCollection, int64, error)
-	GetPublicByUserID(userID uint) ([]model.PostCollection, error)
 	GetCollectionsForViewer(viewerID, targetUserID uint, limit, offset int) ([]model.PostCollection, int64, error)
 	Update(id, userID uint, title, description string, isPublic bool) (*model.PostCollection, error)
 	Delete(id, userID uint) error


### PR DESCRIPTION
## 概要
`PostCollectionServiceInterface`から未使用メソッドを削除し、インターフェースの一貫性を改善。

## 変更内容
- `GetByUserID` と `GetPublicByUserID` を `PostCollectionServiceInterface` から削除
- これらは `GetCollectionsForViewer` に統合済みで、Handlerから呼ばれていなかった

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/handler/... ./internal/service/...` 全テスト通過

Closes #2155