### PR TITLE
refactor: code_snippet/roadmap UpdateのダブルTrimSpace最適化

### DIFF
--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -88,23 +88,23 @@ func (s *CodeSnippetService) Update(id, userID uint, language, fileName, code st
 		return nil, err
 	}
 
-	if strings.TrimSpace(language) != "" {
-		if err := domain.ValidateStringLength(language, 1, 100, "言語"); err != nil {
+	if lang := strings.TrimSpace(language); lang != "" {
+		if err := domain.ValidateStringLength(lang, 1, 100, "言語"); err != nil {
 			return nil, err
 		}
-		snippet.Language = strings.TrimSpace(language)
+		snippet.Language = lang
 	}
-	if strings.TrimSpace(fileName) != "" {
-		if err := domain.ValidateStringLength(fileName, 1, 200, "ファイル名"); err != nil {
+	if fn := strings.TrimSpace(fileName); fn != "" {
+		if err := domain.ValidateStringLength(fn, 1, 200, "ファイル名"); err != nil {
 			return nil, err
 		}
-		snippet.FileName = strings.TrimSpace(fileName)
+		snippet.FileName = fn
 	}
-	if strings.TrimSpace(code) != "" {
-		if err := domain.ValidateStringLength(code, 1, 50000, "コード"); err != nil {
+	if c := strings.TrimSpace(code); c != "" {
+		if err := domain.ValidateStringLength(c, 1, 50000, "コード"); err != nil {
 			return nil, err
 		}
-		snippet.Code = strings.TrimSpace(code)
+		snippet.Code = c
 	}
 
 	if err := s.repo.Update(snippet); err != nil {

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -103,17 +103,17 @@ func (s *RoadmapService) Update(id, userID uint, updates *model.Roadmap) (*model
 		return nil, err
 	}
 
-	if strings.TrimSpace(updates.Title) != "" {
-		if err := domain.ValidateStringLength(updates.Title, 1, 200, "タイトル"); err != nil {
+	if title := strings.TrimSpace(updates.Title); title != "" {
+		if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
 			return nil, err
 		}
-		roadmap.Title = strings.TrimSpace(updates.Title)
+		roadmap.Title = title
 	}
-	if strings.TrimSpace(updates.Description) != "" {
-		if err := domain.ValidateStringLength(updates.Description, 1, 1000, "説明"); err != nil {
+	if desc := strings.TrimSpace(updates.Description); desc != "" {
+		if err := domain.ValidateStringLength(desc, 1, 1000, "説明"); err != nil {
 			return nil, err
 		}
-		roadmap.Description = strings.TrimSpace(updates.Description)
+		roadmap.Description = desc
 	}
 	if strings.TrimSpace(string(updates.Category)) != "" {
 		roadmap.Category = updates.Category
@@ -185,23 +185,23 @@ func (s *RoadmapService) UpdateStep(roadmapID, stepID, userID uint, updates *mod
 		return nil, err
 	}
 
-	if strings.TrimSpace(updates.Title) != "" {
-		if err := domain.ValidateStringLength(updates.Title, 1, 200, "タイトル"); err != nil {
+	if title := strings.TrimSpace(updates.Title); title != "" {
+		if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
 			return nil, err
 		}
-		step.Title = strings.TrimSpace(updates.Title)
+		step.Title = title
 	}
-	if strings.TrimSpace(updates.Description) != "" {
-		if err := domain.ValidateStringLength(updates.Description, 1, 1000, "説明"); err != nil {
+	if desc := strings.TrimSpace(updates.Description); desc != "" {
+		if err := domain.ValidateStringLength(desc, 1, 1000, "説明"); err != nil {
 			return nil, err
 		}
-		step.Description = strings.TrimSpace(updates.Description)
+		step.Description = desc
 	}
-	if strings.TrimSpace(updates.ResourceURL) != "" {
-		if err := domain.ValidateStringLength(updates.ResourceURL, 1, 500, "リソースURL"); err != nil {
+	if url := strings.TrimSpace(updates.ResourceURL); url != "" {
+		if err := domain.ValidateStringLength(url, 1, 500, "リソースURL"); err != nil {
 			return nil, err
 		}
-		step.ResourceURL = strings.TrimSpace(updates.ResourceURL)
+		step.ResourceURL = url
 	}
 
 	if err := s.repo.UpdateStep(step); err != nil {


### PR DESCRIPTION
## 概要
- code_snippet.go Updateメソッド: language/fileName/codeのTrimSpaceをif-scoped変数パターンに変更
- roadmap.go Updateメソッド: Title/DescriptionのTrimSpaceをif-scoped変数パターンに変更
- roadmap.go UpdateStepメソッド: Title/Description/ResourceURLのTrimSpaceをif-scoped変数パターンに変更

## 変更理由
各フィールドで`strings.TrimSpace()`が2回呼ばれていた（条件判定時と代入時）のを、if-scoped変数を使って1回に最適化。

## テスト
- `go test ./internal/service/... -run TestRoadmap` 全テスト通過

closes #2275