### PR TITLE
fix: bookmark_collection/project_milestone CreateのTrimSpace欠如修正

### DIFF
--- a/backend/internal/service/bookmark_collection.go
+++ b/backend/internal/service/bookmark_collection.go
@@ -29,6 +29,9 @@ func (s *BookmarkCollectionService) Create(collection *model.BookmarkCollection)
 	if err := domain.ValidateStringLength(collection.Color, 0, 20, "カラー"); err != nil {
 		return err
 	}
+	collection.Name = strings.TrimSpace(collection.Name)
+	collection.Description = strings.TrimSpace(collection.Description)
+	collection.Color = strings.TrimSpace(collection.Color)
 	return s.repo.Create(collection)
 }
 

--- a/backend/internal/service/project_milestone.go
+++ b/backend/internal/service/project_milestone.go
@@ -54,8 +54,8 @@ func (s *ProjectMilestoneService) Create(userID, projectID uint, title, descript
 
 	milestone := &model.ProjectMilestone{
 		ProjectID:   projectID,
-		Title:       title,
-		Description: description,
+		Title:       strings.TrimSpace(title),
+		Description: strings.TrimSpace(description),
 		DueDate:     dueDate,
 		Status:      model.MilestoneNotStarted,
 	}


### PR DESCRIPTION
## 概要
- bookmark_collection.go Create: Name/Description/ColorのTrimSpace追加（DBにパディング付きの値が保存される問題を修正）
- project_milestone.go Create: Title/DescriptionのTrimSpace追加（同上）

## テスト
- `go test ./internal/service/... -run "TestBookmarkCollection|TestProjectMilestone"` 全通過

closes #2287