### PR TITLE
fix: PostTemplate・BookReviewの入力バリデーション強化

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -34,6 +34,12 @@ func (s *BookReviewService) Create(review *model.BookReview) error {
 	if err := validateRating(review.Rating); err != nil {
 		return err
 	}
+	if len([]rune(strings.TrimSpace(review.Author))) > 200 {
+		return domain.NewError(domain.ErrCodeValidation, "著者名は200文字以下である必要があります", nil)
+	}
+	if len(strings.TrimSpace(review.ISBN)) > 20 {
+		return domain.NewError(domain.ErrCodeValidation, "ISBNは20文字以下である必要があります", nil)
+	}
 	if len(strings.TrimSpace(review.Review)) > 10000 {
 		return domain.NewError(domain.ErrCodeValidation, "レビュー本文は10000文字以下である必要があります", nil)
 	}
@@ -92,9 +98,15 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		review.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Author) != "" {
+		if len([]rune(strings.TrimSpace(updates.Author))) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "著者名は200文字以下である必要があります", nil)
+		}
 		review.Author = strings.TrimSpace(updates.Author)
 	}
 	if strings.TrimSpace(updates.ISBN) != "" {
+		if len(strings.TrimSpace(updates.ISBN)) > 20 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "ISBNは20文字以下である必要があります", nil)
+		}
 		review.ISBN = strings.TrimSpace(updates.ISBN)
 	}
 	if updates.Rating != 0 {

--- a/backend/internal/service/post_template.go
+++ b/backend/internal/service/post_template.go
@@ -23,8 +23,17 @@ func (s *PostTemplateService) Create(tmpl *model.PostTemplate) error {
 	if strings.TrimSpace(tmpl.Name) == "" {
 		return domain.NewError(domain.ErrCodeBadRequest, "テンプレート名は必須です", nil)
 	}
+	if len([]rune(tmpl.Name)) > 100 {
+		return domain.NewError(domain.ErrCodeValidation, "テンプレート名は100文字以下である必要があります", nil)
+	}
 	if strings.TrimSpace(tmpl.ContentTemplate) == "" {
 		return domain.NewError(domain.ErrCodeBadRequest, "テンプレート内容は必須です", nil)
+	}
+	if len([]rune(tmpl.ContentTemplate)) > 50000 {
+		return domain.NewError(domain.ErrCodeValidation, "テンプレート内容は50000文字以下である必要があります", nil)
+	}
+	if len([]rune(tmpl.TitleTemplate)) > 200 {
+		return domain.NewError(domain.ErrCodeValidation, "タイトルテンプレートは200文字以下である必要があります", nil)
 	}
 	return s.repo.Create(tmpl)
 }
@@ -47,12 +56,21 @@ func (s *PostTemplateService) Update(id, userID uint, updates *model.PostTemplat
 	}
 
 	if strings.TrimSpace(updates.Name) != "" {
+		if len([]rune(updates.Name)) > 100 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "テンプレート名は100文字以下である必要があります", nil)
+		}
 		tmpl.Name = updates.Name
 	}
 	if strings.TrimSpace(updates.TitleTemplate) != "" {
+		if len([]rune(updates.TitleTemplate)) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルテンプレートは200文字以下である必要があります", nil)
+		}
 		tmpl.TitleTemplate = updates.TitleTemplate
 	}
 	if strings.TrimSpace(updates.ContentTemplate) != "" {
+		if len([]rune(updates.ContentTemplate)) > 50000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "テンプレート内容は50000文字以下である必要があります", nil)
+		}
 		tmpl.ContentTemplate = updates.ContentTemplate
 	}
 


### PR DESCRIPTION
## 概要
文字数制限が未設定の入力フィールドにバリデーションを追加し、DoS攻撃リスクを軽減。

## 変更内容

### PostTemplateService
- `Create`/`Update`: Name(100文字), TitleTemplate(200文字), ContentTemplate(50000文字)の上限追加

### BookReviewService
- `Create`/`Update`: Author(200文字), ISBN(20文字)の上限追加

## テスト
- 既存テスト全通過
- マルチバイト文字対応（`len([]rune(...))`）

Closes #2159