### PR TITLE
refactor: post.goのfindAndCheckCommentOwnershipをcheckOwnershipヘルパーに統一

### DIFF
--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -221,16 +221,7 @@ func (s *PostService) GetReplies(parentID uint) ([]model.Comment, error) {
 
 // findAndCheckCommentOwnership はコメントの所有権を検証する共通ヘルパー。
 func (s *PostService) findAndCheckCommentOwnership(id, userID uint) (*model.Comment, error) {
-	comment, err := s.repo.FindCommentByID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	if comment.UserID != userID {
-		return nil, ErrForbidden
-	}
-
-	return comment, nil
+	return checkOwnership(s.repo.FindCommentByID, id, userID, func(c *model.Comment) uint { return c.UserID })
 }
 
 // EditComment は所有権を検証した後、コメント内容を更新する。


### PR DESCRIPTION
## 概要
- `post.go` の `findAndCheckCommentOwnership` のインライン所有権チェックを汎用 `checkOwnership` ヘルパーに統一
- 10行のメソッドを1行に簡潔化

## テスト
- 既存テスト全件通過確認済み

Closes #2251