### PR TITLE
feat: 投稿の自分の一覧取得エンドポイント（GET /posts/my）追加

### DIFF
--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -229,6 +229,25 @@ func (h *PostHandler) GetUserPosts(c *gin.Context) {
 	})
 }
 
+// GetMyPosts は認証ユーザー自身の投稿一覧を取得する。
+func (h *PostHandler) GetMyPosts(c *gin.Context) {
+	userID := c.GetUint("userID")
+	limit, offset := parseLimitOffset(c)
+
+	posts, total, err := h.service.GetByUserID(userID, limit, offset)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, dto.PostListResponse{
+		Posts:  ensureSlice(posts),
+		Total:  total,
+		Limit:  limit,
+		Offset: offset,
+	})
+}
+
 // Like は投稿にいいねする。
 func (h *PostHandler) Like(c *gin.Context) {
 	handleToggleAction(c, h.service.Like, "liked")

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -188,6 +188,7 @@ func registerPostRoutes(g *gin.RouterGroup, c *di.Container) {
 		posts.POST("", c.PostHandler.Create)
 		posts.GET("", c.PostHandler.GetAll)
 		posts.GET("/timeline", c.PostHandler.Timeline)
+		posts.GET("/my", c.PostHandler.GetMyPosts)
 		posts.GET("/drafts", c.PostHandler.GetDrafts)
 		posts.PUT("/drafts/auto-save", c.PostHandler.AutoSaveDraft)
 		posts.GET("/:id", c.PostHandler.GetByID)


### PR DESCRIPTION
## 概要
- 他リソース（projects/my, book-reviews/my 等）と統一し、認証ユーザー自身の投稿一覧を取得するエンドポイントを追加

## 新規エンドポイント
- **GET /posts/my** — 認証ユーザーの投稿一覧（ページネーション付き）

## 変更内容
- `handler/post.go`: GetMyPosts メソッド追加
- `router/router.go`: GET /posts/my ルート追加

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/... -v` 全テスト通過

close #2193