### PR TITLE
feat: my系エンドポイント追加（第2弾）

### DIFF
--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -122,6 +122,25 @@ func (h *LearningResourceHandler) GetByUserID(c *gin.Context) {
 	})
 }
 
+// GetMyResources は認証ユーザーの学習リソース一覧を取得する。
+func (h *LearningResourceHandler) GetMyResources(c *gin.Context) {
+	userID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
+
+	resources, total, err := h.service.GetByUserID(userID, userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.ResourceListResponse{
+		Resources: resources,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
+}
+
 // GetPublic は公開学習リソース一覧をページネーション・フィルター付きで取得する。
 func (h *LearningResourceHandler) GetPublic(c *gin.Context) {
 	limit, offset := parseLimitOffset(c)

--- a/backend/internal/handler/post_collection.go
+++ b/backend/internal/handler/post_collection.go
@@ -93,6 +93,25 @@ func (h *PostCollectionHandler) GetByUserID(c *gin.Context) {
 	})
 }
 
+// GetMyCollections は認証ユーザーのコレクション一覧を取得する。
+func (h *PostCollectionHandler) GetMyCollections(c *gin.Context) {
+	userID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
+
+	collections, total, err := h.service.GetCollectionsForViewer(userID, userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.PostCollectionListResponse{
+		Collections: ensureSlice(collections),
+		Total:       total,
+		Limit:       limit,
+		Offset:      offset,
+	})
+}
+
 // Update は指定IDのコレクションを更新する。
 func (h *PostCollectionHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")

--- a/backend/internal/handler/post_series.go
+++ b/backend/internal/handler/post_series.go
@@ -81,6 +81,39 @@ func (h *PostSeriesHandler) GetByUserID(c *gin.Context) {
 	respondPaginated(c, series, total, page, limit)
 }
 
+// GetMySeries は認証ユーザーの投稿シリーズ一覧を取得する。
+func (h *PostSeriesHandler) GetMySeries(c *gin.Context) {
+	userID := c.GetUint("userID")
+	page, limit := parsePagination(c)
+
+	series, err := h.service.GetByUserID(userID, page, limit)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	total, err := h.service.CountByUser(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondPaginated(c, series, total, page, limit)
+}
+
+// GetMySeriesCount は認証ユーザーの投稿シリーズ数を取得する。
+func (h *PostSeriesHandler) GetMySeriesCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	count, err := h.service.CountByUser(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"count": count})
+}
+
 // Update は指定IDのシリーズを更新する。
 func (h *PostSeriesHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -151,6 +151,25 @@ func (h *QuestionHandler) GetByUserID(c *gin.Context) {
 	})
 }
 
+// GetMyQuestions は認証ユーザーの質問一覧を取得する。
+func (h *QuestionHandler) GetMyQuestions(c *gin.Context) {
+	userID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
+
+	questions, total, err := h.service.GetByUserID(userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.QuestionListResponse{
+		Questions: questions,
+		Total:     total,
+		Limit:     limit,
+		Offset:    offset,
+	})
+}
+
 // Update は指定された質問を更新する。
 func (h *QuestionHandler) Update(c *gin.Context) {
 	userID := c.GetUint("userID")

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -223,6 +223,8 @@ func registerPostSeriesRoutes(g *gin.RouterGroup, c *di.Container) {
 	series := g.Group("/post-series")
 	{
 		series.POST("", c.PostSeriesHandler.Create)
+		series.GET("/my", c.PostSeriesHandler.GetMySeries)
+		series.GET("/my/count", c.PostSeriesHandler.GetMySeriesCount)
 		series.GET("/:id", c.PostSeriesHandler.GetByID)
 		series.PUT("/:id", c.PostSeriesHandler.Update)
 		series.DELETE("/:id", c.PostSeriesHandler.Delete)
@@ -237,6 +239,7 @@ func registerPostCollectionRoutes(g *gin.RouterGroup, c *di.Container) {
 	collections := g.Group("/post-collections")
 	{
 		collections.POST("", c.PostCollectionHandler.Create)
+		collections.GET("/my", c.PostCollectionHandler.GetMyCollections)
 		collections.GET("/:id", c.PostCollectionHandler.GetByID)
 		collections.PUT("/:id", c.PostCollectionHandler.Update)
 		collections.DELETE("/:id", c.PostCollectionHandler.Delete)
@@ -442,6 +445,7 @@ func registerResourceRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		resources.POST("", c.LearningResourceHandler.Create)
 		resources.GET("", c.LearningResourceHandler.GetPublic)
+		resources.GET("/my", c.LearningResourceHandler.GetMyResources)
 		resources.GET("/search", c.LearningResourceHandler.Search)
 		resources.GET("/saved", c.LearningResourceHandler.GetSaved)
 		resources.GET("/:id", c.LearningResourceHandler.GetByID)
@@ -578,6 +582,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		questions.POST("", c.QuestionHandler.Create)
 		questions.GET("", c.QuestionHandler.GetAll)
+		questions.GET("/my", c.QuestionHandler.GetMyQuestions)
 		questions.GET("/search", c.QuestionHandler.Search)
 		questions.GET("/solved", c.QuestionHandler.GetSolved)
 		questions.GET("/unanswered", c.QuestionHandler.GetUnanswered)


### PR DESCRIPTION
## 概要
ユーザーが自分のデータを取得する際にuserIDパスパラメータを不要にするmy系エンドポイントを追加。

## 追加エンドポイント（5つ）
- `GET /post-series/my` — 自分のシリーズ一覧（ページネーション付き）
- `GET /post-series/my/count` — 自分のシリーズ数
- `GET /post-collections/my` — 自分のコレクション一覧（ページネーション付き）
- `GET /questions/my` — 自分の質問一覧（ページネーション付き）
- `GET /resources/my` — 自分のリソース一覧（ページネーション付き）

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/handler/... ./internal/service/...` 全テスト通過

Closes #2161