### PR TITLE
fix: URLフィールドの長さ制限追加（ImageURL, DemoURL, GithubURL）

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -131,6 +131,9 @@ func (s *BookReviewService) Update(id, userID uint, updates *model.BookReview) (
 		review.TotalPages = updates.TotalPages
 	}
 	if strings.TrimSpace(updates.ImageURL) != "" {
+		if err := domain.ValidateStringLength(updates.ImageURL, 1, 2000, "画像URL"); err != nil {
+			return nil, err
+		}
 		review.ImageURL = strings.TrimSpace(updates.ImageURL)
 	}
 

--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -134,6 +134,9 @@ func (s *LearningResourceService) Update(id, userID uint, updates *model.Learnin
 		resource.Tags = updates.Tags
 	}
 	if updates.ImageURL != "" {
+		if err := domain.ValidateStringLength(updates.ImageURL, 1, 2000, "画像URL"); err != nil {
+			return nil, err
+		}
 		resource.ImageURL = updates.ImageURL
 	}
 

--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -87,12 +87,21 @@ func (s *ProjectService) Update(id, userID uint, updates *model.Project) (*model
 		project.TechStack = strings.TrimSpace(updates.TechStack)
 	}
 	if strings.TrimSpace(updates.DemoURL) != "" {
+		if err := domain.ValidateStringLength(updates.DemoURL, 1, 2000, "デモURL"); err != nil {
+			return nil, err
+		}
 		project.DemoURL = strings.TrimSpace(updates.DemoURL)
 	}
 	if strings.TrimSpace(updates.GithubURL) != "" {
+		if err := domain.ValidateStringLength(updates.GithubURL, 1, 2000, "GitHub URL"); err != nil {
+			return nil, err
+		}
 		project.GithubURL = strings.TrimSpace(updates.GithubURL)
 	}
 	if strings.TrimSpace(updates.ImageURL) != "" {
+		if err := domain.ValidateStringLength(updates.ImageURL, 1, 2000, "画像URL"); err != nil {
+			return nil, err
+		}
 		project.ImageURL = strings.TrimSpace(updates.ImageURL)
 	}
 	if strings.TrimSpace(updates.Role) != "" {


### PR DESCRIPTION
## 概要
- 複数のUpdateメソッドでURLフィールドに長さ制限がなかった
- 過剰な長さのURLでDB肥大化のリスクがあるため2000文字制限を追加

## 変更内容
| ファイル | フィールド | 制限 |
|----------|----------|------|
| book_review.go | ImageURL | 2000文字 |
| project.go | DemoURL | 2000文字 |
| project.go | GithubURL | 2000文字 |
| project.go | ImageURL | 2000文字 |
| learning_resource.go | ImageURL | 2000文字 |

## テスト
- `go test ./internal/service/... -count=1` 全テスト通過

Closes #2207