### PR TITLE
feat: ノートフォルダの/my/countエンドポイント追加

### DIFF
--- a/backend/internal/handler/note_folder.go
+++ b/backend/internal/handler/note_folder.go
@@ -16,6 +16,7 @@ type NoteFolderServiceInterface interface {
 	GetRootFolders(userID uint) ([]model.NoteFolder, error)
 	Update(id, userID uint, name string, parentID *uint) (*model.NoteFolder, error)
 	Delete(id, userID uint) error
+	CountByUserID(userID uint) (int64, error)
 }
 
 // NoteFolderHandler はノートフォルダ関連のHTTPハンドラ。
@@ -124,6 +125,17 @@ func (h *NoteFolderHandler) Update(c *gin.Context) {
 	}
 
 	respondOK(c, folder)
+}
+
+// GetMyCount は認証ユーザー自身のフォルダ総数を返す。
+func (h *NoteFolderHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }
 
 // Delete はフォルダを削除する。

--- a/backend/internal/handler/note_folder_test.go
+++ b/backend/internal/handler/note_folder_test.go
@@ -54,6 +54,11 @@ func (m *MockNoteFolderService) Delete(id, userID uint) error {
 	return m.Called(id, userID).Error(0)
 }
 
+func (m *MockNoteFolderService) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // newTestNoteFolderHandler はテスト用のNoteFolderHandlerを生成する。
 func newTestNoteFolderHandler() (*NoteFolderHandler, *MockNoteFolderService) {
 	mockService := new(MockNoteFolderService)

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -541,6 +541,7 @@ type NoteFolderRepositoryInterface interface {
 	GetRootFolders(userID uint) ([]model.NoteFolder, error)
 	Update(folder *model.NoteFolder) error
 	Delete(id uint) error
+	CountByUserID(userID uint) (int64, error)
 }
 
 // PostCollectionRepositoryInterface は投稿コレクションデータ操作の契約を定義する。

--- a/backend/internal/repository/note_folder.go
+++ b/backend/internal/repository/note_folder.go
@@ -63,3 +63,10 @@ func (r *NoteFolderRepository) Update(folder *model.NoteFolder) error {
 func (r *NoteFolderRepository) Delete(id uint) error {
 	return r.db.Delete(&model.NoteFolder{}, id).Error
 }
+
+// CountByUserID は指定ユーザーのフォルダ総数を返す。
+func (r *NoteFolderRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.NoteFolder{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -564,6 +564,7 @@ func registerNoteRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		noteFolders.POST("", c.NoteFolderHandler.Create)
 		noteFolders.GET("", c.NoteFolderHandler.GetByUserID)
+		noteFolders.GET("/my/count", c.NoteFolderHandler.GetMyCount)
 		noteFolders.GET("/root", c.NoteFolderHandler.GetRootFolders)
 		noteFolders.GET("/:id", c.NoteFolderHandler.GetByID)
 		noteFolders.GET("/:id/children", c.NoteFolderHandler.GetChildren)

--- a/backend/internal/service/note_folder.go
+++ b/backend/internal/service/note_folder.go
@@ -116,6 +116,11 @@ func (s *NoteFolderService) Update(id, userID uint, name string, parentID *uint)
 	return folder, nil
 }
 
+// CountByUserID は指定ユーザーのフォルダ総数を返す。
+func (s *NoteFolderService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}
+
 // Delete は所有権を検証した後、フォルダを削除する。
 func (s *NoteFolderService) Delete(id, userID uint) error {
 	if _, err := s.findAndCheckOwnership(id, userID); err != nil {

--- a/backend/internal/service/note_folder_test.go
+++ b/backend/internal/service/note_folder_test.go
@@ -53,6 +53,11 @@ func (m *MockNoteFolderRepository) Delete(id uint) error {
 	return args.Error(0)
 }
 
+func (m *MockNoteFolderRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 func TestNoteFolderService_Create(t *testing.T) {
 	mockRepo := new(MockNoteFolderRepository)
 	service := NewNoteFolderService(mockRepo)


### PR DESCRIPTION
## 概要
- ノートフォルダ（note-folders）に `GET /note-folders/my/count` エンドポイントを追加
- ユーザー自身のフォルダ総数を取得可能に

## 変更内容
- Repository: `CountByUserID` メソッド追加（interfaces.go + note_folder.go）
- Service: `CountByUserID` パススルー追加
- Handler: `GetMyCount` ハンドラー追加（インターフェースにも追加）
- Router: `/my/count` ルート追加
- テスト用モック更新（service/note_folder_test.go + handler/note_folder_test.go）

closes #2305