### PR TITLE
refactor: Service層の文字列長チェックをバイト数からルーン数に統一

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -37,10 +37,10 @@ func (s *BookReviewService) Create(review *model.BookReview) error {
 	if len([]rune(strings.TrimSpace(review.Author))) > 200 {
 		return domain.NewError(domain.ErrCodeValidation, "著者名は200文字以下である必要があります", nil)
 	}
-	if len(strings.TrimSpace(review.ISBN)) > 20 {
+	if len([]rune(strings.TrimSpace(review.ISBN))) > 20 {
 		return domain.NewError(domain.ErrCodeValidation, "ISBNは20文字以下である必要があります", nil)
 	}
-	if len(strings.TrimSpace(review.Review)) > 10000 {
+	if len([]rune(strings.TrimSpace(review.Review))) > 10000 {
 		return domain.NewError(domain.ErrCodeValidation, "レビュー本文は10000文字以下である必要があります", nil)
 	}
 	review.Title = strings.TrimSpace(review.Title)
@@ -92,7 +92,7 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		if len(strings.TrimSpace(updates.Title)) > 200 {
+		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
 		}
 		review.Title = strings.TrimSpace(updates.Title)
@@ -104,7 +104,7 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		review.Author = strings.TrimSpace(updates.Author)
 	}
 	if strings.TrimSpace(updates.ISBN) != "" {
-		if len(strings.TrimSpace(updates.ISBN)) > 20 {
+		if len([]rune(strings.TrimSpace(updates.ISBN))) > 20 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "ISBNは20文字以下である必要があります", nil)
 		}
 		review.ISBN = strings.TrimSpace(updates.ISBN)
@@ -116,7 +116,7 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		review.Rating = updates.Rating
 	}
 	if strings.TrimSpace(updates.Review) != "" {
-		if len(strings.TrimSpace(updates.Review)) > 10000 {
+		if len([]rune(strings.TrimSpace(updates.Review))) > 10000 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "レビュー本文は10000文字以下である必要があります", nil)
 		}
 		review.Review = strings.TrimSpace(updates.Review)

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -88,7 +88,7 @@ func (s *CodeSnippetService) Update(id, userID uint, language, fileName, code st
 	}
 
 	if strings.TrimSpace(language) != "" {
-		if len(strings.TrimSpace(language)) > 100 {
+		if len([]rune(strings.TrimSpace(language))) > 100 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "言語は100文字以下である必要があります", nil)
 		}
 		snippet.Language = strings.TrimSpace(language)
@@ -100,7 +100,7 @@ func (s *CodeSnippetService) Update(id, userID uint, language, fileName, code st
 		snippet.FileName = strings.TrimSpace(fileName)
 	}
 	if strings.TrimSpace(code) != "" {
-		if len(strings.TrimSpace(code)) > 50000 {
+		if len([]rune(strings.TrimSpace(code))) > 50000 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "コードは50000文字以下である必要があります", nil)
 		}
 		snippet.Code = strings.TrimSpace(code)

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -100,13 +100,13 @@ func (s *LearningGoalService) Update(id, userID uint, updates *model.LearningGoa
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		if len(strings.TrimSpace(updates.Title)) > 200 {
+		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
 		}
 		goal.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		if len(strings.TrimSpace(updates.Description)) > 1000 {
+		if len([]rune(strings.TrimSpace(updates.Description))) > 1000 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
 		}
 		goal.Description = strings.TrimSpace(updates.Description)

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -24,7 +24,7 @@ func (s *PostCollectionService) Create(collection *model.PostCollection) (*model
 	if err := domain.ValidateStringLength(collection.Title, 1, 200, "タイトル"); err != nil {
 		return nil, err
 	}
-	if len(strings.TrimSpace(collection.Description)) > 1000 {
+	if len([]rune(strings.TrimSpace(collection.Description))) > 1000 {
 		return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
 	}
 	collection.Title = strings.TrimSpace(collection.Title)
@@ -72,7 +72,7 @@ func (s *PostCollectionService) Update(id, userID uint, title, description strin
 	if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
 		return nil, err
 	}
-	if len(strings.TrimSpace(description)) > 1000 {
+	if len([]rune(strings.TrimSpace(description))) > 1000 {
 		return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
 	}
 	collection, err := s.findAndCheckOwnership(id, userID)

--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -63,7 +63,7 @@ func (s *PostSeriesService) Update(id, userID uint, updates *model.PostSeries) (
 		if strings.TrimSpace(updates.Title) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみでは入力できません", nil)
 		}
-		if len(strings.TrimSpace(updates.Title)) > 200 {
+		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
 		}
 		series.Title = strings.TrimSpace(updates.Title)
@@ -72,7 +72,7 @@ func (s *PostSeriesService) Update(id, userID uint, updates *model.PostSeries) (
 		if strings.TrimSpace(updates.Description) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "説明は空白のみでは入力できません", nil)
 		}
-		if len(strings.TrimSpace(updates.Description)) > 1000 {
+		if len([]rune(strings.TrimSpace(updates.Description))) > 1000 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
 		}
 		series.Description = strings.TrimSpace(updates.Description)

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -104,13 +104,13 @@ func (s *RoadmapService) Update(id, userID uint, updates *model.Roadmap) (*model
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		if len(strings.TrimSpace(updates.Title)) > 200 {
+		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
 		}
 		roadmap.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		if len(strings.TrimSpace(updates.Description)) > 1000 {
+		if len([]rune(strings.TrimSpace(updates.Description))) > 1000 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
 		}
 		roadmap.Description = strings.TrimSpace(updates.Description)
@@ -186,19 +186,19 @@ func (s *RoadmapService) UpdateStep(roadmapID, stepID, userID uint, updates *mod
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		if len(strings.TrimSpace(updates.Title)) > 200 {
+		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
 		}
 		step.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		if len(strings.TrimSpace(updates.Description)) > 1000 {
+		if len([]rune(strings.TrimSpace(updates.Description))) > 1000 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
 		}
 		step.Description = strings.TrimSpace(updates.Description)
 	}
 	if strings.TrimSpace(updates.ResourceURL) != "" {
-		if len(strings.TrimSpace(updates.ResourceURL)) > 500 {
+		if len([]rune(strings.TrimSpace(updates.ResourceURL))) > 500 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "リソースURLは500文字以下である必要があります", nil)
 		}
 		step.ResourceURL = strings.TrimSpace(updates.ResourceURL)

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -121,7 +121,7 @@ func (s *StudyCircleService) Update(id, userID uint, name, topic, description *s
 		if strings.TrimSpace(*name) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "サークル名は空白のみでは入力できません", nil)
 		}
-		if len(strings.TrimSpace(*name)) > 100 {
+		if len([]rune(strings.TrimSpace(*name))) > 100 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "サークル名は100文字以下である必要があります", nil)
 		}
 		circle.Name = strings.TrimSpace(*name)
@@ -130,13 +130,13 @@ func (s *StudyCircleService) Update(id, userID uint, name, topic, description *s
 		if strings.TrimSpace(*topic) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "トピックは空白のみでは入力できません", nil)
 		}
-		if len(strings.TrimSpace(*topic)) > 200 {
+		if len([]rune(strings.TrimSpace(*topic))) > 200 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "トピックは200文字以下である必要があります", nil)
 		}
 		circle.Topic = strings.TrimSpace(*topic)
 	}
 	if description != nil {
-		if len(strings.TrimSpace(*description)) > 1000 {
+		if len([]rune(strings.TrimSpace(*description))) > 1000 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
 		}
 		circle.Description = *description
@@ -270,13 +270,13 @@ func (s *StudyCircleService) UpdateStep(circleID, userID, stepID uint, title, de
 		if strings.TrimSpace(*title) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみでは入力できません", nil)
 		}
-		if len(strings.TrimSpace(*title)) > 200 {
+		if len([]rune(strings.TrimSpace(*title))) > 200 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
 		}
 		step.Title = strings.TrimSpace(*title)
 	}
 	if description != nil {
-		if len(strings.TrimSpace(*description)) > 1000 {
+		if len([]rune(strings.TrimSpace(*description))) > 1000 {
 			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
 		}
 		step.Description = *description


### PR DESCRIPTION
## 概要
- Service層の `len(strings.TrimSpace(...))` （バイト数）を `len([]rune(strings.TrimSpace(...)))` （ルーン数）に統一
- 日本語などのマルチバイト文字で正確な文字数制限を行うための修正

## 対象ファイル（7ファイル、23箇所）
- `post_series.go`: Update メソッドの Title, Description
- `post_collection.go`: Create, Update メソッドの Description
- `code_snippet.go`: Update メソッドの Language, Code
- `study_circle.go`: Update メソッドの Name, Topic, Description / UpdateStep の Title, Description
- `learning_goal.go`: Update メソッドの Title, Description
- `roadmap.go`: Update メソッドの Title, Description / UpdateStep の Title, Description, ResourceURL
- `book_review.go`: Create の ISBN, Review / Update の Title, ISBN, Review

## テスト
- `go test ./internal/service/... -v` 全テスト通過

close #2179