### PR TITLE
fix: ChatRoom・PostSeries・RoadmapのCreateにDescriptionバリデーション追加

### DIFF
--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -27,6 +27,9 @@ func (s *ChatRoomService) Create(room *model.ChatRoom, memberIDs []uint) (*model
 	if err := domain.ValidateStringLength(room.Name, 1, 100, "チャットルーム名"); err != nil {
 		return nil, err
 	}
+	if len([]rune(room.Description)) > 500 {
+		return nil, domain.NewError(domain.ErrCodeValidation, "説明は500文字以下である必要があります", nil)
+	}
 	room.Name = strings.TrimSpace(room.Name)
 	if err := s.roomRepo.Create(room); err != nil {
 		return nil, err

--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -24,6 +24,9 @@ func (s *PostSeriesService) Create(series *model.PostSeries) error {
 	if err := domain.ValidateStringLength(series.Title, 1, 200, "タイトル"); err != nil {
 		return err
 	}
+	if len([]rune(series.Description)) > 1000 {
+		return domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+	}
 	series.Title = strings.TrimSpace(series.Title)
 	return s.repo.Create(series)
 }

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -32,6 +32,9 @@ func (s *RoadmapService) Create(roadmap *model.Roadmap) error {
 	if err := domain.ValidateStringLength(roadmap.Title, 1, 200, "タイトル"); err != nil {
 		return err
 	}
+	if len([]rune(roadmap.Description)) > 1000 {
+		return domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+	}
 	roadmap.Title = strings.TrimSpace(roadmap.Title)
 	return s.repo.Create(roadmap)
 }


### PR DESCRIPTION
## 概要
CreateメソッドでDescriptionの最大長チェックが欠落していた3つのサービスに修正を追加。

## 変更内容
- ChatRoom.Create: Description 500文字制限追加（Updateメソッドと統一）
- PostSeries.Create: Description 1000文字制限追加（Updateメソッドと統一）
- Roadmap.Create: Description 1000文字制限追加（Updateメソッドと統一）

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/...` 全テスト通過

closes #2175