### PR TITLE
feat: チャットルームの /my/count エンドポイント追加

### DIFF
--- a/backend/internal/handler/chat_room.go
+++ b/backend/internal/handler/chat_room.go
@@ -19,6 +19,7 @@ type ChatRoomServiceInterface interface {
 	RemoveMember(roomID, userID, targetUserID uint) error
 	GetMessages(roomID, userID uint, page, limit int) ([]model.GroupMessage, error)
 	SendMessage(roomID, userID uint, content string) (*model.GroupMessage, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // ChatRoomHandler はチャットルーム関連のHTTPハンドラ。
@@ -197,4 +198,15 @@ func (h *ChatRoomHandler) SendMessage(c *gin.Context) {
 	}
 
 	respondCreated(c, msg)
+}
+
+// GetMyCount は認証ユーザーが参加しているチャットルーム総数を返す。
+func (h *ChatRoomHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -513,6 +513,10 @@ func (m *MockChatRoomRepository) IsMember(roomID, userID uint) (bool, error) {
 	args := m.Called(roomID, userID)
 	return args.Bool(0), args.Error(1)
 }
+func (m *MockChatRoomRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 
 // MockGroupMessageRepository は GroupMessageRepositoryInterface のモック実装。
 type MockGroupMessageRepository struct{ mock.Mock }
@@ -1389,6 +1393,10 @@ func (m *MockChatRoomService) SendMessage(roomID, userID uint, content string) (
 		return r.(*model.GroupMessage), args.Error(1)
 	}
 	return nil, args.Error(1)
+}
+func (m *MockChatRoomService) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
 }
 
 // setupChatRoomHandler はChatRoomHandlerテスト用のセットアップを行う。

--- a/backend/internal/repository/chat_room.go
+++ b/backend/internal/repository/chat_room.go
@@ -88,6 +88,13 @@ func (r *ChatRoomRepository) GetMembers(roomID uint) ([]model.ChatRoomMember, er
 	return members, err
 }
 
+// CountByUserID は指定ユーザーが参加しているチャットルーム総数を返す。
+func (r *ChatRoomRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.ChatRoomMember{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}
+
 // IsMember は指定ユーザーがチャットルームのメンバーであるかを判定する。
 func (r *ChatRoomRepository) IsMember(roomID, userID uint) (bool, error) {
 	var count int64

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -318,6 +318,7 @@ type ChatRoomRepositoryInterface interface {
 	RemoveMember(roomID, userID uint) error
 	GetMembers(roomID uint) ([]model.ChatRoomMember, error)
 	IsMember(roomID, userID uint) (bool, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // GroupMessageRepositoryInterface はグループメッセージデータ操作の契約を定義する。

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -653,6 +653,7 @@ func registerCommunityRoutes(g *gin.RouterGroup, c *di.Container) {
 		chatRooms.DELETE("/:id/members/:userId", c.ChatRoomHandler.RemoveMember)
 		chatRooms.GET("/:id/messages", c.ChatRoomHandler.GetMessages)
 		chatRooms.POST("/:id/messages", c.ChatRoomHandler.SendMessage)
+		chatRooms.GET("/my/count", c.ChatRoomHandler.GetMyCount)
 	}
 
 	// 書籍レビュー

--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -205,6 +205,11 @@ func (s *ChatRoomService) SendMessage(roomID, userID uint, content string) (*mod
 	return msg, nil
 }
 
+// CountByUserID は指定ユーザーが参加しているチャットルーム総数を返す。
+func (s *ChatRoomService) CountByUserID(userID uint) (int64, error) {
+	return s.roomRepo.CountByUserID(userID)
+}
+
 // IsMember は指定ユーザーがチャットルームのメンバーかを判定する。
 func (s *ChatRoomService) IsMember(roomID, userID uint) (bool, error) {
 	return s.roomRepo.IsMember(roomID, userID)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1141,6 +1141,11 @@ func (m *MockChatRoomRepository) IsMember(roomID, userID uint) (bool, error) {
 	return args.Bool(0), args.Error(1)
 }
 
+func (m *MockChatRoomRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // ============================================================
 // MockGroupMessageRepository は repository.GroupMessageRepositoryInterface のテスト用モック実装。
 // ============================================================


### PR DESCRIPTION
## 概要
Closes #2273

GET /api/v1/chat-rooms/my/count でユーザーが参加しているチャットルーム総数を取得可能にする。

## 変更内容
- **interfaces.go**: ChatRoomRepositoryInterface に CountByUserID 追加
- **chat_room.go (repo)**: chat_room_members テーブルでユーザー参加ルーム数をカウント
- **chat_room.go (service)**: CountByUserID 追加
- **chat_room.go (handler)**: GetMyCount ハンドラー追加
- **router.go**: /my/count ルート追加
- **mock_test.go / testutil_test.go**: モック更新

## テスト計画
- [x] `go build ./...` ビルド成功
- [x] `go test ./internal/service/...` 全テスト PASS
- [x] `go test ./internal/handler/...` 全テスト PASS