### PR TITLE
fix: study_circle・post_collection・code_snippet の Create TrimSpace 不足修正

### DIFF
--- a/backend/internal/service/code_snippet.go
+++ b/backend/internal/service/code_snippet.go
@@ -36,6 +36,7 @@ func (s *CodeSnippetService) Create(snippet *model.CodeSnippet) (*model.CodeSnip
 	}
 	snippet.Language = strings.TrimSpace(snippet.Language)
 	snippet.Code = strings.TrimSpace(snippet.Code)
+	snippet.FileName = strings.TrimSpace(snippet.FileName)
 
 	// 投稿の存在確認
 	if _, err := s.postRepo.FindByID(snippet.PostID); err != nil {

--- a/backend/internal/service/post_collection.go
+++ b/backend/internal/service/post_collection.go
@@ -122,7 +122,7 @@ func (s *PostCollectionService) AddPost(collectionID, userID, postID uint, note 
 	item := &model.PostCollectionItem{
 		CollectionID: collectionID,
 		PostID:       postID,
-		Note:         note,
+		Note:         strings.TrimSpace(note),
 	}
 	return s.repo.AddPost(item)
 }

--- a/backend/internal/service/study_circle.go
+++ b/backend/internal/service/study_circle.go
@@ -56,6 +56,8 @@ func (s *StudyCircleService) Create(circle *model.StudyCircle, memberIDs []uint)
 		return err
 	}
 	circle.Name = strings.TrimSpace(circle.Name)
+	circle.Topic = strings.TrimSpace(circle.Topic)
+	circle.Description = strings.TrimSpace(circle.Description)
 	if circle.MaxMembers < 3 || circle.MaxMembers > 10 {
 		circle.MaxMembers = 5
 	}


### PR DESCRIPTION
## 概要
Create/AddPost メソッドでバリデーション後に TrimSpace を呼ばずにDBに保存していたフィールドを修正。

## 変更内容
- study_circle.go Create: `Topic`, `Description` の TrimSpace 追加
- post_collection.go AddPost: `note` の TrimSpace 追加
- code_snippet.go Create: `FileName` の TrimSpace 追加

closes #2303