### PR TITLE
fix: learning_log_template・post_template Create の TrimSpace 不足修正

### DIFF
--- a/backend/internal/service/learning_log_template.go
+++ b/backend/internal/service/learning_log_template.go
@@ -26,6 +26,10 @@ func NewLearningLogTemplateService(repo repository.LearningLogTemplateRepository
 
 // Create は新しいテンプレートを作成する。
 func (s *LearningLogTemplateService) Create(template *model.LearningLogTemplate) error {
+	template.Name = strings.TrimSpace(template.Name)
+	template.DefaultTitle = strings.TrimSpace(template.DefaultTitle)
+	template.DefaultContent = strings.TrimSpace(template.DefaultContent)
+
 	if err := domain.ValidateStringLength(template.Name, 1, 100, "テンプレート名"); err != nil {
 		return err
 	}

--- a/backend/internal/service/post_template.go
+++ b/backend/internal/service/post_template.go
@@ -20,6 +20,10 @@ func NewPostTemplateService(repo repository.PostTemplateRepositoryInterface) *Po
 
 // Create は新しい投稿テンプレートを作成する。
 func (s *PostTemplateService) Create(tmpl *model.PostTemplate) error {
+	tmpl.Name = strings.TrimSpace(tmpl.Name)
+	tmpl.ContentTemplate = strings.TrimSpace(tmpl.ContentTemplate)
+	tmpl.TitleTemplate = strings.TrimSpace(tmpl.TitleTemplate)
+
 	if err := domain.ValidateStringLength(tmpl.Name, 1, 100, "テンプレート名"); err != nil {
 		return err
 	}


### PR DESCRIPTION
## 概要
- Create メソッドで文字列フィールドへの TrimSpace が不足している2ファイルを修正

## 変更内容
- `learning_log_template.go`: Name・DefaultTitle・DefaultContent にバリデーション前の TrimSpace 追加
- `post_template.go`: Name・ContentTemplate・TitleTemplate にバリデーション前の TrimSpace 追加

Closes #2343