### PR TITLE
test: ブックマークコレクションCount・学習ログバリデーション・AI会話タイトルテスト改善

### DIFF
--- a/backend/internal/handler/bookmark_collection_test.go
+++ b/backend/internal/handler/bookmark_collection_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -377,4 +378,37 @@ func TestBookmarkCollection_GetPosts_InvalidID(t *testing.T) {
 	r.ServeHTTP(w, req)
 
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ============================================================
+// GetMyCount テスト
+// ============================================================
+
+func TestBookmarkCollection_GetMyCount_Success(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("CountByUserID", uint(1)).Return(int64(3), nil)
+
+	r := newRouter(1)
+	r.GET("/bookmark-collections/my/count", h.GetMyCount)
+
+	w := doRequest(r, http.MethodGet, "/bookmark-collections/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Body.String(), `"count":3`)
+	mockSvc.AssertExpectations(t)
+}
+
+func TestBookmarkCollection_GetMyCount_ServiceError(t *testing.T) {
+	mockSvc := new(MockBookmarkCollectionService)
+	h := NewBookmarkCollectionHandler(mockSvc)
+
+	mockSvc.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	r := newRouter(1)
+	r.GET("/bookmark-collections/my/count", h.GetMyCount)
+
+	w := doRequest(r, http.MethodGet, "/bookmark-collections/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	mockSvc.AssertExpectations(t)
 }

--- a/backend/internal/service/ai_advice_test.go
+++ b/backend/internal/service/ai_advice_test.go
@@ -896,9 +896,10 @@ func TestChat_LongTitleTruncation(t *testing.T) {
 	deps.logRepo.On("GetStreakInfo", uint(1)).Return(&model.StreakInfo{}, nil)
 	deps.roadmapRepo.On("GetByUserID", uint(1), 100, 0).Return([]model.Roadmap{}, int64(0), nil)
 	deps.githubRepo.On("GetLanguageStats", uint(1)).Return([]model.GitHubLanguageStat{}, nil)
-	// 会話作成時にタイトルが50文字+...に切り詰められることを検証
+	// 会話作成時にタイトルが50ルーン+...に切り詰められることを検証
 	deps.convRepo.On("CreateConversation", mock.MatchedBy(func(c *model.AIConversation) bool {
-		return len(c.Title) == 53 && c.Title[50:] == "..."
+		runes := []rune(c.Title)
+		return len(runes) == 53 && string(runes[50:]) == "..."
 	})).Return(nil)
 	deps.convRepo.On("AddMessage", mock.AnythingOfType("*model.AIMessage")).Return(nil)
 	deps.llmClient.On("Complete", mock.Anything).Return(&ChatResponse{

--- a/backend/internal/service/bookmark_collection_test.go
+++ b/backend/internal/service/bookmark_collection_test.go
@@ -266,3 +266,31 @@ func TestBookmarkCollection_AddPost_HasPostError(t *testing.T) {
 	err := svc.AddPost(1, 10, 1)
 	assert.Error(t, err)
 }
+
+// ============================================================
+// CountByUserID（ユーザーコレクション総数取得）
+// ============================================================
+
+func TestBookmarkCollection_CountByUserID_Success(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	mockRepo.On("CountByUserID", uint(1)).Return(int64(3), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestBookmarkCollection_CountByUserID_Error(t *testing.T) {
+	mockRepo := new(MockBookmarkCollectionRepository)
+	svc := NewBookmarkCollectionService(mockRepo)
+
+	mockRepo.On("CountByUserID", uint(1)).Return(int64(0), assert.AnError)
+
+	count, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	mockRepo.AssertExpectations(t)
+}

--- a/backend/internal/service/learning_log_test.go
+++ b/backend/internal/service/learning_log_test.go
@@ -1480,6 +1480,36 @@ func TestCalculateGoalProgressPercentage(t *testing.T) {
 }
 
 // ============================================================
+// Create Title/Content バリデーションテスト
+// ============================================================
+
+func TestLearningLogCreate_EmptyTitle(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	log := &model.LearningLog{Title: "", UserID: 1, Duration: 60}
+	err := svc.Create(log)
+	assert.Error(t, err)
+}
+
+func TestLearningLogCreate_TitleExceeds200Runes(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	longTitle := strings.Repeat("あ", 201)
+	log := &model.LearningLog{Title: longTitle, UserID: 1, Duration: 60}
+	err := svc.Create(log)
+	assert.Error(t, err)
+}
+
+func TestLearningLogCreate_ContentExceeds10000Runes(t *testing.T) {
+	svc, _ := newTestLearningLogService()
+
+	longContent := strings.Repeat("あ", 10001)
+	log := &model.LearningLog{Title: "テスト", Content: longContent, UserID: 1, Duration: 60}
+	err := svc.Create(log)
+	assert.Error(t, err)
+}
+
+// ============================================================
 // CountByUserID テスト
 // ============================================================
 


### PR DESCRIPTION
## 概要
Closes #2261

- **bookmark_collection_test.go（Service層）**: CountByUserID の success/error テスト追加
- **handler/bookmark_collection_test.go**: GetMyCount の success/error テスト追加 + `assert` import 修正
- **learning_log_test.go**: Create の Title空・Title 200ルーン超過・Content 10000ルーン超過バリデーションテスト追加
- **ai_advice_test.go**: LongTitleTruncation テストをバイトベースからルーンベースに修正（Unicode対応）

## テスト計画
- [x] `go test ./internal/service/... -v` 全テスト PASS
- [x] `go test ./internal/handler/... -v` 全テスト PASS