### PR TITLE
feat: ブックマークコレクションの自分のコレクション数取得エンドポイント追加

### DIFF
--- a/backend/internal/handler/bookmark_collection.go
+++ b/backend/internal/handler/bookmark_collection.go
@@ -16,6 +16,7 @@ type BookmarkCollectionServiceInterface interface {
 	AddPost(collectionID, postID, userID uint) error
 	RemovePost(collectionID, postID, userID uint) error
 	GetPosts(collectionID uint, limit, offset int) ([]model.Post, int64, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // BookmarkCollectionHandler はブックマークコレクション関連のHTTPハンドラ。
@@ -165,4 +166,15 @@ func (h *BookmarkCollectionHandler) GetPosts(c *gin.Context) {
 		Posts: ensureSlice(posts),
 		Total: total,
 	})
+}
+
+// GetMyCount は認証ユーザーのコレクション総数を返す。
+func (h *BookmarkCollectionHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }

--- a/backend/internal/handler/bookmark_collection_test.go
+++ b/backend/internal/handler/bookmark_collection_test.go
@@ -51,6 +51,10 @@ func (m *MockBookmarkCollectionService) GetPosts(collectionID uint, limit, offse
 	args := m.Called(collectionID, limit, offset)
 	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
 }
+func (m *MockBookmarkCollectionService) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 
 // ============================================================
 // BookmarkCollectionHandler テスト

--- a/backend/internal/repository/bookmark_collection.go
+++ b/backend/internal/repository/bookmark_collection.go
@@ -97,3 +97,10 @@ func (r *BookmarkCollectionRepository) HasPost(collectionID, postID uint) (bool,
 		Count(&count).Error
 	return count > 0, err
 }
+
+// CountByUserID は指定ユーザーのコレクション総数を返す。
+func (r *BookmarkCollectionRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.BookmarkCollection{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -704,6 +704,7 @@ type BookmarkCollectionRepositoryInterface interface {
 	RemovePost(collectionID, postID uint) error
 	GetPosts(collectionID uint, limit, offset int) ([]model.Post, int64, error)
 	HasPost(collectionID, postID uint) (bool, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // PostTemplateRepositoryInterface は投稿テンプレートデータ操作の契約を定義する。

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -825,6 +825,7 @@ func registerBookmarkCollectionRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		collections.POST("", c.BookmarkCollectionHandler.Create)
 		collections.GET("", c.BookmarkCollectionHandler.GetMyCollections)
+		collections.GET("/my/count", c.BookmarkCollectionHandler.GetMyCount)
 		collections.PUT("/:id", c.BookmarkCollectionHandler.Update)
 		collections.DELETE("/:id", c.BookmarkCollectionHandler.Delete)
 		collections.POST("/:id/posts/:postId", c.BookmarkCollectionHandler.AddPost)

--- a/backend/internal/service/bookmark_collection.go
+++ b/backend/internal/service/bookmark_collection.go
@@ -114,3 +114,8 @@ func (s *BookmarkCollectionService) GetPosts(collectionID uint, limit, offset in
 func (s *BookmarkCollectionService) findAndCheckOwnership(id, userID uint) (*model.BookmarkCollection, error) {
 	return checkOwnership(s.repo.FindByID, id, userID, func(c *model.BookmarkCollection) uint { return c.UserID })
 }
+
+// CountByUserID は指定ユーザーのコレクション総数を返す。
+func (s *BookmarkCollectionService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -2604,6 +2604,11 @@ func (m *MockBookmarkCollectionRepository) HasPost(collectionID, postID uint) (b
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockBookmarkCollectionRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // ============================================================
 // MockWidgetSettingsRepository は repository.WidgetSettingsRepositoryInterface のテスト用モック実装。
 // ============================================================


### PR DESCRIPTION
## 概要
- `GET /bookmark-collections/my/count` エンドポイントを追加
- 認証ユーザーのブックマークコレクション総数を `{"count": N}` で返却

## 変更ファイル
- `repository/interfaces.go` — CountByUserID追加
- `repository/bookmark_collection.go` — CountByUserID実装
- `service/bookmark_collection.go` — CountByUserID追加
- `handler/bookmark_collection.go` — GetMyCount追加 + インターフェース更新
- `router/router.go` — ルート追加
- `service/mock_test.go` — モック追加
- `handler/bookmark_collection_test.go` — モック追加

## テスト
- 既存テスト全件通過確認済み

Closes #2257