### PR TITLE
fix: post_collection Create/user UpdateProfileのTrimSpace欠如修正

### DIFF
--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -28,6 +28,7 @@ func (s *PostCollectionService) Create(collection *model.PostCollection) (*model
 		return nil, err
 	}
 	collection.Title = strings.TrimSpace(collection.Title)
+	collection.Description = strings.TrimSpace(collection.Description)
 	if err := s.repo.Create(collection); err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -1,6 +1,8 @@
 package service
 
 import (
+	"strings"
+
 	"github.com/norman6464/devsync/backend/internal/domain"
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/repository"
@@ -99,11 +101,11 @@ func (s *UserService) UpdateProfile(id, userID uint, input *UpdateProfileInput) 
 		return nil, domain.NewError(domain.ErrCodeNotFound, "ユーザーが見つかりません", err)
 	}
 
-	if input.Name != "" {
-		existing.Name = input.Name
+	if name := strings.TrimSpace(input.Name); name != "" {
+		existing.Name = name
 	}
-	existing.Bio = input.Bio
-	existing.AvatarURL = input.AvatarURL
+	existing.Bio = strings.TrimSpace(input.Bio)
+	existing.AvatarURL = strings.TrimSpace(input.AvatarURL)
 	if input.SkillsLanguages != nil {
 		existing.SkillsLanguages = *input.SkillsLanguages
 	}


### PR DESCRIPTION
## 概要
- post_collection.go Create: DescriptionのTrimSpaceが欠如していたため追加
- user.go UpdateProfile: Name/Bio/AvatarURLのTrimSpaceが欠如していたため追加

## テスト
- `go test ./internal/service/... -run "TestPostCollection|TestUser"` 全テスト通過

closes #2279