### PR TITLE
refactor: Searchメソッドの検索クエリバリデーションをヘルパー関数に統一

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -76,10 +76,11 @@ func (s *BookReviewService) GetByRating(userID uint, minRating, maxRating int) (
 
 // Search は書籍レビューをキーワード検索する。
 func (s *BookReviewService) Search(query string, limit, offset int) ([]model.BookReview, int64, error) {
-	if strings.TrimSpace(query) == "" {
-		return nil, 0, domain.NewError(domain.ErrCodeBadRequest, "検索キーワードは必須です", nil)
+	q, err := validateSearchQuery(query)
+	if err != nil {
+		return nil, 0, err
 	}
-	return s.repo.Search(strings.TrimSpace(query), limit, offset)
+	return s.repo.Search(q, limit, offset)
 }
 
 // findAndCheckOwnership は書籍レビューを取得し、指定ユーザーが所有者かを検証する。

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -60,10 +60,11 @@ func (s *CodeSnippetService) GetByPostID(postID uint) ([]model.CodeSnippet, erro
 
 // Search はコードスニペットをキーワード検索する。
 func (s *CodeSnippetService) Search(query string, limit, offset int) ([]model.CodeSnippet, int64, error) {
-	if strings.TrimSpace(query) == "" {
-		return nil, 0, domain.NewError(domain.ErrCodeBadRequest, "検索キーワードは必須です", nil)
+	q, err := validateSearchQuery(query)
+	if err != nil {
+		return nil, 0, err
 	}
-	return s.repo.Search(strings.TrimSpace(query), limit, offset)
+	return s.repo.Search(q, limit, offset)
 }
 
 // GetByUserLanguage は指定ユーザーのスニペットをプログラミング言語でフィルタリングして取得する。

--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -51,10 +51,11 @@ func (s *ProjectService) GetAll(limit, offset int) ([]model.Project, int64, erro
 
 // Search はプロジェクトをキーワード検索する。
 func (s *ProjectService) Search(query string, limit, offset int) ([]model.Project, int64, error) {
-	if strings.TrimSpace(query) == "" {
-		return nil, 0, domain.NewError(domain.ErrCodeBadRequest, "検索キーワードは必須です", nil)
+	q, err := validateSearchQuery(query)
+	if err != nil {
+		return nil, 0, err
 	}
-	return s.repo.Search(strings.TrimSpace(query), limit, offset)
+	return s.repo.Search(q, limit, offset)
 }
 
 // findAndCheckOwnership はプロジェクトを取得し、指定ユーザーが所有者かを検証する。

--- a/backend/internal/service/validation_helpers.go
+++ b/backend/internal/service/validation_helpers.go
@@ -1,0 +1,17 @@
+package service
+
+import (
+	"strings"
+
+	"github.com/norman6464/devsync/backend/internal/domain"
+)
+
+// validateSearchQuery は検索クエリをバリデーションする汎用ヘルパー関数。
+// 空白をトリミングした上で空文字をチェックし、正規化されたクエリを返す。
+func validateSearchQuery(query string) (string, error) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return "", domain.NewError(domain.ErrCodeBadRequest, "検索キーワードは必須です", nil)
+	}
+	return q, nil
+}


### PR DESCRIPTION
## 概要
- 3ファイルで重複していた検索クエリバリデーションパターンを`validateSearchQuery()`ヘルパー関数に集約
- `checkOwnership()`（ownership.go）と同様のサービス層ヘルパーパターン

## 変更内容
- `validation_helpers.go` — `validateSearchQuery()`ヘルパー関数を新規作成
- `book_review.go` — Search内のインラインバリデーションをヘルパー呼び出しに変更
- `code_snippet.go` — 同上
- `project.go` — 同上

closes #2219