### PR TITLE
refactor: note_folder/note_templateバリデーターをValidateStringLengthに統一

### DIFF
--- a/backend/internal/domain/validator/note_folder.go
+++ b/backend/internal/domain/validator/note_folder.go
@@ -1,8 +1,6 @@
 package validator
 
 import (
-	"strings"
-
 	"github.com/norman6464/devsync/backend/internal/domain"
 )
 
@@ -16,17 +14,7 @@ func NewNoteFolderValidator() *NoteFolderValidator {
 
 // ValidateName はフォルダ名のバリデーションを行う。
 func (v *NoteFolderValidator) ValidateName(name string) error {
-	name = strings.TrimSpace(name)
-
-	if name == "" {
-		return domain.NewError(domain.ErrCodeValidation, "フォルダ名を入力してください", nil)
-	}
-
-	if len([]rune(name)) > 100 {
-		return domain.NewError(domain.ErrCodeValidation, "フォルダ名は100文字以下である必要があります", nil)
-	}
-
-	return nil
+	return domain.ValidateStringLength(name, 1, 100, "フォルダ名")
 }
 
 // ValidateCreate はフォルダ作成時のバリデーションを行う。
@@ -37,16 +25,5 @@ func (v *NoteFolderValidator) ValidateCreate(name string) error {
 // ValidateUpdate はフォルダ更新時のバリデーションを行う。
 // 更新時は空文字を許容（部分更新対応）
 func (v *NoteFolderValidator) ValidateUpdate(name string) error {
-	name = strings.TrimSpace(name)
-
-	// 空文字の場合は更新しないとみなしてOK
-	if name == "" {
-		return nil
-	}
-
-	if len([]rune(name)) > 100 {
-		return domain.NewError(domain.ErrCodeValidation, "フォルダ名は100文字以下である必要があります", nil)
-	}
-
-	return nil
+	return domain.ValidateStringLength(name, 0, 100, "フォルダ名")
 }

--- a/backend/internal/domain/validator/note_template.go
+++ b/backend/internal/domain/validator/note_template.go
@@ -1,8 +1,6 @@
 package validator
 
 import (
-	"strings"
-
 	"github.com/norman6464/devsync/backend/internal/domain"
 )
 
@@ -42,40 +40,20 @@ func (v *NoteTemplateValidator) ValidateUpdateTemplate(name, contentTemplate str
 
 // ValidateName はテンプレート名のバリデーション。
 func (v *NoteTemplateValidator) ValidateName(name string) error {
-	name = strings.TrimSpace(name)
-	if name == "" {
-		return domain.NewError(domain.ErrCodeValidation, "テンプレート名を入力してください", nil)
-	}
-	if len([]rune(name)) > 100 {
-		return domain.NewError(domain.ErrCodeValidation, "テンプレート名は100文字以下である必要があります", nil)
-	}
-	return nil
+	return domain.ValidateStringLength(name, 1, 100, "テンプレート名")
 }
 
 // ValidateContentTemplate は本文テンプレートのバリデーション。
 func (v *NoteTemplateValidator) ValidateContentTemplate(content string) error {
-	content = strings.TrimSpace(content)
-	if content == "" {
-		return domain.NewError(domain.ErrCodeValidation, "本文テンプレートを入力してください", nil)
-	}
-	if len([]rune(content)) > 50000 {
-		return domain.NewError(domain.ErrCodeValidation, "本文テンプレートは50000文字以下である必要があります", nil)
-	}
-	return nil
+	return domain.ValidateStringLength(content, 1, 50000, "本文テンプレート")
 }
 
 // ValidateDescription は説明のバリデーション。
 func (v *NoteTemplateValidator) ValidateDescription(description string) error {
-	if len([]rune(description)) > 500 {
-		return domain.NewError(domain.ErrCodeValidation, "説明は500文字以下である必要があります", nil)
-	}
-	return nil
+	return domain.ValidateStringLength(description, 0, 500, "説明")
 }
 
 // ValidateDefaultTitle はデフォルトタイトルのバリデーション。
 func (v *NoteTemplateValidator) ValidateDefaultTitle(title string) error {
-	if len([]rune(title)) > 200 {
-		return domain.NewError(domain.ErrCodeValidation, "デフォルトタイトルは200文字以下である必要があります", nil)
-	}
-	return nil
+	return domain.ValidateStringLength(title, 0, 200, "デフォルトタイトル")
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -266,6 +266,10 @@ func (m *MockCodeSnippetRepository) Search(query string, limit, offset int) ([]m
 	args := m.Called(query, limit, offset)
 	return args.Get(0).([]model.CodeSnippet), args.Get(1).(int64), args.Error(2)
 }
+func (m *MockCodeSnippetRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 
 // MockQuestionRepository は QuestionRepositoryInterface のモック実装。
 type MockQuestionRepository struct{ mock.Mock }
@@ -1868,6 +1872,10 @@ func (m *MockCodeSnippetHandlerService) GetFavoritedByUserID(userID uint, limit,
 func (m *MockCodeSnippetHandlerService) Search(query string, limit, offset int) ([]model.CodeSnippet, int64, error) {
 	args := m.Called(query, limit, offset)
 	return args.Get(0).([]model.CodeSnippet), args.Get(1).(int64), args.Error(2)
+}
+func (m *MockCodeSnippetHandlerService) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
 }
 
 // setupCodeSnippetHandler はCodeSnippetHandlerテスト用のセットアップを行う。

--- a/backend/internal/service/note_folder.go
+++ b/backend/internal/service/note_folder.go
@@ -87,7 +87,7 @@ func (s *NoteFolderService) Update(id, userID uint, name string, parentID *uint)
 		if strings.TrimSpace(name) == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "フォルダ名は空白のみにできません", nil)
 		}
-		folder.Name = name
+		folder.Name = strings.TrimSpace(name)
 	}
 	if parentID != nil {
 		// 自己参照チェック


### PR DESCRIPTION
## 概要
- `domain/validator/note_folder.go`と`note_template.go`のインラインバリデーションを`domain.ValidateStringLength`に統一
- `note_folder.go`サービスのUpdate時にTrimSpace未適用の不具合を修正

## 変更内容
- `validator/note_folder.go` — ValidateName/ValidateUpdateをValidateStringLengthに置換（-17行）
- `validator/note_template.go` — 4メソッドをValidateStringLengthに置換（-25行）
- `service/note_folder.go` — Update時のname代入にTrimSpace適用
- `handler/testutil_test.go` — CodeSnippet関連モックにCountByUserID追加

## テスト
- `go test ./internal/... -count=1` 全パッケージテストパス

closes #2235