### PR TITLE
fix: StudyCircle.CreateにTopicとDescriptionのバリデーション追加

### DIFF
--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -49,6 +49,12 @@ func (s *StudyCircleService) Create(circle *model.StudyCircle, memberIDs []uint)
 	if err := domain.ValidateStringLength(circle.Name, 1, 100, "サークル名"); err != nil {
 		return err
 	}
+	if err := domain.ValidateStringLength(circle.Topic, 0, 200, "トピック"); err != nil {
+		return err
+	}
+	if err := domain.ValidateStringLength(circle.Description, 0, 1000, "説明"); err != nil {
+		return err
+	}
 	circle.Name = strings.TrimSpace(circle.Name)
 	if circle.MaxMembers < 3 || circle.MaxMembers > 10 {
 		circle.MaxMembers = 5


### PR DESCRIPTION
## 概要
- StudyCircleService.Create で Topic と Description のバリデーションが欠如していた
- Update メソッドでは検証されていたが、Create では検証されていなかった

## 変更内容
- Topic: 0〜200文字のバリデーション追加
- Description: 0〜1000文字のバリデーション追加
- `domain.ValidateStringLength` を使用して既存パターンに統一

## テスト
- `go test ./internal/service/... -v` 全テスト通過

close #2191