### PR TITLE
feat: study-circles /my/count エンドポイント追加

### DIFF
--- a/backend/internal/handler/study_circle.go
+++ b/backend/internal/handler/study_circle.go
@@ -29,6 +29,7 @@ type StudyCircleServiceInterface interface {
 	GetByStatus(userID uint, status string) ([]model.StudyCircle, error)
 	UpdateMemberRole(circleID, userID, targetUserID uint, role string) error
 	SearchCircles(query string, limit, offset int) ([]model.StudyCircle, int64, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // StudyCircleHandler はスタディサークル関連のHTTPリクエストを処理する。
@@ -392,4 +393,15 @@ func (h *StudyCircleHandler) Search(c *gin.Context) {
 		Limit:   limit,
 		Offset:  offset,
 	})
+}
+
+// GetMyCount は認証ユーザーが参加しているスタディサークル総数を返す。
+func (h *StudyCircleHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -801,6 +801,11 @@ func (m *MockStudyCircleRepository) UpdateMemberRole(circleID, userID uint, role
 	return args.Error(0)
 }
 
+func (m *MockStudyCircleRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // setupStudyCircleHandler はStudyCircleHandlerテスト用のセットアップを行う。
 func setupStudyCircleHandler() (*StudyCircleHandler, *MockStudyCircleRepository) {
 	repo := new(MockStudyCircleRepository)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -491,6 +491,9 @@ type StudyCircleRepositoryInterface interface {
 
 	// ストリークランキング
 	GetStreakRanking(circleID uint) ([]model.CircleMemberStreak, error)
+
+	// カウント
+	CountByUserID(userID uint) (int64, error)
 }
 
 // NotificationSettingsRepositoryInterface は通知設定データ操作の契約を定義する。

--- a/backend/internal/repository/study_circle.go
+++ b/backend/internal/repository/study_circle.go
@@ -310,3 +310,10 @@ func (r *StudyCircleRepository) Search(query string, limit, offset int) ([]model
 	err := db.Offset(offset).Limit(limit).Find(&circles).Error
 	return circles, total, err
 }
+
+// CountByUserID は指定ユーザーが参加しているスタディサークル総数を返す。
+func (r *StudyCircleRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.StudyCircleMember{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -722,6 +722,7 @@ func registerStudyCircleRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		circles.POST("", c.StudyCircleHandler.Create)
 		circles.GET("", c.StudyCircleHandler.GetMyCircles)
+		circles.GET("/my/count", c.StudyCircleHandler.GetMyCount)
 		circles.GET("/status/:status", c.StudyCircleHandler.GetByStatus)
 		circles.GET("/:id", c.StudyCircleHandler.GetByID)
 		circles.PUT("/:id", c.StudyCircleHandler.Update)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -1811,6 +1811,11 @@ func (m *MockStudyCircleRepository) UpdateMemberRole(circleID, userID uint, role
 	return args.Error(0)
 }
 
+func (m *MockStudyCircleRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // インターフェース適合チェック
 var _ EmailSenderInterface = (*MockEmailSender)(nil)
 var _ repository.ActivityReportRepositoryInterface = (*MockActivityReportRepository)(nil)

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -400,3 +400,8 @@ func (s *StudyCircleService) GetStreakRanking(circleID, userID uint) ([]model.Ci
 func (s *StudyCircleService) SearchCircles(query string, limit, offset int) ([]model.StudyCircle, int64, error) {
 	return s.repo.Search(query, limit, offset)
 }
+
+// CountByUserID は指定ユーザーが参加しているスタディサークル総数を返す。
+func (s *StudyCircleService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}


### PR DESCRIPTION
## 概要
- スタディサークルの参加数を返す GET /api/v1/study-circles/my/count エンドポイントを追加
- study_circle_membersテーブルでユーザーの参加サークル数をカウント

## 変更ファイル（7ファイル）
- repository/interfaces.go: CountByUserID追加
- repository/study_circle.go: CountByUserID実装
- service/study_circle.go: CountByUserID passthrough
- handler/study_circle.go: インターフェース更新 + GetMyCountメソッド
- router/router.go: ルート追加
- service/mock_test.go, handler/testutil_test.go: モック追加

## テスト
- `go test ./internal/service/... -run TestStudyCircle` 全通過
- `go test ./internal/handler/... -run TestStudyCircle` 全通過

closes #2281