### PR TITLE
refactor: Searchハンドラーのクエリ検証をparseSearchQueryに統一

### DIFF
--- a/backend/internal/handler/book_review.go
+++ b/backend/internal/handler/book_review.go
@@ -250,7 +250,10 @@ func (h *BookReviewHandler) UpdateProgress(c *gin.Context) {
 
 // Search は書籍レビューをキーワード検索する。
 func (h *BookReviewHandler) Search(c *gin.Context) {
-	query := c.Query("q")
+	query, ok := parseSearchQuery(c)
+	if !ok {
+		return
+	}
 	limit, offset := parseLimitOffset(c)
 
 	reviews, total, err := h.service.Search(query, limit, offset)

--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -211,9 +211,8 @@ func (h *CodeSnippetHandler) GetByUserLanguage(c *gin.Context) {
 
 // Search はコードスニペットをキーワード検索する。
 func (h *CodeSnippetHandler) Search(c *gin.Context) {
-	q := c.Query("q")
-	if q == "" {
-		respondBadRequest(c, "検索クエリは必須です")
+	q, ok := parseSearchQuery(c)
+	if !ok {
 		return
 	}
 

--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -163,7 +163,10 @@ func (h *LearningResourceHandler) GetPublic(c *gin.Context) {
 
 // Search はキーワードで学習リソースを検索する。
 func (h *LearningResourceHandler) Search(c *gin.Context) {
-	query := c.Query("q")
+	query, ok := parseSearchQuery(c)
+	if !ok {
+		return
+	}
 	limit, offset := parseLimitOffset(c)
 
 	resources, total, err := h.service.Search(query, limit, offset)

--- a/backend/internal/handler/project.go
+++ b/backend/internal/handler/project.go
@@ -233,9 +233,8 @@ func (h *ProjectHandler) GetArchived(c *gin.Context) {
 
 // Search はプロジェクトをキーワード検索する。
 func (h *ProjectHandler) Search(c *gin.Context) {
-	q := c.Query("q")
-	if q == "" {
-		respondBadRequest(c, "検索クエリは必須です")
+	q, ok := parseSearchQuery(c)
+	if !ok {
 		return
 	}
 

--- a/backend/internal/handler/question.go
+++ b/backend/internal/handler/question.go
@@ -84,9 +84,8 @@ func (h *QuestionHandler) GetAll(c *gin.Context) {
 
 // Search はキーワードで質問を検索する。
 func (h *QuestionHandler) Search(c *gin.Context) {
-	q := c.Query("q")
-	if q == "" {
-		respondBadRequest(c, "検索クエリは必須です")
+	q, ok := parseSearchQuery(c)
+	if !ok {
 		return
 	}
 


### PR DESCRIPTION
## 概要
5つのSearchハンドラーが独自にクエリ検証していたのを、既存の`parseSearchQuery`ヘルパーに統一。

## 変更内容
- question, code_snippet, project: インラインの`q == ""`チェックを`parseSearchQuery`に置換
- book_review, learning_resource: 欠落していた空チェック・最大長チェックを`parseSearchQuery`で追加
- 全Searchハンドラーで統一的な検証（空チェック・500文字制限・TrimSpace）を適用

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/...` 全テスト通過

closes #2171