### PR TITLE
test: コードスニペットCountByUserIDとnote_folderのTrimSpaceテスト追加

### DIFF
--- a/backend/internal/handler/code_snippet_test.go
+++ b/backend/internal/handler/code_snippet_test.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"net/http"
 	"testing"
 
@@ -421,4 +422,32 @@ func TestCodeSnippetFork_NotFound(t *testing.T) {
 	})
 
 	assertStatus(t, w, http.StatusNotFound)
+}
+
+// ============================================================
+// GetMyCount テスト
+// ============================================================
+
+func TestCodeSnippetHandler_GetMyCount_Success(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	r := newRouter(1)
+	r.GET("/snippets/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(7), nil)
+
+	w := doRequest(r, "GET", "/snippets/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	svc.AssertExpectations(t)
+}
+
+func TestCodeSnippetHandler_GetMyCount_ServiceError(t *testing.T) {
+	h, svc := setupCodeSnippetHandler()
+	r := newRouter(1)
+	r.GET("/snippets/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, "GET", "/snippets/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
 }

--- a/backend/internal/service/code_snippet_test.go
+++ b/backend/internal/service/code_snippet_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -764,6 +765,31 @@ func TestSnippetSearch_RepoError(t *testing.T) {
 	snippetRepo.On("Search", "test", 20, 0).Return([]model.CodeSnippet{}, int64(0), assert.AnError)
 
 	_, _, err := svc.Search("test", 20, 0)
+	assert.Error(t, err)
+	snippetRepo.AssertExpectations(t)
+}
+
+// ============================================================
+// CountByUserID テスト
+// ============================================================
+
+func TestSnippetCountByUserID_Success(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippetRepo.On("CountByUserID", uint(1)).Return(int64(7), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(7), count)
+	snippetRepo.AssertExpectations(t)
+}
+
+func TestSnippetCountByUserID_Error(t *testing.T) {
+	svc, snippetRepo, _ := newTestCodeSnippetService()
+
+	snippetRepo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	_, err := svc.CountByUserID(1)
 	assert.Error(t, err)
 	snippetRepo.AssertExpectations(t)
 }

--- a/backend/internal/service/note_folder_test.go
+++ b/backend/internal/service/note_folder_test.go
@@ -441,3 +441,20 @@ func TestNoteFolderService_Update_WhitespaceName(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "フォルダ名は空白のみにできません")
 }
+
+func TestNoteFolderService_Update_TrimSpaceName(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	svc := NewNoteFolderService(mockRepo)
+
+	existing := &model.NoteFolder{ID: 1, UserID: 1, Name: "元の名前"}
+	mockRepo.On("FindByID", uint(1)).Return(existing, nil)
+	mockRepo.On("Update", mock.MatchedBy(func(f *model.NoteFolder) bool {
+		return f.Name == "新しい名前"
+	})).Return(nil)
+
+	// 前後に空白がある名前 → TrimSpaceされて保存されるべき
+	result, err := svc.Update(1, 1, "  新しい名前  ", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "新しい名前", result.Name)
+	mockRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- Cycle 21で追加/変更した機能のテストカバレッジを改善

## 追加テスト（5件）
- `code_snippet_test.go` — CountByUserID成功/エラーテスト
- `handler/code_snippet_test.go` — GetMyCount成功/サービスエラーテスト
- `note_folder_test.go` — Update時のTrimSpace動作確認テスト

## テスト
- `go build ./...` ビルド成功
- 新規5テスト全てパス

closes #2237