### PR TITLE
feat: 投稿ブックマーク数カウントエンドポイント追加

### DIFF
--- a/backend/internal/handler/post.go
+++ b/backend/internal/handler/post.go
@@ -49,6 +49,7 @@ type PostServiceInterface interface {
 	CountByUserID(userID uint) (int64, error)
 	CountDraftsByUserID(userID uint) (int64, error)
 	CountScheduledByUserID(userID uint) (int64, error)
+	CountBookmarkedByUserID(userID uint) (int64, error)
 }
 
 // CodeSnippetServiceInterface はCodeSnippetServiceが実装すべきインターフェース。
@@ -487,6 +488,19 @@ func (h *PostHandler) GetBookmarks(c *gin.Context) {
 		Limit:  limit,
 		Offset: (page - 1) * limit,
 	})
+}
+
+// GetBookmarksCount は認証ユーザーのブックマーク済み投稿数を返す。
+func (h *PostHandler) GetBookmarksCount(c *gin.Context) {
+	userID := c.GetUint("userID")
+
+	count, err := h.service.CountBookmarkedByUserID(userID)
+	if err != nil {
+		respondError(c, err)
+		return
+	}
+
+	respondOK(c, gin.H{"count": count})
 }
 
 // AddReaction は投稿にリアクション（絵文字）を追加する。

--- a/backend/internal/handler/testutil_test.go
+++ b/backend/internal/handler/testutil_test.go
@@ -130,6 +130,10 @@ func (m *MockPostRepository) FindBookmarkedByUserID(userID uint, page, limit int
 	args := m.Called(userID, page, limit)
 	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
 }
+func (m *MockPostRepository) CountBookmarkedByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 func (m *MockPostRepository) AddReaction(userID, postID uint, emoji string) error {
 	return m.Called(userID, postID, emoji).Error(0)
 }

--- a/backend/internal/repository/interfaces.go
+++ b/backend/internal/repository/interfaces.go
@@ -77,6 +77,7 @@ type PostRepositoryInterface interface {
 	Unbookmark(userID, postID uint) error
 	HasBookmarked(userID, postID uint) bool
 	FindBookmarkedByUserID(userID uint, page, limit int) ([]model.Post, int64, error)
+	CountBookmarkedByUserID(userID uint) (int64, error)
 	AddReaction(userID, postID uint, emoji string) error
 	RemoveReaction(userID, postID uint, emoji string) error
 	GetReactionsByPostID(postID uint) ([]model.ReactionCount, error)

--- a/backend/internal/repository/post.go
+++ b/backend/internal/repository/post.go
@@ -224,6 +224,13 @@ func (r *PostRepository) FindBookmarkedByUserID(userID uint, page, limit int) ([
 	return posts, total, err
 }
 
+// CountBookmarkedByUserID は指定ユーザーのブックマーク済み投稿数を返す。
+func (r *PostRepository) CountBookmarkedByUserID(userID uint) (int64, error) {
+	var count int64
+	err := r.db.Model(&model.Bookmark{}).Where("user_id = ?", userID).Count(&count).Error
+	return count, err
+}
+
 // AddReaction は投稿にリアクション（絵文字）を追加する。
 func (r *PostRepository) AddReaction(userID, postID uint, emoji string) error {
 	return r.db.Create(&model.Reaction{UserID: userID, PostID: postID, Emoji: emoji}).Error

--- a/backend/internal/router/router.go
+++ b/backend/internal/router/router.go
@@ -207,6 +207,7 @@ func registerPostRoutes(g *gin.RouterGroup, c *di.Container) {
 		posts.POST("/:id/bookmark", c.PostHandler.Bookmark)
 		posts.DELETE("/:id/bookmark", c.PostHandler.Unbookmark)
 		posts.GET("/bookmarks", c.PostHandler.GetBookmarks)
+		posts.GET("/bookmarks/count", c.PostHandler.GetBookmarksCount)
 		posts.GET("/:id/comments", c.PostHandler.GetComments)
 		posts.POST("/:id/comments", c.PostHandler.CreateComment)
 		posts.GET("/:id/comments/:commentId/replies", c.PostHandler.GetReplies)

--- a/backend/internal/service/mock_test.go
+++ b/backend/internal/service/mock_test.go
@@ -207,6 +207,10 @@ func (m *MockPostRepository) FindBookmarkedByUserID(userID uint, page, limit int
 	args := m.Called(userID, page, limit)
 	return args.Get(0).([]model.Post), args.Get(1).(int64), args.Error(2)
 }
+func (m *MockPostRepository) CountBookmarkedByUserID(userID uint) (int64, error) {
+	args := m.Called(userID)
+	return args.Get(0).(int64), args.Error(1)
+}
 
 func (m *MockPostRepository) AddReaction(userID, postID uint, emoji string) error {
 	return m.Called(userID, postID, emoji).Error(0)

--- a/backend/internal/service/post.go
+++ b/backend/internal/service/post.go
@@ -317,6 +317,11 @@ func (s *PostService) GetBookmarks(userID uint, page, limit int) ([]model.Post, 
 	return s.repo.FindBookmarkedByUserID(userID, page, limit)
 }
 
+// CountBookmarkedByUserID は指定ユーザーのブックマーク済み投稿数を返す。
+func (s *PostService) CountBookmarkedByUserID(userID uint) (int64, error) {
+	return s.repo.CountBookmarkedByUserID(userID)
+}
+
 // AddReaction は投稿にリアクション（絵文字）を追加する。
 // 許可された絵文字のみ使用可能。自分の投稿への自己リアクションは禁止する。
 func (s *PostService) AddReaction(userID, postID uint, emoji string) error {


### PR DESCRIPTION
## 概要
- `GET /posts/bookmarks/count`: 認証ユーザーのブックマーク済み投稿数を返す

## 変更内容
- `repository/interfaces.go`: `CountBookmarkedByUserID` をインターフェースに追加
- `repository/post.go`: 実装追加
- `service/post.go`: パススルーメソッド追加
- `handler/post.go`: `GetBookmarksCount` ハンドラ追加
- `router/router.go`: ルート追加
- テストモック更新

Closes #2337