### PR TITLE
fix: ai_chatの会話タイトル生成でUnicode文字列が破損する問題を修正

### DIFF
--- a/backend/internal/service/ai_chat.go
+++ b/backend/internal/service/ai_chat.go
@@ -60,8 +60,8 @@ func (s *AIAdviceService) Chat(userID uint, message string, conversationID uint)
 	} else {
 		// 新規会話作成
 		title := message
-		if len(title) > 50 {
-			title = title[:50] + "..."
+		if runes := []rune(title); len(runes) > 50 {
+			title = string(runes[:50]) + "..."
 		}
 		conv = &model.AIConversation{
 			UserID: userID,


### PR DESCRIPTION
## 概要
- `ai_chat.go` の新規会話作成時、メッセージ先頭50文字をタイトルにする処理でバイト長チェック・バイトスライスを使用していたため、日本語等のマルチバイト文字が途中で切断されて不正なUTF-8になる問題を修正
- `len(title)` → `len([]rune(title))` でルーン長チェック
- `title[:50]` → `string([]rune(title)[:50])` でルーン単位スライス

## テスト
- ビルド通過確認済み

Closes #2247