### PR TITLE
test: ロードマップ CountByUserID・GetMyCount テスト追加

### DIFF
--- a/backend/internal/handler/roadmap_test.go
+++ b/backend/internal/handler/roadmap_test.go
@@ -671,3 +671,30 @@ func TestRoadmapGetMyStats_ServiceError(t *testing.T) {
 	assertStatus(t, w, http.StatusInternalServerError)
 	svc.AssertExpectations(t)
 }
+
+// ---------- GetMyCount ----------
+
+func TestRoadmapGetMyCount_Success(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(5), nil)
+
+	w := doRequest(r, http.MethodGet, "/roadmaps/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Body.String(), `"count":5`)
+	svc.AssertExpectations(t)
+}
+
+func TestRoadmapGetMyCount_ServiceError(t *testing.T) {
+	h, svc := setupRoadmapHandlerMock()
+	r := newRouter(1)
+	r.GET("/roadmaps/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/roadmaps/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
+}

--- a/backend/internal/service/roadmap_test.go
+++ b/backend/internal/service/roadmap_test.go
@@ -1418,3 +1418,29 @@ func TestRoadmapUpdateStep_ResourceURLTooLong(t *testing.T) {
 	assert.Nil(t, result)
 	assert.Contains(t, err.Error(), "500文字以下")
 }
+
+// ============================================================
+// CountByUserID テスト
+// ============================================================
+
+func TestRoadmapCountByUserID_Success(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(5), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+	repo.AssertExpectations(t)
+}
+
+func TestRoadmapCountByUserID_Error(t *testing.T) {
+	svc, repo := newTestRoadmapService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
Closes #2269

Cycle 25 Phase 1 で追加したロードマップの CountByUserID/GetMyCount のテストを追加。

- **roadmap_test.go（Service層）**: CountByUserID success/error テスト
- **handler/roadmap_test.go（Handler層）**: GetMyCount success/error テスト

## テスト計画
- [x] `go test ./internal/service/...` 全テスト PASS
- [x] `go test ./internal/handler/...` 全テスト PASS