### PR TITLE
fix: answer・post EditComment の所有権チェック順序修正

### DIFF
--- a/backend/internal/service/answer.go
+++ b/backend/internal/service/answer.go
@@ -45,11 +45,11 @@ func (s *AnswerService) findAndCheckOwnership(answerID, userID uint) (*model.Ans
 
 // Update は所有権を検証した後、回答を更新する。
 func (s *AnswerService) Update(answerID, userID uint, body string) (*model.Answer, error) {
-	if err := domain.ValidateStringLength(body, 1, 10000, "回答内容"); err != nil {
-		return nil, err
-	}
 	answer, err := s.findAndCheckOwnership(answerID, userID)
 	if err != nil {
+		return nil, err
+	}
+	if err := domain.ValidateStringLength(body, 1, 10000, "回答内容"); err != nil {
 		return nil, err
 	}
 	answer.Body = strings.TrimSpace(body)

--- a/backend/internal/service/answer_test.go
+++ b/backend/internal/service/answer_test.go
@@ -134,7 +134,11 @@ func TestAnswerUpdate_RepoError(t *testing.T) {
 }
 
 func TestAnswerUpdate_EmptyBody(t *testing.T) {
-	svc, _, _ := newTestAnswerService()
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answer := &model.Answer{Body: "元の回答", UserID: 1}
+	answer.ID = 1
+	answerRepo.On("FindByID", uint(1)).Return(answer, nil)
 
 	result, err := svc.Update(1, 1, "")
 	assert.Error(t, err)
@@ -143,7 +147,11 @@ func TestAnswerUpdate_EmptyBody(t *testing.T) {
 }
 
 func TestAnswerUpdate_WhitespaceBody(t *testing.T) {
-	svc, _, _ := newTestAnswerService()
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answer := &model.Answer{Body: "元の回答", UserID: 1}
+	answer.ID = 1
+	answerRepo.On("FindByID", uint(1)).Return(answer, nil)
 
 	result, err := svc.Update(1, 1, "   ")
 	assert.Error(t, err)
@@ -565,7 +573,11 @@ func TestAnswerCreate_BodyTooLong(t *testing.T) {
 }
 
 func TestAnswerUpdate_BodyTooLong(t *testing.T) {
-	svc, _, _ := newTestAnswerService()
+	svc, answerRepo, _ := newTestAnswerService()
+
+	answer := &model.Answer{Body: "元の回答", UserID: 1}
+	answer.ID = 1
+	answerRepo.On("FindByID", uint(1)).Return(answer, nil)
 
 	result, err := svc.Update(1, 1, strings.Repeat("あ", 10001))
 	assert.Error(t, err)

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -226,13 +226,13 @@ func (s *PostService) findAndCheckCommentOwnership(id, userID uint) (*model.Comm
 
 // EditComment は所有権を検証した後、コメント内容を更新する。
 func (s *PostService) EditComment(id, userID uint, content string) (*model.Comment, error) {
-	v := validator.NewPostValidator()
-	if err := v.ValidateComment(content); err != nil {
+	comment, err := s.findAndCheckCommentOwnership(id, userID)
+	if err != nil {
 		return nil, err
 	}
 
-	comment, err := s.findAndCheckCommentOwnership(id, userID)
-	if err != nil {
+	v := validator.NewPostValidator()
+	if err := v.ValidateComment(content); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/service/post_test.go
+++ b/backend/internal/service/post_test.go
@@ -456,7 +456,12 @@ func TestPostEditComment_NotFound(t *testing.T) {
 }
 
 func TestPostEditComment_EmptyContent(t *testing.T) {
-	svc, _, _ := newTestPostService()
+	svc, postRepo, _ := newTestPostService()
+
+	comment := &model.Comment{PostID: 10, Content: "old"}
+	comment.ID = 5
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(5)).Return(comment, nil)
 
 	result, err := svc.EditComment(5, 1, "")
 	assert.Nil(t, result)
@@ -464,7 +469,12 @@ func TestPostEditComment_EmptyContent(t *testing.T) {
 }
 
 func TestPostEditComment_TooLongContent(t *testing.T) {
-	svc, _, _ := newTestPostService()
+	svc, postRepo, _ := newTestPostService()
+
+	comment := &model.Comment{PostID: 10, Content: "old"}
+	comment.ID = 5
+	comment.UserID = 1
+	postRepo.On("FindCommentByID", uint(5)).Return(comment, nil)
 
 	longContent := strings.Repeat("a", 5001)
 	result, err := svc.EditComment(5, 1, longContent)


### PR DESCRIPTION
## 概要
バリデーションが所有権チェックより先に実行されていた情報漏洩パターンを修正。

## 変更内容
- answer.go Update: `findAndCheckOwnership` を `ValidateStringLength` の前に移動
- post.go EditComment: `findAndCheckCommentOwnership` を `ValidateComment` の前に移動
- テスト修正: 所有権チェックが先になったため、バリデーションエラーテストに FindByID モック追加

closes #2311