### PR TITLE
refactor: 「無効なカテゴリです」「無効なソースです」エラーメッセージを定数に集約

### DIFF
--- a/backend/internal/service/errors.go
+++ b/backend/internal/service/errors.go
@@ -17,6 +17,12 @@ var (
 	ErrLLMNotConfigured  = domain.ErrServiceUnavailable // LLM未設定（503）
 )
 
+// 共通バリデーションエラーメッセージ。
+const (
+	msgInvalidCategory = "無効なカテゴリです"
+	msgInvalidSource   = "無効なソースです"
+)
+
 // validateRequiredID はIDが0でないことを検証する。
 // 0の場合はBadRequestエラーを返す。
 func validateRequiredID(id uint, name string) error {

--- a/backend/internal/service/learning_goal.go
+++ b/backend/internal/service/learning_goal.go
@@ -61,7 +61,7 @@ var validGoalCategories = map[string]bool{
 // GetByCategory は指定ユーザーの学習目標をカテゴリでフィルタリングして取得する。
 func (s *LearningGoalService) GetByCategory(userID uint, category string) ([]model.LearningGoal, error) {
 	if !validGoalCategories[category] {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なカテゴリです", nil)
+		return nil, domain.NewError(domain.ErrCodeBadRequest, msgInvalidCategory, nil)
 	}
 	return s.repo.GetByCategory(userID, category)
 }

--- a/backend/internal/service/learning_log.go
+++ b/backend/internal/service/learning_log.go
@@ -48,11 +48,11 @@ func (s *LearningLogService) Create(log *model.LearningLog) error {
 	if log.Category == "" {
 		log.Category = model.LogCategoryOther
 	} else if !model.ValidCategories[log.Category] {
-		return domain.NewError(domain.ErrCodeBadRequest, "無効なカテゴリです", nil)
+		return domain.NewError(domain.ErrCodeBadRequest, msgInvalidCategory, nil)
 	}
 	// Source: 空文字（デフォルト"manual"）または有効な値のみ許可
 	if log.Source != "" && !model.ValidSources[log.Source] {
-		return domain.NewError(domain.ErrCodeBadRequest, "無効なソースです", nil)
+		return domain.NewError(domain.ErrCodeBadRequest, msgInvalidSource, nil)
 	}
 
 	// ゴール紐付けバリデーション
@@ -151,10 +151,10 @@ func (s *LearningLogService) BatchCreate(userID uint, logs []model.LearningLog) 
 		if logs[i].Category == "" {
 			logs[i].Category = model.LogCategoryOther
 		} else if !model.ValidCategories[logs[i].Category] {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なカテゴリです", nil)
+			return nil, domain.NewError(domain.ErrCodeBadRequest, msgInvalidCategory, nil)
 		}
 		if logs[i].Source != "" && !model.ValidSources[logs[i].Source] {
-			return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なソースです", nil)
+			return nil, domain.NewError(domain.ErrCodeBadRequest, msgInvalidSource, nil)
 		}
 	}
 
@@ -178,7 +178,7 @@ func (s *LearningLogService) GetByUserID(userID uint, limit, offset int) ([]mode
 // GetByCategory は指定ユーザーの学習ログをカテゴリでフィルタリングして取得する。
 func (s *LearningLogService) GetByCategory(userID uint, category string) ([]model.LearningLog, error) {
 	if !model.ValidCategories[model.LogCategory(category)] {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なカテゴリです", nil)
+		return nil, domain.NewError(domain.ErrCodeBadRequest, msgInvalidCategory, nil)
 	}
 	return s.repo.GetByCategory(userID, category)
 }
@@ -186,7 +186,7 @@ func (s *LearningLogService) GetByCategory(userID uint, category string) ([]mode
 // GetBySource は指定ユーザーの学習ログをソース（manual/pomodoro）でフィルタリングして取得する。
 func (s *LearningLogService) GetBySource(userID uint, source string) ([]model.LearningLog, error) {
 	if !model.ValidSources[model.LogSource(source)] {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なソースです", nil)
+		return nil, domain.NewError(domain.ErrCodeBadRequest, msgInvalidSource, nil)
 	}
 	return s.repo.GetBySource(userID, source)
 }

--- a/backend/internal/service/learning_log_template.go
+++ b/backend/internal/service/learning_log_template.go
@@ -36,7 +36,7 @@ func (s *LearningLogTemplateService) Create(template *model.LearningLogTemplate)
 		return err
 	}
 	if template.DefaultCategory != "" && !model.ValidCategories[template.DefaultCategory] {
-		return domain.NewError(domain.ErrCodeValidation, "無効なカテゴリです", nil)
+		return domain.NewError(domain.ErrCodeValidation, msgInvalidCategory, nil)
 	}
 	if template.DefaultDuration < 0 || template.DefaultDuration > 1440 {
 		return domain.NewError(domain.ErrCodeValidation, "デフォルト時間は0〜1440分の範囲で指定してください", nil)
@@ -98,7 +98,7 @@ func (s *LearningLogTemplateService) Update(id, userID uint, name, defaultTitle,
 	}
 	if defaultCategory != "" {
 		if !model.ValidCategories[defaultCategory] {
-			return nil, domain.NewError(domain.ErrCodeValidation, "無効なカテゴリです", nil)
+			return nil, domain.NewError(domain.ErrCodeValidation, msgInvalidCategory, nil)
 		}
 		template.DefaultCategory = defaultCategory
 	}

--- a/backend/internal/service/weekly_goal.go
+++ b/backend/internal/service/weekly_goal.go
@@ -19,7 +19,7 @@ func NewWeeklyGoalService(repo repository.WeeklyGoalRepositoryInterface) *Weekly
 // SetGoal はカテゴリ別の週間学習目標を設定する（既存があれば更新）。
 func (s *WeeklyGoalService) SetGoal(userID uint, category string, targetMinutes int) (*model.WeeklyGoal, error) {
 	if !model.ValidCategories[model.LogCategory(category)] {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "無効なカテゴリです", nil)
+		return nil, domain.NewError(domain.ErrCodeBadRequest, msgInvalidCategory, nil)
 	}
 	if targetMinutes < 0 || targetMinutes > 10080 {
 		return nil, domain.NewError(domain.ErrCodeBadRequest, "目標時間は0〜10080分（1週間）で指定してください", nil)


### PR DESCRIPTION
## 概要
- `errors.go` に共通バリデーションエラーメッセージ定数 `msgInvalidCategory`・`msgInvalidSource` を追加
- 4ファイル7箇所の重複リテラルを定数参照に置換

## 変更内容
- `errors.go`: 定数定義追加
- `learning_log.go`: 4箇所（カテゴリ3 + ソース3）→ 定数参照に置換
- `learning_log_template.go`: 2箇所 → 定数参照に置換
- `learning_goal.go`: 1箇所 → 定数参照に置換
- `weekly_goal.go`: 1箇所 → 定数参照に置換

Closes #2331