### PR TITLE
fix: study_circle Update の description に TrimSpace 適用

### DIFF
--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -139,7 +139,7 @@ func (s *StudyCircleService) Update(id, userID uint, name, topic, description *s
 		if err := domain.ValidateStringLength(*description, 0, 1000, "説明"); err != nil {
 			return nil, err
 		}
-		circle.Description = *description
+		circle.Description = strings.TrimSpace(*description)
 	}
 
 	if err := s.repo.Update(circle); err != nil {


### PR DESCRIPTION
## 概要
Closes #2271

study_circle.go の Update メソッドで name・topic には TrimSpace が適用されていたが、description のみ漏れていた問題を修正。

## テスト計画
- [x] `go build ./...` ビルド成功
- [x] `go test ./internal/service/...` 全テスト PASS
- [x] `go test ./internal/handler/...` 全テスト PASS