### PR TITLE
test: post-pin CountByUserID のテスト追加

### DIFF
--- a/backend/internal/service/post_pin_test.go
+++ b/backend/internal/service/post_pin_test.go
@@ -225,3 +225,28 @@ func TestPostPinService_Pin_CountError(t *testing.T) {
 	pinRepo.AssertExpectations(t)
 	postRepo.AssertExpectations(t)
 }
+
+// ============================================================
+// CountByUserID テスト
+// ============================================================
+
+func TestPostPinService_CountByUserID_Success(t *testing.T) {
+	svc, pinRepo, _ := newPostPinTestService()
+
+	pinRepo.On("CountByUserID", uint(1)).Return(int64(2), nil)
+
+	count, err := svc.CountByUserID(1)
+	assert.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+	pinRepo.AssertExpectations(t)
+}
+
+func TestPostPinService_CountByUserID_Error(t *testing.T) {
+	svc, pinRepo, _ := newPostPinTestService()
+
+	pinRepo.On("CountByUserID", uint(1)).Return(int64(0), errors.New("db error"))
+
+	_, err := svc.CountByUserID(1)
+	assert.Error(t, err)
+	pinRepo.AssertExpectations(t)
+}


### PR DESCRIPTION
## 概要
- Cycle 32 Phase 1 で追加した post-pin の CountByUserID メソッドに対するService層テストを追加

## テスト内容
- `TestPostPinService_CountByUserID_Success`: 正常系（カウント取得成功）
- `TestPostPinService_CountByUserID_Error`: エラー系（DB エラー）

Closes #2325