### PR TITLE
fix: note_template・project_milestone・learning_log_template の Update TrimSpace 不整合修正

### DIFF
--- a/backend/internal/service/learning_log_template.go
+++ b/backend/internal/service/learning_log_template.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -76,19 +78,22 @@ func (s *LearningLogTemplateService) Update(id, userID uint, name, defaultTitle,
 		return nil, err
 	}
 
-	if name != "" {
+	if strings.TrimSpace(name) != "" {
+		name = strings.TrimSpace(name)
 		if err := domain.ValidateStringLength(name, 1, 100, "テンプレート名"); err != nil {
 			return nil, err
 		}
 		template.Name = name
 	}
-	if defaultTitle != "" {
+	if strings.TrimSpace(defaultTitle) != "" {
+		defaultTitle = strings.TrimSpace(defaultTitle)
 		if err := domain.ValidateStringLength(defaultTitle, 1, 200, "デフォルトタイトル"); err != nil {
 			return nil, err
 		}
 		template.DefaultTitle = defaultTitle
 	}
-	if defaultContent != "" {
+	if strings.TrimSpace(defaultContent) != "" {
+		defaultContent = strings.TrimSpace(defaultContent)
 		if err := domain.ValidateStringLength(defaultContent, 1, 50000, "デフォルト本文"); err != nil {
 			return nil, err
 		}

--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -79,19 +79,19 @@ func (s *NoteTemplateService) Update(id, userID uint, name, description, default
 	}
 
 	if strings.TrimSpace(name) != "" {
-		template.Name = name
+		template.Name = strings.TrimSpace(name)
 	}
 	if strings.TrimSpace(description) != "" {
-		template.Description = description
+		template.Description = strings.TrimSpace(description)
 	}
 	if strings.TrimSpace(defaultTitle) != "" {
-		template.DefaultTitle = defaultTitle
+		template.DefaultTitle = strings.TrimSpace(defaultTitle)
 	}
 	if strings.TrimSpace(contentTemplate) != "" {
-		template.ContentTemplate = contentTemplate
+		template.ContentTemplate = strings.TrimSpace(contentTemplate)
 	}
 	if strings.TrimSpace(defaultTags) != "" {
-		template.DefaultTags = defaultTags
+		template.DefaultTags = strings.TrimSpace(defaultTags)
 	}
 	if isDefault != nil {
 		template.IsDefault = *isDefault

--- a/backend/internal/service/project_milestone.go
+++ b/backend/internal/service/project_milestone.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"time"
 
 	"github.com/norman6464/devsync/backend/internal/domain"
@@ -78,13 +79,15 @@ func (s *ProjectMilestoneService) Update(userID, milestoneID uint, title, descri
 		return nil, err
 	}
 
-	if title != "" {
+	if strings.TrimSpace(title) != "" {
+		title = strings.TrimSpace(title)
 		if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
 			return nil, err
 		}
 		milestone.Title = title
 	}
-	if description != "" {
+	if strings.TrimSpace(description) != "" {
+		description = strings.TrimSpace(description)
 		if err := domain.ValidateStringLength(description, 1, 1000, "説明"); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## 概要
Closes #2263

Update メソッドで TrimSpace が適切に適用されていない問題を3ファイルで修正。

- **note_template.go**: `strings.TrimSpace()` でチェック後に未トリムの値を代入していた問題を修正（5フィールド）
- **project_milestone.go**: title/description に TrimSpace を適用（`strings` import 追加）
- **learning_log_template.go**: name/defaultTitle/defaultContent に TrimSpace を適用（`strings` import 追加）

## テスト計画
- [x] `go build ./...` ビルド成功
- [x] `go test ./internal/service/...` 全テスト PASS
- [x] `go test ./internal/handler/...` 全テスト PASS