### PR TITLE
test: 最近追加したエンドポイントのハンドラーテスト追加

### DIFF
--- a/backend/internal/handler/message_test.go
+++ b/backend/internal/handler/message_test.go
@@ -132,3 +132,41 @@ func TestMessage_GetMessages_ServiceError(t *testing.T) {
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }
+
+// ============================================================
+// MarkAsRead テスト
+// ============================================================
+
+func TestMessage_MarkAsRead_Success(t *testing.T) {
+	h, svc := setupMessageHandler()
+	svc.On("MarkAsRead", uint(5), uint(1)).Return(nil)
+
+	r := newRouter(1)
+	r.PUT("/messages/:userId/read", h.MarkAsRead)
+
+	w := doRequest(r, http.MethodPut, "/messages/5/read", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestMessage_MarkAsRead_InvalidID(t *testing.T) {
+	h, _ := setupMessageHandler()
+
+	r := newRouter(1)
+	r.PUT("/messages/:userId/read", h.MarkAsRead)
+
+	w := doRequest(r, http.MethodPut, "/messages/abc/read", nil)
+	assertStatus(t, w, http.StatusBadRequest)
+}
+
+func TestMessage_MarkAsRead_ServiceError(t *testing.T) {
+	h, svc := setupMessageHandler()
+	svc.On("MarkAsRead", uint(5), uint(1)).Return(errors.New("db error"))
+
+	r := newRouter(1)
+	r.PUT("/messages/:userId/read", h.MarkAsRead)
+
+	w := doRequest(r, http.MethodPut, "/messages/5/read", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/post_test.go
+++ b/backend/internal/handler/post_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -1320,4 +1321,34 @@ func TestPostGetReactionsBatch_ServiceError(t *testing.T) {
 		"post_ids": []uint{1},
 	})
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// GetMyPosts テスト
+// ============================================================
+
+func TestPostGetMyPosts_Success(t *testing.T) {
+	h, postRepo, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.GET("/posts/my", h.GetMyPosts)
+
+	postRepo.On("FindByUserID", uint(1), 20, 0).Return([]model.Post{
+		{Title: "My Post 1"}, {Title: "My Post 2"},
+	}, int64(2), nil)
+
+	w := doRequest(r, http.MethodGet, "/posts/my", nil)
+	assertStatus(t, w, http.StatusOK)
+	postRepo.AssertExpectations(t)
+}
+
+func TestPostGetMyPosts_ServiceError(t *testing.T) {
+	h, postRepo, _, _ := setupPostHandler()
+	r := newRouter(1)
+	r.GET("/posts/my", h.GetMyPosts)
+
+	postRepo.On("FindByUserID", uint(1), 20, 0).Return([]model.Post(nil), int64(0), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/posts/my", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	postRepo.AssertExpectations(t)
 }

--- a/backend/internal/handler/roadmap_test.go
+++ b/backend/internal/handler/roadmap_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -640,4 +641,33 @@ func TestRoadmapReorderSteps_InvalidID(t *testing.T) {
 		"orders": []map[string]interface{}{{"step_id": 1, "order_index": 0}},
 	})
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// GetMyStats テスト
+// ============================================================
+
+func TestRoadmapGetMyStats_Success(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps/my/stats", h.GetMyStats)
+
+	stats := &model.RoadmapStats{TotalRoadmaps: 3, ActiveRoadmaps: 2, CompletedRoadmaps: 1, TotalSteps: 10, CompletedSteps: 5}
+	svc.On("GetStats", uint(1)).Return(stats, nil)
+
+	w := doRequest(r, http.MethodGet, "/roadmaps/my/stats", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestRoadmapGetMyStats_ServiceError(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps/my/stats", h.GetMyStats)
+
+	svc.On("GetStats", uint(1)).Return(nil, errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/roadmaps/my/stats", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
 }


### PR DESCRIPTION
## 概要
- 最近のサイクルで追加したエンドポイントのハンドラーテストが欠けていたため追加

## 追加テスト（7件）
| ファイル | テスト名 | 検証内容 |
|----------|----------|----------|
| post_test.go | TestPostGetMyPosts_Success | 正常系 |
| post_test.go | TestPostGetMyPosts_ServiceError | サービスエラー |
| roadmap_test.go | TestRoadmapGetMyStats_Success | 正常系 |
| roadmap_test.go | TestRoadmapGetMyStats_ServiceError | サービスエラー |
| message_test.go | TestMessage_MarkAsRead_Success | 正常系 |
| message_test.go | TestMessage_MarkAsRead_InvalidID | 無効ID |
| message_test.go | TestMessage_MarkAsRead_ServiceError | サービスエラー |

## テスト
- `go test ./internal/handler/... -count=1` 全テスト通過
- `go test ./internal/service/... -count=1` 全テスト通過

Closes #2205