### PR TITLE
feat: コードスニペットのマイカウントエンドポイント追加

### DIFF
--- a/backend/internal/handler/code_snippet.go
+++ b/backend/internal/handler/code_snippet.go
@@ -22,6 +22,7 @@ type CodeSnippetHandlerServiceInterface interface {
 	Favorite(userID, snippetID uint) error
 	Unfavorite(userID, snippetID uint) error
 	GetFavoritedByUserID(userID uint, limit, offset int) ([]model.CodeSnippet, int64, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // CodeSnippetHandler はコードスニペット関連のHTTPハンドラ。
@@ -279,4 +280,15 @@ func (h *CodeSnippetHandler) GetFavorites(c *gin.Context) {
 		Snippets: ensureSlice(snippets),
 		Total:    total,
 	})
+}
+
+// GetMyCount は認証ユーザーのコードスニペット総数を返す。
+func (h *CodeSnippetHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }

--- a/backend/internal/repository/code_snippet.go
+++ b/backend/internal/repository/code_snippet.go
@@ -145,3 +145,9 @@ func (r *CodeSnippetRepository) FindFavoritedByUserID(userID uint, limit, offset
 
 	return snippets, total, err
 }
+
+func (r *CodeSnippetRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.CodeSnippet{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -344,6 +344,7 @@ type CodeSnippetRepositoryInterface interface {
 	Unfavorite(userID, snippetID uint) error
 	HasFavorited(userID, snippetID uint) (bool, error)
 	FindFavoritedByUserID(userID uint, limit, offset int) ([]model.CodeSnippet, int64, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // GitHubRepositoryInterface はGitHub連携データ操作の契約を定義する。

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -284,6 +284,7 @@ func registerPostViewRoutes(g *gin.RouterGroup, c *di.Container) {
 func registerSnippetRoutes(g *gin.RouterGroup, c *di.Container) {
 	snippets := g.Group("/snippets")
 	{
+		snippets.GET("/my/count", c.CodeSnippetHandler.GetMyCount)
 		snippets.GET("/search", c.CodeSnippetHandler.Search)
 		snippets.GET("/:id", c.CodeSnippetHandler.GetByID)
 		snippets.PUT("/:id", c.CodeSnippetHandler.Update)

--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -207,3 +207,8 @@ func (s *CodeSnippetService) Unfavorite(userID, snippetID uint) error {
 func (s *CodeSnippetService) GetFavoritedByUserID(userID uint, limit, offset int) ([]model.CodeSnippet, int64, error) {
 	return s.repo.FindFavoritedByUserID(userID, limit, offset)
 }
+
+// CountByUserID は指定ユーザーのコードスニペット総数を返す。
+func (s *CodeSnippetService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1243,6 +1243,11 @@ func (m *MockCodeSnippetRepository) Search(query string, limit, offset int) ([]m
 	return args.Get(0).([]model.CodeSnippet), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockCodeSnippetRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // ============================================================
 // インターフェース適合チェック（コンパイル時検証）
 // ============================================================


### PR DESCRIPTION
## 概要
- `GET /snippets/my/count` エンドポイントを追加
- 認証ユーザーのコードスニペット総数を取得できるようにした

## 変更内容
- `repository/interfaces.go` — CodeSnippetRepositoryInterfaceにCountByUserID追加
- `repository/code_snippet.go` — CountByUserID実装
- `service/code_snippet.go` — CountByUserIDサービスメソッド追加
- `handler/code_snippet.go` — GetMyCountハンドラー追加
- `router/router.go` — エンドポイント登録
- `service/mock_test.go` — モック更新

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/... -v` 全テストパス

closes #2233