### PR TITLE
fix: widget_settings設定フィールドに長さ制限追加

### DIFF
--- a/backend/internal/service/widget_settings.go
+++ b/backend/internal/service/widget_settings.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"encoding/json"
-	"strings"
 
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
@@ -39,8 +38,8 @@ func (s *WidgetSettingsService) GetSettings(userID uint) (*model.WidgetSettings,
 // UpdateSettings はウィジェット設定を更新する。
 // 設定はJSON配列形式である必要がある。
 func (s *WidgetSettingsService) UpdateSettings(userID uint, settings string) error {
-	if strings.TrimSpace(settings) == "" {
-		return domain.NewError(domain.ErrCodeBadRequest, "設定は必須です", nil)
+	if err := domain.ValidateStringLength(settings, 1, 10000, "設定"); err != nil {
+		return err
 	}
 
 	if !json.Valid([]byte(settings)) {

--- a/backend/internal/service/widget_settings_test.go
+++ b/backend/internal/service/widget_settings_test.go
@@ -71,7 +71,7 @@ func TestWidgetSettingsUpdateSettings_EmptySettings(t *testing.T) {
 
 	err := svc.UpdateSettings(1, "")
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "設定は必須です")
+	assert.Contains(t, err.Error(), "設定を入力してください")
 }
 
 func TestWidgetSettingsUpdateSettings_InvalidJSON(t *testing.T) {


### PR DESCRIPTION
## 概要
- `widget_settings.go`のUpdateSettingsメソッドで`settings`フィールドに長さ制限がなかった問題を修正
- 巨大なJSON配列送信によるDBブロート攻撃を防止

## 変更内容
- `widget_settings.go` — 空チェック(`strings.TrimSpace == ""`)を`domain.ValidateStringLength(settings, 1, 10000, "設定")`に置き換え、10000文字上限を追加。不要な`strings` importを除去
- `widget_settings_test.go` — エラーメッセージ期待値を「設定は必須です」→「設定を入力してください」に更新

closes #2223