### PR TITLE
refactor: post_collection Update所有権チェック順序修正

### DIFF
--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -70,14 +70,15 @@ func (s *PostCollectionService) findAndCheckOwnership(id, userID uint) (*model.P
 
 // Update は所有権を検証した後、コレクションを更新する。
 func (s *PostCollectionService) Update(id, userID uint, title, description string, isPublic bool) (*model.PostCollection, error) {
+	collection, err := s.findAndCheckOwnership(id, userID)
+	if err != nil {
+		return nil, err
+	}
+
 	if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
 		return nil, err
 	}
 	if err := domain.ValidateStringLength(description, 0, 1000, "説明"); err != nil {
-		return nil, err
-	}
-	collection, err := s.findAndCheckOwnership(id, userID)
-	if err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/service/post_collection_test.go
+++ b/backend/internal/service/post_collection_test.go
@@ -225,7 +225,10 @@ func TestPostCollectionUpdate_RepoError(t *testing.T) {
 }
 
 func TestPostCollectionUpdate_EmptyTitle(t *testing.T) {
-	svc, _ := newTestPostCollectionService()
+	svc, repo := newTestPostCollectionService()
+	collection := &model.PostCollection{Title: "Old", UserID: 1}
+	collection.ID = 10
+	repo.On("FindByID", uint(10)).Return(collection, nil)
 
 	result, err := svc.Update(10, 1, "", "desc", false)
 	assert.Error(t, err)
@@ -234,7 +237,10 @@ func TestPostCollectionUpdate_EmptyTitle(t *testing.T) {
 }
 
 func TestPostCollectionUpdate_WhitespaceTitle(t *testing.T) {
-	svc, _ := newTestPostCollectionService()
+	svc, repo := newTestPostCollectionService()
+	collection := &model.PostCollection{Title: "Old", UserID: 1}
+	collection.ID = 10
+	repo.On("FindByID", uint(10)).Return(collection, nil)
 
 	result, err := svc.Update(10, 1, "   ", "desc", false)
 	assert.Error(t, err)
@@ -446,7 +452,10 @@ func TestPostCollectionCreate_DescriptionTooLong(t *testing.T) {
 }
 
 func TestPostCollectionUpdate_TitleTooLong(t *testing.T) {
-	svc, _ := newTestPostCollectionService()
+	svc, repo := newTestPostCollectionService()
+	collection := &model.PostCollection{Title: "Old", UserID: 1}
+	collection.ID = 1
+	repo.On("FindByID", uint(1)).Return(collection, nil)
 
 	result, err := svc.Update(1, 1, strings.Repeat("あ", 201), "説明", true)
 	assert.Error(t, err)
@@ -455,7 +464,10 @@ func TestPostCollectionUpdate_TitleTooLong(t *testing.T) {
 }
 
 func TestPostCollectionUpdate_DescriptionTooLong(t *testing.T) {
-	svc, _ := newTestPostCollectionService()
+	svc, repo := newTestPostCollectionService()
+	collection := &model.PostCollection{Title: "Old", UserID: 1}
+	collection.ID = 1
+	repo.On("FindByID", uint(1)).Return(collection, nil)
 
 	result, err := svc.Update(1, 1, "タイトル", strings.Repeat("あ", 1001), true)
 	assert.Error(t, err)


### PR DESCRIPTION
## 概要
- post_collection.go Updateメソッドで所有権チェックをバリデーションより先に実行するよう変更
- 未認可ユーザーのリクエストがバリデーションエラーを返さず、正しくForbiddenを返すように改善

## テスト
- テストをリファクタリングに合わせて更新（FindByIDモック追加）
- `go test ./internal/service/... -run TestPostCollection` 全通過

closes #2291