### PR TITLE
test: validateSearchQueryヘルパーとNote GetMyCountハンドラーのテスト追加

### DIFF
--- a/backend/internal/handler/note_test.go
+++ b/backend/internal/handler/note_test.go
@@ -760,3 +760,31 @@ func TestNoteHandler_Export_ServiceError(t *testing.T) {
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }
+
+// ============================================================
+// GetMyCount テスト
+// ============================================================
+
+func TestNoteHandler_GetMyCount_Success(t *testing.T) {
+	h, svc := newTestNoteHandler()
+	r := newRouter(1)
+	r.GET("/notes/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(42), nil)
+
+	w := doRequest(r, "GET", "/notes/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteHandler_GetMyCount_ServiceError(t *testing.T) {
+	h, svc := newTestNoteHandler()
+	r := newRouter(1)
+	r.GET("/notes/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, "GET", "/notes/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/service/validation_helpers_test.go
+++ b/backend/internal/service/validation_helpers_test.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSearchQuery_EmptyQuery(t *testing.T) {
+	_, err := validateSearchQuery("")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "検索キーワードは必須です")
+}
+
+func TestValidateSearchQuery_WhitespaceOnly(t *testing.T) {
+	_, err := validateSearchQuery("   \t  ")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "検索キーワードは必須です")
+}
+
+func TestValidateSearchQuery_ValidQuery(t *testing.T) {
+	q, err := validateSearchQuery("  Go言語  ")
+	assert.NoError(t, err)
+	assert.Equal(t, "Go言語", q)
+}


### PR DESCRIPTION
## 概要
- 前フェーズで追加した`validateSearchQuery`ヘルパーと`GET /notes/my/count`ハンドラーに対するテストを追加

## 追加テスト（5件）
### validation_helpers_test.go（新規）
- `TestValidateSearchQuery_EmptyQuery` — 空文字列でエラー
- `TestValidateSearchQuery_WhitespaceOnly` — 空白のみでエラー
- `TestValidateSearchQuery_ValidQuery` — 正常なクエリが正規化されて返る

### handler/note_test.go
- `TestNoteHandler_GetMyCount_Success` — 正常レスポンス（count: 42）
- `TestNoteHandler_GetMyCount_ServiceError` — サービスエラー時500レスポンス

closes #2221