### PR TITLE
fix: learning_logのTitle/Content長制限追加・post_collectionのTrimSpace漏れ修正

### DIFF
--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -33,6 +33,13 @@ func NewLearningLogService(repo repository.LearningLogRepositoryInterface, goalR
 // Duration、Category、Sourceのバリデーションを行う。
 // GoalIDが指定されている場合、ゴールの進捗を自動更新する。
 func (s *LearningLogService) Create(log *model.LearningLog) error {
+	// Title/Content バリデーション
+	if err := domain.ValidateStringLength(log.Title, 1, 200, "タイトル"); err != nil {
+		return err
+	}
+	if err := domain.ValidateStringLength(log.Content, 0, 10000, "内容"); err != nil {
+		return err
+	}
 	// Duration: 0以上1440以下（24時間）
 	if err := validateDuration(log.Duration); err != nil {
 		return err
@@ -219,10 +226,16 @@ func (s *LearningLogService) Update(id, userID uint, updates *model.LearningLog)
 	}
 
 	if strings.TrimSpace(updates.Title) != "" {
-		log.Title = updates.Title
+		if err := domain.ValidateStringLength(updates.Title, 1, 200, "タイトル"); err != nil {
+			return nil, err
+		}
+		log.Title = strings.TrimSpace(updates.Title)
 	}
 	if strings.TrimSpace(updates.Content) != "" {
-		log.Content = updates.Content
+		if err := domain.ValidateStringLength(updates.Content, 1, 10000, "内容"); err != nil {
+			return nil, err
+		}
+		log.Content = strings.TrimSpace(updates.Content)
 	}
 	if strings.TrimSpace(string(updates.Category)) != "" {
 		log.Category = updates.Category

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -80,8 +80,8 @@ func (s *PostCollectionService) Update(id, userID uint, title, description strin
 		return nil, err
 	}
 
-	collection.Title = title
-	collection.Description = description
+	collection.Title = strings.TrimSpace(title)
+	collection.Description = strings.TrimSpace(description)
 	collection.IsPublic = isPublic
 
 	if err := s.repo.Update(collection); err != nil {


### PR DESCRIPTION
## 概要
- `learning_log.go` Create: Title(1-200文字)・Content(0-10000文字)のValidateStringLength追加
- `learning_log.go` Update: Title/ContentにValidateStringLength + TrimSpace追加（無制限サイズのDBへの格納を防止）
- `post_collection.go` Update: Title/DescriptionにTrimSpace追加（Createとの不整合修正）

## テスト
- 既存テスト全件通過確認済み

Closes #2255