### PR TITLE
refactor: project・resource_review Update の double TrimSpace 最適化

### DIFF
--- a/backend/internal/service/project.go
+++ b/backend/internal/service/project.go
@@ -75,41 +75,41 @@ func (s *ProjectService) Update(id, userID uint, updates *model.Project) (*model
 		return nil, err
 	}
 
-	if strings.TrimSpace(updates.Title) != "" {
-		project.Title = strings.TrimSpace(updates.Title)
+	if title := strings.TrimSpace(updates.Title); title != "" {
+		project.Title = title
 	}
-	if strings.TrimSpace(updates.Description) != "" {
-		project.Description = strings.TrimSpace(updates.Description)
+	if desc := strings.TrimSpace(updates.Description); desc != "" {
+		project.Description = desc
 	}
-	if strings.TrimSpace(updates.TechStack) != "" {
-		if err := domain.ValidateStringLength(updates.TechStack, 1, 500, "技術スタック"); err != nil {
+	if ts := strings.TrimSpace(updates.TechStack); ts != "" {
+		if err := domain.ValidateStringLength(ts, 1, 500, "技術スタック"); err != nil {
 			return nil, err
 		}
-		project.TechStack = strings.TrimSpace(updates.TechStack)
+		project.TechStack = ts
 	}
-	if strings.TrimSpace(updates.DemoURL) != "" {
-		if err := domain.ValidateStringLength(updates.DemoURL, 1, 2000, "デモURL"); err != nil {
+	if demoURL := strings.TrimSpace(updates.DemoURL); demoURL != "" {
+		if err := domain.ValidateStringLength(demoURL, 1, 2000, "デモURL"); err != nil {
 			return nil, err
 		}
-		project.DemoURL = strings.TrimSpace(updates.DemoURL)
+		project.DemoURL = demoURL
 	}
-	if strings.TrimSpace(updates.GithubURL) != "" {
-		if err := domain.ValidateStringLength(updates.GithubURL, 1, 2000, "GitHub URL"); err != nil {
+	if ghURL := strings.TrimSpace(updates.GithubURL); ghURL != "" {
+		if err := domain.ValidateStringLength(ghURL, 1, 2000, "GitHub URL"); err != nil {
 			return nil, err
 		}
-		project.GithubURL = strings.TrimSpace(updates.GithubURL)
+		project.GithubURL = ghURL
 	}
-	if strings.TrimSpace(updates.ImageURL) != "" {
-		if err := domain.ValidateStringLength(updates.ImageURL, 1, 2000, "画像URL"); err != nil {
+	if imgURL := strings.TrimSpace(updates.ImageURL); imgURL != "" {
+		if err := domain.ValidateStringLength(imgURL, 1, 2000, "画像URL"); err != nil {
 			return nil, err
 		}
-		project.ImageURL = strings.TrimSpace(updates.ImageURL)
+		project.ImageURL = imgURL
 	}
-	if strings.TrimSpace(updates.Role) != "" {
-		if err := domain.ValidateStringLength(updates.Role, 1, 100, "役割"); err != nil {
+	if role := strings.TrimSpace(updates.Role); role != "" {
+		if err := domain.ValidateStringLength(role, 1, 100, "役割"); err != nil {
 			return nil, err
 		}
-		project.Role = strings.TrimSpace(updates.Role)
+		project.Role = role
 	}
 	if updates.StartDate != nil {
 		project.StartDate = updates.StartDate

--- a/backend/internal/service/resource_review.go
+++ b/backend/internal/service/resource_review.go
@@ -72,12 +72,11 @@ func (s *ResourceReviewService) Update(id, userID uint, rating int, comment stri
 		}
 		review.Rating = rating
 	}
-	if strings.TrimSpace(comment) != "" {
-		comment = strings.TrimSpace(comment)
-		if err := domain.ValidateStringLength(comment, 1, 5000, "コメント"); err != nil {
+	if c := strings.TrimSpace(comment); c != "" {
+		if err := domain.ValidateStringLength(c, 1, 5000, "コメント"); err != nil {
 			return nil, err
 		}
-		review.Comment = comment
+		review.Comment = c
 	}
 
 	if err := s.repo.Update(review); err != nil {


### PR DESCRIPTION
## 概要
- project.go Update: Title, Description, TechStack, DemoURL, GithubURL, ImageURL, Role の7箇所を if スコープ変数パターンに統一
- resource_review.go Update: comment の1箇所を if スコープ変数パターンに統一

## 変更理由
`strings.TrimSpace()` が条件チェックと代入で二重呼出しされていたパターンを最適化

closes #2307