### PR TITLE
feat: ロードマップ統計とスタディサークル検索のエンドポイント追加

### DIFF
--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -26,6 +26,7 @@ type RoadmapServiceInterface interface {
 	BatchCompleteSteps(roadmapID, userID uint, stepIDs []uint) (*model.Roadmap, error)
 	DeleteStep(roadmapID, stepID, userID uint) error
 	ReorderSteps(roadmapID, userID uint, orders []model.StepOrder) error
+	GetStats(userID uint) (*model.RoadmapStats, error)
 }
 
 // RoadmapHandler はロードマップ関連のHTTPハンドラ。
@@ -364,4 +365,17 @@ func (h *RoadmapHandler) ReorderSteps(c *gin.Context) {
 	}
 
 	respondOK(c, domain.NewMessageResponse("steps reordered"))
+}
+
+// GetMyStats は認証ユーザーのロードマップ統計情報を取得する。
+func (h *RoadmapHandler) GetMyStats(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	stats, err := h.service.GetStats(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, stats)
 }

--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -28,6 +28,7 @@ type StudyCircleServiceInterface interface {
 	GetStreakRanking(circleID, userID uint) ([]model.CircleMemberStreak, error)
 	GetByStatus(userID uint, status string) ([]model.StudyCircle, error)
 	UpdateMemberRole(circleID, userID, targetUserID uint, role string) error
+	SearchCircles(query string, limit, offset int) ([]model.StudyCircle, int64, error)
 }
 
 // StudyCircleHandler はスタディサークル関連のHTTPリクエストを処理する。
@@ -369,4 +370,26 @@ func (h *StudyCircleHandler) UpdateMemberRole(c *gin.Context) {
 	}
 
 	respondOK(c, domain.NewMessageResponse("メンバー役割を更新しました"))
+}
+
+// Search はスタディサークルをキーワード検索する。
+func (h *StudyCircleHandler) Search(c *gin.Context) {
+	query, ok := parseSearchQuery(c)
+	if !ok {
+		return
+	}
+	limit, offset := parseLimitOffset(c)
+
+	circles, total, err := h.service.SearchCircles(query, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.StudyCircleListResponse{
+		Circles: circles,
+		Total:   total,
+		Limit:   limit,
+		Offset:  offset,
+	})
 }

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -628,6 +628,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		roadmaps.DELETE("/:id/steps/:stepId", c.RoadmapHandler.DeleteStep)
 		roadmaps.POST("/:id/steps/batch-complete", c.RoadmapHandler.BatchCompleteSteps)
 		roadmaps.PUT("/:id/steps/reorder", c.RoadmapHandler.ReorderSteps)
+		roadmaps.GET("/my/stats", c.RoadmapHandler.GetMyStats)
 	}
 
 	// チャットルーム
@@ -728,6 +729,7 @@ func registerStudyCircleRoutes(g *gin.RouterGroup, c *di.Container) {
 		circles.POST("/:id/checkins", c.StudyCircleHandler.CreateCheckin)
 		circles.GET("/:id/checkins", c.StudyCircleHandler.GetCheckins)
 		circles.GET("/:id/streak-ranking", c.StudyCircleHandler.GetStreakRanking)
+		circles.GET("/search", c.StudyCircleHandler.Search)
 	}
 }
 


### PR DESCRIPTION
## 概要
- Service層に実装済みだがHandler層で未公開だった2つのメソッドのエンドポイントを追加

## 新規エンドポイント
1. **GET /roadmaps/my/stats** — 認証ユーザーのロードマップ統計（総数/進行中/完了/ステップ数）
2. **GET /study-circles/search?q=keyword** — スタディサークルのキーワード検索

## 変更内容
- `handler/roadmap.go`: GetStats をインターフェースに追加、GetMyStats ハンドラ追加
- `handler/study_circle.go`: SearchCircles をインターフェースに追加、Search ハンドラ追加
- `router/router.go`: 2ルート追加

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/... -v` 全テスト通過

close #2185