### PR TITLE
feat: 学習リソースのマイカウントエンドポイント追加

### DIFF
--- a/backend/internal/handler/learning_resource.go
+++ b/backend/internal/handler/learning_resource.go
@@ -24,6 +24,7 @@ type LearningResourceServiceInterface interface {
 	Unsave(userID, resourceID uint) error
 	GetSavedByUserID(userID uint, limit, offset int) ([]model.LearningResource, int64, error)
 	GetByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // LearningResourceHandler は学習リソース関連のHTTPハンドラ。
@@ -298,4 +299,15 @@ func (h *LearningResourceHandler) GetSaved(c *gin.Context) {
 		Limit:     limit,
 		Offset:    offset,
 	})
+}
+
+// GetMyCount は認証ユーザーの学習リソース総数を返す。
+func (h *LearningResourceHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -398,6 +398,10 @@ func (m *MockLearningResourceRepository) FindByDifficulty(difficulty string, lim
 	args := m.Called(difficulty, limit, offset)
 	return args.Get(0).([]model.LearningResource), args.Get(1).(int64), args.Error(2)
 }
+func (m *MockLearningResourceRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 
 // MockRoadmapRepository は RoadmapRepositoryInterface のモック実装。
 type MockRoadmapRepository struct{ mock.Mock }

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -250,6 +250,7 @@ type LearningResourceRepositoryInterface interface {
 	HasSaved(userID, resourceID uint) (bool, error)
 	FindSavedByUserID(userID uint, limit, offset int) ([]model.LearningResource, int64, error)
 	FindByDifficulty(difficulty string, limit, offset int) ([]model.LearningResource, int64, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // ResourceReviewRepositoryInterface は学習リソースレビューデータ操作の契約を定義する。

--- a/backend/internal/repository/learning_resource.go
+++ b/backend/internal/repository/learning_resource.go
@@ -200,3 +200,9 @@ func (r *LearningResourceRepository) FindByDifficulty(difficulty string, limit, 
 
 	return resources, total, err
 }
+
+func (r *LearningResourceRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.LearningResource{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -453,6 +453,7 @@ func registerResourceRoutes(g *gin.RouterGroup, c *di.Container) {
 		resources.POST("", c.LearningResourceHandler.Create)
 		resources.GET("", c.LearningResourceHandler.GetPublic)
 		resources.GET("/my", c.LearningResourceHandler.GetMyResources)
+		resources.GET("/my/count", c.LearningResourceHandler.GetMyCount)
 		resources.GET("/search", c.LearningResourceHandler.Search)
 		resources.GET("/saved", c.LearningResourceHandler.GetSaved)
 		resources.GET("/:id", c.LearningResourceHandler.GetByID)

--- a/backend/internal/service/learning_resource.go
+++ b/backend/internal/service/learning_resource.go
@@ -227,3 +227,8 @@ func (s *LearningResourceService) Unsave(userID, resourceID uint) error {
 func (s *LearningResourceService) GetSavedByUserID(userID uint, limit, offset int) ([]model.LearningResource, int64, error) {
 	return s.repo.FindSavedByUserID(userID, limit, offset)
 }
+
+// CountByUserID は指定ユーザーの学習リソース総数を返す。
+func (s *LearningResourceService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -900,6 +900,11 @@ func (m *MockLearningResourceRepository) FindByDifficulty(difficulty string, lim
 	return args.Get(0).([]model.LearningResource), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockLearningResourceRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // ============================================================
 // MockResourceReviewRepository は repository.ResourceReviewRepositoryInterface のテスト用モック実装。
 // ============================================================


### PR DESCRIPTION
## 概要
- `GET /resources/my/count` エンドポイントを追加
- 認証ユーザーの学習リソース総数を取得できるようにした

## 変更内容
- `repository/interfaces.go` — LearningResourceRepositoryInterfaceにCountByUserID追加
- `repository/learning_resource.go` — CountByUserID実装
- `service/learning_resource.go` — CountByUserIDサービスメソッド追加
- `handler/learning_resource.go` — GetMyCountハンドラー追加
- `router/router.go` — エンドポイント登録
- `service/mock_test.go`、`handler/testutil_test.go` — モック更新

## テスト
- `go build ./...` ビルド成功
- `go test ./internal/service/... -v` 全テストパス

closes #2241