### PR TITLE
fix: note_template・book_review・resource_review Create の TrimSpace 不足修正

### DIFF
--- a/backend/internal/service/book_review.go
+++ b/backend/internal/service/book_review.go
@@ -47,6 +47,8 @@ func (s *BookReviewService) Create(review *model.BookReview) error {
 		return domain.NewError(domain.ErrCodeValidation, "総ページ数は0〜99999の範囲で指定してください", nil)
 	}
 	review.Title = strings.TrimSpace(review.Title)
+	review.Author = strings.TrimSpace(review.Author)
+	review.ISBN = strings.TrimSpace(review.ISBN)
 	review.Review = strings.TrimSpace(review.Review)
 	return s.repo.Create(review)
 }

--- a/backend/internal/service/note_template.go
+++ b/backend/internal/service/note_template.go
@@ -26,6 +26,11 @@ func NewNoteTemplateService(repo repository.NoteTemplateRepositoryInterface, not
 
 // Create は新しいテンプレートを作成する。
 func (s *NoteTemplateService) Create(template *model.NoteTemplate) error {
+	template.Name = strings.TrimSpace(template.Name)
+	template.ContentTemplate = strings.TrimSpace(template.ContentTemplate)
+	template.Description = strings.TrimSpace(template.Description)
+	template.DefaultTitle = strings.TrimSpace(template.DefaultTitle)
+
 	v := validator.NewNoteTemplateValidator()
 	if err := v.ValidateCreateTemplate(template.Name, template.ContentTemplate); err != nil {
 		return err

--- a/backend/internal/service/resource_review.go
+++ b/backend/internal/service/resource_review.go
@@ -36,6 +36,7 @@ func (s *ResourceReviewService) Create(review *model.ResourceReview) error {
 	}
 
 	// コメントバリデーション
+	review.Comment = strings.TrimSpace(review.Comment)
 	if err := domain.ValidateStringLength(review.Comment, 0, 5000, "コメント"); err != nil {
 		return err
 	}


### PR DESCRIPTION
## 概要
- Create メソッドで文字列フィールドへの TrimSpace が不足している3ファイルを修正

## 変更内容
- `note_template.go`: Name・ContentTemplate・Description・DefaultTitle にバリデーション前の TrimSpace 追加
- `book_review.go`: Author・ISBN に TrimSpace 追加（Title・Review は既存対応済み）
- `resource_review.go`: Comment にバリデーション前の TrimSpace 追加

Closes #2335