### PR TITLE
feat: 学習目標の/my/countエンドポイント追加

### DIFF
--- a/backend/internal/handler/learning_goal.go
+++ b/backend/internal/handler/learning_goal.go
@@ -27,6 +27,7 @@ type LearningGoalServiceInterface interface {
 		GoalID   uint
 		Progress int
 	}) ([]model.LearningGoal, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // LearningGoalHandler は学習目標関連のHTTPハンドラ。
@@ -349,6 +350,17 @@ func (h *LearningGoalHandler) GetActiveGoals(c *gin.Context) {
 	}
 
 	respondOK(c, ensureSlice(goals))
+}
+
+// GetMyCount は認証ユーザー自身の学習目標総数を返す。
+func (h *LearningGoalHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }
 
 // GetForecast は認証ユーザーのアクティブ目標の達成予測一覧を返す。

--- a/backend/internal/handler/learning_goal_test.go
+++ b/backend/internal/handler/learning_goal_test.go
@@ -71,6 +71,11 @@ func (m *MockLearningGoalRepository) GetPublicGoals(limit, offset int) ([]model.
 	return args.Get(0).([]model.LearningGoal), args.Get(1).(int64), args.Error(2)
 }
 
+func (m *MockLearningGoalRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // setupLearningGoalHandler はテスト用のLearningGoalHandlerとモックを準備する。
 func setupLearningGoalHandler() (*LearningGoalHandler, *MockLearningGoalRepository) {
 	repo := new(MockLearningGoalRepository)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -192,6 +192,7 @@ type LearningGoalRepositoryInterface interface {
 	GetPublicByUserID(userID uint, limit, offset int) ([]model.LearningGoal, int64, error)
 	GetPublicGoals(limit, offset int) ([]model.LearningGoal, int64, error)
 	GetStats(userID uint) (*model.LearningGoalStats, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // RankingRepositoryInterface はランキングデータ操作の契約を定義する。

--- a/backend/internal/repository/learning_goal.go
+++ b/backend/internal/repository/learning_goal.go
@@ -91,6 +91,13 @@ func (r *LearningGoalRepository) GetPublicGoals(limit, offset int) ([]model.Lear
 	return goals, total, err
 }
 
+// CountByUserID は指定ユーザーの学習目標総数を返す。
+func (r *LearningGoalRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.LearningGoal{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}
+
 // GetStats は指定ユーザーの学習目標統計情報を算出する。
 // 目標総数、アクティブ数、完了数、平均進捗率を返す。
 func (r *LearningGoalRepository) GetStats(userID uint) (*model.LearningGoalStats, error) {

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -391,6 +391,7 @@ func registerGoalRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		goals.POST("", c.LearningGoalHandler.Create)
 		goals.GET("", c.LearningGoalHandler.GetMyGoals)
+		goals.GET("/my/count", c.LearningGoalHandler.GetMyCount)
 		goals.GET("/:id", c.LearningGoalHandler.GetByID)
 		goals.PUT("/:id", c.LearningGoalHandler.Update)
 		goals.DELETE("/:id", c.LearningGoalHandler.Delete)

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -244,6 +244,11 @@ func (s *LearningGoalService) GetPublicByUserID(userID uint, limit, offset int) 
 	return s.repo.GetPublicByUserID(userID, limit, offset)
 }
 
+// CountByUserID は指定ユーザーの学習目標総数を返す。
+func (s *LearningGoalService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}
+
 // Delete は所有権を検証した後、学習目標を削除する。
 func (s *LearningGoalService) Delete(id, userID uint) error {
 	if _, err := s.findAndCheckOwnership(id, userID); err != nil {

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -689,6 +689,11 @@ func (m *MockLearningGoalRepository) GetStats(userID uint) (*model.LearningGoalS
 	return args.Get(0).(*model.LearningGoalStats), args.Error(1)
 }
 
+func (m *MockLearningGoalRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // ============================================================
 // MockProjectRepository は repository.ProjectRepositoryInterface のテスト用モック実装。
 // ============================================================


### PR DESCRIPTION
## 概要
- 学習目標（goals）に `GET /goals/my/count` エンドポイントを追加
- ユーザー自身の学習目標総数を取得可能に

## 変更内容
- Repository: `CountByUserID` メソッド追加（interfaces.go + learning_goal.go）
- Service: `CountByUserID` パススルー追加
- Handler: `GetMyCount` ハンドラー追加（インターフェースにも追加）
- Router: `/my/count` ルート追加
- テスト用モック更新（service/mock_test.go + handler/learning_goal_test.go）

closes #2297