### PR TITLE
fix: PostCollection.AddPostのnoteとBookReview.CreateのTotalPagesにバリデーション追加

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -43,6 +43,9 @@ func (s *BookReviewService) Create(review *model.BookReview) error {
 	if len([]rune(strings.TrimSpace(review.Review))) > 10000 {
 		return domain.NewError(domain.ErrCodeValidation, "レビュー本文は10000文字以下である必要があります", nil)
 	}
+	if review.TotalPages < 0 || review.TotalPages > 99999 {
+		return domain.NewError(domain.ErrCodeValidation, "総ページ数は0〜99999の範囲で指定してください", nil)
+	}
 	review.Title = strings.TrimSpace(review.Title)
 	review.Review = strings.TrimSpace(review.Review)
 	return s.repo.Create(review)

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -101,6 +101,10 @@ func (s *PostCollectionService) Delete(id, userID uint) error {
 // AddPost は所有権を検証した後、コレクションに投稿を追加する。
 // 同じ投稿がすでに追加されている場合はエラーを返す。
 func (s *PostCollectionService) AddPost(collectionID, userID, postID uint, note string) error {
+	if len([]rune(strings.TrimSpace(note))) > 500 {
+		return domain.NewError(domain.ErrCodeValidation, "メモは500文字以下である必要があります", nil)
+	}
+
 	if _, err := s.findAndCheckOwnership(collectionID, userID); err != nil {
 		return err
 	}


### PR DESCRIPTION
## 概要
- PostCollectionService.AddPost の note パラメータに500文字制限を追加（バリデーション未実施だった）
- BookReviewService.Create の TotalPages に0〜99999の範囲チェックを追加（上限チェック未実施だった）

## 変更内容
- **post_collection.go**: AddPost の先頭で note の長さチェック（500文字以下）
- **book_review.go**: Create で TotalPages の範囲チェック（0〜99999）

## テスト
- `go test ./internal/service/... -v` 全テスト通過

close #2183