### PR TITLE
feat: CodeSnippet・Projectに検索エンドポイント追加

### DIFF
--- a/backend/internal/dto/code_snippet_dto.go
+++ b/backend/internal/dto/code_snippet_dto.go
@@ -8,6 +8,14 @@ type CodeSnippetFavoritesResponse struct {
 	Total    int64               `json:"total"`
 }
 
+// CodeSnippetListResponse はコードスニペット検索結果レスポンス。
+type CodeSnippetListResponse struct {
+	Snippets []model.CodeSnippet `json:"snippets"`
+	Total    int64               `json:"total"`
+	Limit    int                 `json:"limit"`
+	Offset   int                 `json:"offset"`
+}
+
 // CreateCodeSnippetRequest はコードスニペット作成リクエスト。
 type CreateCodeSnippetRequest struct {
 	Language string `json:"language" binding:"required,max=100" validate:"required,max=100"`

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -17,6 +17,7 @@ type CodeSnippetHandlerServiceInterface interface {
 	GetComments(snippetID uint) ([]model.SnippetComment, error)
 	CreateComment(comment *model.SnippetComment) error
 	DeleteComment(id, userID uint) error
+	Search(query string, limit, offset int) ([]model.CodeSnippet, int64, error)
 	Fork(userID, snippetID, targetPostID uint) (*model.CodeSnippet, error)
 	Favorite(userID, snippetID uint) error
 	Unfavorite(userID, snippetID uint) error
@@ -206,6 +207,30 @@ func (h *CodeSnippetHandler) GetByUserLanguage(c *gin.Context) {
 		return
 	}
 	respondOK(c, ensureSlice(snippets))
+}
+
+// Search はコードスニペットをキーワード検索する。
+func (h *CodeSnippetHandler) Search(c *gin.Context) {
+	q := c.Query("q")
+	if q == "" {
+		respondBadRequest(c, "検索クエリは必須です")
+		return
+	}
+
+	limit, offset := parseLimitOffset(c)
+
+	snippets, total, err := h.service.Search(q, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.CodeSnippetListResponse{
+		Snippets: ensureSlice(snippets),
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
+	})
 }
 
 // Favorite はスニペットをお気に入りに追加する。

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -13,6 +13,7 @@ type ProjectServiceInterface interface {
 	GetByUserID(userID uint, limit, offset int) ([]model.Project, int64, error)
 	GetFeaturedByUserID(userID uint) ([]model.Project, error)
 	GetAll(limit, offset int) ([]model.Project, int64, error)
+	Search(query string, limit, offset int) ([]model.Project, int64, error)
 	Update(id, userID uint, updates *model.Project) (*model.Project, error)
 	UpdateFeatured(id, userID uint, featured bool) (*model.Project, error)
 	Delete(id, userID uint) error
@@ -217,6 +218,30 @@ func (h *ProjectHandler) GetArchived(c *gin.Context) {
 	limit, offset := parseLimitOffset(c)
 
 	projects, total, err := h.service.GetArchivedByUserID(userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.ProjectListResponse{
+		Projects: projects,
+		Total:    total,
+		Limit:    limit,
+		Offset:   offset,
+	})
+}
+
+// Search はプロジェクトをキーワード検索する。
+func (h *ProjectHandler) Search(c *gin.Context) {
+	q := c.Query("q")
+	if q == "" {
+		respondBadRequest(c, "検索クエリは必須です")
+		return
+	}
+
+	limit, offset := parseLimitOffset(c)
+
+	projects, total, err := h.service.Search(q, limit, offset)
 	if err != nil {
 		respondError(c, err)
 		return

--- a/backend/internal/repository/code_snippet.go
+++ b/backend/internal/repository/code_snippet.go
@@ -41,6 +41,17 @@ func (r *CodeSnippetRepository) FindByUserIDAndLanguage(userID uint, language st
 	return snippets, err
 }
 
+// Search はコードスニペットを言語・ファイル名・コード内容からキーワード検索する。
+func (r *CodeSnippetRepository) Search(query string, limit, offset int) ([]model.CodeSnippet, int64, error) {
+	var snippets []model.CodeSnippet
+	var total int64
+	like := EscapeLikePattern(query)
+	q := r.db.Where("language ILIKE ? OR file_name ILIKE ? OR code ILIKE ?", like, like, like)
+	q.Model(&model.CodeSnippet{}).Count(&total)
+	err := q.Preload("User").Order("created_at DESC").Limit(limit).Offset(offset).Find(&snippets).Error
+	return snippets, total, err
+}
+
 // Update は既存のコードスニペットを更新する。
 func (r *CodeSnippetRepository) Update(snippet *model.CodeSnippet) error {
 	return r.db.Save(snippet).Error

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -209,6 +209,7 @@ type ProjectRepositoryInterface interface {
 	Update(project *model.Project) error
 	Delete(id uint) error
 	FindAll(limit, offset int) ([]model.Project, int64, error)
+	Search(query string, limit, offset int) ([]model.Project, int64, error)
 	Archive(id uint) error
 	Unarchive(id uint) error
 	FindArchivedByUserID(userID uint, limit, offset int) ([]model.Project, int64, error)
@@ -327,6 +328,7 @@ type CodeSnippetRepositoryInterface interface {
 	FindByID(id uint) (*model.CodeSnippet, error)
 	FindByPostID(postID uint) ([]model.CodeSnippet, error)
 	FindByUserIDAndLanguage(userID uint, language string) ([]model.CodeSnippet, error)
+	Search(query string, limit, offset int) ([]model.CodeSnippet, int64, error)
 	Update(snippet *model.CodeSnippet) error
 	Delete(id uint) error
 	CreateComment(comment *model.SnippetComment) error

--- a/backend/internal/repository/project.go
+++ b/backend/internal/repository/project.go
@@ -79,6 +79,17 @@ func (r *ProjectRepository) FindAll(limit, offset int) ([]model.Project, int64, 
 	return projects, total, err
 }
 
+// Search はプロジェクトをタイトル・説明・技術スタックからキーワード検索する。
+func (r *ProjectRepository) Search(query string, limit, offset int) ([]model.Project, int64, error) {
+	var projects []model.Project
+	var total int64
+	like := EscapeLikePattern(query)
+	q := r.db.Where("title ILIKE ? OR description ILIKE ? OR tech_stack ILIKE ?", like, like, like)
+	q.Model(&model.Project{}).Count(&total)
+	err := q.Preload("User").Preload("GithubRepo").Order("created_at DESC").Limit(limit).Offset(offset).Find(&projects).Error
+	return projects, total, err
+}
+
 // Archive は指定IDのプロジェクトをアーカイブする。
 func (r *ProjectRepository) Archive(id uint) error {
 	return r.db.Model(&model.Project{}).Where("id = ?", id).Update("is_archived", true).Error

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -282,6 +282,7 @@ func registerPostViewRoutes(g *gin.RouterGroup, c *di.Container) {
 func registerSnippetRoutes(g *gin.RouterGroup, c *di.Container) {
 	snippets := g.Group("/snippets")
 	{
+		snippets.GET("/search", c.CodeSnippetHandler.Search)
 		snippets.GET("/:id", c.CodeSnippetHandler.GetByID)
 		snippets.PUT("/:id", c.CodeSnippetHandler.Update)
 		snippets.DELETE("/:id", c.CodeSnippetHandler.Delete)
@@ -422,6 +423,7 @@ func registerProjectRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		projects.POST("", c.ProjectHandler.Create)
 		projects.GET("", c.ProjectHandler.GetAll)
+		projects.GET("/search", c.ProjectHandler.Search)
 		projects.GET("/my", c.ProjectHandler.GetMyProjects)
 		projects.GET("/:id", c.ProjectHandler.GetByID)
 		projects.PUT("/:id", c.ProjectHandler.Update)

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -58,6 +58,14 @@ func (s *CodeSnippetService) GetByPostID(postID uint) ([]model.CodeSnippet, erro
 	return s.repo.FindByPostID(postID)
 }
 
+// Search はコードスニペットをキーワード検索する。
+func (s *CodeSnippetService) Search(query string, limit, offset int) ([]model.CodeSnippet, int64, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, 0, domain.NewError(domain.ErrCodeBadRequest, "検索キーワードは必須です", nil)
+	}
+	return s.repo.Search(strings.TrimSpace(query), limit, offset)
+}
+
 // GetByUserLanguage は指定ユーザーのスニペットをプログラミング言語でフィルタリングして取得する。
 func (s *CodeSnippetService) GetByUserLanguage(userID uint, language string) ([]model.CodeSnippet, error) {
 	if language == "" {

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -734,6 +734,11 @@ func (m *MockProjectRepository) FindArchivedByUserID(userID uint, limit, offset 
 	return args.Get(0).([]model.Project), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockProjectRepository) Search(query string, limit, offset int) ([]model.Project, int64, error) {
+	args := m.Called(query, limit, offset)
+	return args.Get(0).([]model.Project), args.Get(1).(int64), args.Error(2)
+}
+
 // ============================================================
 // MockBookReviewRepository は repository.BookReviewRepositoryInterface のテスト用モック実装。
 // ============================================================
@@ -1206,6 +1211,11 @@ func (m *MockCodeSnippetRepository) HasFavorited(userID, snippetID uint) (bool, 
 
 func (m *MockCodeSnippetRepository) FindFavoritedByUserID(userID uint, limit, offset int) ([]model.CodeSnippet, int64, error) {
 	args := m.Called(userID, limit, offset)
+	return args.Get(0).([]model.CodeSnippet), args.Get(1).(int64), args.Error(2)
+}
+
+func (m *MockCodeSnippetRepository) Search(query string, limit, offset int) ([]model.CodeSnippet, int64, error) {
+	args := m.Called(query, limit, offset)
 	return args.Get(0).([]model.CodeSnippet), args.Get(1).(int64), args.Error(2)
 }
 

--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -49,6 +49,14 @@ func (s *ProjectService) GetAll(limit, offset int) ([]model.Project, int64, erro
 	return s.repo.FindAll(limit, offset)
 }
 
+// Search はプロジェクトをキーワード検索する。
+func (s *ProjectService) Search(query string, limit, offset int) ([]model.Project, int64, error) {
+	if strings.TrimSpace(query) == "" {
+		return nil, 0, domain.NewError(domain.ErrCodeBadRequest, "検索キーワードは必須です", nil)
+	}
+	return s.repo.Search(strings.TrimSpace(query), limit, offset)
+}
+
 // findAndCheckOwnership はプロジェクトを取得し、指定ユーザーが所有者かを検証する。
 func (s *ProjectService) findAndCheckOwnership(id, userID uint) (*model.Project, error) {
 	return checkOwnership(s.repo.FindByID, id, userID, func(p *model.Project) uint { return p.UserID })


### PR DESCRIPTION
## 概要
CodeSnippetとProjectにキーワード検索エンドポイントを追加。

## 変更内容
- Repository層: `Search` メソッド追加（ILIKE検索、ページネーション対応）
  - CodeSnippet: language, file_name, code を対象に検索
  - Project: title, description, tech_stack を対象に検索
- Service層: 空クエリバリデーション付き `Search` メソッド追加
- Handler層: `GET /snippets/search?q=xxx` と `GET /projects/search?q=xxx` エンドポイント追加
- DTO: `CodeSnippetListResponse` 追加
- テスト用モックに `Search` メソッド追加

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/...` 全テスト通過

closes #2169