### PR TITLE
fix: user UpdateProfile・note Update の TrimSpace 不足修正

### DIFF
--- a/backend/internal/service/note.go
+++ b/backend/internal/service/note.go
@@ -60,19 +60,21 @@ func (s *NoteService) Update(id, userID uint, title, content, tags string, folde
 	}
 
 	if title != "" {
-		if strings.TrimSpace(title) == "" {
+		t := strings.TrimSpace(title)
+		if t == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "タイトルは空白のみにできません", nil)
 		}
-		note.Title = title
+		note.Title = t
 	}
 	if content != "" {
-		if strings.TrimSpace(content) == "" {
+		c := strings.TrimSpace(content)
+		if c == "" {
 			return nil, domain.NewError(domain.ErrCodeBadRequest, "本文は空白のみにできません", nil)
 		}
-		note.Content = content
+		note.Content = c
 	}
 	if tags != "" {
-		note.Tags = tags
+		note.Tags = strings.TrimSpace(tags)
 	}
 	if folderID != nil {
 		note.FolderID = folderID

--- a/backend/internal/service/user.go
+++ b/backend/internal/service/user.go
@@ -107,16 +107,16 @@ func (s *UserService) UpdateProfile(id, userID uint, input *UpdateProfileInput) 
 	existing.Bio = strings.TrimSpace(input.Bio)
 	existing.AvatarURL = strings.TrimSpace(input.AvatarURL)
 	if input.SkillsLanguages != nil {
-		existing.SkillsLanguages = *input.SkillsLanguages
+		existing.SkillsLanguages = strings.TrimSpace(*input.SkillsLanguages)
 	}
 	if input.SkillsFrameworks != nil {
-		existing.SkillsFrameworks = *input.SkillsFrameworks
+		existing.SkillsFrameworks = strings.TrimSpace(*input.SkillsFrameworks)
 	}
 	if input.AtCoderUsername != nil {
-		existing.AtCoderUsername = *input.AtCoderUsername
+		existing.AtCoderUsername = strings.TrimSpace(*input.AtCoderUsername)
 	}
 	if input.PaizaRank != nil {
-		existing.PaizaRank = *input.PaizaRank
+		existing.PaizaRank = strings.TrimSpace(*input.PaizaRank)
 	}
 	if input.OnboardingCompleted != nil {
 		existing.OnboardingCompleted = *input.OnboardingCompleted


### PR DESCRIPTION
## 概要
- `user.go` UpdateProfile で `SkillsLanguages`、`SkillsFrameworks`、`AtCoderUsername`、`PaizaRank` に TrimSpace を追加
- `note.go` Update で `title`、`content`、`tags` のトリム済み値を保存するよう修正

## 変更内容
- `backend/internal/service/user.go`: 4箇所に `strings.TrimSpace()` 追加
- `backend/internal/service/note.go`: 空白チェック後にトリム済み値を保存するよう修正（3箇所）

Closes #2319