### PR TITLE
test: study_circle CountByUserID/GetMyCountテスト追加

### DIFF
--- a/backend/internal/handler/study_circle_test.go
+++ b/backend/internal/handler/study_circle_test.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"testing"
 
@@ -592,4 +593,31 @@ func TestStudyCircle_GetByStatus_InvalidStatus(t *testing.T) {
 
 	w := doRequest(r, http.MethodGet, "/study-circles/status/invalid", nil)
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ---------- GetMyCount ----------
+
+func TestStudyCircleGetMyCount_Success(t *testing.T) {
+	h, repo := setupStudyCircleHandler()
+	r := newRouter(1)
+	r.GET("/study-circles/my/count", h.GetMyCount)
+
+	repo.On("CountByUserID", uint(1)).Return(int64(4), nil)
+
+	w := doRequest(r, http.MethodGet, "/study-circles/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Body.String(), `"count":4`)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleGetMyCount_RepoError(t *testing.T) {
+	h, repo := setupStudyCircleHandler()
+	r := newRouter(1)
+	r.GET("/study-circles/my/count", h.GetMyCount)
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/study-circles/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	repo.AssertExpectations(t)
 }

--- a/backend/internal/service/study_circle_test.go
+++ b/backend/internal/service/study_circle_test.go
@@ -1177,3 +1177,27 @@ func TestStudyCircleUpdateMemberRole_TargetNotMember(t *testing.T) {
 	assert.ErrorIs(t, err, ErrNotFound)
 	repo.AssertExpectations(t)
 }
+
+// --- CountByUserID ---
+
+func TestStudyCircleCountByUserID_Success(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(4), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(4), count)
+	repo.AssertExpectations(t)
+}
+
+func TestStudyCircleCountByUserID_Error(t *testing.T) {
+	svc, repo := newTestStudyCircleService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- Service層: CountByUserID の成功/エラーテスト追加
- Handler層: GetMyCount の成功/リポジトリエラーテスト追加

## テスト
- `go test ./internal/service/... -run TestStudyCircleCount` 全通過
- `go test ./internal/handler/... -run TestStudyCircleGetMyCount` 全通過

closes #2285