### PR TITLE
fix: CodeSnippet・Project・ProjectMilestoneの入力バリデーション強化

### DIFF
--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -31,6 +31,9 @@ func (s *CodeSnippetService) Create(snippet *model.CodeSnippet) (*model.CodeSnip
 	if err := domain.ValidateStringLength(snippet.Code, 1, 50000, "コード"); err != nil {
 		return nil, err
 	}
+	if len([]rune(snippet.FileName)) > 200 {
+		return nil, domain.NewError(domain.ErrCodeValidation, "ファイル名は200文字以下である必要があります", nil)
+	}
 	snippet.Language = strings.TrimSpace(snippet.Language)
 	snippet.Code = strings.TrimSpace(snippet.Code)
 
@@ -83,6 +86,9 @@ func (s *CodeSnippetService) Update(id, userID uint, language, fileName, code st
 		snippet.Language = strings.TrimSpace(language)
 	}
 	if strings.TrimSpace(fileName) != "" {
+		if len([]rune(strings.TrimSpace(fileName))) > 200 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "ファイル名は200文字以下である必要があります", nil)
+		}
 		snippet.FileName = strings.TrimSpace(fileName)
 	}
 	if strings.TrimSpace(code) != "" {

--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -3,6 +3,7 @@ package service
 import (
 	"strings"
 
+	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/domain/validator"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -72,6 +73,9 @@ func (s *ProjectService) Update(id, userID uint, updates *model.Project) (*model
 		project.Description = strings.TrimSpace(updates.Description)
 	}
 	if strings.TrimSpace(updates.TechStack) != "" {
+		if len([]rune(strings.TrimSpace(updates.TechStack))) > 500 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "技術スタックは500文字以下である必要があります", nil)
+		}
 		project.TechStack = strings.TrimSpace(updates.TechStack)
 	}
 	if strings.TrimSpace(updates.DemoURL) != "" {
@@ -84,6 +88,9 @@ func (s *ProjectService) Update(id, userID uint, updates *model.Project) (*model
 		project.ImageURL = strings.TrimSpace(updates.ImageURL)
 	}
 	if strings.TrimSpace(updates.Role) != "" {
+		if len([]rune(strings.TrimSpace(updates.Role))) > 100 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "役割は100文字以下である必要があります", nil)
+		}
 		project.Role = strings.TrimSpace(updates.Role)
 	}
 	if updates.StartDate != nil {

--- a/backend/internal/service/project_milestone.go
+++ b/backend/internal/service/project_milestone.go
@@ -51,6 +51,10 @@ func (s *ProjectMilestoneService) Create(userID, projectID uint, title, descript
 		return domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
 	}
 
+	if len([]rune(description)) > 1000 {
+		return domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+	}
+
 	milestone := &model.ProjectMilestone{
 		ProjectID:   projectID,
 		Title:       title,
@@ -85,6 +89,9 @@ func (s *ProjectMilestoneService) Update(userID, milestoneID uint, title, descri
 		milestone.Title = title
 	}
 	if description != "" {
+		if len([]rune(description)) > 1000 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		}
 		milestone.Description = description
 	}
 	if dueDate != nil {


### PR DESCRIPTION
## 概要
文字数制限が未設定のフィールドにバリデーションを追加し、DoS攻撃リスクを軽減。

## 変更内容

### CodeSnippetService
- `Create`/`Update`: FileName(200文字)の上限追加

### ProjectService
- `Update`: TechStack(500文字), Role(100文字)の上限追加

### ProjectMilestoneService
- `Create`/`Update`: Description(1000文字)の上限追加

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/...` 全テスト通過

Closes #2167