### PR TITLE
feat: 学習ログのマイカウントエンドポイント追加

### DIFF
--- a/backend/internal/handler/learning_log.go
+++ b/backend/internal/handler/learning_log.go
@@ -34,6 +34,7 @@ type LearningLogServiceInterface interface {
 	GetGoalProgress(goalID, userID uint) (*model.GoalProgress, error)
 	GetFavorites(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	GetMonthlySummary(userID uint, months int) ([]model.MonthlySummary, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // LearningLogHandler は学習ログ関連のHTTPハンドラ。
@@ -72,6 +73,19 @@ func (h *LearningLogHandler) Create(c *gin.Context) {
 	}
 
 	respondCreated(c, log)
+}
+
+// GetMyCount は認証ユーザー自身の学習ログ総数を返す。
+func (h *LearningLogHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"count": count})
 }
 
 // BatchCreate は複数の学習ログを一括作成する。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -175,6 +175,7 @@ type LearningLogRepositoryInterface interface {
 	SumDurationByGoalID(goalID uint) (int, error)
 	GetFavorites(userID uint, limit, offset int) ([]model.LearningLog, int64, error)
 	GetMonthlySummary(userID uint, months int) ([]model.MonthlySummary, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // LearningGoalRepositoryInterface は学習目標データ操作の契約を定義する。

--- a/backend/internal/repository/learning_log.go
+++ b/backend/internal/repository/learning_log.go
@@ -241,3 +241,10 @@ func (r *LearningLogRepository) GetCalendarData(userID uint) ([]model.CalendarEn
 		Find(&entries).Error
 	return entries, err
 }
+
+// CountByUserID は指定ユーザーの学習ログ総数を返す。
+func (r *LearningLogRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.LearningLog{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -505,6 +505,7 @@ func registerLearningLogRoutes(g *gin.RouterGroup, c *di.Container) {
 		learningLogs.POST("/batch", c.LearningLogHandler.BatchCreate)
 		learningLogs.POST("/import", c.LearningLogHandler.ImportCSV)
 		learningLogs.GET("", c.LearningLogHandler.GetMyLogs)
+		learningLogs.GET("/my/count", c.LearningLogHandler.GetMyCount)
 		learningLogs.GET("/export", c.LearningLogHandler.ExportLogs)
 		learningLogs.GET("/favorites", c.LearningLogHandler.GetFavorites)
 		learningLogs.GET("/recent-categories", c.LearningLogHandler.GetRecentCategories)

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -475,3 +475,8 @@ func (s *LearningLogService) ImportCSV(userID uint, data []byte) ([]model.Learni
 
 	return logs, nil
 }
+
+// CountByUserID は指定ユーザーの学習ログ総数を返す。
+func (s *LearningLogService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -615,6 +615,11 @@ func (m *MockLearningLogRepository) GetMonthlySummary(userID uint, months int) (
 	return args.Get(0).([]model.MonthlySummary), args.Error(1)
 }
 
+func (m *MockLearningLogRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // ============================================================
 // MockLearningGoalRepository は repository.LearningGoalRepositoryInterface のテスト用モック実装。
 // ============================================================


### PR DESCRIPTION
## 概要
- `GET /learning-logs/my/count` エンドポイントを追加
- 認証ユーザーの学習ログ総数を取得できるようにした

## 変更内容
- `repository/interfaces.go` — LearningLogRepositoryInterfaceにCountByUserID追加
- `repository/learning_log.go` — CountByUserID実装
- `service/learning_log.go` — CountByUserIDサービスメソッド追加
- `handler/learning_log.go` — GetMyCountハンドラー追加
- `router/router.go` — エンドポイント登録
- `service/mock_test.go` — モック更新

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/... -v` 全テストパス

closes #2225