### PR TITLE
feat: post-pins /my/count エンドポイント追加

### DIFF
--- a/backend/internal/handler/post_pin.go
+++ b/backend/internal/handler/post_pin.go
@@ -14,6 +14,7 @@ type PostPinServiceInterface interface {
 	GetByUserID(userID uint) ([]model.PostPin, error)
 	Reorder(userID uint, postIDs []uint) error
 	IsPinned(userID, postID uint) (bool, error)
+	CountByUserID(userID uint) (int64, error)
 }
 
 // PostPinHandler は投稿ピン留めのHTTPハンドラー。
@@ -69,6 +70,17 @@ func (h *PostPinHandler) GetByUserID(c *gin.Context) {
 		return
 	}
 	respondOK(c, dto.PinsResponse{Pins: pins})
+}
+
+// GetMyCount は認証ユーザー自身のピン留め投稿数を返す。
+func (h *PostPinHandler) GetMyCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+	count, err := h.service.CountByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+	respondOK(c, gin.H{"count": count})
 }
 
 // Reorder はピン留めの表示順序を変更する。

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -266,6 +266,7 @@ func registerPostTagRoutes(g *gin.RouterGroup, c *di.Container) {
 func registerPostPinRoutes(g *gin.RouterGroup, c *di.Container) {
 	pins := g.Group("/post-pins")
 	{
+		pins.GET("/my/count", c.PostPinHandler.GetMyCount)
 		pins.POST("/posts/:postId", c.PostPinHandler.Pin)
 		pins.DELETE("/posts/:postId", c.PostPinHandler.Unpin)
 		pins.GET("/users/:userId", c.PostPinHandler.GetByUserID)

--- a/backend/internal/service/post_pin.go
+++ b/backend/internal/service/post_pin.go
@@ -92,3 +92,8 @@ func (s *PostPinService) Reorder(userID uint, postIDs []uint) error {
 func (s *PostPinService) IsPinned(userID, postID uint) (bool, error) {
 	return s.pinRepo.IsPinned(userID, postID)
 }
+
+// CountByUserID は指定ユーザーのピン留め投稿数を返す。
+func (s *PostPinService) CountByUserID(userID uint) (int64, error) {
+	return s.pinRepo.CountByUserID(userID)
+}


### PR DESCRIPTION
## 概要
- post-pins リソースに `/my/count` エンドポイントを追加
- 認証ユーザーのピン留め投稿数を取得可能に

## 変更内容
- `backend/internal/service/post_pin.go`: CountByUserID メソッド追加
- `backend/internal/handler/post_pin.go`: インターフェースに CountByUserID 追加、GetMyCount ハンドラ追加
- `backend/internal/router/router.go`: `GET /post-pins/my/count` ルート追加

Closes #2321