### PR TITLE
fix: note_folder/note_templateバリデーターのUnicode文字数チェック修正

### DIFF
--- a/backend/internal/domain/validator/note_folder.go
+++ b/backend/internal/domain/validator/note_folder.go
@@ -22,7 +22,7 @@ func (v *NoteFolderValidator) ValidateName(name string) error {
 		return domain.NewError(domain.ErrCodeValidation, "フォルダ名を入力してください", nil)
 	}
 
-	if len(name) > 100 {
+	if len([]rune(name)) > 100 {
 		return domain.NewError(domain.ErrCodeValidation, "フォルダ名は100文字以下である必要があります", nil)
 	}
 
@@ -44,7 +44,7 @@ func (v *NoteFolderValidator) ValidateUpdate(name string) error {
 		return nil
 	}
 
-	if len(name) > 100 {
+	if len([]rune(name)) > 100 {
 		return domain.NewError(domain.ErrCodeValidation, "フォルダ名は100文字以下である必要があります", nil)
 	}
 

--- a/backend/internal/domain/validator/note_template.go
+++ b/backend/internal/domain/validator/note_template.go
@@ -46,7 +46,7 @@ func (v *NoteTemplateValidator) ValidateName(name string) error {
 	if name == "" {
 		return domain.NewError(domain.ErrCodeValidation, "テンプレート名を入力してください", nil)
 	}
-	if len(name) > 100 {
+	if len([]rune(name)) > 100 {
 		return domain.NewError(domain.ErrCodeValidation, "テンプレート名は100文字以下である必要があります", nil)
 	}
 	return nil
@@ -66,7 +66,7 @@ func (v *NoteTemplateValidator) ValidateContentTemplate(content string) error {
 
 // ValidateDescription は説明のバリデーション。
 func (v *NoteTemplateValidator) ValidateDescription(description string) error {
-	if len(description) > 500 {
+	if len([]rune(description)) > 500 {
 		return domain.NewError(domain.ErrCodeValidation, "説明は500文字以下である必要があります", nil)
 	}
 	return nil
@@ -74,7 +74,7 @@ func (v *NoteTemplateValidator) ValidateDescription(description string) error {
 
 // ValidateDefaultTitle はデフォルトタイトルのバリデーション。
 func (v *NoteTemplateValidator) ValidateDefaultTitle(title string) error {
-	if len(title) > 200 {
+	if len([]rune(title)) > 200 {
 		return domain.NewError(domain.ErrCodeValidation, "デフォルトタイトルは200文字以下である必要があります", nil)
 	}
 	return nil

--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -547,8 +547,8 @@ func TestNoteTemplateService_Delete_NotFound(t *testing.T) {
 func TestNoteTemplateService_Create_DefaultTitleValidationError(t *testing.T) {
 	svc, _, _ := newTestNoteTemplateService()
 
-	// 101文字のデフォルトタイトル → バリデーションエラー
-	longTitle := strings.Repeat("あ", 101)
+	// 201文字のデフォルトタイトル → バリデーションエラー
+	longTitle := strings.Repeat("あ", 201)
 	template := &model.NoteTemplate{
 		UserID:          1,
 		Name:            "テンプレート",


### PR DESCRIPTION
## 概要
- `domain/validator/note_folder.go`と`note_template.go`で`len()`（バイト長）を使っていたため、日本語やemoji等のマルチバイト文字で文字数制限が正しく機能しなかった
- `len([]rune())`に修正してUnicode文字数でチェックするようにした

## 変更内容
- `note_folder.go` — 2箇所: ValidateName, ValidateUpdate
- `note_template.go` — 3箇所: ValidateName, ValidateDescription, ValidateDefaultTitle
- `note_template_test.go` — DefaultTitleテストの文字数を修正（バイト長バグに依存していたため）

## テスト
- `go test ./internal/... -count=1` 全パッケージテストパス

closes #2231