### PR TITLE
fix: user.goのUnicode文字数チェック修正とlearning_resourceのTags長制限追加

### DIFF
--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -26,6 +26,9 @@ func (s *LearningResourceService) Create(resource *model.LearningResource) error
 	if err := v.ValidateCreateResource(resource.Title, resource.Description, resource.URL, string(resource.Category), string(resource.Difficulty)); err != nil {
 		return err
 	}
+	if err := domain.ValidateStringLength(resource.Tags, 0, 1000, "タグ"); err != nil {
+		return err
+	}
 	return s.repo.Create(resource)
 }
 
@@ -131,6 +134,9 @@ func (s *LearningResourceService) Update(id, userID uint, updates *model.Learnin
 		resource.Difficulty = updates.Difficulty
 	}
 	if updates.Tags != "" {
+		if err := domain.ValidateStringLength(updates.Tags, 1, 1000, "タグ"); err != nil {
+			return nil, err
+		}
 		resource.Tags = updates.Tags
 	}
 	if updates.ImageURL != "" {

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -60,17 +60,17 @@ func (s *UserService) Update(user *model.User) error {
 	if err := domain.ValidateStringLength(user.Name, 1, 100, "名前"); err != nil {
 		return err
 	}
-	if len(user.Bio) > 500 {
-		return domain.NewError(domain.ErrCodeValidation, "自己紹介は500文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(user.Bio, 0, 500, "自己紹介"); err != nil {
+		return err
 	}
-	if len(user.SkillsLanguages) > 500 {
-		return domain.NewError(domain.ErrCodeValidation, "プログラミング言語スキルは500文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(user.SkillsLanguages, 0, 500, "プログラミング言語スキル"); err != nil {
+		return err
 	}
-	if len(user.SkillsFrameworks) > 500 {
-		return domain.NewError(domain.ErrCodeValidation, "フレームワークスキルは500文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(user.SkillsFrameworks, 0, 500, "フレームワークスキル"); err != nil {
+		return err
 	}
-	if len(user.AvatarURL) > 2000 {
-		return domain.NewError(domain.ErrCodeValidation, "アバターURLは2000文字以下である必要があります", nil)
+	if err := domain.ValidateStringLength(user.AvatarURL, 0, 2000, "アバターURL"); err != nil {
+		return err
 	}
 	return s.repo.Update(user)
 }


### PR DESCRIPTION
## 概要
- `user.go`の4フィールドで`len()`（バイト長）を使っていたため、マルチバイト文字で文字数制限が正しく機能しなかった
- `learning_resource.go`のTagsフィールドに長さ制限がなく、無制限の入力が可能だった

## 変更内容
- `user.go` — Bio/SkillsLanguages/SkillsFrameworks/AvatarURLを`domain.ValidateStringLength`に統一
- `learning_resource.go` — Create/UpdateのTagsフィールドに0-1000文字の長さ制限追加

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/... -v` 全テストパス

closes #2239