### PR TITLE
test: バリデーション境界値テスト追加（マルチバイト対応）

### DIFF
--- a/backend/internal/domain/validators_test.go
+++ b/backend/internal/domain/validators_test.go
@@ -102,9 +102,11 @@ func TestValidateTitle(t *testing.T) {
 	}{
 		{"有効なタイトル", "My Title", false},
 		{"有効なタイトル（長い）", strings.Repeat("a", 200), false},
+		{"有効なタイトル（マルチバイト200文字）", strings.Repeat("あ", 200), false},
 		{"無効なタイトル（空）", "", true},
 		{"無効なタイトル（スペースのみ）", "   ", true},
 		{"無効なタイトル（長すぎる）", strings.Repeat("a", 201), true},
+		{"無効なタイトル（マルチバイト201文字）", strings.Repeat("あ", 201), true},
 	}
 
 	for _, tt := range tests {
@@ -128,9 +130,11 @@ func TestValidateContent(t *testing.T) {
 	}{
 		{"有効なコンテンツ", "Some content", false},
 		{"有効なコンテンツ（長い）", strings.Repeat("a", 10000), false},
+		{"有効なコンテンツ（マルチバイト10000文字）", strings.Repeat("あ", 10000), false},
 		{"無効なコンテンツ（空）", "", true},
 		{"無効なコンテンツ（スペースのみ）", "   ", true},
 		{"無効なコンテンツ（長すぎる）", strings.Repeat("a", 10001), true},
+		{"無効なコンテンツ（マルチバイト10001文字）", strings.Repeat("あ", 10001), true},
 	}
 
 	for _, tt := range tests {
@@ -261,6 +265,8 @@ func TestValidateTags(t *testing.T) {
 		{"無効なタグ（多すぎる）", []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11"}, true},
 		{"無効なタグ（空文字）", []string{"tag1", ""}, true},
 		{"無効なタグ（長すぎる）", []string{strings.Repeat("a", 31)}, true},
+		{"有効なタグ（マルチバイト30文字）", []string{strings.Repeat("あ", 30)}, false},
+		{"無効なタグ（マルチバイト31文字）", []string{strings.Repeat("あ", 31)}, true},
 	}
 
 	for _, tt := range tests {
@@ -320,8 +326,10 @@ func TestValidateStringLength(t *testing.T) {
 		{"有効な文字列", "test", 1, 10, "テスト", false},
 		{"最小長ちょうど", "a", 1, 10, "テスト", false},
 		{"最大長ちょうど", strings.Repeat("a", 10), 1, 10, "テスト", false},
+		{"マルチバイト最大長ちょうど", strings.Repeat("あ", 10), 1, 10, "テスト", false},
 		{"無効（短すぎる）", "", 1, 10, "テスト", true},
 		{"無効（長すぎる）", strings.Repeat("a", 11), 1, 10, "テスト", true},
+		{"無効（マルチバイト長すぎる）", strings.Repeat("あ", 11), 1, 10, "テスト", true},
 		{"最大長制限なし", strings.Repeat("a", 1000), 1, 0, "テスト", false},
 	}
 

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -743,3 +743,49 @@ func TestBookReviewUpdate_ReviewTooLong(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "レビュー本文は10000文字以下")
 }
+
+func TestBookReviewCreate_AuthorTooLong(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{Title: "テスト本", UserID: 1, Rating: 4, Author: strings.Repeat("あ", 201)}
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "著者名は200文字以下")
+}
+
+func TestBookReviewCreate_ISBNTooLong(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{Title: "テスト本", UserID: 1, Rating: 4, ISBN: strings.Repeat("0", 21)}
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "ISBNは20文字以下")
+}
+
+func TestBookReviewUpdate_AuthorTooLong(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Old", Rating: 3}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.BookReview{Author: strings.Repeat("あ", 201)}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "著者名は200文字以下")
+}
+
+func TestBookReviewUpdate_ISBNTooLong(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "Old", Rating: 3}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.BookReview{ISBN: strings.Repeat("0", 21)}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "ISBNは20文字以下")
+}

--- a/backend/internal/service/post_template_test.go
+++ b/backend/internal/service/post_template_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -61,6 +62,49 @@ func TestPostTemplateCreate_EmptyContent(t *testing.T) {
 	err := svc.Create(tmpl)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "テンプレート内容")
+}
+
+func TestPostTemplateCreate_NameTooLong(t *testing.T) {
+	svc, _ := newTestPostTemplateService()
+
+	tmpl := &model.PostTemplate{
+		UserID:          1,
+		Name:            strings.Repeat("あ", 101),
+		ContentTemplate: "内容",
+	}
+
+	err := svc.Create(tmpl)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "100文字以下")
+}
+
+func TestPostTemplateCreate_ContentTooLong(t *testing.T) {
+	svc, _ := newTestPostTemplateService()
+
+	tmpl := &model.PostTemplate{
+		UserID:          1,
+		Name:            "テスト",
+		ContentTemplate: strings.Repeat("あ", 50001),
+	}
+
+	err := svc.Create(tmpl)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "50000文字以下")
+}
+
+func TestPostTemplateCreate_TitleTemplateTooLong(t *testing.T) {
+	svc, _ := newTestPostTemplateService()
+
+	tmpl := &model.PostTemplate{
+		UserID:          1,
+		Name:            "テスト",
+		ContentTemplate: "内容",
+		TitleTemplate:   strings.Repeat("あ", 201),
+	}
+
+	err := svc.Create(tmpl)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "200文字以下")
 }
 
 func TestPostTemplateCreate_RepoError(t *testing.T) {
@@ -226,6 +270,42 @@ func TestPostTemplateDelete_NotFound(t *testing.T) {
 
 	err := svc.Delete(999, 1)
 	assert.Error(t, err)
+}
+
+func TestPostTemplateUpdate_NameTooLong(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	existing := &model.PostTemplate{UserID: 1, Name: "テスト", ContentTemplate: "内容"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.Update(1, 1, &model.PostTemplate{Name: strings.Repeat("あ", 101)})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "100文字以下")
+}
+
+func TestPostTemplateUpdate_TitleTemplateTooLong(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	existing := &model.PostTemplate{UserID: 1, Name: "テスト", ContentTemplate: "内容"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.Update(1, 1, &model.PostTemplate{TitleTemplate: strings.Repeat("あ", 201)})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "200文字以下")
+}
+
+func TestPostTemplateUpdate_ContentTooLong(t *testing.T) {
+	svc, repo := newTestPostTemplateService()
+
+	existing := &model.PostTemplate{UserID: 1, Name: "テスト", ContentTemplate: "内容"}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	_, err := svc.Update(1, 1, &model.PostTemplate{ContentTemplate: strings.Repeat("あ", 50001)})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "50000文字以下")
 }
 
 func TestPostTemplateUpdate_RepoError(t *testing.T) {


### PR DESCRIPTION
## 概要
マルチバイト文字での境界値テストと、新規追加バリデーションのテストを追加。

## 追加テスト（18件）

### domain/validators_test.go（8件）
- ValidateTitle: マルチバイト200文字（OK）/201文字（NG）
- ValidateContent: マルチバイト10000文字（OK）/10001文字（NG）
- ValidateStringLength: マルチバイト境界値テスト2件
- ValidateTags: マルチバイト30文字（OK）/31文字（NG）

### post_template_test.go（6件）
- Create: Name(101文字), ContentTemplate(50001文字), TitleTemplate(201文字)
- Update: Name(101文字), TitleTemplate(201文字), ContentTemplate(50001文字)

### book_review_test.go（4件）
- Create: Author(201文字), ISBN(21文字)
- Update: Author(201文字), ISBN(21文字)

## テスト結果
全テスト通過

Closes #2165