### PR TITLE
test: note_template CountByUserID/GetMyCountテスト追加

### DIFF
--- a/backend/internal/handler/note_template_test.go
+++ b/backend/internal/handler/note_template_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -253,6 +254,33 @@ func TestNoteTemplateDelete_InvalidID(t *testing.T) {
 	w := doRequest(r, "DELETE", "/note-templates/abc", nil)
 
 	assertStatus(t, w, http.StatusBadRequest)
+}
+
+// ---------- GetMyCount ----------
+
+func TestNoteTemplateGetMyCount_Success(t *testing.T) {
+	h, svc := setupNoteTemplateHandler()
+	r := newRouter(1)
+	r.GET("/note-templates/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(5), nil)
+
+	w := doRequest(r, http.MethodGet, "/note-templates/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	assert.Contains(t, w.Body.String(), `"count":5`)
+	svc.AssertExpectations(t)
+}
+
+func TestNoteTemplateGetMyCount_ServiceError(t *testing.T) {
+	h, svc := setupNoteTemplateHandler()
+	r := newRouter(1)
+	r.GET("/note-templates/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/note-templates/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
+	svc.AssertExpectations(t)
 }
 
 func TestNoteTemplateUseTemplate_InvalidID(t *testing.T) {

--- a/backend/internal/service/note_template_test.go
+++ b/backend/internal/service/note_template_test.go
@@ -593,6 +593,30 @@ func TestNoteTemplateUpdate_WhitespaceDefaultTitle(t *testing.T) {
 	assert.Equal(t, "Original Title", result.DefaultTitle)
 }
 
+// --- CountByUserID ---
+
+func TestNoteTemplateCountByUserID_Success(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(5), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+	repo.AssertExpectations(t)
+}
+
+func TestNoteTemplateCountByUserID_Error(t *testing.T) {
+	svc, repo, _ := newTestNoteTemplateService()
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	count, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	assert.Equal(t, int64(0), count)
+	repo.AssertExpectations(t)
+}
+
 func TestNoteTemplateUpdate_WhitespaceDefaultTags(t *testing.T) {
 	svc, repo, _ := newTestNoteTemplateService()
 	existing := &model.NoteTemplate{Name: "Template", ContentTemplate: "Content", DefaultTags: "go,rust", UserID: 1}


### PR DESCRIPTION
## 概要
- Service層: CountByUserID の成功/エラーテスト追加
- Handler層: GetMyCount の成功/サービスエラーテスト追加

## テスト
- `go test ./internal/service/... -run TestNoteTemplateCount` 全通過
- `go test ./internal/handler/... -run TestNoteTemplateGetMyCount` 全通過

closes #2293