### PR TITLE
test: 学習目標 CountByUserID/GetMyCount テスト追加

### DIFF
--- a/backend/internal/handler/learning_goal_test.go
+++ b/backend/internal/handler/learning_goal_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -724,4 +725,30 @@ func TestLearningGoalGetPublicByUserID_Success(t *testing.T) {
 
 	w := doRequest(r, http.MethodGet, "/goals/public/user/5", nil)
 	assertStatus(t, w, http.StatusOK)
+}
+
+// ========== GetMyCount ==========
+
+func TestLearningGoalGetMyCount_Success(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.GET("/goals/my/count", h.GetMyCount)
+
+	repo.On("CountByUserID", uint(1)).Return(int64(7), nil)
+
+	w := doRequest(r, http.MethodGet, "/goals/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	assert.Equal(t, float64(7), body["count"])
+}
+
+func TestLearningGoalGetMyCount_ServiceError(t *testing.T) {
+	h, repo := setupLearningGoalHandler()
+	r := newRouter(1)
+	r.GET("/goals/my/count", h.GetMyCount)
+
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, http.MethodGet, "/goals/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
 }

--- a/backend/internal/service/learning_goal_test.go
+++ b/backend/internal/service/learning_goal_test.go
@@ -981,6 +981,27 @@ func TestCalculateGoalForecast_MediumDifficulty(t *testing.T) {
 	assert.Equal(t, "medium", f.Difficulty) // 8/10 = 0.8, 0.5 < 0.8 ≤ 1.0
 }
 
+// ============================================================
+// CountByUserID テスト
+// ============================================================
+
+func TestLearningGoalCountByUserID_Success(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	repo.On("CountByUserID", uint(1)).Return(int64(5), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(5), count)
+}
+
+func TestLearningGoalCountByUserID_Error(t *testing.T) {
+	svc, repo := newTestLearningGoalService()
+	repo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	_, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+}
+
 func TestCalculateGoalForecast_PastDeadline(t *testing.T) {
 	deadline := time.Now().Add(-2 * 24 * time.Hour)
 	goal := &model.LearningGoal{


### PR DESCRIPTION
## 概要
- Service層: CountByUserID の成功・エラーテスト追加
- Handler層: GetMyCount の成功・サービスエラーテスト追加

closes #2301