### PR TITLE
fix: BookReview.UpdateにTotalPages範囲チェックを追加

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -124,6 +124,12 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		}
 		review.Review = strings.TrimSpace(updates.Review)
 	}
+	if updates.TotalPages != 0 {
+		if updates.TotalPages < 0 || updates.TotalPages > 99999 {
+			return nil, domain.NewError(domain.ErrCodeValidation, "総ページ数は0〜99999の範囲で指定してください", nil)
+		}
+		review.TotalPages = updates.TotalPages
+	}
 	if strings.TrimSpace(updates.ImageURL) != "" {
 		review.ImageURL = strings.TrimSpace(updates.ImageURL)
 	}

--- a/backend/internal/service/book_review_test.go
+++ b/backend/internal/service/book_review_test.go
@@ -823,6 +823,49 @@ func TestBookReviewCreate_TotalPagesAtMaxLimit(t *testing.T) {
 	repo.AssertExpectations(t)
 }
 
+func TestBookReviewUpdate_TotalPagesNegative(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "テスト本", Rating: 4, TotalPages: 300}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.BookReview{TotalPages: -1}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "総ページ数は0〜99999")
+}
+
+func TestBookReviewUpdate_TotalPagesTooLarge(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "テスト本", Rating: 4, TotalPages: 300}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+
+	updates := &model.BookReview{TotalPages: 100000}
+	result, err := svc.Update(1, 1, updates)
+	assert.Error(t, err)
+	assert.Nil(t, result)
+	assert.Contains(t, err.Error(), "総ページ数は0〜99999")
+}
+
+func TestBookReviewUpdate_TotalPagesValid(t *testing.T) {
+	svc, repo := newTestBookReviewService()
+
+	existing := &model.BookReview{UserID: 1, Title: "テスト本", Rating: 4, TotalPages: 300}
+	existing.ID = 1
+	repo.On("FindByID", uint(1)).Return(existing, nil)
+	repo.On("Update", existing).Return(nil)
+
+	updates := &model.BookReview{TotalPages: 500}
+	result, err := svc.Update(1, 1, updates)
+	assert.NoError(t, err)
+	assert.Equal(t, 500, result.TotalPages)
+	repo.AssertExpectations(t)
+}
+
 // ============================================================
 // CountByUserID テスト
 // ============================================================


### PR DESCRIPTION
## 概要
- BookReviewService.Update にTotalPages の範囲チェック（0〜99999）を追加
- Createメソッドには既にあったがUpdateには欠けていた

## 変更内容
- `book_review.go`: Update メソッドに TotalPages 更新ロジック + 範囲チェック追加
- `book_review_test.go`: テスト3件追加（負値、超大値、正常値）

## テスト
- `go test ./internal/service/... -count=1` 全テスト通過

Closes #2199