### PR TITLE
refactor: UpdateメソッドのインラインバリデーションをValidateStringLengthに統一

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -95,20 +95,20 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Title, 1, 200, "タイトル"); err != nil {
+			return nil, err
 		}
 		review.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Author) != "" {
-		if len([]rune(strings.TrimSpace(updates.Author))) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "著者名は200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Author, 1, 200, "著者名"); err != nil {
+			return nil, err
 		}
 		review.Author = strings.TrimSpace(updates.Author)
 	}
 	if strings.TrimSpace(updates.ISBN) != "" {
-		if len([]rune(strings.TrimSpace(updates.ISBN))) > 20 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "ISBNは20文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.ISBN, 1, 20, "ISBN"); err != nil {
+			return nil, err
 		}
 		review.ISBN = strings.TrimSpace(updates.ISBN)
 	}
@@ -119,8 +119,8 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		review.Rating = updates.Rating
 	}
 	if strings.TrimSpace(updates.Review) != "" {
-		if len([]rune(strings.TrimSpace(updates.Review))) > 10000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "レビュー本文は10000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Review, 1, 10000, "レビュー本文"); err != nil {
+			return nil, err
 		}
 		review.Review = strings.TrimSpace(updates.Review)
 	}

--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -90,20 +90,14 @@ func (s *ChatRoomService) Update(roomID, userID uint, name, description string) 
 	}
 
 	if name != "" {
-		if strings.TrimSpace(name) == "" {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "チャットルーム名は空白のみでは入力できません", nil)
-		}
-		if len([]rune(strings.TrimSpace(name))) > 100 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "チャットルーム名は100文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(name, 1, 100, "チャットルーム名"); err != nil {
+			return nil, err
 		}
 		room.Name = strings.TrimSpace(name)
 	}
 	if description != "" {
-		if strings.TrimSpace(description) == "" {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "説明は空白のみでは入力できません", nil)
-		}
-		if len([]rune(strings.TrimSpace(description))) > 500 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "説明は500文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(description, 1, 500, "説明"); err != nil {
+			return nil, err
 		}
 		room.Description = strings.TrimSpace(description)
 	}

--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -637,7 +637,7 @@ func TestChatRoomUpdate_WhitespaceName(t *testing.T) {
 	result, err := svc.Update(10, 1, "   ", "Valid description")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "空白のみ")
+	assert.Contains(t, err.Error(), "チャットルーム名を入力してください")
 }
 
 func TestChatRoomUpdate_WhitespaceDescription(t *testing.T) {
@@ -650,5 +650,5 @@ func TestChatRoomUpdate_WhitespaceDescription(t *testing.T) {
 	result, err := svc.Update(10, 1, "New Name", "   \t  ")
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "空白のみ")
+	assert.Contains(t, err.Error(), "説明を入力してください")
 }

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -88,20 +88,20 @@ func (s *CodeSnippetService) Update(id, userID uint, language, fileName, code st
 	}
 
 	if strings.TrimSpace(language) != "" {
-		if len([]rune(strings.TrimSpace(language))) > 100 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "言語は100文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(language, 1, 100, "言語"); err != nil {
+			return nil, err
 		}
 		snippet.Language = strings.TrimSpace(language)
 	}
 	if strings.TrimSpace(fileName) != "" {
-		if len([]rune(strings.TrimSpace(fileName))) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "ファイル名は200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(fileName, 1, 200, "ファイル名"); err != nil {
+			return nil, err
 		}
 		snippet.FileName = strings.TrimSpace(fileName)
 	}
 	if strings.TrimSpace(code) != "" {
-		if len([]rune(strings.TrimSpace(code))) > 50000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "コードは50000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(code, 1, 50000, "コード"); err != nil {
+			return nil, err
 		}
 		snippet.Code = strings.TrimSpace(code)
 	}

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -100,14 +100,14 @@ func (s *LearningGoalService) Update(id, userID uint, updates *model.LearningGoa
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Title, 1, 200, "タイトル"); err != nil {
+			return nil, err
 		}
 		goal.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		if len([]rune(strings.TrimSpace(updates.Description))) > 1000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Description, 1, 1000, "説明"); err != nil {
+			return nil, err
 		}
 		goal.Description = strings.TrimSpace(updates.Description)
 	}

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -72,8 +72,8 @@ func (s *PostCollectionService) Update(id, userID uint, title, description strin
 	if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
 		return nil, err
 	}
-	if len([]rune(strings.TrimSpace(description))) > 1000 {
-		return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(description, 0, 1000, "説明"); err != nil {
+		return nil, err
 	}
 	collection, err := s.findAndCheckOwnership(id, userID)
 	if err != nil {

--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -60,20 +60,14 @@ func (s *PostSeriesService) Update(id, userID uint, updates *model.PostSeries) (
 	}
 
 	if updates.Title != "" {
-		if strings.TrimSpace(updates.Title) == "" {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみでは入力できません", nil)
-		}
-		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Title, 1, 200, "タイトル"); err != nil {
+			return nil, err
 		}
 		series.Title = strings.TrimSpace(updates.Title)
 	}
 	if updates.Description != "" {
-		if strings.TrimSpace(updates.Description) == "" {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "説明は空白のみでは入力できません", nil)
-		}
-		if len([]rune(strings.TrimSpace(updates.Description))) > 1000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Description, 1, 1000, "説明"); err != nil {
+			return nil, err
 		}
 		series.Description = strings.TrimSpace(updates.Description)
 	}

--- a/backend/internal/service/post_series_test.go
+++ b/backend/internal/service/post_series_test.go
@@ -486,7 +486,7 @@ func TestPostSeriesUpdate_WhitespaceTitle(t *testing.T) {
 	result, err := svc.Update(1, 1, updates)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "空白のみ")
+	assert.Contains(t, err.Error(), "タイトルを入力してください")
 }
 
 func TestPostSeriesUpdate_WhitespaceDescription(t *testing.T) {
@@ -501,7 +501,7 @@ func TestPostSeriesUpdate_WhitespaceDescription(t *testing.T) {
 	result, err := svc.Update(1, 1, updates)
 	assert.Error(t, err)
 	assert.Nil(t, result)
-	assert.Contains(t, err.Error(), "空白のみ")
+	assert.Contains(t, err.Error(), "説明を入力してください")
 }
 
 func TestPostSeriesUpdate_Description(t *testing.T) {

--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -81,8 +81,8 @@ func (s *ProjectService) Update(id, userID uint, updates *model.Project) (*model
 		project.Description = strings.TrimSpace(updates.Description)
 	}
 	if strings.TrimSpace(updates.TechStack) != "" {
-		if len([]rune(strings.TrimSpace(updates.TechStack))) > 500 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "技術スタックは500文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.TechStack, 1, 500, "技術スタック"); err != nil {
+			return nil, err
 		}
 		project.TechStack = strings.TrimSpace(updates.TechStack)
 	}
@@ -96,8 +96,8 @@ func (s *ProjectService) Update(id, userID uint, updates *model.Project) (*model
 		project.ImageURL = strings.TrimSpace(updates.ImageURL)
 	}
 	if strings.TrimSpace(updates.Role) != "" {
-		if len([]rune(strings.TrimSpace(updates.Role))) > 100 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "役割は100文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Role, 1, 100, "役割"); err != nil {
+			return nil, err
 		}
 		project.Role = strings.TrimSpace(updates.Role)
 	}

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -104,14 +104,14 @@ func (s *RoadmapService) Update(id, userID uint, updates *model.Roadmap) (*model
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Title, 1, 200, "タイトル"); err != nil {
+			return nil, err
 		}
 		roadmap.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		if len([]rune(strings.TrimSpace(updates.Description))) > 1000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Description, 1, 1000, "説明"); err != nil {
+			return nil, err
 		}
 		roadmap.Description = strings.TrimSpace(updates.Description)
 	}
@@ -186,20 +186,20 @@ func (s *RoadmapService) UpdateStep(roadmapID, stepID, userID uint, updates *mod
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		if len([]rune(strings.TrimSpace(updates.Title))) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Title, 1, 200, "タイトル"); err != nil {
+			return nil, err
 		}
 		step.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Description) != "" {
-		if len([]rune(strings.TrimSpace(updates.Description))) > 1000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Description, 1, 1000, "説明"); err != nil {
+			return nil, err
 		}
 		step.Description = strings.TrimSpace(updates.Description)
 	}
 	if strings.TrimSpace(updates.ResourceURL) != "" {
-		if len([]rune(strings.TrimSpace(updates.ResourceURL))) > 500 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "リソースURLは500文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.ResourceURL, 1, 500, "リソースURL"); err != nil {
+			return nil, err
 		}
 		step.ResourceURL = strings.TrimSpace(updates.ResourceURL)
 	}

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -124,26 +124,20 @@ func (s *StudyCircleService) Update(id, userID uint, name, topic, description *s
 	}
 
 	if name != nil {
-		if strings.TrimSpace(*name) == "" {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "サークル名は空白のみでは入力できません", nil)
-		}
-		if len([]rune(strings.TrimSpace(*name))) > 100 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "サークル名は100文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(*name, 1, 100, "サークル名"); err != nil {
+			return nil, err
 		}
 		circle.Name = strings.TrimSpace(*name)
 	}
 	if topic != nil {
-		if strings.TrimSpace(*topic) == "" {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "トピックは空白のみでは入力できません", nil)
-		}
-		if len([]rune(strings.TrimSpace(*topic))) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "トピックは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(*topic, 1, 200, "トピック"); err != nil {
+			return nil, err
 		}
 		circle.Topic = strings.TrimSpace(*topic)
 	}
 	if description != nil {
-		if len([]rune(strings.TrimSpace(*description))) > 1000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(*description, 0, 1000, "説明"); err != nil {
+			return nil, err
 		}
 		circle.Description = *description
 	}
@@ -273,17 +267,14 @@ func (s *StudyCircleService) UpdateStep(circleID, userID, stepID uint, title, de
 	}
 
 	if title != nil {
-		if strings.TrimSpace(*title) == "" {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみでは入力できません", nil)
-		}
-		if len([]rune(strings.TrimSpace(*title))) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(*title, 1, 200, "タイトル"); err != nil {
+			return nil, err
 		}
 		step.Title = strings.TrimSpace(*title)
 	}
 	if description != nil {
-		if len([]rune(strings.TrimSpace(*description))) > 1000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(*description, 0, 1000, "説明"); err != nil {
+			return nil, err
 		}
 		step.Description = *description
 	}


### PR DESCRIPTION
## 概要
- 9ファイル・11メソッドの`len([]rune(strings.TrimSpace(...)))`パターンと関連する空白チェックを`domain.ValidateStringLength()`に統一
- Cycle 15 Phase 2 でCreateメソッドは統一済み、今回はUpdateメソッドを対象

## 変更対象
| ファイル | メソッド | 置換数 |
|----------|----------|--------|
| study_circle.go | Update, UpdateStep | 5 |
| code_snippet.go | Update | 3 |
| post_collection.go | Update | 1 |
| post_series.go | Update | 2 |
| roadmap.go | Update, UpdateStep | 5 |
| book_review.go | Update | 4 |
| learning_goal.go | Update | 2 |
| project.go | Update | 2 |
| chat_room.go | Update | 2 |

## テスト
- `go test ./internal/service/... -count=1` 全テスト通過
- 空白チェックテスト4件を新メッセージ形式に更新

Closes #2195