### PR TITLE
feat: 学習ログテンプレートの/my/countエンドポイント追加

### DIFF
--- a/backend/internal/handler/learning_log_template.go
+++ b/backend/internal/handler/learning_log_template.go
@@ -15,6 +15,7 @@ type LearningLogTemplateServiceInterface interface {
 	Update(id, userID uint, name, defaultTitle, defaultContent string, defaultCategory model.LogCategory, defaultDuration *int, isDefault *bool) (*model.LearningLogTemplate, error)
 	Delete(id, userID uint) error
 	UseTemplate(id, userID uint) (*model.LearningLog, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // LearningLogTemplateHandler は学習ログテンプレート関連のHTTPハンドラ。
@@ -116,6 +117,17 @@ func (h *LearningLogTemplateHandler) Update(c *gin.Context) {
 	}
 
 	respondOK(c, template)
+}
+
+// GetMyCount は認証ユーザー自身のテンプレート総数を返す。
+func (h *LearningLogTemplateHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }
 
 // Delete はテンプレートを削除する。

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -779,6 +779,7 @@ type LearningLogTemplateRepositoryInterface interface {
 	Update(template *model.LearningLogTemplate) error
 	Delete(id uint) error
 	ClearDefaultFlag(userID uint) error
+	CountByUserID(userID uint) (int64, error)
 }
 
 // NoteTemplateRepositoryInterface はノートテンプレートデータ操作の契約を定義する。

--- a/backend/internal/repository/learning_log_template.go
+++ b/backend/internal/repository/learning_log_template.go
@@ -57,6 +57,13 @@ func (r *LearningLogTemplateRepository) Delete(id uint) error {
 	return r.db.Delete(&model.LearningLogTemplate{}, id).Error
 }
 
+// CountByUserID は指定ユーザーのテンプレート総数を返す。
+func (r *LearningLogTemplateRepository) CountByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.LearningLogTemplate{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}
+
 // ClearDefaultFlag は指定ユーザーの全テンプレートのis_defaultをfalseにする。
 func (r *LearningLogTemplateRepository) ClearDefaultFlag(userID uint) error {
 	return r.db.Model(&model.LearningLogTemplate{}).

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -494,6 +494,7 @@ func registerLearningLogTemplateRoutes(g *gin.RouterGroup, c *di.Container) {
 	{
 		logTemplates.POST("", c.LearningLogTemplateHandler.Create)
 		logTemplates.GET("", c.LearningLogTemplateHandler.GetByUserID)
+		logTemplates.GET("/my/count", c.LearningLogTemplateHandler.GetMyCount)
 		logTemplates.GET("/default", c.LearningLogTemplateHandler.GetDefault)
 		logTemplates.GET("/:id", c.LearningLogTemplateHandler.GetByID)
 		logTemplates.PUT("/:id", c.LearningLogTemplateHandler.Update)

--- a/backend/internal/service/learning_log_template.go
+++ b/backend/internal/service/learning_log_template.go
@@ -123,6 +123,11 @@ func (s *LearningLogTemplateService) Update(id, userID uint, name, defaultTitle,
 	return template, nil
 }
 
+// CountByUserID は指定ユーザーのテンプレート総数を返す。
+func (s *LearningLogTemplateService) CountByUserID(userID uint) (int64, error) {
+	return s.repo.CountByUserID(userID)
+}
+
 // Delete は所有権を検証した後、テンプレートを削除する。
 func (s *LearningLogTemplateService) Delete(id, userID uint) error {
 	if _, err := s.findAndCheckOwnership(id, userID); err != nil {

--- a/backend/internal/service/learning_log_template_test.go
+++ b/backend/internal/service/learning_log_template_test.go
@@ -52,6 +52,11 @@ func (m *MockLearningLogTemplateRepository) ClearDefaultFlag(userID uint) error 
 	return m.Called(userID).Error(0)
 }
 
+func (m *MockLearningLogTemplateRepository) CountByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
+
 // MockLearningLogCreator は学習ログ作成のモック実装。
 type MockLearningLogCreator struct {
 	mock.Mock


### PR DESCRIPTION
## 概要
- 学習ログテンプレート（learning-log-templates）に `GET /learning-log-templates/my/count` エンドポイントを追加
- ユーザー自身のテンプレート総数を取得可能に

## 変更内容
- Repository: `CountByUserID` メソッド追加（interfaces.go + learning_log_template.go）
- Service: `CountByUserID` パススルー追加
- Handler: `GetMyCount` ハンドラー追加（インターフェースにも追加）
- Router: `/my/count` ルート追加
- テスト用モック更新（service/learning_log_template_test.go）

closes #2313