### PR TITLE
test: ノートフォルダ CountByUserID/GetMyCount テスト追加

### DIFF
--- a/backend/internal/handler/note_folder_test.go
+++ b/backend/internal/handler/note_folder_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/norman6464/devsync/backend/internal/model"
 	"github.com/norman6464/devsync/backend/internal/service"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -321,4 +322,32 @@ func TestNoteFolderHandler_Delete_ServiceError(t *testing.T) {
 
 	w := doRequest(r, "DELETE", "/folders/1", nil)
 	assertStatus(t, w, http.StatusForbidden)
+}
+
+// ============================================================
+// GetMyCount テスト
+// ============================================================
+
+func TestNoteFolderHandler_GetMyCount_Success(t *testing.T) {
+	h, svc := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.GET("/folders/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(4), nil)
+
+	w := doRequest(r, "GET", "/folders/my/count", nil)
+	assertStatus(t, w, http.StatusOK)
+	body := parseJSON(t, w)
+	assert.Equal(t, float64(4), body["count"])
+}
+
+func TestNoteFolderHandler_GetMyCount_ServiceError(t *testing.T) {
+	h, svc := newTestNoteFolderHandler()
+	r := newRouter(1)
+	r.GET("/folders/my/count", h.GetMyCount)
+
+	svc.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	w := doRequest(r, "GET", "/folders/my/count", nil)
+	assertStatus(t, w, http.StatusInternalServerError)
 }

--- a/backend/internal/service/note_folder_test.go
+++ b/backend/internal/service/note_folder_test.go
@@ -463,3 +463,26 @@ func TestNoteFolderService_Update_TrimSpaceName(t *testing.T) {
 	assert.Equal(t, "新しい名前", result.Name)
 	mockRepo.AssertExpectations(t)
 }
+
+func TestNoteFolderService_CountByUserID_Success(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	svc := NewNoteFolderService(mockRepo)
+
+	mockRepo.On("CountByUserID", uint(1)).Return(int64(3), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(3), count)
+	mockRepo.AssertExpectations(t)
+}
+
+func TestNoteFolderService_CountByUserID_Error(t *testing.T) {
+	mockRepo := new(MockNoteFolderRepository)
+	svc := NewNoteFolderService(mockRepo)
+
+	mockRepo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	_, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	mockRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- Service層: CountByUserID の成功・エラーテスト追加
- Handler層: GetMyCount の成功・サービスエラーテスト追加

closes #2309