### PR TITLE
feat: 投稿コレクションの自分のコレクション数取得エンドポイント追加

### DIFF
--- a/backend/internal/handler/post_collection.go
+++ b/backend/internal/handler/post_collection.go
@@ -16,6 +16,7 @@ type PostCollectionServiceInterface interface {
 	AddPost(collectionID, userID, postID uint, note string) error
 	RemovePost(collectionID, userID, postID uint) error
 	GetPosts(collectionID uint) ([]model.PostCollectionItem, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // PostCollectionHandler は投稿コレクション関連のHTTPハンドラ。
@@ -205,4 +206,15 @@ func (h *PostCollectionHandler) RemovePost(c *gin.Context) {
 	}
 
 	respondDeleted(c)
+}
+
+// GetMyCount は認証ユーザーのコレクション総数を返す。
+func (h *PostCollectionHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }

--- a/backend/internal/handler/post_collection_test.go
+++ b/backend/internal/handler/post_collection_test.go
@@ -68,6 +68,10 @@ func (m *MockPostCollectionService) GetPosts(collectionID uint) ([]model.PostCol
 	}
 	return nil, args.Error(1)
 }
+func (m *MockPostCollectionService) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 
 func setupPostCollectionHandler() (*PostCollectionHandler, *MockPostCollectionService) {
 	svc := new(MockPostCollectionService)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -549,6 +549,7 @@ type PostCollectionRepositoryInterface interface {
 	RemovePost(collectionID, postID uint) error
 	HasPost(collectionID, postID uint) (bool, error)
 	GetPostsByCollectionID(collectionID uint) ([]model.PostCollectionItem, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // PostSeriesRepositoryInterface は投稿シリーズデータ操作の契約を定義する。

--- a/backend/internal/repository/post_collection.go
+++ b/backend/internal/repository/post_collection.go
@@ -91,3 +91,10 @@ func (r *PostCollectionRepository) GetPostsByCollectionID(collectionID uint) ([]
 		Find(&items).Error
 	return items, err
 }
+
+// CountByUserID は指定ユーザーのコレクション総数を返す。
+func (r *PostCollectionRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.PostCollection{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -242,6 +242,7 @@ func registerPostCollectionRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		collections.POST("", c.PostCollectionHandler.Create)
 		collections.GET("/my", c.PostCollectionHandler.GetMyCollections)
+		collections.GET("/my/count", c.PostCollectionHandler.GetMyCount)
 		collections.GET("/:id", c.PostCollectionHandler.GetByID)
 		collections.PUT("/:id", c.PostCollectionHandler.Update)
 		collections.DELETE("/:id", c.PostCollectionHandler.Delete)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1996,6 +1996,11 @@ func (m *MockPostCollectionRepository) GetPostsByCollectionID(collectionID uint)
 	return args.Get(0).([]model.PostCollectionItem), args.Error(1)
 }
 
+func (m *MockPostCollectionRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // ============================================================
 // MockPostPinRepository は repository.PostPinRepositoryInterface のテスト用モック実装。
 // ============================================================

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -137,3 +137,8 @@ func (s *PostCollectionService) RemovePost(collectionID, userID, postID uint) er
 func (s *PostCollectionService) GetPosts(collectionID uint) ([]model.PostCollectionItem, error) {
 	return s.repo.GetPostsByCollectionID(collectionID)
 }
+
+// CountByUserID は指定ユーザーのコレクション総数を返す。
+func (s *PostCollectionService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}


### PR DESCRIPTION
## 概要
- `GET /post-collections/my/count` エンドポイントを追加
- 認証ユーザーの投稿コレクション総数を `{"count": N}` で返却

## 変更ファイル
- `repository/interfaces.go` — CountByUserID追加
- `repository/post_collection.go` — CountByUserID実装
- `service/post_collection.go` — CountByUserID追加
- `handler/post_collection.go` — GetMyCount追加 + インターフェース更新
- `router/router.go` — ルート追加
- `service/mock_test.go` — モック追加
- `handler/post_collection_test.go` — モック追加

## テスト
- 既存テスト全件通過確認済み

Closes #2249