### PR TITLE
refactor: note_template/learning_log_template UpdateのダブルTrimSpace最適化

### DIFF
--- a/backend/internal/service/learning_log_template.go
+++ b/backend/internal/service/learning_log_template.go
@@ -78,26 +78,23 @@ func (s *LearningLogTemplateService) Update(id, userID uint, name, defaultTitle,
 		return nil, err
 	}
 
-	if strings.TrimSpace(name) != "" {
-		name = strings.TrimSpace(name)
-		if err := domain.ValidateStringLength(name, 1, 100, "テンプレート名"); err != nil {
+	if n := strings.TrimSpace(name); n != "" {
+		if err := domain.ValidateStringLength(n, 1, 100, "テンプレート名"); err != nil {
 			return nil, err
 		}
-		template.Name = name
+		template.Name = n
 	}
-	if strings.TrimSpace(defaultTitle) != "" {
-		defaultTitle = strings.TrimSpace(defaultTitle)
-		if err := domain.ValidateStringLength(defaultTitle, 1, 200, "デフォルトタイトル"); err != nil {
+	if dt := strings.TrimSpace(defaultTitle); dt != "" {
+		if err := domain.ValidateStringLength(dt, 1, 200, "デフォルトタイトル"); err != nil {
 			return nil, err
 		}
-		template.DefaultTitle = defaultTitle
+		template.DefaultTitle = dt
 	}
-	if strings.TrimSpace(defaultContent) != "" {
-		defaultContent = strings.TrimSpace(defaultContent)
-		if err := domain.ValidateStringLength(defaultContent, 1, 50000, "デフォルト本文"); err != nil {
+	if dc := strings.TrimSpace(defaultContent); dc != "" {
+		if err := domain.ValidateStringLength(dc, 1, 50000, "デフォルト本文"); err != nil {
 			return nil, err
 		}
-		template.DefaultContent = defaultContent
+		template.DefaultContent = dc
 	}
 	if defaultCategory != "" {
 		if !model.ValidCategories[defaultCategory] {

--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -78,20 +78,20 @@ func (s *NoteTemplateService) Update(id, userID uint, name, description, default
 		return nil, err
 	}
 
-	if strings.TrimSpace(name) != "" {
-		template.Name = strings.TrimSpace(name)
+	if n := strings.TrimSpace(name); n != "" {
+		template.Name = n
 	}
-	if strings.TrimSpace(description) != "" {
-		template.Description = strings.TrimSpace(description)
+	if d := strings.TrimSpace(description); d != "" {
+		template.Description = d
 	}
-	if strings.TrimSpace(defaultTitle) != "" {
-		template.DefaultTitle = strings.TrimSpace(defaultTitle)
+	if dt := strings.TrimSpace(defaultTitle); dt != "" {
+		template.DefaultTitle = dt
 	}
-	if strings.TrimSpace(contentTemplate) != "" {
-		template.ContentTemplate = strings.TrimSpace(contentTemplate)
+	if ct := strings.TrimSpace(contentTemplate); ct != "" {
+		template.ContentTemplate = ct
 	}
-	if strings.TrimSpace(defaultTags) != "" {
-		template.DefaultTags = strings.TrimSpace(defaultTags)
+	if tags := strings.TrimSpace(defaultTags); tags != "" {
+		template.DefaultTags = tags
 	}
 	if isDefault != nil {
 		template.IsDefault = *isDefault


### PR DESCRIPTION
## 概要
- note_template.go Update: name/description/defaultTitle/contentTemplate/defaultTagsの5フィールドをif-scoped変数パターンに変更
- learning_log_template.go Update: name/defaultTitle/defaultContentの3フィールドをif-scoped変数パターンに変更

## テスト
- `go test ./internal/service/... -run "TestNoteTemplate|TestLearningLogTemplate"` 全通過

closes #2283