### PR TITLE
refactor: ranking.go の period バリデーション重複解消と magic number 定数化

### DIFF
--- a/backend/internal/service/ranking.go
+++ b/backend/internal/service/ranking.go
@@ -6,6 +6,8 @@ import (
 	"github.com/norman6464/devsync/backend/internal/repository"
 )
 
+const maxLanguageNameLength = 50
+
 // RankingService はランキングのビジネスロジックを提供する。
 // リポジトリ層に処理を委譲する薄いラッパー。
 type RankingService struct {
@@ -22,20 +24,28 @@ var validRankingPeriods = map[string]bool{
 	"weekly": true, "monthly": true,
 }
 
+// validatePeriod は期間パラメータを検証する。
+func validatePeriod(period string) error {
+	if !validRankingPeriods[period] {
+		return domain.NewError(domain.ErrCodeBadRequest, "periodはweekly/monthlyのいずれかを指定してください", nil)
+	}
+	return nil
+}
+
 // ContributionRanking は指定期間のコントリビューションランキングを返す。
 func (s *RankingService) ContributionRanking(period string) ([]model.RankingEntry, error) {
-	if !validRankingPeriods[period] {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "periodはweekly/monthlyのいずれかを指定してください", nil)
+	if err := validatePeriod(period); err != nil {
+		return nil, err
 	}
 	return s.repo.ContributionRanking(period)
 }
 
 // LanguageRanking は指定言語・期間の言語別ランキングを返す。
 func (s *RankingService) LanguageRanking(language, period string) ([]model.RankingEntry, error) {
-	if !validRankingPeriods[period] {
-		return nil, domain.NewError(domain.ErrCodeBadRequest, "periodはweekly/monthlyのいずれかを指定してください", nil)
+	if err := validatePeriod(period); err != nil {
+		return nil, err
 	}
-	if len(language) > 50 {
+	if len(language) > maxLanguageNameLength {
 		return nil, domain.NewError(domain.ErrCodeBadRequest, "言語名が長すぎます", nil)
 	}
 	return s.repo.LanguageRanking(language, period)


### PR DESCRIPTION
## 概要
- period バリデーションを `validatePeriod` 共通ヘルパー関数に抽出
- 言語名長さ制限のマジックナンバー `50` を `maxLanguageNameLength` 定数に変更

## 変更内容
- `backend/internal/service/ranking.go`: 重複バリデーション → ヘルパー関数化、定数化

Closes #2339