### PR TITLE
refactor: learning_log・post_template Update の double TrimSpace 最適化

### DIFF
--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -225,19 +225,19 @@ func (s *LearningLogService) Update(id, userID uint, updates *model.LearningLog)
 		return nil, err
 	}
 
-	if strings.TrimSpace(updates.Title) != "" {
-		if err := domain.ValidateStringLength(updates.Title, 1, 200, "タイトル"); err != nil {
+	if title := strings.TrimSpace(updates.Title); title != "" {
+		if err := domain.ValidateStringLength(title, 1, 200, "タイトル"); err != nil {
 			return nil, err
 		}
-		log.Title = strings.TrimSpace(updates.Title)
+		log.Title = title
 	}
-	if strings.TrimSpace(updates.Content) != "" {
-		if err := domain.ValidateStringLength(updates.Content, 1, 10000, "内容"); err != nil {
+	if content := strings.TrimSpace(updates.Content); content != "" {
+		if err := domain.ValidateStringLength(content, 1, 10000, "内容"); err != nil {
 			return nil, err
 		}
-		log.Content = strings.TrimSpace(updates.Content)
+		log.Content = content
 	}
-	if strings.TrimSpace(string(updates.Category)) != "" {
+	if cat := strings.TrimSpace(string(updates.Category)); cat != "" {
 		log.Category = updates.Category
 	}
 	if updates.Duration != 0 {

--- a/backend/internal/service/post_template.go
+++ b/backend/internal/service/post_template.go
@@ -49,23 +49,23 @@ func (s *PostTemplateService) Update(id, userID uint, updates *model.PostTemplat
 		return nil, err
 	}
 
-	if strings.TrimSpace(updates.Name) != "" {
-		if err := domain.ValidateStringLength(updates.Name, 1, 100, "テンプレート名"); err != nil {
+	if name := strings.TrimSpace(updates.Name); name != "" {
+		if err := domain.ValidateStringLength(name, 1, 100, "テンプレート名"); err != nil {
 			return nil, err
 		}
-		tmpl.Name = strings.TrimSpace(updates.Name)
+		tmpl.Name = name
 	}
-	if strings.TrimSpace(updates.TitleTemplate) != "" {
-		if err := domain.ValidateStringLength(updates.TitleTemplate, 1, 200, "タイトルテンプレート"); err != nil {
+	if tt := strings.TrimSpace(updates.TitleTemplate); tt != "" {
+		if err := domain.ValidateStringLength(tt, 1, 200, "タイトルテンプレート"); err != nil {
 			return nil, err
 		}
-		tmpl.TitleTemplate = strings.TrimSpace(updates.TitleTemplate)
+		tmpl.TitleTemplate = tt
 	}
-	if strings.TrimSpace(updates.ContentTemplate) != "" {
-		if err := domain.ValidateStringLength(updates.ContentTemplate, 1, 50000, "テンプレート内容"); err != nil {
+	if ct := strings.TrimSpace(updates.ContentTemplate); ct != "" {
+		if err := domain.ValidateStringLength(ct, 1, 50000, "テンプレート内容"); err != nil {
 			return nil, err
 		}
-		tmpl.ContentTemplate = strings.TrimSpace(updates.ContentTemplate)
+		tmpl.ContentTemplate = ct
 	}
 
 	if err := s.repo.Update(tmpl); err != nil {


### PR DESCRIPTION
## 概要
- `learning_log.go` Update メソッドの Title・Content・Category で `strings.TrimSpace` が2回呼ばれていたのを if-scoped 変数で1回に最適化
- `post_template.go` Update メソッドの Name・TitleTemplate・ContentTemplate で同様の最適化

## 変更内容
- `backend/internal/service/learning_log.go`: 3箇所の double TrimSpace を if-scoped 変数に統一
- `backend/internal/service/post_template.go`: 3箇所の double TrimSpace を if-scoped 変数に統一

Closes #2315