### PR TITLE
feat: note-templates /my/count エンドポイント追加

### DIFF
--- a/backend/internal/handler/note_template.go
+++ b/backend/internal/handler/note_template.go
@@ -15,6 +15,7 @@ type NoteTemplateServiceInterface interface {
 	Update(id, userID uint, name, description, defaultTitle, contentTemplate, defaultTags string, isDefault *bool) (*model.NoteTemplate, error)
 	Delete(id, userID uint) error
 	UseTemplate(id, userID uint) (*model.Note, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // NoteTemplateHandler はノートテンプレート関連のHTTPハンドラ。
@@ -149,4 +150,15 @@ func (h *NoteTemplateHandler) UseTemplate(c *gin.Context) {
 	}
 
 	respondCreated(c, note)
+}
+
+// GetMyCount は認証ユーザーのノートテンプレート総数を返す。
+func (h *NoteTemplateHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -1987,6 +1987,11 @@ func (m *MockNoteTemplateService) UseTemplate(id, userID uint) (*model.Note, err
 	return nil, args.Error(1)
 }
 
+func (m *MockNoteTemplateService) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func setupNoteTemplateHandler() (*NoteTemplateHandler, *MockNoteTemplateService) {
 	svc := new(MockNoteTemplateService)
 	h := NewNoteTemplateHandler(svc)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -788,4 +788,5 @@ type NoteTemplateRepositoryInterface interface {
 	Update(template *model.NoteTemplate) error
 	Delete(id uint) error
 	ClearDefaultFlag(userID uint) error
+	CountByUserID(userID uint) (int64, error)
 }

--- a/backend/internal/repository/note_template.go
+++ b/backend/internal/repository/note_template.go
@@ -64,3 +64,10 @@ func (r *NoteTemplateRepository) ClearDefaultFlag(userID uint) error {
 		Where("user_id = ?", userID).
 		Update("is_default", false).Error
 }
+
+// CountByUserID は指定ユーザーのノートテンプレート総数を返す。
+func (r *NoteTemplateRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.NoteTemplate{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -574,6 +574,7 @@ func registerNoteRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		noteTemplates.POST("", c.NoteTemplateHandler.Create)
 		noteTemplates.GET("", c.NoteTemplateHandler.GetByUserID)
+		noteTemplates.GET("/my/count", c.NoteTemplateHandler.GetMyCount)
 		noteTemplates.GET("/default", c.NoteTemplateHandler.GetDefault)
 		noteTemplates.GET("/:id", c.NoteTemplateHandler.GetByID)
 		noteTemplates.PUT("/:id", c.NoteTemplateHandler.Update)

--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -161,3 +161,8 @@ func (s *NoteTemplateService) UseTemplate(id, userID uint) (*model.Note, error) 
 	}
 	return note, nil
 }
+
+// CountByUserID は指定ユーザーのノートテンプレート総数を返す。
+func (s *NoteTemplateService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}

--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -52,6 +52,11 @@ func (m *MockNoteTemplateRepository) ClearDefaultFlag(userID uint) error {
 	return m.Called(userID).Error(0)
 }
 
+func (m *MockNoteTemplateRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // MockNoteCreator はNoteCreatorInterfaceのモック実装。
 type MockNoteCreator struct {
 	mock.Mock


### PR DESCRIPTION
## 概要
- ノートテンプレート数を返す GET /api/v1/note-templates/my/count エンドポイントを追加

## 変更ファイル（7ファイル）
- repository/interfaces.go: CountByUserID追加
- repository/note_template.go: CountByUserID実装
- service/note_template.go: CountByUserID passthrough
- handler/note_template.go: インターフェース更新 + GetMyCountメソッド
- router/router.go: ルート追加
- service/note_template_test.go, handler/testutil_test.go: モック追加

## テスト
- `go test ./internal/service/... -run TestNoteTemplate` 全通過

closes #2289