### PR TITLE
fix: resource_progress.noteとbookmark_collectionフィールドに長さ制限追加

### DIFF
--- a/backend/internal/service/bookmark_collection.go
+++ b/backend/internal/service/bookmark_collection.go
@@ -20,8 +20,14 @@ func NewBookmarkCollectionService(repo repository.BookmarkCollectionRepositoryIn
 
 // Create は新しいブックマークコレクションを作成する。
 func (s *BookmarkCollectionService) Create(collection *model.BookmarkCollection) error {
-	if strings.TrimSpace(collection.Name) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "コレクション名は必須です", nil)
+	if err := domain.ValidateStringLength(collection.Name, 1, 100, "コレクション名"); err != nil {
+		return err
+	}
+	if err := domain.ValidateStringLength(collection.Description, 0, 500, "説明"); err != nil {
+		return err
+	}
+	if err := domain.ValidateStringLength(collection.Color, 0, 20, "カラー"); err != nil {
+		return err
 	}
 	return s.repo.Create(collection)
 }
@@ -39,12 +45,21 @@ func (s *BookmarkCollectionService) Update(id, userID uint, updates *model.Bookm
 	}
 
 	if strings.TrimSpace(updates.Name) != "" {
-		collection.Name = updates.Name
+		if err := domain.ValidateStringLength(updates.Name, 1, 100, "コレクション名"); err != nil {
+			return nil, err
+		}
+		collection.Name = strings.TrimSpace(updates.Name)
 	}
 	if updates.Description != "" {
+		if err := domain.ValidateStringLength(updates.Description, 1, 500, "説明"); err != nil {
+			return nil, err
+		}
 		collection.Description = updates.Description
 	}
 	if updates.Color != "" {
+		if err := domain.ValidateStringLength(updates.Color, 1, 20, "カラー"); err != nil {
+			return nil, err
+		}
 		collection.Color = updates.Color
 	}
 

--- a/backend/internal/service/resource_progress.go
+++ b/backend/internal/service/resource_progress.go
@@ -43,6 +43,11 @@ func (s *ResourceProgressService) UpsertProgress(userID, resourceID uint, status
 		return nil, domain.NewError(domain.ErrCodeValidation, "進捗率は0〜100の範囲で指定してください", nil)
 	}
 
+	// メモの長さ制限
+	if err := domain.ValidateStringLength(note, 0, 1000, "メモ"); err != nil {
+		return nil, err
+	}
+
 	progress := &model.ResourceProgress{
 		UserID:            userID,
 		ResourceID:        resourceID,


### PR DESCRIPTION
## 概要
- 入力バリデーションの長さ制限が漏れていた箇所を修正し、DBブロート攻撃を防止

## 変更内容
### resource_progress.go
- `note`フィールドに0-1000文字の長さ制限を追加（制限なし→制限あり）

### bookmark_collection.go
- Create: `Name`を`ValidateStringLength(1-100)`に統一、`Description(0-500)`, `Color(0-20)`の制限追加
- Update: `Name(1-100)`, `Description(1-500)`, `Color(1-20)`の制限追加

closes #2215