### PR TITLE
fix: post_series/chat_room/roadmap CreateのDescription TrimSpace欠如修正

### DIFF
--- a/backend/internal/service/chat_room.go
+++ b/backend/internal/service/chat_room.go
@@ -31,6 +31,7 @@ func (s *ChatRoomService) Create(room *model.ChatRoom, memberIDs []uint) (*model
 		return nil, err
 	}
 	room.Name = strings.TrimSpace(room.Name)
+	room.Description = strings.TrimSpace(room.Description)
 	if err := s.roomRepo.Create(room); err != nil {
 		return nil, err
 	}

--- a/backend/internal/service/post_series.go
+++ b/backend/internal/service/post_series.go
@@ -28,6 +28,7 @@ func (s *PostSeriesService) Create(series *model.PostSeries) error {
 		return err
 	}
 	series.Title = strings.TrimSpace(series.Title)
+	series.Description = strings.TrimSpace(series.Description)
 	return s.repo.Create(series)
 }
 

--- a/backend/internal/service/roadmap.go
+++ b/backend/internal/service/roadmap.go
@@ -36,6 +36,7 @@ func (s *RoadmapService) Create(roadmap *model.Roadmap) error {
 		return err
 	}
 	roadmap.Title = strings.TrimSpace(roadmap.Title)
+	roadmap.Description = strings.TrimSpace(roadmap.Description)
 	return s.repo.Create(roadmap)
 }
 


### PR DESCRIPTION
## 概要
- post_series.go Create: DescriptionのTrimSpace追加
- chat_room.go Create: DescriptionのTrimSpace追加
- roadmap.go Create: DescriptionのTrimSpace追加

Titleはトリムされていたが、DescriptionがトリムされずにDBに保存されていた問題を修正。

## テスト
- `go test ./internal/service/... -run "TestPostSeries|TestChatRoom|TestRoadmap"` 全通過

closes #2295