### PR TITLE
refactor: post_tag/note_linkの所有権チェックをcheckOwnershipヘルパーに統一

### DIFF
--- a/backend/internal/service/note_link.go
+++ b/backend/internal/service/note_link.go
@@ -88,12 +88,8 @@ func (s *NoteLinkService) DeleteLink(sourceNoteID, targetNoteID, userID uint) er
 // GetLinkStats はノートのリンク統計（フォワードリンク数・バックリンク数）を返す。
 // ノートの所有者のみ取得可能。
 func (s *NoteLinkService) GetLinkStats(noteID, userID uint) (*model.NoteLinkStats, error) {
-	note, err := s.noteRepo.FindByID(noteID)
-	if err != nil {
-		return nil, ErrNotFound
-	}
-	if note.UserID != userID {
-		return nil, ErrForbidden
+	if _, err := checkOwnership(s.noteRepo.FindByID, noteID, userID, func(n *model.Note) uint { return n.UserID }); err != nil {
+		return nil, err
 	}
 
 	forwardCount, err := s.repo.CountBySourceNoteID(noteID)

--- a/backend/internal/service/post_tag.go
+++ b/backend/internal/service/post_tag.go
@@ -23,12 +23,8 @@ func NewPostTagService(tagRepo repository.PostTagRepositoryInterface, postRepo r
 
 // SetTags は投稿のタグを設定する。所有権チェック・バリデーション付き。
 func (s *PostTagService) SetTags(postID, userID uint, tags []string) error {
-	post, err := s.postRepo.FindByID(postID)
-	if err != nil {
+	if _, err := checkOwnership(s.postRepo.FindByID, postID, userID, func(p *model.Post) uint { return p.UserID }); err != nil {
 		return err
-	}
-	if post.UserID != userID {
-		return ErrForbidden
 	}
 
 	// 正規化: 小文字変換・トリム・空文字除外・重複除外
@@ -39,8 +35,8 @@ func (s *PostTagService) SetTags(postID, userID uint, tags []string) error {
 	}
 
 	for _, tag := range normalized {
-		if len(tag) > 50 {
-			return domain.NewError(domain.ErrCodeValidation, "タグは50文字以下である必要があります", nil)
+		if err := domain.ValidateStringLength(tag, 1, 50, "タグ"); err != nil {
+			return err
 		}
 	}
 


### PR DESCRIPTION
## 概要
- `post_tag.go`: インライン所有権チェックを`checkOwnership`ヘルパーに置換
- `post_tag.go`: `len(tag)`バイト長チェックを`domain.ValidateStringLength`ルーン長に修正（Unicode対応）
- `note_link.go`: `GetLinkStats`のインライン所有権チェックを`checkOwnership`に統一

## テスト
- 既存テスト全件通過確認済み

Closes #2243