### PR TITLE
test: Update系バリデーションテスト追加（Project TechStack/Role, CodeSnippet FileName）

### DIFF
--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -490,6 +490,18 @@ func TestSnippetUpdate_CodeTooLong(t *testing.T) {
 	assert.Contains(t, err.Error(), "コードは50000文字以下")
 }
 
+func TestSnippetUpdate_FileNameTooLong(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+	existing := &model.CodeSnippet{PostID: 5, UserID: 1, Language: "go", FileName: "main.go", Code: "package main"}
+	existing.ID = 10
+	snippetRepo.On("FindByID", uint(10)).Return(existing, nil)
+
+	result, err := svc.Update(10, 1, "", strings.Repeat("a", 201), "")
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "ファイル名は200文字以下")
+}
+
 func TestSnippetCreateComment_ContentTooLong(t *testing.T) {
 	svc, _, _ := newTestCodeSnippetService()
 

--- a/backend/internal/service/project_test.go
+++ b/backend/internal/service/project_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -463,6 +464,30 @@ func TestProjectUpdate_TrimsPaddedTitle(t *testing.T) {
 	result, err := svc.Update(1, 1, &model.Project{Title: "  New Title  "})
 	assert.NoError(t, err)
 	assert.Equal(t, "New Title", result.Title)
+}
+
+func TestProjectUpdate_TechStackTooLong(t *testing.T) {
+	svc, repo := newTestProjectService()
+	existing := &model.Project{Title: "Project", Description: "Desc", TechStack: "Go", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	result, err := svc.Update(1, 1, &model.Project{TechStack: strings.Repeat("a", 501)})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "技術スタックは500文字以下")
+}
+
+func TestProjectUpdate_RoleTooLong(t *testing.T) {
+	svc, repo := newTestProjectService()
+	existing := &model.Project{Title: "Project", Description: "Desc", Role: "Backend", UserID: 1}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	result, err := svc.Update(1, 1, &model.Project{Role: strings.Repeat("a", 101)})
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "役割は100文字以下")
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
- ValidateStringLengthに統一済みのUpdateメソッドで不足していたバリデーションテストを3件追加

## 追加テスト
| ファイル | テスト名 | 検証内容 |
|----------|----------|----------|
| project_test.go | TestProjectUpdate_TechStackTooLong | 技術スタック501文字でエラー |
| project_test.go | TestProjectUpdate_RoleTooLong | 役割101文字でエラー |
| code_snippet_test.go | TestSnippetUpdate_FileNameTooLong | ファイル名201文字でエラー |

## テスト
- `go test ./internal/service/... -count=1` 全テスト通過

Closes #2197