### PR TITLE
refactor: Createメソッドのインラインバリデーションをdomain.ValidateStringLengthに統一

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -34,14 +34,14 @@ func (s *BookReviewService) Create(review *model.BookReview) error {
 	if err := validateRating(review.Rating); err != nil {
 		return err
 	}
-	if len([]rune(strings.TrimSpace(review.Author))) > 200 {
-		return domain.NewError(domain.ErrCodeValidation, "著者名は200文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(review.Author, 0, 200, "著者名"); err != nil {
+		return err
 	}
-	if len([]rune(strings.TrimSpace(review.ISBN))) > 20 {
-		return domain.NewError(domain.ErrCodeValidation, "ISBNは20文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(review.ISBN, 0, 20, "ISBN"); err != nil {
+		return err
 	}
-	if len([]rune(strings.TrimSpace(review.Review))) > 10000 {
-		return domain.NewError(domain.ErrCodeValidation, "レビュー本文は10000文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(review.Review, 0, 10000, "レビュー本文"); err != nil {
+		return err
 	}
 	if review.TotalPages < 0 || review.TotalPages > 99999 {
 		return domain.NewError(domain.ErrCodeValidation, "総ページ数は0〜99999の範囲で指定してください", nil)

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -31,8 +31,8 @@ func (s *CodeSnippetService) Create(snippet *model.CodeSnippet) (*model.CodeSnip
 	if err := domain.ValidateStringLength(snippet.Code, 1, 50000, "コード"); err != nil {
 		return nil, err
 	}
-	if len([]rune(snippet.FileName)) > 200 {
-		return nil, domain.NewError(domain.ErrCodeValidation, "ファイル名は200文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(snippet.FileName, 0, 200, "ファイル名"); err != nil {
+		return nil, err
 	}
 	snippet.Language = strings.TrimSpace(snippet.Language)
 	snippet.Code = strings.TrimSpace(snippet.Code)

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -24,8 +24,8 @@ func (s *PostCollectionService) Create(collection *model.PostCollection) (*model
 	if err := domain.ValidateStringLength(collection.Title, 1, 200, "タイトル"); err != nil {
 		return nil, err
 	}
-	if len([]rune(strings.TrimSpace(collection.Description))) > 1000 {
-		return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(collection.Description, 0, 1000, "説明"); err != nil {
+		return nil, err
 	}
 	collection.Title = strings.TrimSpace(collection.Title)
 	if err := s.repo.Create(collection); err != nil {
@@ -101,8 +101,8 @@ func (s *PostCollectionService) Delete(id, userID uint) error {
 // AddPost は所有権を検証した後、コレクションに投稿を追加する。
 // 同じ投稿がすでに追加されている場合はエラーを返す。
 func (s *PostCollectionService) AddPost(collectionID, userID, postID uint, note string) error {
-	if len([]rune(strings.TrimSpace(note))) > 500 {
-		return domain.NewError(domain.ErrCodeValidation, "メモは500文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(note, 0, 500, "メモ"); err != nil {
+		return err
 	}
 
 	if _, err := s.findAndCheckOwnership(collectionID, userID); err != nil {

--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -24,8 +24,8 @@ func (s *PostSeriesService) Create(series *model.PostSeries) error {
 	if err := domain.ValidateStringLength(series.Title, 1, 200, "タイトル"); err != nil {
 		return err
 	}
-	if len([]rune(series.Description)) > 1000 {
-		return domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(series.Description, 0, 1000, "説明"); err != nil {
+		return err
 	}
 	series.Title = strings.TrimSpace(series.Title)
 	return s.repo.Create(series)

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -32,8 +32,8 @@ func (s *RoadmapService) Create(roadmap *model.Roadmap) error {
 	if err := domain.ValidateStringLength(roadmap.Title, 1, 200, "タイトル"); err != nil {
 		return err
 	}
-	if len([]rune(roadmap.Description)) > 1000 {
-		return domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(roadmap.Description, 0, 1000, "説明"); err != nil {
+		return err
 	}
 	roadmap.Title = strings.TrimSpace(roadmap.Title)
 	return s.repo.Create(roadmap)


### PR DESCRIPTION
## 概要
- Create メソッドの `len([]rune(...)) > N` インラインチェックを `domain.ValidateStringLength()` に統一
- エラーメッセージ形式の一貫性を確保

## 変更内容（8箇所）
- **book_review.go**: Author(200), ISBN(20), Review(10000)
- **code_snippet.go**: FileName(200)
- **roadmap.go**: Description(1000)
- **post_series.go**: Description(1000)
- **post_collection.go**: Description(1000), Note(500)

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/... -v` 全テスト通過

close #2187