### PR TITLE
test: learning resourceカウント・タグUnicodeバリデーションのテスト追加

### DIFF
--- a/backend/internal/handler/learning_resource_test.go
+++ b/backend/internal/handler/learning_resource_test.go
@@ -578,3 +578,32 @@ func TestResourceUpdate_InvalidImageURL(t *testing.T) {
 	})
 	assertStatus(t, w, http.StatusBadRequest)
 }
+
+// ============================================================
+// GetMyCount（自分のリソース総数取得）
+// ============================================================
+
+func TestResourceGetMyCount_Success(t *testing.T) {
+	h, repo := setupLearningResourceHandler()
+	r := newRouter(1)
+	r.GET("/resources/my/count", h.GetMyCount)
+
+	repo.On("CountByUserID", uint(1)).Return(int64(7), nil)
+
+	w := doRequest(r, http.MethodGet, "/resources/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Body.String(), `"count":7`)
+	repo.AssertExpectations(t)
+}
+
+func TestResourceGetMyCount_ServiceError(t *testing.T) {
+	h, repo := setupLearningResourceHandler()
+	r := newRouter(1)
+	r.GET("/resources/my/count", h.GetMyCount)
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/resources/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/learning_resource_test.go
+++ b/backend/internal/service/learning_resource_test.go
@@ -869,3 +869,29 @@ func TestLearningResourceGetByDifficulty_RepoError(t *testing.T) {
 	assert.Equal(t, int64(0), total)
 	repo.AssertExpectations(t)
 }
+
+// ============================================================
+// CountByUserID（ユーザーリソース総数取得）
+// ============================================================
+
+func TestLearningResourceCountByUserID_Success(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(42), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(42), count)
+	repo.AssertExpectations(t)
+}
+
+func TestLearningResourceCountByUserID_Error(t *testing.T) {
+	svc, repo := newTestLearningResourceService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
+}

--- a/backend/internal/service/post_tag_test.go
+++ b/backend/internal/service/post_tag_test.go
@@ -318,3 +318,33 @@ func TestPostTagSetTags_TagExactly50Chars(t *testing.T) {
 	assert.NoError(t, err)
 	tagRepo.AssertExpectations(t)
 }
+
+func TestPostTagSetTags_UnicodeTagWithin50Runes(t *testing.T) {
+	svc, tagRepo, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	// 50文字の日本語タグ（150バイトだがルーン数は50なので許容される）
+	unicodeTag := strings.Repeat("あ", 50)
+	tagRepo.On("SetTags", uint(10), []string{unicodeTag}).Return(nil)
+
+	err := svc.SetTags(10, 1, []string{unicodeTag})
+	assert.NoError(t, err)
+	tagRepo.AssertExpectations(t)
+}
+
+func TestPostTagSetTags_UnicodeTagExceeds50Runes(t *testing.T) {
+	svc, _, postRepo := newTestPostTagService()
+
+	post := &model.Post{UserID: 1}
+	post.ID = 10
+	postRepo.On("FindByID", uint(10)).Return(post, nil)
+
+	// 51文字の日本語タグ（ルーン数が50を超えるのでエラー）
+	unicodeTag := strings.Repeat("あ", 51)
+	err := svc.SetTags(10, 1, []string{unicodeTag})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "タグは50文字以下である必要があります")
+}


### PR DESCRIPTION
## 概要
- `learning_resource_test.go`: CountByUserID 成功・エラーテスト追加
- `handler/learning_resource_test.go`: GetMyCount ハンドラーテスト追加
- `post_tag_test.go`: Unicode日本語タグの50文字ルーン長バリデーションテスト追加（#2244 の検証）

## テスト
- 新規6テスト全件通過確認済み

Closes #2245