### PR TITLE
feat: GET /notes/my/count エンドポイント追加

### DIFF
--- a/backend/internal/handler/note.go
+++ b/backend/internal/handler/note.go
@@ -92,6 +92,19 @@ func (h *NoteHandler) GetByUserID(c *gin.Context) {
 	respondPaginated(c, notes, total, page, limit)
 }
 
+// GetMyCount は認証ユーザー自身のノート総数を返す。
+func (h *NoteHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"count": count})
+}
+
 // GetByFolderID は指定フォルダ内のノート一覧を所有権検証付きで取得する。
 func (h *NoteHandler) GetByFolderID(c *gin.Context) {
 	folderID, ok := parseID(c, "folderId")

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -531,6 +531,7 @@ func registerNoteRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		notes.POST("", c.NoteHandler.Create)
 		notes.GET("", c.NoteHandler.GetByUserID)
+		notes.GET("/my/count", c.NoteHandler.GetMyCount)
 		notes.GET("/search", c.NoteHandler.Search)
 		notes.GET("/favorites", c.NoteHandler.GetFavorites)
 		notes.GET("/archived", c.NoteHandler.GetArchived)


### PR DESCRIPTION
## 概要
- 他リソース（posts, projects, book-reviews, questions, post-series）と統一して、認証ユーザーのノート総数を返す`GET /notes/my/count`エンドポイントを追加

## 変更内容
- `handler/note.go` — `GetMyCount`ハンドラー追加（既存の`CountByUserID`サービスメソッドを利用）
- `router/router.go` — `notes.GET("/my/count", c.NoteHandler.GetMyCount)`登録

## レスポンス例
```json
{ "count": 42 }
```

closes #2217