### PR TITLE
test: chat_room CountByUserID/GetMyCountテスト追加

### DIFF
--- a/backend/internal/handler/chat_room_test.go
+++ b/backend/internal/handler/chat_room_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -361,6 +362,33 @@ func TestChatRoomSendMessage_NotMember(t *testing.T) {
 		"content": "Hello",
 	})
 	assertStatus(t, w, http.StatusForbidden)
+}
+
+// ---------- GetMyCount ----------
+
+func TestChatRoomGetMyCount_Success(t *testing.T) {
+	h, svc := setupChatRoomHandler()
+	r := newRouter(1)
+	r.GET("/chat-rooms/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(3), nil)
+
+	w := doRequest(r, http.MethodGet, "/chat-rooms/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Body.String(), `"count":3`)
+	svc.AssertExpectations(t)
+}
+
+func TestChatRoomGetMyCount_ServiceError(t *testing.T) {
+	h, svc := setupChatRoomHandler()
+	r := newRouter(1)
+	r.GET("/chat-rooms/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/chat-rooms/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
 }
 
 func TestChatRoomSendMessage_ValidationError(t *testing.T) {

--- a/backend/internal/service/chat_room_test.go
+++ b/backend/internal/service/chat_room_test.go
@@ -649,6 +649,32 @@ func TestChatRoomUpdate_WhitespaceName(t *testing.T) {
 	assert.Contains(t, err.Error(), "チャットルーム名を入力してください")
 }
 
+// ============================================================
+// CountByUserID テスト
+// ============================================================
+
+func TestChatRoomCountByUserID_Success(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	roomRepo.On("CountByUserID", uint(1)).Return(int64(3), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+	roomRepo.AssertExpectations(t)
+}
+
+func TestChatRoomCountByUserID_Error(t *testing.T) {
+	svc, roomRepo, _ := newTestChatRoomService()
+
+	roomRepo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	roomRepo.AssertExpectations(t)
+}
+
 func TestChatRoomUpdate_WhitespaceDescription(t *testing.T) {
 	svc, roomRepo, _ := newTestChatRoomService()
 


### PR DESCRIPTION
## 概要
- Service層: CountByUserID の成功/エラーテスト追加
- Handler層: GetMyCount の成功/サービスエラーテスト追加

## テスト
- `go test ./internal/service/... -run TestChatRoomCount` 全通過
- `go test ./internal/handler/... -run TestChatRoomGetMyCount` 全通過

closes #2277