### PR TITLE
test: CodeSnippet・ProjectのSearchメソッドテスト追加

### DIFF
--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -712,3 +712,46 @@ func TestSnippetGetFavoritedByUserID_Empty(t *testing.T) {
 	assert.Equal(t, int64(0), total)
 	snippetRepo.AssertExpectations(t)
 }
+
+// ---------- 検索テスト ----------
+
+func TestSnippetSearch_Success(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	expected := []model.CodeSnippet{
+		{Language: "go", Code: "package main"},
+	}
+	snippetRepo.On("Search", "main", 20, 0).Return(expected, int64(1), nil)
+
+	result, total, err := svc.Search("main", 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
+	snippetRepo.AssertExpectations(t)
+}
+
+func TestSnippetSearch_EmptyQuery(t *testing.T) {
+	svc, _, _ := newTestCodeSnippetService()
+
+	_, _, err := svc.Search("", 20, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "検索キーワードは必須です")
+}
+
+func TestSnippetSearch_WhitespaceQuery(t *testing.T) {
+	svc, _, _ := newTestCodeSnippetService()
+
+	_, _, err := svc.Search("   ", 20, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "検索キーワードは必須です")
+}
+
+func TestSnippetSearch_RepoError(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippetRepo.On("Search", "test", 20, 0).Return([]model.CodeSnippet{}, int64(0), assert.AnError)
+
+	_, _, err := svc.Search("test", 20, 0)
+	assert.Error(t, err)
+	snippetRepo.AssertExpectations(t)
+}

--- a/backend/internal/service/project_test.go
+++ b/backend/internal/service/project_test.go
@@ -562,3 +562,48 @@ func TestProjectGetArchivedByUserID_Success(t *testing.T) {
 	assert.Equal(t, int64(1), total)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// 検索テスト
+// ============================================================
+
+func TestProjectSearch_Success(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	expected := []model.Project{
+		{Title: "React App", TechStack: "React, TypeScript"},
+	}
+	repo.On("Search", "React", 20, 0).Return(expected, int64(1), nil)
+
+	result, total, err := svc.Search("React", 20, 0)
+	assert.NoError(t, err)
+	assert.Len(t, result, 1)
+	assert.Equal(t, int64(1), total)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectSearch_EmptyQuery(t *testing.T) {
+	svc, _ := newTestProjectService()
+
+	_, _, err := svc.Search("", 20, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "検索キーワードは必須です")
+}
+
+func TestProjectSearch_WhitespaceQuery(t *testing.T) {
+	svc, _ := newTestProjectService()
+
+	_, _, err := svc.Search("   ", 20, 0)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "検索キーワードは必須です")
+}
+
+func TestProjectSearch_RepoError(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	repo.On("Search", "test", 20, 0).Return([]model.Project{}, int64(0), assert.AnError)
+
+	_, _, err := svc.Search("test", 20, 0)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
Cycle 13 Phase 1で追加したSearch機能のService層テストを追加。

## テスト内容
- **CodeSnippetService.Search**: 成功、空クエリエラー、空白クエリエラー、リポジトリエラーの4テスト
- **ProjectService.Search**: 成功、空クエリエラー、空白クエリエラー、リポジトリエラーの4テスト

## テスト結果
- 8テスト全て通過
- 既存テストに影響なし

closes #2173