### PR TITLE
test: 学習ログCountByUserIDとリソースレビューコメント長テスト追加

### DIFF
--- a/backend/internal/handler/learning_log_test.go
+++ b/backend/internal/handler/learning_log_test.go
@@ -730,3 +730,31 @@ func TestLearningLog_ImportCSV_ServiceError(t *testing.T) {
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }
+
+// ============================================================
+// GetMyCount テスト
+// ============================================================
+
+func TestLearningLogHandler_GetMyCount_Success(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/learning-logs/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(15), nil)
+
+	w := doRequest(r, "GET", "/learning-logs/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestLearningLogHandler_GetMyCount_ServiceError(t *testing.T) {
+	h, svc := setupLearningLogHandler()
+	r := newRouter(1)
+	r.GET("/learning-logs/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, "GET", "/learning-logs/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1499,6 +1499,11 @@ func (m *MockLearningLogService) GetGoalProgress(goalID, userID uint) (*model.Go
 	return args.Get(0).(*model.GoalProgress), args.Error(1)
 }
 
+func (m *MockLearningLogService) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // setupLearningLogHandler はLearningLogHandlerテスト用のセットアップを行う。
 func setupLearningLogHandler() (*LearningLogHandler, *MockLearningLogService) {
 	svc := new(MockLearningLogService)

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -1478,3 +1478,28 @@ func TestCalculateGoalProgressPercentage(t *testing.T) {
 		})
 	}
 }
+
+// ============================================================
+// CountByUserID テスト
+// ============================================================
+
+func TestLearningLogCountByUserID_Success(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(42), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(42), count)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningLogCountByUserID_Error(t *testing.T) {
+	svc, repo := newTestLearningLogService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	_, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/resource_review_test.go
+++ b/backend/internal/service/resource_review_test.go
@@ -238,3 +238,40 @@ func TestResourceReviewDelete_NotFound(t *testing.T) {
 	err := svc.Delete(99, 1)
 	assert.ErrorIs(t, err, ErrNotFound)
 }
+
+// ============================================================
+// コメント長バリデーションテスト
+// ============================================================
+
+func TestResourceReviewCreate_CommentTooLong(t *testing.T) {
+	svc, _, resourceRepo := newTestResourceReviewService()
+
+	resource := &model.LearningResource{UserID: 2}
+	resource.ID = 10
+	resourceRepo.On("FindByID", uint(10)).Return(resource, nil)
+
+	longComment := string(make([]rune, 5001))
+	review := &model.ResourceReview{
+		UserID:     1,
+		ResourceID: 10,
+		Rating:     4,
+		Comment:    longComment,
+	}
+
+	err := svc.Create(review)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "コメント")
+}
+
+func TestResourceReviewUpdate_CommentTooLong(t *testing.T) {
+	svc, reviewRepo, _ := newTestResourceReviewService()
+
+	existing := &model.ResourceReview{UserID: 1, Rating: 3}
+	existing.ID = 1
+	reviewRepo.On("FindByID", uint(1)).Return(existing, nil)
+
+	longComment := string(make([]rune, 5001))
+	_, err := svc.Update(1, 1, 0, longComment)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "コメント")
+}


### PR DESCRIPTION
## 概要
- Cycle 20で追加/変更した機能のテストカバレッジを改善

## 追加テスト（6件）
- `learning_log_test.go` — CountByUserID成功/エラーテスト
- `handler/learning_log_test.go` — GetMyCount成功/サービスエラーテスト
- `resource_review_test.go` — Create/Updateコメント長超過テスト

## テスト
- `go build ./...` ビルド成功
- 新規6テスト全てパス

closes #2229