### PR TITLE
feat: ロードマップの /my/count エンドポイント追加

### DIFF
--- a/backend/internal/handler/roadmap.go
+++ b/backend/internal/handler/roadmap.go
@@ -27,6 +27,7 @@ type RoadmapServiceInterface interface {
 	DeleteStep(roadmapID, stepID, userID uint) error
 	ReorderSteps(roadmapID, userID uint, orders []model.StepOrder) error
 	GetStats(userID uint) (*model.RoadmapStats, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // RoadmapHandler はロードマップ関連のHTTPハンドラ。
@@ -365,6 +366,17 @@ func (h *RoadmapHandler) ReorderSteps(c *gin.Context) {
 	}
 
 	respondOK(c, domain.NewMessageResponse("steps reordered"))
+}
+
+// GetMyCount は認証ユーザーのロードマップ総数を返す。
+func (h *RoadmapHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }
 
 // GetMyStats は認証ユーザーのロードマップ統計情報を取得する。

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -471,6 +471,10 @@ func (m *MockRoadmapRepository) GetByStatus(userID uint, status string) ([]model
 	args := m.Called(userID, status)
 	return args.Get(0).([]model.Roadmap), args.Error(1)
 }
+func (m *MockRoadmapRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 
 // MockChatRoomRepository は ChatRoomRepositoryInterface のモック実装。
 type MockChatRoomRepository struct{ mock.Mock }
@@ -1131,6 +1135,10 @@ func (m *MockRoadmapService) GetStats(userID uint) (*model.RoadmapStats, error) 
 		return s.(*model.RoadmapStats), args.Error(1)
 	}
 	return nil, args.Error(1)
+}
+func (m *MockRoadmapService) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
 }
 
 // setupRoadmapHandlerMock はRoadmapHandlerテスト用のモックセットアップを行う。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -303,6 +303,7 @@ type RoadmapRepositoryInterface interface {
 	FindStepByID(stepID uint) (*model.RoadmapStep, error)
 	ReorderSteps(roadmapID uint, stepOrders []model.StepOrder) error
 	GetTemplates() ([]model.Roadmap, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // ChatRoomRepositoryInterface はチャットルームデータ操作の契約を定義する。

--- a/backend/internal/repository/roadmap.go
+++ b/backend/internal/repository/roadmap.go
@@ -276,6 +276,13 @@ func (r *RoadmapRepository) ReorderSteps(roadmapID uint, stepOrders []model.Step
 	})
 }
 
+// CountByUserID は指定ユーザーのロードマップ総数を返す。
+func (r *RoadmapRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.Roadmap{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}
+
 // GetTemplates はテンプレートとしてマークされた全ロードマップをステップ付きで取得する。
 func (r *RoadmapRepository) GetTemplates() ([]model.Roadmap, error) {
 	var templates []model.Roadmap

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -637,6 +637,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		roadmaps.POST("/:id/steps/batch-complete", c.RoadmapHandler.BatchCompleteSteps)
 		roadmaps.PUT("/:id/steps/reorder", c.RoadmapHandler.ReorderSteps)
 		roadmaps.GET("/my/stats", c.RoadmapHandler.GetMyStats)
+		roadmaps.GET("/my/count", c.RoadmapHandler.GetMyCount)
 	}
 
 	// チャットルーム

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1080,6 +1080,11 @@ func (m *MockRoadmapRepository) GetTemplates() ([]model.Roadmap, error) {
 	return args.Get(0).([]model.Roadmap), args.Error(1)
 }
 
+func (m *MockRoadmapRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // ============================================================
 // MockChatRoomRepository は repository.ChatRoomRepositoryInterface のテスト用モック実装。
 // ============================================================

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -443,6 +443,11 @@ func (s *RoadmapService) SeedTemplates(userID uint) error {
 	return nil
 }
 
+// CountByUserID は指定ユーザーのロードマップ総数を返す。
+func (s *RoadmapService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}
+
 // ReorderSteps は所有権を検証した後、ステップの表示順序を一括更新する。
 func (s *RoadmapService) ReorderSteps(roadmapID, userID uint, orders []model.StepOrder) error {
 	if _, err := s.findAndCheckOwnership(roadmapID, userID); err != nil {


### PR DESCRIPTION
## 概要
Closes #2265

GET /api/v1/roadmaps/my/count でユーザーのロードマップ総数を取得可能にする。

## 変更内容
- **interfaces.go**: RoadmapRepositoryInterface に CountByUserID 追加
- **roadmap.go (repo)**: CountByUserID 実装
- **roadmap.go (service)**: CountByUserID 追加
- **roadmap.go (handler)**: GetMyCount ハンドラー追加
- **router.go**: /my/count ルート追加
- **mock_test.go / testutil_test.go**: モック更新

## テスト計画
- [x] `go build ./...` ビルド成功
- [x] `go test ./internal/service/...` 全テスト PASS
- [x] `go test ./internal/handler/...` 全テスト PASS