### PR TITLE
feat: 投稿数カウントエンドポイント追加（GET /posts/my/count）

### DIFF
--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -46,6 +46,7 @@ type PostServiceInterface interface {
 	CancelSchedule(id, userID uint) (*model.Post, error)
 	GetScheduled(userID uint) ([]model.Post, error)
 	AutoSaveDraft(userID, draftID uint, title, content, imageURLs string) (*model.Post, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // CodeSnippetServiceInterface はCodeSnippetServiceが実装すべきインターフェース。
@@ -246,6 +247,19 @@ func (h *PostHandler) GetMyPosts(c *gin.Context) {
 		Limit:  limit,
 		Offset: offset,
 	})
+}
+
+// GetMyCount は認証ユーザーの投稿数を返す。
+func (h *PostHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"count": count})
 }
 
 // Like は投稿にいいねする。

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -164,6 +164,10 @@ func (m *MockPostRepository) FindScheduledByUserID(userID uint) ([]model.Post, e
 	args := m.Called(userID)
 	return args.Get(0).([]model.Post), args.Error(1)
 }
+func (m *MockPostRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 func (m *MockPostRepository) GetReplies(parentID uint) ([]model.Comment, error) {
 	args := m.Called(parentID)
 	return args.Get(0).([]model.Comment), args.Error(1)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -84,6 +84,7 @@ type PostRepositoryInterface interface {
 	GetReactionsBatch(postIDs []uint) (map[uint][]model.ReactionCount, error)
 	GetUserReactionsBatch(userID uint, postIDs []uint) (map[uint][]string, error)
 	FindScheduledByUserID(userID uint) ([]model.Post, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // FollowRepositoryInterface はフォロー関係データ操作の契約を定義する。

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -46,6 +46,13 @@ func (r *PostRepository) CountAll() (int64, error) {
 	return count, err
 }
 
+// CountByUserID は指定ユーザーの公開済み投稿数を返す。
+func (r *PostRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.Post{}).Where("user_id = ? AND is_draft = ?", userID, false).Count(&count).Error
+	return count, err
+}
+
 // FindByUserID は指定ユーザーの投稿をページネーション付きで取得する（新しい順）。下書きは除外。
 func (r *PostRepository) FindByUserID(userID uint, limit, offset int) ([]model.Post, int64, error) {
 	var posts []model.Post

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -189,6 +189,7 @@ func registerPostRoutes(g *gin.RouterGroup, c *di.Container) {
 		posts.GET("", c.PostHandler.GetAll)
 		posts.GET("/timeline", c.PostHandler.Timeline)
 		posts.GET("/my", c.PostHandler.GetMyPosts)
+		posts.GET("/my/count", c.PostHandler.GetMyCount)
 		posts.GET("/drafts", c.PostHandler.GetDrafts)
 		posts.PUT("/drafts/auto-save", c.PostHandler.AutoSaveDraft)
 		posts.GET("/:id", c.PostHandler.GetByID)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -240,6 +240,10 @@ func (m *MockPostRepository) FindScheduledByUserID(userID uint) ([]model.Post, e
 	args := m.Called(userID)
 	return args.Get(0).([]model.Post), args.Error(1)
 }
+func (m *MockPostRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 
 // ============================================================
 // MockFollowRepository は repository.FollowRepositoryInterface のテスト用モック実装。

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -79,6 +79,11 @@ func (s *PostService) CountAll() (int64, error) {
 	return s.repo.CountAll()
 }
 
+// CountByUserID は指定ユーザーの公開済み投稿数を取得する。
+func (s *PostService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}
+
 // GetByUserID は指定ユーザーの投稿をページネーション付きで取得する。
 func (s *PostService) GetByUserID(userID uint, limit, offset int) ([]model.Post, int64, error) {
 	return s.repo.FindByUserID(userID, limit, offset)


### PR DESCRIPTION
## 概要
- ユーザー自身の公開済み投稿数を取得するエンドポイントを追加
- 既存の `/post-series/my/count`, `/projects/my/count` 等と統一的なパターン

## 変更内容
- `repository/interfaces.go`: PostRepositoryInterface に CountByUserID 追加
- `repository/post.go`: CountByUserID 実装追加
- `service/post.go`: CountByUserID メソッド追加
- `handler/post.go`: PostServiceInterface に追加 + GetMyCount ハンドラー追加
- `router/router.go`: `GET /posts/my/count` ルート追加
- テストモック同期（service/mock_test.go, handler/testutil_test.go）

## テスト
- `go test ./internal/service/... -count=1` 全テスト通過
- `go test ./internal/handler/... -count=1` 全テスト通過

Closes #2209