### PR TITLE
test: BookReview TotalPagesとPostCollection Noteのバリデーションテスト追加

### DIFF
--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -791,6 +791,39 @@ func TestBookReviewUpdate_ISBNTooLong(t *testing.T) {
 }
 
 // ============================================================
+// TotalPages バリデーションテスト
+// ============================================================
+
+func TestBookReviewCreate_TotalPagesNegative(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{Title: "テスト本", UserID: 1, Rating: 4, TotalPages: -1}
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "総ページ数は0〜99999")
+}
+
+func TestBookReviewCreate_TotalPagesTooLarge(t *testing.T) {
+	svc, _ := newTestBookReviewService()
+
+	review := &model.BookReview{Title: "テスト本", UserID: 1, Rating: 4, TotalPages: 100000}
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "総ページ数は0〜99999")
+}
+
+func TestBookReviewCreate_TotalPagesAtMaxLimit(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	review := &model.BookReview{Title: "テスト本", UserID: 1, Rating: 4, TotalPages: 99999}
+	repo.On("Create", review).Return(nil)
+
+	err := svc.Create(review)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}
+
+// ============================================================
 // CountByUserID テスト
 // ============================================================
 

--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -509,3 +509,31 @@ func TestGetCollectionsForViewer_OtherUserRepoError(t *testing.T) {
 	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// AddPost メモバリデーションテスト
+// ============================================================
+
+func TestPostCollectionAddPost_NoteTooLong(t *testing.T) {
+	svc, _ := newTestPostCollectionService()
+
+	longNote := strings.Repeat("あ", 501)
+	err := svc.AddPost(1, 1, 1, longNote)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "メモは500文字以下")
+}
+
+func TestPostCollectionAddPost_NoteAtLimit(t *testing.T) {
+	svc, repo := newTestPostCollectionService()
+
+	collection := &model.PostCollection{UserID: 1}
+	collection.ID = 1
+	repo.On("FindByID", uint(1)).Return(collection, nil)
+	repo.On("HasPost", uint(1), uint(10)).Return(false, nil)
+	repo.On("AddPost", mock.AnythingOfType("*model.PostCollectionItem")).Return(nil)
+
+	note := strings.Repeat("あ", 500)
+	err := svc.AddPost(1, 1, 10, note)
+	assert.NoError(t, err)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- Cycle 14 Phase 4 で追加した入力バリデーションのテストを追加

## テストケース
- **book_review_test.go**: TotalPages 負値/上限超過/上限値（3テスト）
- **post_collection_test.go**: Note 上限超過/上限値（2テスト）

## テスト
- `go test ./internal/service/... -run "TotalPages|NoteTooLong|NoteAtLimit" -v` 全7テスト通過

close #2189