### PR TITLE
refactor: resource_reviewの所有権チェックをcheckOwnershipヘルパーに統一

### DIFF
--- a/backend/internal/service/resource_review.go
+++ b/backend/internal/service/resource_review.go
@@ -29,13 +29,13 @@ func (s *ResourceReviewService) Create(review *model.ResourceReview) error {
 	}
 
 	// 評価値バリデーション（1-5）
-	if review.Rating < 1 || review.Rating > 5 {
-		return domain.NewError(domain.ErrCodeValidation, "評価は1〜5の範囲で指定してください", nil)
+	if err := validateRating(review.Rating); err != nil {
+		return err
 	}
 
 	// コメントバリデーション
-	if len(review.Comment) > 5000 {
-		return domain.NewError(domain.ErrCodeValidation, "コメントは5000文字以下で入力してください", nil)
+	if err := domain.ValidateStringLength(review.Comment, 0, 5000, "コメント"); err != nil {
+		return err
 	}
 
 	// 重複チェック
@@ -52,25 +52,27 @@ func (s *ResourceReviewService) GetByResourceID(resourceID uint, limit, offset i
 	return s.repo.FindByResourceID(resourceID, limit, offset)
 }
 
+// findAndCheckOwnership はレビューを取得し、指定ユーザーが所有者かを検証する。
+func (s *ResourceReviewService) findAndCheckOwnership(id, userID uint) (*model.ResourceReview, error) {
+	return checkOwnership(s.repo.FindByID, id, userID, func(r *model.ResourceReview) uint { return r.UserID })
+}
+
 // Update はレビューを更新する。所有者のみ更新可能。
 func (s *ResourceReviewService) Update(id, userID uint, rating int, comment string) (*model.ResourceReview, error) {
-	review, err := s.repo.FindByID(id)
+	review, err := s.findAndCheckOwnership(id, userID)
 	if err != nil {
-		return nil, ErrNotFound
-	}
-	if review.UserID != userID {
-		return nil, ErrForbidden
+		return nil, err
 	}
 
 	if rating != 0 {
-		if rating < 1 || rating > 5 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "評価は1〜5の範囲で指定してください", nil)
+		if err := validateRating(rating); err != nil {
+			return nil, err
 		}
 		review.Rating = rating
 	}
 	if comment != "" {
-		if len(comment) > 5000 {
-			return nil, domain.NewError(domain.ErrCodeValidation, "コメントは5000文字以下で入力してください", nil)
+		if err := domain.ValidateStringLength(comment, 1, 5000, "コメント"); err != nil {
+			return nil, err
 		}
 		review.Comment = comment
 	}
@@ -83,12 +85,8 @@ func (s *ResourceReviewService) Update(id, userID uint, rating int, comment stri
 
 // Delete はレビューを削除する。所有者のみ削除可能。
 func (s *ResourceReviewService) Delete(id, userID uint) error {
-	review, err := s.repo.FindByID(id)
-	if err != nil {
-		return ErrNotFound
-	}
-	if review.UserID != userID {
-		return ErrForbidden
+	if _, err := s.findAndCheckOwnership(id, userID); err != nil {
+		return err
 	}
 	return s.repo.Delete(id)
 }

--- a/backend/internal/service/resource_review_test.go
+++ b/backend/internal/service/resource_review_test.go
@@ -181,7 +181,7 @@ func TestResourceReviewUpdate_Forbidden(t *testing.T) {
 func TestResourceReviewUpdate_NotFound(t *testing.T) {
 	svc, reviewRepo, _ := newTestResourceReviewService()
 
-	reviewRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	reviewRepo.On("FindByID", uint(99)).Return(nil, ErrNotFound)
 
 	_, err := svc.Update(99, 1, 5, "")
 	assert.ErrorIs(t, err, ErrNotFound)
@@ -233,7 +233,7 @@ func TestResourceReviewDelete_Forbidden(t *testing.T) {
 func TestResourceReviewDelete_NotFound(t *testing.T) {
 	svc, reviewRepo, _ := newTestResourceReviewService()
 
-	reviewRepo.On("FindByID", uint(99)).Return(nil, errors.New("not found"))
+	reviewRepo.On("FindByID", uint(99)).Return(nil, ErrNotFound)
 
 	err := svc.Delete(99, 1)
 	assert.ErrorIs(t, err, ErrNotFound)


### PR DESCRIPTION
## 概要
- `resource_review.go`のUpdate/Deleteメソッドのインライン所有権チェックを`checkOwnership`ヘルパーに統一
- 評価値バリデーションを`validateRating`関数に統一
- コメント長チェックを`domain.ValidateStringLength`に統一（Unicode対応）

## 変更内容
- `resource_review.go` — `findAndCheckOwnership`メソッド追加、インラインチェック置換
- `resource_review_test.go` — モック戻り値を`ErrNotFound`に統一

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/... -run TestResourceReview -v` 全14テストパス

closes #2227