### PR TITLE
feat: メッセージ既読エンドポイント追加（PUT /messages/:userId/read）

### DIFF
--- a/backend/internal/handler/message.go
+++ b/backend/internal/handler/message.go
@@ -11,6 +11,7 @@ type MessageServiceInterface interface {
 	GetConversations(userID uint) ([]model.ConversationSummary, error)
 	GetConversation(userID, otherUserID uint, page, limit int) ([]model.Message, error)
 	SendMessage(msg *model.Message) error
+	MarkAsRead(senderID, receiverID uint) error
 }
 
 // MessageHandler はDM（ダイレクトメッセージ）関連のHTTPハンドラ。
@@ -51,6 +52,21 @@ func (h *MessageHandler) GetMessages(c *gin.Context) {
 		return
 	}
 	respondOK(c, ensureSlice(messages))
+}
+
+// MarkAsRead は指定ユーザーからのメッセージを既読にマークする。
+func (h *MessageHandler) MarkAsRead(c *gin.Context) {
+	userID := c.GetUint("userID")
+	senderID, ok := parseID(c, "userId")
+	if !ok {
+		return
+	}
+
+	if err := h.service.MarkAsRead(senderID, userID); err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"message": "既読にしました"})
 }
 
 // SendMessage は指定ユーザーにDMを送信する。

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1489,6 +1489,9 @@ func (m *MockMessageService) GetConversation(userID, otherUserID uint, page, lim
 func (m *MockMessageService) SendMessage(msg *model.Message) error {
 	return m.Called(msg).Error(0)
 }
+func (m *MockMessageService) MarkAsRead(senderID, receiverID uint) error {
+	return m.Called(senderID, receiverID).Error(0)
+}
 
 // setupMessageHandler はMessageHandlerテスト用のセットアップを行う。
 func setupMessageHandler() (*MessageHandler, *MockMessageService) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -314,6 +314,7 @@ func registerMessageRoutes(g *gin.RouterGroup, c *di.Container) {
 		messages.GET("", c.MessageHandler.GetConversations)
 		messages.GET("/:userId", c.MessageHandler.GetMessages)
 		messages.POST("/:userId", c.MessageHandler.SendMessage)
+		messages.PUT("/:userId/read", c.MessageHandler.MarkAsRead)
 	}
 }
 


### PR DESCRIPTION
## 概要
- MessageService.MarkAsRead をエンドポイントとして公開
- 現在は GetConversation 内で暗黙的に既読処理されるのみで、明示的な既読APIがなかった

## 変更内容
- `handler/message.go`: MessageServiceInterface に MarkAsRead 追加、ハンドラーメソッド追加
- `router/router.go`: `PUT /messages/:userId/read` ルート追加
- `handler/testutil_test.go`: MockMessageService にモックメソッド追加

## テスト
- `go build ./...` ビルド通過
- `go test ./internal/service/... -count=1` 全テスト通過

Closes #2201