### PR TITLE
refactor: 残りのlen([]rune(...))インラインバリデーションをValidateStringLengthに統一

### DIFF
--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -27,8 +27,8 @@ func (s *ChatRoomService) Create(room *model.ChatRoom, memberIDs []uint) (*model
 	if err := domain.ValidateStringLength(room.Name, 1, 100, "チャットルーム名"); err != nil {
 		return nil, err
 	}
-	if len([]rune(room.Description)) > 500 {
-		return nil, domain.NewError(domain.ErrCodeValidation, "説明は500文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(room.Description, 0, 500, "説明"); err != nil {
+		return nil, err
 	}
 	room.Name = strings.TrimSpace(room.Name)
 	if err := s.roomRepo.Create(room); err != nil {

--- a/backend/internal/service/learning_log_template.go
+++ b/backend/internal/service/learning_log_template.go
@@ -24,17 +24,14 @@ func NewLearningLogTemplateService(repo repository.LearningLogTemplateRepository
 
 // Create は新しいテンプレートを作成する。
 func (s *LearningLogTemplateService) Create(template *model.LearningLogTemplate) error {
-	if template.Name == "" {
-		return domain.NewError(domain.ErrCodeValidation, "テンプレート名は必須です", nil)
+	if err := domain.ValidateStringLength(template.Name, 1, 100, "テンプレート名"); err != nil {
+		return err
 	}
-	if len([]rune(template.Name)) > 100 {
-		return domain.NewError(domain.ErrCodeValidation, "テンプレート名は100文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(template.DefaultTitle, 0, 200, "デフォルトタイトル"); err != nil {
+		return err
 	}
-	if len([]rune(template.DefaultTitle)) > 200 {
-		return domain.NewError(domain.ErrCodeValidation, "デフォルトタイトルは200文字以下である必要があります", nil)
-	}
-	if len([]rune(template.DefaultContent)) > 50000 {
-		return domain.NewError(domain.ErrCodeValidation, "デフォルト本文は50000文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(template.DefaultContent, 0, 50000, "デフォルト本文"); err != nil {
+		return err
 	}
 	if template.DefaultCategory != "" && !model.ValidCategories[template.DefaultCategory] {
 		return domain.NewError(domain.ErrCodeValidation, "無効なカテゴリです", nil)
@@ -80,20 +77,20 @@ func (s *LearningLogTemplateService) Update(id, userID uint, name, defaultTitle,
 	}
 
 	if name != "" {
-		if len([]rune(name)) > 100 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "テンプレート名は100文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(name, 1, 100, "テンプレート名"); err != nil {
+			return nil, err
 		}
 		template.Name = name
 	}
 	if defaultTitle != "" {
-		if len([]rune(defaultTitle)) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "デフォルトタイトルは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(defaultTitle, 1, 200, "デフォルトタイトル"); err != nil {
+			return nil, err
 		}
 		template.DefaultTitle = defaultTitle
 	}
 	if defaultContent != "" {
-		if len([]rune(defaultContent)) > 50000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "デフォルト本文は50000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(defaultContent, 1, 50000, "デフォルト本文"); err != nil {
+			return nil, err
 		}
 		template.DefaultContent = defaultContent
 	}

--- a/backend/internal/service/learning_log_template_test.go
+++ b/backend/internal/service/learning_log_template_test.go
@@ -123,7 +123,7 @@ func TestLogTemplateService_Create_EmptyName(t *testing.T) {
 
 	err := svc.Create(template)
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "テンプレート名は必須です")
+	assert.Contains(t, err.Error(), "テンプレート名を入力してください")
 }
 
 func TestLogTemplateService_Create_NameTooLong(t *testing.T) {

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -451,11 +451,11 @@ func (s *PostService) GetScheduled(userID uint) ([]model.Post, error) {
 // 作成途中の投稿を許容するため、タイトル・本文は空でも許可する（長さ上限のみ検証）。
 func (s *PostService) AutoSaveDraft(userID, draftID uint, title, content, imageURLs string) (*model.Post, error) {
 	// 長さ上限のみバリデーション
-	if len([]rune(title)) > 200 {
-		return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(title, 0, 200, "タイトル"); err != nil {
+		return nil, err
 	}
-	if len([]rune(content)) > 50000 {
-		return nil, domain.NewError(domain.ErrCodeValidation, "本文は50000文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(content, 0, 50000, "本文"); err != nil {
+		return nil, err
 	}
 
 	// 新規作成

--- a/backend/internal/service/post_template.go
+++ b/backend/internal/service/post_template.go
@@ -20,20 +20,14 @@ func NewPostTemplateService(repo repository.PostTemplateRepositoryInterface) *Po
 
 // Create は新しい投稿テンプレートを作成する。
 func (s *PostTemplateService) Create(tmpl *model.PostTemplate) error {
-	if strings.TrimSpace(tmpl.Name) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "テンプレート名は必須です", nil)
+	if err := domain.ValidateStringLength(tmpl.Name, 1, 100, "テンプレート名"); err != nil {
+		return err
 	}
-	if len([]rune(tmpl.Name)) > 100 {
-		return domain.NewError(domain.ErrCodeValidation, "テンプレート名は100文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(tmpl.ContentTemplate, 1, 50000, "テンプレート内容"); err != nil {
+		return err
 	}
-	if strings.TrimSpace(tmpl.ContentTemplate) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "テンプレート内容は必須です", nil)
-	}
-	if len([]rune(tmpl.ContentTemplate)) > 50000 {
-		return domain.NewError(domain.ErrCodeValidation, "テンプレート内容は50000文字以下である必要があります", nil)
-	}
-	if len([]rune(tmpl.TitleTemplate)) > 200 {
-		return domain.NewError(domain.ErrCodeValidation, "タイトルテンプレートは200文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(tmpl.TitleTemplate, 0, 200, "タイトルテンプレート"); err != nil {
+		return err
 	}
 	return s.repo.Create(tmpl)
 }
@@ -56,22 +50,22 @@ func (s *PostTemplateService) Update(id, userID uint, updates *model.PostTemplat
 	}
 
 	if strings.TrimSpace(updates.Name) != "" {
-		if len([]rune(updates.Name)) > 100 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "テンプレート名は100文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.Name, 1, 100, "テンプレート名"); err != nil {
+			return nil, err
 		}
-		tmpl.Name = updates.Name
+		tmpl.Name = strings.TrimSpace(updates.Name)
 	}
 	if strings.TrimSpace(updates.TitleTemplate) != "" {
-		if len([]rune(updates.TitleTemplate)) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルテンプレートは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.TitleTemplate, 1, 200, "タイトルテンプレート"); err != nil {
+			return nil, err
 		}
-		tmpl.TitleTemplate = updates.TitleTemplate
+		tmpl.TitleTemplate = strings.TrimSpace(updates.TitleTemplate)
 	}
 	if strings.TrimSpace(updates.ContentTemplate) != "" {
-		if len([]rune(updates.ContentTemplate)) > 50000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "テンプレート内容は50000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(updates.ContentTemplate, 1, 50000, "テンプレート内容"); err != nil {
+			return nil, err
 		}
-		tmpl.ContentTemplate = updates.ContentTemplate
+		tmpl.ContentTemplate = strings.TrimSpace(updates.ContentTemplate)
 	}
 
 	if err := s.repo.Update(tmpl); err != nil {

--- a/backend/internal/service/project_milestone.go
+++ b/backend/internal/service/project_milestone.go
@@ -44,15 +44,11 @@ func (s *ProjectMilestoneService) Create(userID, projectID uint, title, descript
 		return err
 	}
 
-	if title == "" {
-		return domain.NewError(domain.ErrCodeValidation, "タイトルは必須です", nil)
+	if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
+		return err
 	}
-	if len([]rune(title)) > 200 {
-		return domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
-	}
-
-	if len([]rune(description)) > 1000 {
-		return domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(description, 0, 1000, "説明"); err != nil {
+		return err
 	}
 
 	milestone := &model.ProjectMilestone{
@@ -83,14 +79,14 @@ func (s *ProjectMilestoneService) Update(userID, milestoneID uint, title, descri
 	}
 
 	if title != "" {
-		if len([]rune(title)) > 200 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "タイトルは200文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
+			return nil, err
 		}
 		milestone.Title = title
 	}
 	if description != "" {
-		if len([]rune(description)) > 1000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "説明は1000文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(description, 1, 1000, "説明"); err != nil {
+			return nil, err
 		}
 		milestone.Description = description
 	}


### PR DESCRIPTION
## 概要
- service層に残っていた`len([]rune(...))`によるインラインバリデーション19箇所を`domain.ValidateStringLength()`に統一
- 5ファイル修正、テスト1件のエラーメッセージ期待値を更新

## 変更ファイル
- `post.go` — AutoSaveDraft: title(0-200), content(0-50000)
- `post_template.go` — Create/Update: Name(1-100), ContentTemplate(1-50000), TitleTemplate(0/1-200)
- `chat_room.go` — Create: Description(0-500)
- `learning_log_template.go` — Create/Update: Name(1-100), DefaultTitle(0/1-200), DefaultContent(0/1-50000)
- `project_milestone.go` — Create/Update: title(1-200), description(0/1-1000)
- `learning_log_template_test.go` — エラーメッセージ期待値更新

## 除外
- `hashtag.go`の`len([]rune(tag)) < 2`はフィルタ条件でバリデーションではないため対象外

closes #2211