### PR TITLE
test: CountByUserIDのService層テスト追加（Project/BookReview/Question）

### DIFF
--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -789,3 +789,29 @@ func TestBookReviewUpdate_ISBNTooLong(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "ISBNは20文字以下")
 }
+
+// ============================================================
+// CountByUserID テスト
+// ============================================================
+
+func TestBookReviewCountByUserID_Success(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(8), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(8), count)
+	repo.AssertExpectations(t)
+}
+
+func TestBookReviewCountByUserID_Error(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/project_test.go
+++ b/backend/internal/service/project_test.go
@@ -607,3 +607,29 @@ func TestProjectSearch_RepoError(t *testing.T) {
 	assert.Error(t, err)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// CountByUserID テスト
+// ============================================================
+
+func TestProjectCountByUserID_Success(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(5), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+	repo.AssertExpectations(t)
+}
+
+func TestProjectCountByUserID_Error(t *testing.T) {
+	svc, repo := newTestProjectService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/question_test.go
+++ b/backend/internal/service/question_test.go
@@ -714,3 +714,29 @@ func TestQuestionGetUnanswered_RepoError(t *testing.T) {
 	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// CountByUserID テスト
+// ============================================================
+
+func TestQuestionCountByUserID_Success(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(12), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(12), count)
+	repo.AssertExpectations(t)
+}
+
+func TestQuestionCountByUserID_Error(t *testing.T) {
+	svc, repo := newTestQuestionService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- Cycle 14 Phase 1 で追加した CountByUserID メソッドのService層テストを追加
- 3サービス × 2ケース（Success/Error）= 計6テスト

## 対象
- `project_test.go`: TestProjectCountByUserID_Success, TestProjectCountByUserID_Error
- `book_review_test.go`: TestBookReviewCountByUserID_Success, TestBookReviewCountByUserID_Error
- `question_test.go`: TestQuestionCountByUserID_Success, TestQuestionCountByUserID_Error

## テスト
- `go test ./internal/service/... -run CountByUserID -v` 全9テスト通過（既存3 + 新規6）

close #2181